### PR TITLE
test: cover ACP replay edge cases

### DIFF
--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -852,6 +852,7 @@ impl crate::app::App {
                     &source,
                     &requested_schema,
                     allow_custom,
+                    is_replay,
                 );
             }
             AcpSessionUpdate::Cancelled => {
@@ -1095,6 +1096,7 @@ impl crate::app::App {
         source: &str,
         requested_schema: &Value,
         allow_custom: bool,
+        is_replay: bool,
     ) {
         self.finalize_streaming_segment();
         let fields = ElicitationState::parse_schema(requested_schema);
@@ -1113,23 +1115,25 @@ impl crate::app::App {
                 "question skipped - unsupported schema",
             );
         } else {
-            self.elicitation = Some(ElicitationState {
-                elicitation_id: elicitation_id.to_string(),
-                message: message.to_string(),
-                source: source.to_string(),
-                fields,
-                field_cursor: 0,
-                option_cursor: 0,
-                selected: std::collections::HashMap::new(),
-                text_input: String::new(),
-                text_cursor: 0,
-                allow_custom,
-                custom_active: false,
-                custom_input: String::new(),
-                custom_cursor: 0,
-                custom_line_width: 1,
-                custom_scroll: 0,
-            });
+            if !is_replay {
+                self.elicitation = Some(ElicitationState {
+                    elicitation_id: elicitation_id.to_string(),
+                    message: message.to_string(),
+                    source: source.to_string(),
+                    fields,
+                    field_cursor: 0,
+                    option_cursor: 0,
+                    selected: std::collections::HashMap::new(),
+                    text_input: String::new(),
+                    text_cursor: 0,
+                    allow_custom,
+                    custom_active: false,
+                    custom_input: String::new(),
+                    custom_cursor: 0,
+                    custom_line_width: 1,
+                    custom_scroll: 0,
+                });
+            }
             self.messages.push(ChatEntry::Elicitation {
                 elicitation_id: elicitation_id.to_string(),
                 message: message.to_string(),
@@ -1611,6 +1615,15 @@ mod tests {
             is_replay: false,
             update,
         });
+    }
+
+    fn failed_tool_end(tool_call_id: &str, name: &str) -> AcpSessionUpdate {
+        AcpSessionUpdate::ToolCallEnd {
+            tool_call_id: Some(tool_call_id.into()),
+            name: name.into(),
+            is_error: true,
+            result: Some("failed".into()),
+        }
     }
 
     fn assert_single_assistant(
@@ -2602,6 +2615,187 @@ mod tests {
                 ChatEntry::ToolCall { .. },
                 ChatEntry::Assistant { content: second, message_id: Some(second_id), .. },
             ] if first == "hello" && first_id == "a1" && second == "after" && second_id == "a2"
+        ));
+    }
+
+    #[test]
+    fn native_duplicate_user_message_id_is_not_appended() {
+        let mut app = app_with_active_session();
+        let update = AcpSessionUpdate::UserMessage {
+            content: serde_json::json!({ "text": "hello" }),
+            message_id: Some("u1".into()),
+        };
+
+        apply_live_update(&mut app, update.clone());
+        apply_live_update(&mut app, update);
+
+        assert!(matches!(
+            app.messages.as_slice(),
+            [ChatEntry::User { text, message_id: Some(message_id) }]
+                if text == "hello" && message_id == "u1"
+        ));
+    }
+
+    #[test]
+    fn native_duplicate_thinking_only_assistant_is_not_appended() {
+        let mut app = app_with_active_session();
+        let update = AcpSessionUpdate::AssistantMessage {
+            content: String::new(),
+            thinking: Some("checking".into()),
+            message_id: Some("a1".into()),
+        };
+
+        apply_live_update(&mut app, update.clone());
+        apply_live_update(&mut app, update);
+
+        assert!(matches!(
+            app.messages.as_slice(),
+            [ChatEntry::Thinking { content, message_id: Some(message_id) }]
+                if content == "checking" && message_id == "a1"
+        ));
+    }
+
+    #[test]
+    fn native_duplicate_acp_error_is_not_appended() {
+        let mut app = app_with_active_session();
+        let event = AcpAppEvent::Error {
+            message: "connection lost".into(),
+        };
+
+        app.handle_acp_event(event.clone());
+        app.handle_acp_event(event);
+
+        assert!(
+            matches!(app.messages.as_slice(), [ChatEntry::Error(message)] if message == "connection lost")
+        );
+    }
+
+    #[test]
+    fn native_failed_tool_end_before_start_reconciles_when_start_arrives() {
+        let mut app = app_with_active_session();
+
+        apply_live_update(&mut app, failed_tool_end("tool-1", "shell"));
+        apply_live_update(
+            &mut app,
+            AcpSessionUpdate::ToolCallStart {
+                tool_call_id: Some("tool-1".into()),
+                name: "shell".into(),
+                arguments: Some(serde_json::json!({ "command": "echo late" })),
+            },
+        );
+
+        assert!(matches!(
+            app.messages.as_slice(),
+            [ChatEntry::ToolCall { tool_call_id: Some(tool_call_id), name, is_error: true, detail: ToolDetail::Shell { command, .. } }]
+                if tool_call_id == "tool-1" && name == "shell" && command == "echo late"
+        ));
+    }
+
+    #[test]
+    fn native_repeated_failed_tool_end_dedupes_fallback_by_call_id_and_name() {
+        let mut app = app_with_active_session();
+
+        apply_live_update(&mut app, failed_tool_end("tool-1", "shell"));
+        apply_live_update(&mut app, failed_tool_end("tool-1", "shell"));
+        apply_live_update(&mut app, failed_tool_end("tool-2", "shell"));
+
+        assert!(matches!(
+            app.messages.as_slice(),
+            [
+                ChatEntry::ToolCall { tool_call_id: Some(first), name: first_name, is_error: true, .. },
+                ChatEntry::ToolCall { tool_call_id: Some(second), name: second_name, is_error: true, .. },
+            ] if first == "tool-1" && first_name == "shell (failed)"
+                && second == "tool-2" && second_name == "shell (failed)"
+        ));
+    }
+
+    #[test]
+    fn native_live_elicitation_creates_card_and_active_state() {
+        let mut app = app_with_active_session();
+
+        apply_live_update(
+            &mut app,
+            AcpSessionUpdate::ElicitationRequested {
+                elicitation_id: "elic-1".into(),
+                message: "Choose a target".into(),
+                requested_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": { "target": { "type": "string", "enum": ["staging"] } },
+                    "required": ["target"]
+                }),
+                source: "builtin:question".into(),
+                allow_custom: true,
+            },
+        );
+
+        assert_eq!(
+            app.elicitation
+                .as_ref()
+                .map(|state| state.elicitation_id.as_str()),
+            Some("elic-1")
+        );
+        assert!(matches!(
+            app.messages.as_slice(),
+            [ChatEntry::Elicitation { elicitation_id, message, outcome: None, .. }]
+                if elicitation_id == "elic-1" && message == "Choose a target"
+        ));
+    }
+
+    #[test]
+    fn native_replay_elicitation_creates_card_without_active_state() {
+        let mut app = app_with_active_session();
+
+        app.handle_acp_event(AcpAppEvent::SessionReplay {
+            session_id: TEST_SESSION_ID.into(),
+            updates: vec![AcpSessionUpdate::ElicitationRequested {
+                elicitation_id: "elic-1".into(),
+                message: "Choose a target".into(),
+                requested_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": { "target": { "type": "string", "enum": ["staging"] } },
+                    "required": ["target"]
+                }),
+                source: "builtin:question".into(),
+                allow_custom: true,
+            }],
+        });
+
+        assert!(app.elicitation.is_none());
+        assert!(matches!(
+            app.messages.as_slice(),
+            [ChatEntry::Elicitation { elicitation_id, message, outcome: None, .. }]
+                if elicitation_id == "elic-1" && message == "Choose a target"
+        ));
+    }
+
+    #[test]
+    fn native_session_replay_is_idempotent() {
+        let mut app = app_with_active_session();
+        let updates = vec![
+            AcpSessionUpdate::UserMessage {
+                content: serde_json::json!({ "text": "hello" }),
+                message_id: Some("u1".into()),
+            },
+            AcpSessionUpdate::AssistantMessage {
+                content: "world".into(),
+                thinking: None,
+                message_id: Some("a1".into()),
+            },
+        ];
+
+        for _ in 0..2 {
+            app.handle_acp_event(AcpAppEvent::SessionReplay {
+                session_id: TEST_SESSION_ID.into(),
+                updates: updates.clone(),
+            });
+        }
+
+        assert!(matches!(
+            app.messages.as_slice(),
+            [
+                ChatEntry::User { message_id: Some(user_id), .. },
+                ChatEntry::Assistant { message_id: Some(assistant_id), .. },
+            ] if user_id == "u1" && assistant_id == "a1"
         ));
     }
 }

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -698,11 +698,14 @@ impl crate::app::App {
                 content,
                 message_id,
             } => {
+                // `Finished` clears non-durable streaming thinking, so only an unterminated
+                // replay can be present here for a second identical application.
                 if is_replay
                     && message_id.as_deref().is_some_and(|incoming| {
                         self.messages.iter().any(|entry| {
                             matches!(entry, ChatEntry::Thinking { message_id: Some(existing), .. } if existing == incoming)
-                        })
+                        }) || (self.streaming_thinking_message_id.as_deref() == Some(incoming)
+                            && self.streaming_thinking == content)
                     })
                 {
                     return;
@@ -1978,6 +1981,50 @@ mod tests {
             ] if content == "Let me check." && message_id == "assistant-1" && tool_call_id == "tool-1"
         ));
         assert!(app.streaming_content.is_empty());
