### PR TITLE
feat: implement ACP workspace session pagination

### DIFF
--- a/src/acp_client.rs
+++ b/src/acp_client.rs
@@ -22,8 +22,8 @@ use crate::acp_state::{AcpAppEvent, AcpModelsMetaInfo, AcpSessionUpdate};
 use crate::protocol::{
     AgentInfo, AuthProvidersData, ClientMsg, ForkResultData, MeshInviteCreatedInfo, MeshNodesInfo,
     MeshStatusInfo, OAuthFlowData, OAuthResultData, ProfileInfo, RedoResultData,
-    RemoteSessionAttachInfo, RemoteSessionListInfo, SessionGroup, SessionSummary, UndoResultData,
-    UndoStackFrame,
+    RemoteSessionAttachInfo, RemoteSessionListInfo, SessionGroup, SessionListRequest,
+    SessionSummary, UndoResultData, UndoStackFrame,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -920,14 +920,26 @@ async fn handle_client_msg<C: AcpConnection>(
             );
             post_connect_diagnostics(connection, srv_tx).await;
         }
-        ClientMsg::ListSessions { cursor, cwd, .. } => {
-            let requested_cwd = cwd.and_then(|cwd| (cwd != "__none__").then_some(cwd));
+        ClientMsg::ListSessions {
+            request,
+            cursor,
+            cwd,
+            ..
+        } => {
             let mut req = acp::ListSessionsRequest::new().cursor(cursor);
-            if let Some(cwd) = requested_cwd.as_deref() {
+            if let Some(cwd) = cwd.as_deref() {
                 req = req.cwd(PathBuf::from(cwd));
             }
-            let response = connection.request(req).await?;
-            send_session_list(srv_tx, requested_cwd, response);
+            match connection.request(req).await {
+                Ok(response) => send_session_list(srv_tx, request, response),
+                Err(err) => send_acp(
+                    srv_tx,
+                    AcpAppEvent::SessionListFailed {
+                        request,
+                        message: format!("ACP session/list failed: {err:?}"),
+                    },
+                ),
+            }
         }
         ClientMsg::NewSession {
             cwd, profile_id, ..
@@ -2455,7 +2467,7 @@ fn flatten_select_entries(option: &Value) -> Vec<&Value> {
 
 fn send_session_list(
     srv_tx: &mpsc::UnboundedSender<ServerChannelMsg>,
-    requested_cwd: Option<String>,
+    request: SessionListRequest,
     response: acp::ListSessionsResponse,
 ) {
     let mut groups: BTreeMap<Option<String>, Vec<SessionSummary>> = BTreeMap::new();
@@ -2463,8 +2475,9 @@ fn send_session_list(
 
     for session in response.sessions {
         let cwd = session.cwd.to_string_lossy().to_string();
-        let group_key = requested_cwd
-            .clone()
+        let group_key = request
+            .cwd()
+            .map(str::to_string)
             .or_else(|| (!cwd.is_empty()).then_some(cwd.clone()));
         groups.entry(group_key).or_default().push(SessionSummary {
             session_id: session.session_id.to_string(),
@@ -2488,40 +2501,34 @@ fn send_session_list(
         });
     }
 
-    if let Some(cwd) = requested_cwd.clone() {
-        groups.entry(Some(cwd)).or_default();
+    if let Some(cwd) = request.cwd() {
+        groups.entry(Some(cwd.to_string())).or_default();
     }
 
-    let root_has_more = requested_cwd.is_none() && response_cursor.is_some();
-    let total_count: usize = groups.values().map(Vec::len).sum();
+    let workspace_cursor = request
+        .cwd()
+        .is_some()
+        .then_some(response_cursor.clone())
+        .flatten();
     let groups = groups
         .into_iter()
-        .map(|(cwd, sessions)| {
-            let next_cursor = if requested_cwd.is_some() {
-                response_cursor.clone()
-            } else if root_has_more && !sessions.is_empty() {
-                Some(sessions.len().to_string())
-            } else {
-                None
-            };
-            SessionGroup {
-                cwd,
-                latest_activity: sessions
-                    .first()
-                    .and_then(|session| session.updated_at.clone()),
-                total_count: Some(sessions.len() as u64),
-                next_cursor,
-                sessions,
-            }
+        .map(|(cwd, sessions)| SessionGroup {
+            cwd,
+            latest_activity: sessions
+                .first()
+                .and_then(|session| session.updated_at.clone()),
+            total_count: None,
+            next_cursor: workspace_cursor.clone(),
+            sessions,
         })
         .collect::<Vec<_>>();
 
     send_acp(
         srv_tx,
         AcpAppEvent::SessionList {
+            request,
             groups,
-            next_cursor: None,
-            total_count: Some(total_count as u64),
+            next_cursor: response_cursor,
         },
     );
 }
@@ -2876,7 +2883,7 @@ mod tests {
     }
 
     #[test]
-    fn acp_root_session_list_maps_global_cursor_to_group_offsets() {
+    fn acp_root_session_list_preserves_only_the_global_cursor() {
         let (tx, mut rx) = mpsc::unbounded_channel();
         let response = acp::ListSessionsResponse::new(vec![
             acp::SessionInfo::new(acp::SessionId::from("s1"), Path::new("/repo")),
@@ -2885,20 +2892,18 @@ mod tests {
         ])
         .next_cursor(Some("100".to_string()));
 
-        send_session_list(&tx, None, response);
+        send_session_list(&tx, SessionListRequest::Discovery, response);
 
         let ServerChannelMsg::Acp(event) = rx.try_recv().expect("session list event");
         assert!(matches!(
             event,
             AcpAppEvent::SessionList {
+                request: SessionListRequest::Discovery,
                 groups,
-                next_cursor: None,
-                ..
-            } if groups.len() == 2
-                && groups.iter().any(|group| group.cwd.as_deref() == Some("/repo")
-                    && group.next_cursor.as_deref() == Some("2"))
-                && groups.iter().any(|group| group.cwd.as_deref() == Some("/other")
-                    && group.next_cursor.as_deref() == Some("1"))
+                next_cursor: Some(cursor),
+            } if cursor == "100"
+                && groups.len() == 2
+                && groups.iter().all(|group| group.next_cursor.is_none())
         ));
     }
 
@@ -2912,16 +2917,24 @@ mod tests {
         ])
         .next_cursor(Some("cursor-2".to_string()));
 
-        send_session_list(&tx, Some("/repo".to_string()), response);
+        send_session_list(
+            &tx,
+            SessionListRequest::WorkspaceContinuation {
+                cwd: "/repo".to_string(),
+            },
+            response,
+        );
 
         let ServerChannelMsg::Acp(event) = rx.try_recv().expect("session list event");
         assert!(matches!(
             event,
             AcpAppEvent::SessionList {
+                request: SessionListRequest::WorkspaceContinuation { cwd },
                 groups,
-                next_cursor: None,
-                ..
-            } if groups.len() == 1
+                next_cursor: Some(root_cursor),
+            } if cwd == "/repo"
+                && root_cursor == "cursor-2"
+                && groups.len() == 1
                 && groups[0].cwd.as_deref() == Some("/repo")
                 && groups[0].next_cursor.as_deref() == Some("cursor-2")
                 && groups[0].sessions[0].session_id == "s1"

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -7,12 +7,13 @@ use crate::acp_client::{
 };
 use crate::app::{
     ActivityState, ChatEntry, DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus,
-    ElicitationState, LogLevel, Popup, Screen, ToolDetail,
+    ElicitationState, LogLevel, POPUP_SESSION_PAGE_TARGET, Popup, Screen, ToolDetail,
 };
 use crate::protocol::{
     AgentInfo, AuthProviderEntry, ClientMsg, ForkResultData, MeshInviteCreatedInfo, MeshNodesInfo,
     MeshStatusInfo, ModelEntry, OAuthFlowData, OAuthResultData, ProfileInfo, RedoResultData,
-    RemoteSessionAttachInfo, RemoteSessionListInfo, SessionGroup, UndoResultData, UndoStackFrame,
+    RemoteSessionAttachInfo, RemoteSessionListInfo, SessionGroup, SessionListRequest,
+    UndoResultData, UndoStackFrame,
 };
 use crate::tool_detail;
 
@@ -117,9 +118,13 @@ pub(crate) enum AcpAppEvent {
     RemoteSessions(RemoteSessionListInfo),
     RemoteSessionAttached(RemoteSessionAttachInfo),
     SessionList {
+        request: SessionListRequest,
         groups: Vec<SessionGroup>,
         next_cursor: Option<String>,
-        total_count: Option<u64>,
+    },
+    SessionListFailed {
+        request: SessionListRequest,
+        message: String,
     },
     SessionCreated {
         agent_id: String,
@@ -305,11 +310,14 @@ impl crate::app::App {
                 attached.attached,
             ),
             AcpAppEvent::SessionList {
+                request,
                 groups,
                 next_cursor,
-                total_count,
-            } => {
-                self.apply_acp_session_list(groups, next_cursor, total_count);
+            } => self.apply_acp_session_list(request, groups, next_cursor),
+            AcpAppEvent::SessionListFailed { request, message } => {
+                self.apply_acp_session_list_failure(&request);
+                self.push_acp_error(&message);
+                self.set_status(LogLevel::Error, "acp", format!("error: {message}"));
                 vec![]
             }
             AcpAppEvent::SessionCreated {
@@ -574,91 +582,156 @@ impl crate::app::App {
 
     fn apply_acp_session_list(
         &mut self,
+        request: SessionListRequest,
         mut groups: Vec<SessionGroup>,
-        _next_cursor: Option<String>,
-        total_count: Option<u64>,
-    ) {
-        let response_cwd = if groups.len() == 1 {
-            groups.first().and_then(|group| group.cwd.clone())
-        } else {
-            None
-        };
-        let is_group_page = response_cwd
-            .as_ref()
-            .map(|cwd| self.pending_session_group_loads.remove(&Some(cwd.clone())))
-            .unwrap_or_else(|| self.pending_session_group_loads.remove(&None));
-
-        groups.retain(|group| is_group_page || !group.sessions.is_empty());
+        next_cursor: Option<String>,
+    ) -> Vec<ClientMsg> {
         for group in &mut groups {
+            group.total_count = None;
             for session in &group.sessions {
                 if let Some(node_id) = session.node_id.as_deref() {
                     self.remember_remote_session_node(&session.session_id, node_id);
                 }
             }
-            group
+            group.sessions.sort_by(|a, b| {
+                b.updated_at
+                    .cmp(&a.updated_at)
+                    .then_with(|| b.session_id.cmp(&a.session_id))
+            });
+            group.latest_activity = group
                 .sessions
-                .sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+                .first()
+                .and_then(|session| session.updated_at.clone());
         }
 
-        if is_group_page {
-            for group in groups {
-                if let Some(existing) = self
+        let mut commands = Vec::new();
+        match request {
+            SessionListRequest::Discovery => {
+                self.session_discovery_in_progress = false;
+                for mut group in groups {
+                    group.next_cursor = None;
+                    match group.cwd.clone() {
+                        Some(cwd) => {
+                            let hydrated = self.hydrated_session_groups.contains(&cwd);
+                            if let Some(existing) = self
+                                .session_groups
+                                .iter_mut()
+                                .find(|existing| existing.cwd.as_deref() == Some(cwd.as_str()))
+                            {
+                                if !hydrated {
+                                    merge_session_page(
+                                        existing,
+                                        group.sessions,
+                                        Some(POPUP_SESSION_PAGE_TARGET),
+                                    );
+                                }
+                            } else {
+                                group.sessions.truncate(POPUP_SESSION_PAGE_TARGET);
+                                self.session_groups.push(group);
+                            }
+
+                            if !hydrated
+                                && self.pending_session_group_loads.insert(Some(cwd.clone()))
+                            {
+                                commands.push(ClientMsg::list_sessions_workspace(cwd));
+                            }
+                        }
+                        None => {
+                            if let Some(existing) = self
+                                .session_groups
+                                .iter_mut()
+                                .find(|existing| existing.cwd.is_none())
+                            {
+                                merge_session_page(
+                                    existing,
+                                    group.sessions,
+                                    Some(POPUP_SESSION_PAGE_TARGET),
+                                );
+                            } else {
+                                group.sessions.truncate(POPUP_SESSION_PAGE_TARGET);
+                                self.session_groups.push(group);
+                            }
+                        }
+                    }
+                }
+
+                if let Some(cursor) = next_cursor
+                    && self.session_discovery_cursors.insert(cursor.clone())
+                {
+                    self.session_discovery_in_progress = true;
+                    commands.push(ClientMsg::list_sessions_discovery(Some(cursor)));
+                }
+            }
+            SessionListRequest::WorkspaceFirstPage { cwd } => {
+                self.pending_session_group_loads.remove(&Some(cwd.clone()));
+                self.hydrated_session_groups.insert(cwd.clone());
+                let mut group = groups
+                    .into_iter()
+                    .find(|group| group.cwd.as_deref() == Some(cwd.as_str()))
+                    .unwrap_or_else(|| SessionGroup {
+                        cwd: Some(cwd.clone()),
+                        ..SessionGroup::default()
+                    });
+                group.cwd = Some(cwd.clone());
+                group.total_count = None;
+
+                if group.sessions.is_empty() {
+                    self.session_groups
+                        .retain(|existing| existing.cwd.as_deref() != Some(cwd.as_str()));
+                } else if let Some(existing) = self
                     .session_groups
                     .iter_mut()
-                    .find(|existing| existing.cwd == group.cwd)
+                    .find(|existing| existing.cwd.as_deref() == Some(cwd.as_str()))
                 {
-                    let mut seen = existing
-                        .sessions
-                        .iter()
-                        .map(|session| session.session_id.clone())
-                        .collect::<std::collections::HashSet<_>>();
-                    existing.sessions.extend(
-                        group
-                            .sessions
-                            .into_iter()
-                            .filter(|session| seen.insert(session.session_id.clone())),
-                    );
-                    existing
-                        .sessions
-                        .sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
-                    existing.latest_activity = existing
-                        .sessions
-                        .first()
-                        .and_then(|session| session.updated_at.clone())
-                        .or(group.latest_activity);
-                    existing.total_count = group.total_count;
-                    existing.next_cursor = group.next_cursor;
-                } else if !group.sessions.is_empty() {
+                    *existing = group;
+                } else {
                     self.session_groups.push(group);
                 }
             }
-        } else {
-            groups.sort_by(|a, b| {
-                let a_latest = a.sessions.first().and_then(|s| s.updated_at.as_deref());
-                let b_latest = b.sessions.first().and_then(|s| s.updated_at.as_deref());
-                b_latest.cmp(&a_latest)
-            });
-            self.session_groups = groups;
+            SessionListRequest::WorkspaceContinuation { cwd } => {
+                self.pending_session_group_loads.remove(&Some(cwd.clone()));
+                let page = groups
+                    .into_iter()
+                    .find(|group| group.cwd.as_deref() == Some(cwd.as_str()))
+                    .unwrap_or_else(|| SessionGroup {
+                        cwd: Some(cwd.clone()),
+                        ..SessionGroup::default()
+                    });
+                if let Some(existing) = self
+                    .session_groups
+                    .iter_mut()
+                    .find(|existing| existing.cwd.as_deref() == Some(cwd.as_str()))
+                {
+                    existing.next_cursor = page.next_cursor.clone();
+                    merge_session_page(existing, page.sessions, None);
+                } else if !page.sessions.is_empty() {
+                    self.session_groups.push(page);
+                }
+            }
         }
 
+        self.session_groups
+            .retain(|group| !group.sessions.is_empty());
         self.session_groups.sort_by(|a, b| {
-            let a_latest = a.sessions.first().and_then(|s| s.updated_at.as_deref());
-            let b_latest = b.sessions.first().and_then(|s| s.updated_at.as_deref());
-            b_latest.cmp(&a_latest)
+            b.latest_activity
+                .cmp(&a.latest_activity)
+                .then_with(|| a.cwd.cmp(&b.cwd))
         });
-
-        let total: usize = self.session_groups.iter().map(|g| g.sessions.len()).sum();
-        if !is_group_page && let Some(root_total) = total_count {
-            self.push_log(
-                LogLevel::Info,
-                "session",
-                format!("session list: total root sessions={root_total}, loaded={total}"),
-            );
-        }
 
         let visible_len = self.visible_start_items().len();
         if self.session_cursor >= visible_len && visible_len > 0 {
             self.session_cursor = visible_len - 1;
+        }
+        commands
+    }
+
+    fn apply_acp_session_list_failure(&mut self, request: &SessionListRequest) {
+        match request {
+            SessionListRequest::Discovery => self.session_discovery_in_progress = false,
+            SessionListRequest::WorkspaceFirstPage { cwd }
+            | SessionListRequest::WorkspaceContinuation { cwd } => {
+                self.pending_session_group_loads.remove(&Some(cwd.clone()));
+            }
         }
     }
 
@@ -1610,6 +1683,36 @@ impl crate::app::App {
     }
 }
 
+fn merge_session_page(
+    group: &mut SessionGroup,
+    sessions: Vec<crate::protocol::SessionSummary>,
+    cap: Option<usize>,
+) {
+    let mut seen = group
+        .sessions
+        .iter()
+        .map(|session| session.session_id.clone())
+        .collect::<HashSet<_>>();
+    group.sessions.extend(
+        sessions
+            .into_iter()
+            .filter(|session| seen.insert(session.session_id.clone())),
+    );
+    group.sessions.sort_by(|a, b| {
+        b.updated_at
+            .cmp(&a.updated_at)
+            .then_with(|| b.session_id.cmp(&a.session_id))
+    });
+    if let Some(cap) = cap {
+        group.sessions.truncate(cap);
+    }
+    group.latest_activity = group
+        .sessions
+        .first()
+        .and_then(|session| session.updated_at.clone());
+    group.total_count = None;
+}
+
 fn normalize_replay_updates(updates: Vec<AcpSessionUpdate>) -> Vec<AcpSessionUpdate> {
     let finalized_messages = finalized_assistant_messages(&updates);
     let mut normalized = Vec::with_capacity(updates.len());
@@ -2372,6 +2475,111 @@ mod tests {
     }
 
     #[test]
+    fn acp_discovery_hydrates_workspaces_and_replays_root_cursor() {
+        let mut app = App::new();
+        app.session_discovery_in_progress = true;
+
+        let replies = app.handle_acp_event(AcpAppEvent::SessionList {
+            request: SessionListRequest::Discovery,
+            groups: vec![session_group("/repo", &["s1", "s2"])],
+            next_cursor: Some("opaque-root-2".into()),
+        });
+
+        assert!(app.session_discovery_in_progress);
+        assert!(
+            app.pending_session_group_loads
+                .contains(&Some("/repo".into()))
+        );
+        assert_eq!(app.session_groups[0].next_cursor, None);
+        assert!(replies.iter().any(|reply| matches!(
+            reply,
+            ClientMsg::ListSessions {
+                request: SessionListRequest::WorkspaceFirstPage { cwd },
+                cursor: None,
+                ..
+            } if cwd == "/repo"
+        )));
+        assert!(replies.iter().any(|reply| matches!(
+            reply,
+            ClientMsg::ListSessions {
+                request: SessionListRequest::Discovery,
+                cursor: Some(cursor),
+                cwd: None,
+                ..
+            } if cursor == "opaque-root-2"
+        )));
+    }
+
+    #[test]
+    fn acp_workspace_first_page_replaces_discovery_preview() {
+        let mut app = App::new();
+        app.session_groups = vec![session_group("/repo", &["preview"])];
+        app.pending_session_group_loads.insert(Some("/repo".into()));
+        let mut page = session_group("/repo", &["new-1", "new-2"]);
+        page.next_cursor = Some("opaque-workspace-2".into());
+
+        app.handle_acp_event(AcpAppEvent::SessionList {
+            request: SessionListRequest::WorkspaceFirstPage {
+                cwd: "/repo".into(),
+            },
+            groups: vec![page],
+            next_cursor: Some("opaque-workspace-2".into()),
+        });
+
+        assert!(app.hydrated_session_groups.contains("/repo"));
+        assert!(app.pending_session_group_loads.is_empty());
+        assert_eq!(app.session_groups[0].total_count, None);
+        assert_eq!(
+            app.session_groups[0]
+                .sessions
+                .iter()
+                .map(|session| session.session_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["new-2", "new-1"]
+        );
+        assert_eq!(
+            app.session_groups[0].next_cursor.as_deref(),
+            Some("opaque-workspace-2")
+        );
+    }
+
+    #[test]
+    fn acp_discovery_merges_later_workspaces_without_overwriting_hydrated_groups() {
+        let mut app = App::new();
+        app.session_discovery_in_progress = true;
+        app.hydrated_session_groups.insert("/repo".into());
+        app.session_groups = vec![session_group("/repo", &["authoritative"])];
+
+        let replies = app.handle_acp_event(AcpAppEvent::SessionList {
+            request: SessionListRequest::Discovery,
+            groups: vec![
+                session_group("/repo", &["stale-discovery"]),
+                session_group("/later", &["later-1"]),
+            ],
+            next_cursor: None,
+        });
+
+        let repo = app
+            .session_groups
+            .iter()
+            .find(|group| group.cwd.as_deref() == Some("/repo"))
+            .unwrap();
+        assert_eq!(repo.sessions[0].session_id, "authoritative");
+        assert!(
+            app.session_groups
+                .iter()
+                .any(|group| group.cwd.as_deref() == Some("/later"))
+        );
+        assert!(replies.iter().any(|reply| matches!(
+            reply,
+            ClientMsg::ListSessions {
+                request: SessionListRequest::WorkspaceFirstPage { cwd },
+                ..
+            } if cwd == "/later"
+        )));
+    }
+
+    #[test]
     fn acp_group_session_page_merges_group_and_dedupes() {
         let mut app = App::new();
         app.session_groups = vec![session_group("/repo", &["s1"])];
@@ -2380,9 +2588,11 @@ mod tests {
         let mut group = session_group("/repo", &["s1", "s2"]);
         group.next_cursor = Some("cursor-2".into());
         app.handle_acp_event(AcpAppEvent::SessionList {
+            request: SessionListRequest::WorkspaceContinuation {
+                cwd: "/repo".into(),
+            },
             groups: vec![group],
-            next_cursor: None,
-            total_count: None,
+            next_cursor: Some("cursor-2".into()),
         });
 
         assert!(app.pending_session_group_loads.is_empty());
@@ -2397,8 +2607,23 @@ mod tests {
                 .iter()
                 .map(|session| session.session_id.as_str())
                 .collect::<Vec<_>>(),
-            vec!["s1", "s2"]
+            vec!["s2", "s1"]
         );
+    }
+
+    #[test]
+    fn acp_session_list_failure_clears_scoped_pending_state() {
+        let mut app = App::new();
+        app.pending_session_group_loads.insert(Some("/repo".into()));
+
+        app.handle_acp_event(AcpAppEvent::SessionListFailed {
+            request: SessionListRequest::WorkspaceContinuation {
+                cwd: "/repo".into(),
+            },
+            message: "failed".into(),
+        });
+
+        assert!(app.pending_session_group_loads.is_empty());
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1119,9 +1119,8 @@ pub enum StartPageItem {
 
 /// Maximum number of recent sessions shown per group on the start page.
 pub const MAX_RECENT_SESSIONS: usize = 3;
-/// Target visible sessions per group when auto-filling the sessions popup.
+/// Maximum discovery-preview sessions retained before the workspace page arrives.
 pub const POPUP_SESSION_PAGE_TARGET: usize = 10;
-pub const SESSION_GROUP_PAGE_LIMIT: u32 = 10;
 pub const SESSION_CHILD_PAGE_LIMIT: u32 = 10;
 
 /// Maximum number of workspace groups shown on the start page.
@@ -1214,8 +1213,14 @@ pub struct App {
     /// Groups whose header has been collapsed by the user in the session popup.
     /// Separate from `collapsed_groups` so start-page and popup states are independent.
     pub popup_collapsed_groups: HashSet<String>,
-    /// CWDs with an outstanding group-page session request.
+    /// Whether global ACP session discovery has another request in flight.
+    pub session_discovery_in_progress: bool,
+    /// Opaque global cursors already queued during the current discovery pass.
+    pub session_discovery_cursors: HashSet<String>,
+    /// CWDs with an outstanding first-page or continuation request.
     pub pending_session_group_loads: HashSet<Option<String>>,
+    /// CWDs whose authoritative first workspace page has been loaded.
+    pub hydrated_session_groups: HashSet<String>,
     /// Root session IDs expanded to show fork children.
     pub expanded_session_children: HashSet<String>,
     /// Parent session IDs with an outstanding child-page request.
@@ -1443,16 +1448,26 @@ fn move_wrapping_cursor(cursor: usize, len: usize, delta: isize) -> usize {
 }
 
 impl App {
+    pub fn begin_session_discovery(&mut self) -> Option<ClientMsg> {
+        if self.session_discovery_in_progress || !self.pending_session_group_loads.is_empty() {
+            return None;
+        }
+        self.session_groups.clear();
+        self.session_discovery_cursors.clear();
+        self.pending_session_group_loads.clear();
+        self.hydrated_session_groups.clear();
+        self.session_discovery_in_progress = true;
+        Some(ClientMsg::list_sessions_browse())
+    }
+
     pub fn session_group_page_request(&mut self, group_idx: usize) -> Option<ClientMsg> {
         let group = self.session_groups.get(group_idx)?;
         let cursor = group.next_cursor.clone()?;
-        let cwd = group.cwd.clone();
-        self.pending_session_group_loads.insert(cwd.clone());
-        Some(ClientMsg::list_sessions_group(
-            cwd,
-            cursor,
-            SESSION_GROUP_PAGE_LIMIT,
-        ))
+        let cwd = group.cwd.clone()?;
+        if !self.pending_session_group_loads.insert(Some(cwd.clone())) {
+            return None;
+        }
+        Some(ClientMsg::list_sessions_group(cwd, cursor))
     }
 
     pub fn session_child_page_request(
@@ -1485,7 +1500,10 @@ impl App {
             session_popup_tab: 0,
             collapsed_groups: HashSet::new(),
             popup_collapsed_groups: HashSet::new(),
+            session_discovery_in_progress: false,
+            session_discovery_cursors: HashSet::new(),
             pending_session_group_loads: HashSet::new(),
+            hydrated_session_groups: HashSet::new(),
             expanded_session_children: HashSet::new(),
             pending_session_child_loads: HashSet::new(),
             start_page_scroll: 0,
@@ -2393,6 +2411,8 @@ impl App {
             ConnectionEvent::Disconnected { reason } => {
                 self.conn = ConnState::Disconnected;
                 self.reconnect_delay_ms = None;
+                self.session_discovery_in_progress = false;
+                self.pending_session_group_loads.clear();
                 self.set_status(
                     LogLevel::Warn,
                     "connection",
@@ -10006,6 +10026,20 @@ mod popup_item_tests {
     }
 
     // ── no MAX_VISIBLE_GROUPS cap ─────────────────────────────────────────────
+
+    #[test]
+    fn popup_items_hide_group_load_more_while_request_is_pending() {
+        let mut app = App::new();
+        let mut group = make_group(Some("/workspace/project"), &["s1"]);
+        group.next_cursor = Some("opaque-workspace-2".to_string());
+        app.session_groups = vec![group];
+        app.pending_session_group_loads
+            .insert(Some("/workspace/project".to_string()));
+
+        assert!(!app.visible_popup_items().iter().any(
+            |item| matches!(item, PopupItem::LoadMore { parent_path, .. } if parent_path.is_empty())
+        ));
+    }
 
     #[test]
     fn popup_items_shows_all_groups_beyond_cap() {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -202,7 +202,9 @@ fn open_session_popup(
     app.session_popup_tab = 0;
     app.session_cursor = 0;
     app.session_filter.clear();
-    cmd_tx.send(ClientMsg::list_sessions_browse())?;
+    if let Some(request) = app.begin_session_discovery() {
+        cmd_tx.send(request)?;
+    }
     Ok(())
 }
 
@@ -2027,7 +2029,9 @@ fn try_execute_slash_command(
             app.session_popup_tab = 0;
             app.session_cursor = 0;
             app.session_filter.clear();
-            cmd_tx.send(ClientMsg::list_sessions_browse())?;
+            if let Some(request) = app.begin_session_discovery() {
+                cmd_tx.send(request)?;
+            }
         }
         "delegates" => {
             app.take_input();

--- a/src/main.rs
+++ b/src/main.rs
@@ -2164,7 +2164,9 @@ async fn run_loop(
                         app.handle_connection_event(state);
                         if app.conn == app::ConnState::Connected {
                             cmd_tx.send(ClientMsg::Init)?;
-                            cmd_tx.send(ClientMsg::list_sessions_browse())?;
+                            if let Some(request) = app.begin_session_discovery() {
+                                cmd_tx.send(request)?;
+                            }
                             cmd_tx.send(ClientMsg::ListAllModels { refresh: false })?;
                             if let Some(session_id) = app.session_id.clone() {
                                 if let Some(node_id) = app.session_remote_node_id(&session_id) {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -9,11 +9,29 @@ pub enum SessionScope {
     Forks,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionListRequest {
+    Discovery,
+    WorkspaceFirstPage { cwd: String },
+    WorkspaceContinuation { cwd: String },
+}
+
+impl SessionListRequest {
+    pub fn cwd(&self) -> Option<&str> {
+        match self {
+            Self::Discovery => None,
+            Self::WorkspaceFirstPage { cwd } | Self::WorkspaceContinuation { cwd } => Some(cwd),
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", content = "data", rename_all = "snake_case")]
 pub enum ClientMsg {
     Init,
     ListSessions {
+        #[serde(skip)]
+        request: SessionListRequest,
         #[serde(skip_serializing_if = "Option::is_none")]
         mode: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -155,9 +173,14 @@ pub enum ClientMsg {
 
 impl ClientMsg {
     pub fn list_sessions_browse() -> Self {
+        Self::list_sessions_discovery(None)
+    }
+
+    pub fn list_sessions_discovery(cursor: Option<String>) -> Self {
         Self::ListSessions {
+            request: SessionListRequest::Discovery,
             mode: None,
-            cursor: None,
+            cursor,
             limit: None,
             cwd: None,
             query: None,
@@ -166,12 +189,26 @@ impl ClientMsg {
         }
     }
 
-    pub fn list_sessions_group(cwd: Option<String>, cursor: String, limit: u32) -> Self {
+    pub fn list_sessions_workspace(cwd: String) -> Self {
         Self::ListSessions {
+            request: SessionListRequest::WorkspaceFirstPage { cwd: cwd.clone() },
+            mode: Some("group".to_string()),
+            cursor: None,
+            limit: Some(10),
+            cwd: Some(cwd),
+            query: None,
+            include_remote: None,
+            session_scope: SessionScope::Root,
+        }
+    }
+
+    pub fn list_sessions_group(cwd: String, cursor: String) -> Self {
+        Self::ListSessions {
+            request: SessionListRequest::WorkspaceContinuation { cwd: cwd.clone() },
             mode: Some("group".to_string()),
             cursor: Some(cursor),
-            limit: Some(limit),
-            cwd: Some(cwd.unwrap_or_else(|| "__none__".to_string())),
+            limit: Some(10),
+            cwd: Some(cwd),
             query: None,
             include_remote: None,
             session_scope: SessionScope::Root,
@@ -213,14 +250,52 @@ mod client_msg_tests {
     }
 
     #[test]
+    fn list_sessions_workspace_serializes_cwd_without_cursor() {
+        let value = serde_json::to_value(ClientMsg::list_sessions_workspace(
+            "/workspace/project".to_string(),
+        ))
+        .unwrap();
+        assert_eq!(
+            value,
+            json!({
+                "type": "list_sessions",
+                "data": {
+                    "mode": "group",
+                    "limit": 10,
+                    "cwd": "/workspace/project",
+                    "session_scope": "root"
+                }
+            })
+        );
+    }
+
+    #[test]
     fn list_sessions_group_omits_include_remote_for_pagination() {
         let value = serde_json::to_value(ClientMsg::list_sessions_group(
-            Some("/workspace/project".to_string()),
+            "/workspace/project".to_string(),
             "cursor-1".to_string(),
-            10,
         ))
         .unwrap();
         assert!(value["data"].get("include_remote").is_none());
+    }
+
+    #[test]
+    fn list_sessions_discovery_serializes_opaque_cursor() {
+        let value = serde_json::to_value(ClientMsg::list_sessions_discovery(Some(
+            "opaque-root-2".to_string(),
+        )))
+        .unwrap();
+        assert_eq!(
+            value,
+            json!({
+                "type": "list_sessions",
+                "data": {
+                    "cursor": "opaque-root-2",
+                    "include_remote": true,
+                    "session_scope": "root"
+                }
+            })
+        );
     }
 
     #[test]
@@ -279,9 +354,8 @@ mod client_msg_tests {
     #[test]
     fn list_sessions_group_serializes_backend_pagination_fields() {
         let value = serde_json::to_value(ClientMsg::list_sessions_group(
-            Some("/workspace/project".to_string()),
+            "/workspace/project".to_string(),
             "cursor-1".to_string(),
-            10,
         ))
         .unwrap();
         assert_eq!(

--- a/src/server_msg.rs
+++ b/src/server_msg.rs
@@ -4148,6 +4148,7 @@ mod session_list_pagination_tests {
                 ..
             }
         ));
+        assert!(app.session_group_page_request(0).is_none());
 
         let replies = app.handle_server_msg(list_msg(
             vec![

--- a/src/session.rs
+++ b/src/session.rs
@@ -402,7 +402,9 @@ impl App {
                         }
                     }
                 }
-                if group.next_cursor.is_some() {
+                if group.next_cursor.is_some()
+                    && !self.pending_session_group_loads.contains(&group.cwd)
+                {
                     items.push(PopupItem::LoadMore {
                         group_idx,
                         parent_path: Vec::new(),


### PR DESCRIPTION
## What changed

- preserve and replay opaque ACP discovery and workspace cursors
- hydrate each discovered workspace with a scoped `session/list { cwd }` request
- replace provisional discovery rows, then merge and deduplicate continuation pages
- suppress duplicate workspace loads and clear pending state on failures or disconnects
- hide workspace load-more actions while requests are pending
- add regression coverage for discovery, hydration, cursor forwarding, and pagination

## Validation

- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test` (855 tests passed)
- `git diff --check`