+    }
+
+    #[test]
+    fn repeated_terminal_replay_thinking_delta_is_idempotent() {
+        let mut app = app_with_active_session();
+        let updates = vec![AcpSessionUpdate::AssistantThinkingDelta {
+            content: "inspect files".into(),
+            message_id: Some("assistant-1".into()),
+        }];
+
+        for _ in 0..2 {
+            app.handle_acp_event(AcpAppEvent::SessionReplay {
+                session_id: TEST_SESSION_ID.into(),
+                updates: updates.clone(),
+            });
+        }
+
+        assert_eq!(app.streaming_thinking, "inspect files");
+        assert_eq!(
+            app.streaming_thinking_message_id.as_deref(),
+            Some("assistant-1")
+        );
+        assert!(app.messages.is_empty());
+    }
+
+    #[test]
+    fn replay_thinking_chunks_with_matching_id_are_not_suppressed() {
+        let mut app = app_with_active_session();
+
+        for content in ["hel", "lo"] {
+            app.handle_acp_event(AcpAppEvent::SessionReplay {
+                session_id: TEST_SESSION_ID.into(),
+                updates: vec![AcpSessionUpdate::AssistantThinkingDelta {
+                    content: content.into(),
+                    message_id: Some("assistant-1".into()),
+                }],
+            });
+        }
+
+        assert_eq!(app.streaming_thinking, "hello");
+        assert_eq!(
+            app.streaming_thinking_message_id.as_deref(),
+            Some("assistant-1")
+        );
     }
 
     #[test]

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -698,6 +698,15 @@ impl crate::app::App {
                 content,
                 message_id,
             } => {
+                if is_replay
+                    && message_id.as_deref().is_some_and(|incoming| {
+                        self.messages.iter().any(|entry| {
+                            matches!(entry, ChatEntry::Thinking { message_id: Some(existing), .. } if existing == incoming)
+                        })
+                    })
+                {
+                    return;
+                }
                 let active_message_id = self
                     .streaming_content_message_id
                     .as_deref()
@@ -1098,6 +1107,20 @@ impl crate::app::App {
         allow_custom: bool,
         is_replay: bool,
     ) {
+        // An elicitation ID is the durable identity across live delivery and replay.
+        // Keep an existing card (and any recorded outcome) rather than reopening it.
+        if self.messages.iter().any(|entry| {
+            matches!(
+                entry,
+                ChatEntry::Elicitation {
+                    elicitation_id: existing_id,
+                    ..
+                } if existing_id == elicitation_id
+            )
+        }) {
+            return;
+        }
+
         self.finalize_streaming_segment();
         let fields = ElicitationState::parse_schema(requested_schema);
         if fields.is_empty() {
@@ -1958,6 +1981,41 @@ mod tests {
     }
 
     #[test]
+    fn repeated_replay_thinking_deltas_preserve_tool_boundaries() {
+        let mut app = app_with_active_session();
+        let updates = vec![
+            AcpSessionUpdate::AssistantThinkingDelta {
+                content: "inspect ".into(),
+                message_id: Some("assistant-1".into()),
+            },
+            AcpSessionUpdate::AssistantThinkingDelta {
+                content: "files".into(),
+                message_id: Some("assistant-1".into()),
+            },
+            AcpSessionUpdate::ToolCallStart {
+                tool_call_id: Some("tool-1".into()),
+                name: "shell".into(),
+                arguments: Some(serde_json::json!({ "command": "pwd" })),
+            },
+        ];
+
+        for _ in 0..2 {
+            app.handle_acp_event(AcpAppEvent::SessionReplay {
+                session_id: TEST_SESSION_ID.into(),
+                updates: updates.clone(),
+            });
+        }
+
+        assert!(matches!(
+            app.messages.as_slice(),
+            [
+                ChatEntry::Thinking { content, message_id: Some(message_id) },
+                ChatEntry::ToolCall { tool_call_id: Some(tool_call_id), .. },
+            ] if content == "inspect files" && message_id == "assistant-1" && tool_call_id == "tool-1"
+        ));
+    }
+
+    #[test]
     fn final_assistant_replaces_matching_thinking_without_crossing_tool() {
         let mut app = app_with_active_session();
         app.messages.push(ChatEntry::Thinking {
@@ -2765,6 +2823,103 @@ mod tests {
             app.messages.as_slice(),
             [ChatEntry::Elicitation { elicitation_id, message, outcome: None, .. }]
                 if elicitation_id == "elic-1" && message == "Choose a target"
+        ));
+    }
+
+    #[test]
+    fn native_repeated_replay_elicitation_preserves_existing_outcome() {
+        let mut app = app_with_active_session();
+        let updates = vec![AcpSessionUpdate::ElicitationRequested {
+            elicitation_id: "elic-1".into(),
+            message: "Choose a target".into(),
+            requested_schema: serde_json::json!({
+                "type": "object",
+                "properties": { "target": { "type": "string", "enum": ["staging"] } },
+                "required": ["target"]
+            }),
+            source: "builtin:question".into(),
+            allow_custom: true,
+        }];
+
+        for _ in 0..2 {
+            app.handle_acp_event(AcpAppEvent::SessionReplay {
+                session_id: TEST_SESSION_ID.into(),
+                updates: updates.clone(),
+            });
+        }
+        app.resolve_elicitation("elic-1", "staging");
+        app.handle_acp_event(AcpAppEvent::SessionReplay {
+            session_id: TEST_SESSION_ID.into(),
+            updates,
+        });
+
+        assert!(app.elicitation.is_none());
+        assert!(matches!(
+            app.messages.as_slice(),
+            [ChatEntry::Elicitation { elicitation_id, outcome: Some(outcome), .. }]
+                if elicitation_id == "elic-1" && outcome == "staging"
+        ));
+    }
+
+    #[test]
+    fn native_live_elicitation_is_not_reopened_by_replay_and_distinct_ids_append() {
+        let mut app = app_with_active_session();
+        let elicitation = |id: &str| AcpSessionUpdate::ElicitationRequested {
+            elicitation_id: id.into(),
+            message: "Choose a target".into(),
+            requested_schema: serde_json::json!({
+                "type": "object",
+                "properties": { "target": { "type": "string", "enum": ["staging"] } },
+                "required": ["target"]
+            }),
+            source: "builtin:question".into(),
+            allow_custom: true,
+        };
+
+        apply_live_update(&mut app, elicitation("elic-live"));
+        app.handle_acp_event(AcpAppEvent::SessionReplay {
+            session_id: TEST_SESSION_ID.into(),
+            updates: vec![elicitation("elic-live"), elicitation("elic-replayed")],
+        });
+
+        assert_eq!(
+            app.elicitation
+                .as_ref()
+                .map(|state| state.elicitation_id.as_str()),
+            Some("elic-live")
+        );
+        assert!(matches!(
+            app.messages.as_slice(),
+            [
+                ChatEntry::Elicitation { elicitation_id: first, .. },
+                ChatEntry::Elicitation { elicitation_id: second, .. },
+            ] if first == "elic-live" && second == "elic-replayed"
+        ));
+    }
+
+    #[test]
+    fn native_unsupported_replay_elicitation_is_idempotent() {
+        let mut app = app_with_active_session();
+        let updates = vec![AcpSessionUpdate::ElicitationRequested {
+            elicitation_id: "elic-unsupported".into(),
+            message: "Upload a file".into(),
+            requested_schema: serde_json::json!({ "type": "array" }),
+            source: "extension:file-picker".into(),
+            allow_custom: false,
+        }];
+
+        for _ in 0..2 {
+            app.handle_acp_event(AcpAppEvent::SessionReplay {
+                session_id: TEST_SESSION_ID.into(),
+                updates: updates.clone(),
+            });
+        }
+
+        assert!(matches!(
+            app.messages.as_slice(),
+            [ChatEntry::Elicitation { elicitation_id, outcome: Some(outcome), .. }]
+                if elicitation_id == "elic-unsupported"
+                    && outcome == "unsupported schema - cannot answer in TUI"
         ));
     }
 

--- a/src/server_msg.rs
+++ b/src/server_msg.rs
@@ -2136,7 +2136,10 @@ fn fallback_failed_tool_name(tool_name: &str) -> String {
 }
 
 fn is_same_tool_call(existing_id: &Option<String>, tool_call_id: Option<&str>) -> bool {
-    existing_id.as_deref() == tool_call_id
+    matches!(
+        (existing_id.as_deref(), tool_call_id),
+        (Some(existing_id), Some(tool_call_id)) if existing_id == tool_call_id
+    )
 }
 
 fn push_error_message(messages: &mut Vec<ChatEntry>, message: &str) -> bool {
@@ -2256,6 +2259,28 @@ mod tool_call_replay_tests {
                 is_error: true,
                 detail: ToolDetail::None,
             }] if id == "missing-start" && name == "ls (failed)"
+        ));
+    }
+
+    #[test]
+    fn missing_id_failed_tool_ends_create_distinct_fallback_cards() {
+        let mut app = App::new();
+        let failed_end = EventKind::ToolCallEnd {
+            tool_call_id: None,
+            tool_name: "ls".into(),
+            is_error: Some(true),
+            result: None,
+        };
+
+        app.handle_event_kind(&failed_end, true, None);
+        app.handle_event_kind(&failed_end, true, None);
+
+        assert!(matches!(
+            app.messages.as_slice(),
+            [
+                ChatEntry::ToolCall { tool_call_id: None, name: first, is_error: true, .. },
+                ChatEntry::ToolCall { tool_call_id: None, name: second, is_error: true, .. },
+            ] if first == "ls (failed)" && second == "ls (failed)"
         ));
     }
 

--- a/src/tool_detail.rs
+++ b/src/tool_detail.rs
@@ -175,10 +175,13 @@ pub(crate) fn reconcile_tool_call_start(
             if existing != id {
                 continue;
             }
-            if name == &fallback_name {
+            let is_failed_fallback = name == &fallback_name;
+            if is_failed_fallback {
                 *name = tool_name.to_string();
             }
-            if matches!(detail, ToolDetail::None) && !matches!(start_detail, ToolDetail::None) {
+            if (is_failed_fallback || matches!(detail, ToolDetail::None))
+                && !matches!(start_detail, ToolDetail::None)
+            {
                 *detail = start_detail;
             }
             return true;
@@ -278,6 +281,7 @@ pub(crate) fn mark_tool_call_failed(
     tool_name: &str,
 ) -> bool {
     let Some(id) = tool_call_id else { return false };
+    let fallback_name = format!("{tool_name} (failed)");
     for entry in messages.iter_mut().rev() {
         if let ChatEntry::ToolCall {
             tool_call_id: Some(existing),
@@ -286,8 +290,7 @@ pub(crate) fn mark_tool_call_failed(
             ..
         } = entry
             && existing == id
-            && name == tool_name
-            && !*is_error
+            && (name == tool_name || name == &fallback_name)
         {
             *is_error = true;
             return true;


### PR DESCRIPTION
## What changed
- port representative live and replay state coverage to native `AcpAppEvent` tests
- preserve elicitation history during replay without opening active input state
- deduplicate repeated failed tool-end fallbacks and retain late-start details

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test acp_state --lib`
- `cargo test --all-targets`
- `git diff --check`

## Deferred
ACP does not currently provide enough information to safely port undo-frontier pruning, question answer backfill, or delegate-child routing. This PR intentionally does not broaden the protocol.