### PR TITLE
merge: sync main into component refactor

### DIFF
--- a/src/acp_client.rs
+++ b/src/acp_client.rs
@@ -22,8 +22,8 @@ use crate::acp_state::{AcpAppEvent, AcpModelsMetaInfo, AcpSessionUpdate};
 use crate::protocol::{
     AgentInfo, AuthProvidersData, ClientMsg, ForkResultData, MeshInviteCreatedInfo, MeshNodesInfo,
     MeshStatusInfo, OAuthFlowData, OAuthResultData, ProfileInfo, RedoResultData,
-    RemoteSessionAttachInfo, RemoteSessionListInfo, SessionGroup, SessionSummary, UndoResultData,
-    UndoStackFrame,
+    RemoteSessionAttachInfo, RemoteSessionListInfo, SessionGroup, SessionListRequest,
+    SessionSummary, UndoResultData, UndoStackFrame,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -920,14 +920,26 @@ async fn handle_client_msg<C: AcpConnection>(
             );
             post_connect_diagnostics(connection, srv_tx).await;
         }
-        ClientMsg::ListSessions { cursor, cwd, .. } => {
-            let requested_cwd = cwd.and_then(|cwd| (cwd != "__none__").then_some(cwd));
+        ClientMsg::ListSessions {
+            request,
+            cursor,
+            cwd,
+            ..
+        } => {
             let mut req = acp::ListSessionsRequest::new().cursor(cursor);
-            if let Some(cwd) = requested_cwd.as_deref() {
+            if let Some(cwd) = cwd.as_deref() {
                 req = req.cwd(PathBuf::from(cwd));
             }
-            let response = connection.request(req).await?;
-            send_session_list(srv_tx, requested_cwd, response);
+            match connection.request(req).await {
+                Ok(response) => send_session_list(srv_tx, request, response),
+                Err(err) => send_acp(
+                    srv_tx,
+                    AcpAppEvent::SessionListFailed {
+                        request,
+                        message: format!("ACP session/list failed: {err:?}"),
+                    },
+                ),
+            }
         }
         ClientMsg::NewSession {
             cwd, profile_id, ..
@@ -2455,7 +2467,7 @@ fn flatten_select_entries(option: &Value) -> Vec<&Value> {
 
 fn send_session_list(
     srv_tx: &mpsc::UnboundedSender<ServerChannelMsg>,
-    requested_cwd: Option<String>,
+    request: SessionListRequest,
     response: acp::ListSessionsResponse,
 ) {
     let mut groups: BTreeMap<Option<String>, Vec<SessionSummary>> = BTreeMap::new();
@@ -2463,8 +2475,9 @@ fn send_session_list(
 
     for session in response.sessions {
         let cwd = session.cwd.to_string_lossy().to_string();
-        let group_key = requested_cwd
-            .clone()
+        let group_key = request
+            .cwd()
+            .map(str::to_string)
             .or_else(|| (!cwd.is_empty()).then_some(cwd.clone()));
         groups.entry(group_key).or_default().push(SessionSummary {
             session_id: session.session_id.to_string(),
@@ -2488,40 +2501,34 @@ fn send_session_list(
         });
     }
 
-    if let Some(cwd) = requested_cwd.clone() {
-        groups.entry(Some(cwd)).or_default();
+    if let Some(cwd) = request.cwd() {
+        groups.entry(Some(cwd.to_string())).or_default();
     }
 
-    let root_has_more = requested_cwd.is_none() && response_cursor.is_some();
-    let total_count: usize = groups.values().map(Vec::len).sum();
+    let workspace_cursor = request
+        .cwd()
+        .is_some()
+        .then_some(response_cursor.clone())
+        .flatten();
     let groups = groups
         .into_iter()
-        .map(|(cwd, sessions)| {
-            let next_cursor = if requested_cwd.is_some() {
-                response_cursor.clone()
-            } else if root_has_more && !sessions.is_empty() {
-                Some(sessions.len().to_string())
-            } else {
-                None
-            };
-            SessionGroup {
-                cwd,
-                latest_activity: sessions
-                    .first()
-                    .and_then(|session| session.updated_at.clone()),
-                total_count: Some(sessions.len() as u64),
-                next_cursor,
-                sessions,
-            }
+        .map(|(cwd, sessions)| SessionGroup {
+            cwd,
+            latest_activity: sessions
+                .first()
+                .and_then(|session| session.updated_at.clone()),
+            total_count: None,
+            next_cursor: workspace_cursor.clone(),
+            sessions,
         })
         .collect::<Vec<_>>();
 
     send_acp(
         srv_tx,
         AcpAppEvent::SessionList {
+            request,
             groups,
-            next_cursor: None,
-            total_count: Some(total_count as u64),
+            next_cursor: response_cursor,
         },
     );
 }
@@ -2876,7 +2883,7 @@ mod tests {
     }
 
     #[test]
-    fn acp_root_session_list_maps_global_cursor_to_group_offsets() {
+    fn acp_root_session_list_preserves_only_the_global_cursor() {
         let (tx, mut rx) = mpsc::unbounded_channel();
         let response = acp::ListSessionsResponse::new(vec![
             acp::SessionInfo::new(acp::SessionId::from("s1"), Path::new("/repo")),
@@ -2885,20 +2892,18 @@ mod tests {
         ])
         .next_cursor(Some("100".to_string()));
 
-        send_session_list(&tx, None, response);
+        send_session_list(&tx, SessionListRequest::Discovery, response);
 
         let ServerChannelMsg::Acp(event) = rx.try_recv().expect("session list event");
         assert!(matches!(
             event,
             AcpAppEvent::SessionList {
+                request: SessionListRequest::Discovery,
                 groups,
-                next_cursor: None,
-                ..
-            } if groups.len() == 2
-                && groups.iter().any(|group| group.cwd.as_deref() == Some("/repo")
-                    && group.next_cursor.as_deref() == Some("2"))
-                && groups.iter().any(|group| group.cwd.as_deref() == Some("/other")
-                    && group.next_cursor.as_deref() == Some("1"))
+                next_cursor: Some(cursor),
+            } if cursor == "100"
+                && groups.len() == 2
+                && groups.iter().all(|group| group.next_cursor.is_none())
         ));
     }
 
@@ -2912,16 +2917,24 @@ mod tests {
         ])
         .next_cursor(Some("cursor-2".to_string()));
 
-        send_session_list(&tx, Some("/repo".to_string()), response);
+        send_session_list(
+            &tx,
+            SessionListRequest::WorkspaceContinuation {
+                cwd: "/repo".to_string(),
+            },
+            response,
+        );
 
         let ServerChannelMsg::Acp(event) = rx.try_recv().expect("session list event");
         assert!(matches!(
             event,
             AcpAppEvent::SessionList {
+                request: SessionListRequest::WorkspaceContinuation { cwd },
                 groups,
-                next_cursor: None,
-                ..
-            } if groups.len() == 1
+                next_cursor: Some(root_cursor),
+            } if cwd == "/repo"
+                && root_cursor == "cursor-2"
+                && groups.len() == 1
                 && groups[0].cwd.as_deref() == Some("/repo")
                 && groups[0].next_cursor.as_deref() == Some("cursor-2")
                 && groups[0].sessions[0].session_id == "s1"

--- a/src/acp_client.rs
+++ b/src/acp_client.rs
@@ -20,7 +20,7 @@ use tokio_tungstenite::{connect_async, tungstenite::Message};
 use crate::ServerChannelMsg;
 use crate::acp_state::{AcpAppEvent, AcpModelsMetaInfo, AcpSessionUpdate};
 use crate::protocol::{
-    AuthProvidersData, ClientMsg, ForkResultData, MeshInviteCreatedInfo, MeshNodesInfo,
+    AgentInfo, AuthProvidersData, ClientMsg, ForkResultData, MeshInviteCreatedInfo, MeshNodesInfo,
     MeshStatusInfo, OAuthFlowData, OAuthResultData, ProfileInfo, RedoResultData,
     RemoteSessionAttachInfo, RemoteSessionListInfo, SessionGroup, SessionSummary, UndoResultData,
     UndoStackFrame,
@@ -96,6 +96,81 @@ struct AcpModelsMeta {
 struct AcpModelsResponse {
     models: Vec<AcpModelEntry>,
     meta: Option<AcpModelsMeta>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct AcpProfilesResponse {
+    profiles: Vec<ProfileInfo>,
+    #[serde(default)]
+    active_profile_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct AcpProfileAgentsResponse {
+    profile_id: String,
+    agents: Vec<AgentInfo>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct DelegateModelOverrideInfo {
+    pub model_id: String,
+    #[serde(default)]
+    pub node_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct AcpDelegateModelResponse {
+    session_id: String,
+    agent_id: String,
+    #[serde(default)]
+    model: Option<DelegateModelOverrideInfo>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DelegationUpdateState {
+    Requested,
+    Forked,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DelegationUpdateNotification {
+    pub version: u32,
+    pub session_id: String,
+    pub delegation_id: String,
+    #[serde(default)]
+    pub tool_call_id: Option<String>,
+    pub state: DelegationUpdateState,
+    pub target_agent_id: String,
+    pub objective: String,
+    #[serde(default)]
+    pub child_session_id: Option<String>,
+    pub requested_at: i64,
+    #[serde(default)]
+    pub forked_at: Option<i64>,
+    #[serde(default)]
+    pub finished_at: Option<i64>,
+    pub updated_at: i64,
+    #[serde(default)]
+    pub result_summary: Option<String>,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+fn normalize_profile_agents_response(
+    response: Value,
+) -> Result<AcpProfileAgentsResponse, serde_json::Error> {
+    serde_json::from_value(ext_payload(&response).clone())
+}
+
+fn normalize_delegate_model_response(
+    response: Value,
+) -> Result<AcpDelegateModelResponse, serde_json::Error> {
+    serde_json::from_value(ext_payload(&response).clone())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -588,6 +663,9 @@ async fn handle_websocket_text(
                 send_models(srv_tx, &response);
             }
         }
+        "querymt/session/delegationUpdate" | "_querymt/session/delegationUpdate" => {
+            handle_delegation_notification(srv_tx, envelope.params);
+        }
         "querymt/mesh/nodesChanged" | "querymt/mesh/joined" | "querymt/mesh/peerExpired" => {
             if let Ok(nodes_resp) =
                 call_querymt_ext(connection, "querymt/mesh/nodes", json!({})).await
@@ -600,6 +678,35 @@ async fn handle_websocket_text(
         _ => {}
     }
     Ok(())
+}
+
+fn is_delegation_notification_method(method: &str) -> bool {
+    matches!(
+        method,
+        "querymt/session/delegationUpdate" | "_querymt/session/delegationUpdate"
+    )
+}
+
+fn handle_delegation_notification(srv_tx: &mpsc::UnboundedSender<ServerChannelMsg>, params: Value) {
+    match serde_json::from_value::<DelegationUpdateNotification>(params) {
+        Ok(update) if update.version == 1 => {
+            send_acp(srv_tx, AcpAppEvent::DelegationUpdate(update));
+        }
+        Ok(update) => send_acp(
+            srv_tx,
+            AcpAppEvent::InfoLog {
+                target: "delegation",
+                message: format!("ignored delegation notification version {}", update.version),
+            },
+        ),
+        Err(err) => send_acp(
+            srv_tx,
+            AcpAppEvent::InfoLog {
+                target: "delegation",
+                message: format!("invalid delegation notification: {err}"),
+            },
+        ),
+    }
 }
 
 async fn handle_ws_elicitation_requested(
@@ -728,6 +835,24 @@ pub async fn run_stdio_agent(
             },
             acp_sdk::on_receive_notification!(),
         )
+        .on_receive_notification(
+            {
+                let srv_tx = srv_tx.clone();
+                async move |notification: UntypedMessage, cx| {
+                    let (method, params) = notification.clone().into_parts();
+                    if is_delegation_notification_method(&method) {
+                        handle_delegation_notification(&srv_tx, params);
+                        Ok(acp_sdk::Handled::Yes)
+                    } else {
+                        Ok(acp_sdk::Handled::No {
+                            message: (notification, cx),
+                            retry: false,
+                        })
+                    }
+                }
+            },
+            acp_sdk::on_receive_notification!(),
+        )
         .on_receive_request(
             async move |request: acp::RequestPermissionRequest, responder, _cx| {
                 let response = permission_response_for(&request);
@@ -843,6 +968,7 @@ async fn handle_client_msg<C: AcpConnection>(
             let snapshot_provider_change =
                 snapshot_provider_change_from_load_value(&response_value);
             let snapshot_updates = snapshot_updates_from_load_value(&response_value);
+            let delegation_updates = delegation_updates_from_load_value(&response_value);
 
             let identity = state.agent_identity().await;
             let profile_id = response
@@ -866,6 +992,15 @@ async fn handle_client_msg<C: AcpConnection>(
                     AcpAppEvent::SessionReplay {
                         session_id: session_id.clone(),
                         updates: history_updates,
+                    },
+                );
+            }
+            if !delegation_updates.is_empty() {
+                send_acp(
+                    srv_tx,
+                    AcpAppEvent::DelegationReplay {
+                        session_id: session_id.clone(),
+                        updates: delegation_updates,
                     },
                 );
             }
@@ -996,6 +1131,62 @@ async fn handle_client_msg<C: AcpConnection>(
                 state.select_model(model.id.clone()).await;
                 send_provider_changed(srv_tx, &model);
             }
+        }
+        ClientMsg::ListProfiles => match load_acp_profiles(connection).await {
+            Ok(response) => send_profiles(srv_tx, response),
+            Err(err) => send_acp(
+                srv_tx,
+                AcpAppEvent::InfoLog {
+                    target: "profiles",
+                    message: format!("profile catalog unavailable: {err}"),
+                },
+            ),
+        },
+        ClientMsg::ListProfileAgents { profile_id } => {
+            match load_acp_profile_agents(connection, &profile_id).await {
+                Ok(response) => send_acp(
+                    srv_tx,
+                    AcpAppEvent::ProfileAgents {
+                        profile_id: response.profile_id,
+                        agents: response.agents,
+                    },
+                ),
+                Err(err) => send_acp(
+                    srv_tx,
+                    AcpAppEvent::InfoLog {
+                        target: "profiles",
+                        message: format!("profile agents unavailable for {profile_id}: {err}"),
+                    },
+                ),
+            }
+        }
+        ClientMsg::SetDelegateModel {
+            session_id,
+            agent_id,
+            model_id,
+            node_id,
+        } => {
+            let response = call_querymt_ext(
+                connection,
+                "querymt/session/setDelegateModel",
+                json!({
+                    "session_id": session_id,
+                    "agent_id": agent_id,
+                    "model_id": model_id,
+                    "node_id": node_id,
+                }),
+            )
+            .await?;
+            let response = normalize_delegate_model_response(response)
+                .map_err(acp_sdk::Error::into_internal_error)?;
+            send_acp(
+                srv_tx,
+                AcpAppEvent::DelegateModelSet {
+                    session_id: response.session_id,
+                    agent_id: response.agent_id,
+                    model: response.model,
+                },
+            );
         }
         ClientMsg::ListAuthProviders => {
             let response = call_querymt_ext(connection, "querymt/auth/status", json!({})).await?;
@@ -1211,8 +1402,6 @@ async fn handle_client_msg<C: AcpConnection>(
         }
         ClientMsg::ListSessionChildren { .. }
         | ClientMsg::DismissRemoteSession { .. }
-        | ClientMsg::ListProfiles
-        | ClientMsg::SetActiveProfile { .. }
         | ClientMsg::SetApiToken { .. }
         | ClientMsg::ClearApiToken { .. }
         | ClientMsg::SetAuthMethod { .. } => {
@@ -1272,6 +1461,40 @@ fn ext_payload(response: &Value) -> &Value {
     response.get("data").unwrap_or(response)
 }
 
+async fn load_acp_profiles<C: AcpConnection>(
+    connection: &C,
+) -> Result<AcpProfilesResponse, acp_sdk::Error> {
+    let response = call_querymt_ext(connection, "querymt/profiles", json!({})).await?;
+    normalize_profiles_response(response).map_err(acp_sdk::Error::into_internal_error)
+}
+
+fn normalize_profiles_response(response: Value) -> Result<AcpProfilesResponse, serde_json::Error> {
+    serde_json::from_value(ext_payload(&response).clone())
+}
+
+async fn load_acp_profile_agents<C: AcpConnection>(
+    connection: &C,
+    profile_id: &str,
+) -> Result<AcpProfileAgentsResponse, acp_sdk::Error> {
+    let response = call_querymt_ext(
+        connection,
+        "querymt/profile/agents",
+        json!({ "profile_id": profile_id }),
+    )
+    .await?;
+    normalize_profile_agents_response(response).map_err(acp_sdk::Error::into_internal_error)
+}
+
+fn send_profiles(srv_tx: &mpsc::UnboundedSender<ServerChannelMsg>, response: AcpProfilesResponse) {
+    send_acp(
+        srv_tx,
+        AcpAppEvent::Profiles {
+            profiles: response.profiles,
+            active_profile_id: response.active_profile_id,
+        },
+    );
+}
+
 fn load_session_cwd(cwd: Option<&str>, default_cwd: PathBuf) -> PathBuf {
     cwd.and_then(|cwd| (!cwd.trim().is_empty()).then(|| PathBuf::from(cwd)))
         .unwrap_or(default_cwd)
@@ -1324,6 +1547,19 @@ async fn post_connect_diagnostics<C: AcpConnection>(
             {
                 send_acp(srv_tx, AcpAppEvent::MeshNodes(nodes));
             }
+            if methods.iter().any(|m| m == "querymt/profiles") {
+                match load_acp_profiles(connection).await {
+                    Ok(profiles) => send_profiles(srv_tx, profiles),
+                    Err(err) => send_error(srv_tx, format!("failed to load profiles: {err}")),
+                }
+            } else if payload
+                .get("features")
+                .and_then(|features| features.get("profiles"))
+                .and_then(Value::as_bool)
+                == Some(false)
+            {
+                send_profiles(srv_tx, AcpProfilesResponse::default());
+            }
         }
         Err(err) => {
             send_acp(
@@ -1373,9 +1609,15 @@ fn fork_session_meta(message_id: &str) -> serde_json::Map<String, Value> {
 
 const SESSION_LOAD_SNAPSHOT_META_KEY: &str = "querymt/sessionLoadSnapshot.v1";
 
+fn session_load_snapshot_from_load_value(response: &Value) -> Option<&Value> {
+    response
+        .get("_meta")
+        .or_else(|| response.get("meta"))
+        .and_then(|meta| meta.get(SESSION_LOAD_SNAPSHOT_META_KEY))
+}
+
 fn session_load_audit_from_load_value(response: &Value) -> Value {
-    let meta = response.get("_meta").or_else(|| response.get("meta"));
-    let snapshot = meta.and_then(|m| m.get(SESSION_LOAD_SNAPSHOT_META_KEY));
+    let snapshot = session_load_snapshot_from_load_value(response);
     match snapshot {
         Some(snapshot) => snapshot
             .get("audit")
@@ -1383,6 +1625,17 @@ fn session_load_audit_from_load_value(response: &Value) -> Value {
             .unwrap_or_else(|| json!({ "events": [] })),
         None => json!({ "events": [] }),
     }
+}
+
+fn delegation_updates_from_load_value(response: &Value) -> Vec<DelegationUpdateNotification> {
+    session_load_snapshot_from_load_value(response)
+        .and_then(|snapshot| snapshot.get("delegationUpdates"))
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|update| serde_json::from_value(update.clone()).ok())
+        .filter(|update: &DelegationUpdateNotification| update.version == 1)
+        .collect()
 }
 
 fn snapshot_provider_change_from_load_value(response: &Value) -> Option<SnapshotProviderChange> {
@@ -2178,6 +2431,7 @@ fn profile_infos_from_option(option: &Value) -> Vec<ProfileInfo> {
                 tags: Vec::new(),
                 source: None,
                 config_kind: None,
+                fingerprint: None,
             })
         })
         .collect()
@@ -2765,6 +3019,50 @@ mod tests {
     }
 
     #[test]
+    fn session_load_delegation_updates_parse_latest_snapshots() {
+        let response = json!({
+            "_meta": {
+                "querymt/sessionLoadSnapshot.v1": {
+                    "audit": { "events": [] },
+                    "delegationUpdates": [{
+                        "version": 1,
+                        "sessionId": "parent",
+                        "delegationId": "delegation-1",
+                        "toolCallId": "call-1",
+                        "state": "completed",
+                        "targetAgentId": "coder",
+                        "objective": "Implement it",
+                        "childSessionId": "child-1",
+                        "requestedAt": 100,
+                        "forkedAt": 110,
+                        "finishedAt": 120,
+                        "updatedAt": 120,
+                        "resultSummary": "done",
+                        "error": null
+                    }]
+                }
+            }
+        });
+
+        let updates = delegation_updates_from_load_value(&response);
+
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].state, DelegationUpdateState::Completed);
+        assert_eq!(updates[0].tool_call_id.as_deref(), Some("call-1"));
+    }
+
+    #[test]
+    fn delegation_notification_method_accepts_stdio_and_websocket_shapes() {
+        assert!(is_delegation_notification_method(
+            "querymt/session/delegationUpdate"
+        ));
+        assert!(is_delegation_notification_method(
+            "_querymt/session/delegationUpdate"
+        ));
+        assert!(!is_delegation_notification_method("session/update"));
+    }
+
+    #[test]
     fn session_load_audit_missing_snapshot_returns_empty_events() {
         let audit = session_load_audit_from_load_value(&json!({}));
         assert_eq!(
@@ -3161,6 +3459,124 @@ mod tests {
                 cost_usd: Some(0.25)
             }
         ));
+    }
+
+    #[test]
+    fn normalize_profiles_response_accepts_direct_full_metadata() {
+        let response = normalize_profiles_response(json!({
+            "profiles": [{
+                "id": "coder-delegate",
+                "name": "Coder Delegate",
+                "description": "Delegates coding tasks",
+                "tags": ["coding", "delegate"],
+                "source": "local:/tmp/coder.toml",
+                "config_kind": "toml",
+                "fingerprint": "sha256:abc"
+            }],
+            "active_profile_id": "coder-delegate"
+        }))
+        .expect("profile response");
+
+        assert_eq!(
+            response.active_profile_id.as_deref(),
+            Some("coder-delegate")
+        );
+        assert_eq!(response.profiles.len(), 1);
+        let profile = &response.profiles[0];
+        assert_eq!(profile.name, "Coder Delegate");
+        assert_eq!(profile.tags, ["coding", "delegate"]);
+        assert_eq!(profile.source.as_deref(), Some("local:/tmp/coder.toml"));
+        assert_eq!(profile.config_kind.as_deref(), Some("toml"));
+        assert_eq!(profile.fingerprint.as_deref(), Some("sha256:abc"));
+    }
+
+    #[test]
+    fn normalize_profiles_response_accepts_wrapped_and_empty_responses() {
+        let wrapped = normalize_profiles_response(json!({
+            "data": {
+                "profiles": [{ "id": "fast", "name": "Fast" }],
+                "active_profile_id": "fast"
+            }
+        }))
+        .expect("wrapped profile response");
+        assert_eq!(wrapped.profiles[0].id, "fast");
+
+        let empty = normalize_profiles_response(json!({
+            "profiles": [],
+            "active_profile_id": null
+        }))
+        .expect("empty profile response");
+        assert!(empty.profiles.is_empty());
+        assert!(empty.active_profile_id.is_none());
+        assert!(normalize_profiles_response(json!({})).is_err());
+    }
+
+    #[test]
+    fn delegation_update_payload_uses_camel_case_contract() {
+        let update: DelegationUpdateNotification = serde_json::from_value(json!({
+            "version": 1,
+            "sessionId": "parent",
+            "delegationId": "delegation-1",
+            "toolCallId": "call-1",
+            "state": "forked",
+            "targetAgentId": "coder",
+            "objective": "Implement it",
+            "childSessionId": "child-1",
+            "requestedAt": 100,
+            "forkedAt": 110,
+            "finishedAt": null,
+            "updatedAt": 110,
+            "resultSummary": null,
+            "error": null
+        }))
+        .expect("delegation update");
+
+        assert_eq!(update.state, DelegationUpdateState::Forked);
+        assert_eq!(update.child_session_id.as_deref(), Some("child-1"));
+    }
+
+    #[test]
+    fn normalize_profile_agents_response_accepts_direct_and_wrapped_payloads() {
+        let direct = normalize_profile_agents_response(json!({
+            "profile_id": "quorum",
+            "agents": [
+                { "id": "primary", "name": "Session" },
+                {
+                    "id": "coder",
+                    "name": "Coder",
+                    "description": "Writes code",
+                    "capabilities": ["coding"]
+                }
+            ]
+        }))
+        .expect("profile agents");
+        assert_eq!(direct.profile_id, "quorum");
+        assert_eq!(direct.agents[1].id, "coder");
+        assert_eq!(direct.agents[1].capabilities, ["coding"]);
+
+        let wrapped = normalize_profile_agents_response(json!({
+            "data": { "profile_id": "single", "agents": [{ "id": "primary", "name": "Session" }] }
+        }))
+        .expect("wrapped profile agents");
+        assert_eq!(wrapped.profile_id, "single");
+        assert!(normalize_profile_agents_response(json!({ "profile_id": "bad" })).is_err());
+    }
+
+    #[test]
+    fn normalize_delegate_model_response_preserves_model_and_node() {
+        let response = normalize_delegate_model_response(json!({
+            "data": {
+                "session_id": "parent",
+                "agent_id": "coder",
+                "model": { "model_id": "openai/gpt-5", "node_id": "node-1" }
+            }
+        }))
+        .expect("delegate model response");
+        assert_eq!(response.session_id, "parent");
+        assert_eq!(response.agent_id, "coder");
+        let model = response.model.expect("model");
+        assert_eq!(model.model_id, "openai/gpt-5");
+        assert_eq!(model.node_id.as_deref(), Some("node-1"));
     }
 
     #[test]

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -2,7 +2,13 @@ use std::collections::HashSet;
 
 use serde_json::Value;
 
-use crate::app::{ActivityState, ChatEntry, ElicitationState, LogLevel, Popup, Screen, ToolDetail};
+use crate::acp_client::{
+    DelegateModelOverrideInfo, DelegationUpdateNotification, DelegationUpdateState,
+};
+use crate::app::{
+    ActivityState, ChatEntry, DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus,
+    ElicitationState, LogLevel, Popup, Screen, ToolDetail,
+};
 use crate::protocol::{
     AgentInfo, AuthProviderEntry, ClientMsg, ForkResultData, MeshInviteCreatedInfo, MeshNodesInfo,
     MeshStatusInfo, ModelEntry, OAuthFlowData, OAuthResultData, ProfileInfo, RedoResultData,
@@ -88,6 +94,15 @@ pub(crate) enum AcpAppEvent {
         profiles: Vec<ProfileInfo>,
         active_profile_id: Option<String>,
     },
+    ProfileAgents {
+        profile_id: String,
+        agents: Vec<AgentInfo>,
+    },
+    DelegateModelSet {
+        session_id: String,
+        agent_id: String,
+        model: Option<DelegateModelOverrideInfo>,
+    },
     ProviderChanged {
         provider: String,
         model: String,
@@ -125,6 +140,11 @@ pub(crate) enum AcpAppEvent {
         session_id: String,
         updates: Vec<AcpSessionUpdate>,
     },
+    DelegationUpdate(DelegationUpdateNotification),
+    DelegationReplay {
+        session_id: String,
+        updates: Vec<DelegationUpdateNotification>,
+    },
     Models {
         models: Vec<ModelEntry>,
         meta: Option<AcpModelsMetaInfo>,
@@ -160,18 +180,19 @@ impl crate::app::App {
                 agent_mode,
                 reasoning_effort,
             } => {
-                self.profiles = profiles;
-                if let Some(profile_id) = active_profile_id {
-                    self.active_profile_id = Some(profile_id);
-                }
-                if self.profile_cursor >= self.profiles.len() {
-                    self.profile_cursor = self.profiles.len().saturating_sub(1);
+                // ACP initialization sends a placeholder empty catalog before
+                // capability-gated profile discovery completes.
+                if !profiles.is_empty() {
+                    self.apply_profile_catalog(profiles, active_profile_id);
                 }
                 self.agent_id = Some(agent_id.clone());
                 self.agents = vec![AgentInfo {
                     id: agent_id,
                     name: agent_name,
+                    description: None,
+                    capabilities: Vec::new(),
                 }];
+                self.agents_profile_id = None;
                 if let Some(mode) = agent_mode {
                     self.agent_mode = mode;
                     if self.agent_mode != "review" {
@@ -202,14 +223,41 @@ impl crate::app::App {
             AcpAppEvent::Profiles {
                 profiles,
                 active_profile_id,
+            } => self.apply_profile_catalog(profiles, active_profile_id),
+            AcpAppEvent::ProfileAgents { profile_id, agents } => {
+                if self.desired_agents_profile_id() == Some(profile_id.as_str()) {
+                    self.agents = agents;
+                    self.agents_profile_id = Some(profile_id);
+                    self.model_popup_agent_tab = self
+                        .model_popup_agent_tab
+                        .min(self.model_popup_tab_count().saturating_sub(1));
+                    if self.parent_session_id.is_none()
+                        && let (Some(session_id), Some(profile_id)) = (
+                            self.session_id.as_deref(),
+                            self.agents_profile_id.as_deref(),
+                        )
+                    {
+                        return self.delegate_model_commands_for_session(session_id, profile_id);
+                    }
+                }
+                vec![]
+            }
+            AcpAppEvent::DelegateModelSet {
+                session_id,
+                agent_id,
+                model,
             } => {
-                self.profiles = profiles;
-                if let Some(profile_id) = active_profile_id {
-                    self.active_profile_id = Some(profile_id);
-                }
-                if self.profile_cursor >= self.profiles.len() {
-                    self.profile_cursor = self.profiles.len().saturating_sub(1);
-                }
+                self.set_status(
+                    LogLevel::Info,
+                    "model",
+                    match model {
+                        Some(model) => format!(
+                            "delegate model set for {agent_id} in {session_id}: {}",
+                            model.model_id
+                        ),
+                        None => format!("delegate model reset for {agent_id} in {session_id}"),
+                    },
+                );
                 vec![]
             }
             AcpAppEvent::ProviderChanged {
@@ -316,7 +364,6 @@ impl crate::app::App {
                         None
                     },
                 );
-
                 if ur.success {
                     self.recent_prompt_text = None;
                     self.streaming_content.clear();
@@ -388,6 +435,21 @@ impl crate::app::App {
                         "fork",
                         fr.message.unwrap_or_else(|| "fork failed".into()),
                     );
+                }
+                vec![]
+            }
+            AcpAppEvent::DelegationUpdate(update) => {
+                self.apply_acp_delegation_update(update);
+                vec![]
+            }
+            AcpAppEvent::DelegationReplay {
+                session_id,
+                updates,
+            } => {
+                if self.session_id.as_deref() == Some(session_id.as_str()) {
+                    for update in updates {
+                        self.apply_acp_delegation_update(update);
+                    }
                 }
                 vec![]
             }
@@ -472,6 +534,42 @@ impl crate::app::App {
                 vec![]
             }
         }
+    }
+
+    fn apply_profile_catalog(
+        &mut self,
+        profiles: Vec<ProfileInfo>,
+        backend_active_profile_id: Option<String>,
+    ) -> Vec<ClientMsg> {
+        let previous_profile_id = self.active_profile_id.clone();
+        let is_available =
+            |profile_id: &str| profiles.iter().any(|profile| profile.id == profile_id);
+        let selected = self
+            .active_profile_id
+            .take()
+            .filter(|profile_id| is_available(profile_id));
+        let backend_default =
+            backend_active_profile_id.filter(|profile_id| is_available(profile_id));
+        self.active_profile_id = selected
+            .or(backend_default)
+            .or_else(|| profiles.first().map(|profile| profile.id.clone()));
+        self.profiles = profiles;
+        if self.profile_cursor >= self.profiles.len() {
+            self.profile_cursor = self.profiles.len().saturating_sub(1);
+        }
+        let desired_profile_id = self.desired_agents_profile_id().map(str::to_string);
+        if self.active_profile_id != previous_profile_id
+            || self.agents_profile_id.as_deref() != desired_profile_id.as_deref()
+            || self.agents.len() <= 1
+        {
+            self.agents.clear();
+            self.agents_profile_id = None;
+            self.model_popup_agent_tab = 0;
+            return desired_profile_id
+                .map(|profile_id| vec![ClientMsg::ListProfileAgents { profile_id }])
+                .unwrap_or_default();
+        }
+        vec![]
     }
 
     fn apply_acp_session_list(
@@ -576,10 +674,18 @@ impl crate::app::App {
         self.reset_active_session_view();
         self.screen = Screen::Chat;
         self.set_status(LogLevel::Info, "session", "session created");
-        vec![ClientMsg::SubscribeSession {
-            session_id,
+        let mut commands = vec![ClientMsg::SubscribeSession {
+            session_id: session_id.clone(),
             agent_id: self.agent_id.clone(),
-        }]
+        }];
+        if let Some(profile_id) = self.current_session_profile_id().map(str::to_string) {
+            if self.agents_profile_id.as_deref() == Some(profile_id.as_str()) {
+                commands.extend(self.delegate_model_commands_for_session(&session_id, &profile_id));
+            } else {
+                commands.push(ClientMsg::ListProfileAgents { profile_id });
+            }
+        }
+        commands
     }
 
     fn apply_acp_session_loaded(
@@ -606,9 +712,19 @@ impl crate::app::App {
             Screen::Chat
         };
         self.set_status(LogLevel::Debug, "activity", "ready");
-        vec![ClientMsg::SetAgentMode {
+        let mut commands = vec![ClientMsg::SetAgentMode {
             mode: self.agent_mode.clone(),
-        }]
+        }];
+        if self.parent_session_id.is_none()
+            && let Some(profile_id) = self.current_session_profile_id().map(str::to_string)
+        {
+            if self.agents_profile_id.as_deref() == Some(profile_id.as_str()) {
+                commands.extend(self.delegate_model_commands_for_session(&session_id, &profile_id));
+            } else {
+                commands.push(ClientMsg::ListProfileAgents { profile_id });
+            }
+        }
+        commands
     }
 
     fn reset_active_session_view(&mut self) {
@@ -628,6 +744,11 @@ impl crate::app::App {
         if self.parent_session_id.is_none() {
             self.delegate_entries.clear();
             self.pending_delegate_child_states.clear();
+            self.pending_delegate_child_stats.clear();
+            self.delegate_child_message_ids.clear();
+            self.delegation_update_times.clear();
+            self.delegation_result_summaries.clear();
+            self.delegation_errors.clear();
             self.pending_delegate_tool_calls.clear();
         }
         self.file_index.clear();
@@ -643,6 +764,241 @@ impl crate::app::App {
         self.session_stats = crate::app::SessionStatsLite::default();
     }
 
+    fn upsert_provisional_delegate(
+        &mut self,
+        tool_call_id: Option<&str>,
+        arguments: Option<&Value>,
+    ) {
+        let Some(tool_call_id) = tool_call_id else {
+            return;
+        };
+        if self
+            .delegate_entries
+            .iter()
+            .any(|entry| entry.delegate_tool_call_id.as_deref() == Some(tool_call_id))
+        {
+            return;
+        }
+        let target_agent_id = arguments
+            .and_then(|value| value.get("target_agent_id"))
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let objective = arguments
+            .and_then(|value| value.get("objective"))
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        self.delegate_entries.push(DelegateEntry {
+            delegation_id: format!("tool:{tool_call_id}"),
+            child_session_id: None,
+            delegate_tool_call_id: Some(tool_call_id.to_string()),
+            target_agent_id,
+            objective,
+            status: DelegateStatus::InProgress,
+            stats: DelegateStats::default(),
+            started_at: None,
+            ended_at: None,
+            child_state: DelegateChildState::None,
+        });
+        self.invalidate_delegate_render_cache();
+    }
+
+    fn apply_acp_delegation_update(&mut self, update: DelegationUpdateNotification) {
+        if update.version != 1 || self.session_id.as_deref() != Some(update.session_id.as_str()) {
+            return;
+        }
+        let existing_index = self
+            .delegate_entries
+            .iter()
+            .position(|entry| entry.delegation_id == update.delegation_id);
+        if let Some(existing_timestamp) = self.delegation_update_times.get(&update.delegation_id) {
+            let incoming_rank = delegation_state_rank(update.state);
+            let existing_rank = existing_index
+                .map(|index| delegate_entry_lifecycle_rank(&self.delegate_entries[index]))
+                .unwrap_or(0);
+            if *existing_timestamp > update.updated_at
+                || (*existing_timestamp == update.updated_at && existing_rank > incoming_rank)
+            {
+                return;
+            }
+        }
+        let index = existing_index.or_else(|| {
+            update.tool_call_id.as_deref().and_then(|tool_call_id| {
+                self.delegate_entries
+                    .iter()
+                    .position(|entry| entry.delegate_tool_call_id.as_deref() == Some(tool_call_id))
+            })
+        });
+        let status = match update.state {
+            DelegationUpdateState::Requested | DelegationUpdateState::Forked => {
+                DelegateStatus::InProgress
+            }
+            DelegationUpdateState::Completed => DelegateStatus::Completed,
+            DelegationUpdateState::Failed => DelegateStatus::Failed,
+            DelegationUpdateState::Cancelled => DelegateStatus::Cancelled,
+        };
+        let index = if let Some(index) = index {
+            index
+        } else {
+            self.delegate_entries.push(DelegateEntry {
+                delegation_id: update.delegation_id.clone(),
+                child_session_id: None,
+                delegate_tool_call_id: update.tool_call_id.clone(),
+                target_agent_id: Some(update.target_agent_id.clone()),
+                objective: update.objective.clone(),
+                status,
+                stats: DelegateStats::default(),
+                started_at: Some(update.requested_at),
+                ended_at: None,
+                child_state: DelegateChildState::None,
+            });
+            self.delegate_entries.len() - 1
+        };
+        let entry = &mut self.delegate_entries[index];
+        entry.delegation_id = update.delegation_id.clone();
+        if update.tool_call_id.is_some() {
+            entry.delegate_tool_call_id = update.tool_call_id.clone();
+        }
+        entry.target_agent_id = Some(update.target_agent_id);
+        entry.objective = update.objective;
+        entry.status = status;
+        entry.started_at = Some(update.requested_at);
+        entry.ended_at = update.finished_at;
+        entry.child_session_id = update.child_session_id.clone();
+        if status != DelegateStatus::InProgress {
+            entry.child_state = DelegateChildState::None;
+        }
+        self.delegation_update_times
+            .insert(update.delegation_id.clone(), update.updated_at);
+        match update.result_summary {
+            Some(summary) => {
+                self.delegation_result_summaries
+                    .insert(update.delegation_id.clone(), summary);
+            }
+            None => {
+                self.delegation_result_summaries
+                    .remove(&update.delegation_id);
+            }
+        }
+        match update.error {
+            Some(error) => {
+                self.delegation_errors
+                    .insert(update.delegation_id.clone(), error);
+            }
+            None => {
+                self.delegation_errors.remove(&update.delegation_id);
+            }
+        }
+        if let Some(child_session_id) = update.child_session_id {
+            if let Some(stats) = self.pending_delegate_child_stats.remove(&child_session_id) {
+                self.delegate_entries[index].stats = stats;
+            }
+            if let Some(state) = self.pending_delegate_child_states.remove(&child_session_id) {
+                self.delegate_entries[index].child_state = state;
+            }
+        }
+        self.invalidate_delegate_render_cache();
+    }
+
+    fn apply_acp_delegate_child_update(&mut self, session_id: &str, update: &AcpSessionUpdate) {
+        let index = self
+            .delegate_entries
+            .iter()
+            .position(|entry| entry.child_session_id.as_deref() == Some(session_id));
+        let mut state = index
+            .map(|index| self.delegate_entries[index].child_state.clone())
+            .or_else(|| self.pending_delegate_child_states.get(session_id).cloned())
+            .unwrap_or_default();
+        let mut stats = index
+            .map(|index| self.delegate_entries[index].stats.clone())
+            .or_else(|| self.pending_delegate_child_stats.get(session_id).cloned())
+            .unwrap_or_default();
+        match update {
+            AcpSessionUpdate::ToolCallStart { .. } => {
+                stats.tool_calls = stats.tool_calls.saturating_add(1);
+                state = DelegateChildState::OtherProgress;
+            }
+            AcpSessionUpdate::AssistantMessage { message_id, .. } => {
+                let should_increment = message_id.as_ref().is_none_or(|message_id| {
+                    self.delegate_child_message_ids
+                        .entry(session_id.to_string())
+                        .or_default()
+                        .insert(message_id.clone())
+                });
+                if should_increment {
+                    stats.messages = stats.messages.saturating_add(1);
+                }
+                state = DelegateChildState::AssistantMessage;
+            }
+            AcpSessionUpdate::AssistantContentDelta { message_id, .. } => {
+                let should_increment = message_id.as_ref().is_some_and(|message_id| {
+                    self.delegate_child_message_ids
+                        .entry(session_id.to_string())
+                        .or_default()
+                        .insert(message_id.clone())
+                });
+                if should_increment {
+                    stats.messages = stats.messages.saturating_add(1);
+                }
+                state = DelegateChildState::AssistantMessage;
+            }
+            AcpSessionUpdate::AssistantThinkingDelta { .. } | AcpSessionUpdate::TurnStarted => {
+                state = DelegateChildState::OtherProgress;
+            }
+            AcpSessionUpdate::UserMessage { .. } => state = DelegateChildState::UserMessage,
+            AcpSessionUpdate::UsageUpdate {
+                used,
+                size,
+                cost_usd,
+            } => {
+                if *used > 0 {
+                    stats.context_tokens = *used;
+                }
+                if *size > 0 {
+                    stats.context_limit = *size;
+                }
+                if let Some(cost) = cost_usd {
+                    stats.cost_usd = *cost;
+                }
+            }
+            AcpSessionUpdate::ElicitationRequested {
+                elicitation_id,
+                message,
+                requested_schema,
+                source,
+                ..
+            } => {
+                state = DelegateChildState::PendingElicitation {
+                    elicitation_id: elicitation_id.clone(),
+                    message: message.clone(),
+                    requested_schema: requested_schema.clone(),
+                    source: source.clone(),
+                };
+            }
+            AcpSessionUpdate::ToolCallEnd { name, .. } if name == "question" => {
+                state = DelegateChildState::QuestionToolFinished;
+            }
+            AcpSessionUpdate::ToolCallEnd { .. }
+            | AcpSessionUpdate::TimingUpdate { .. }
+            | AcpSessionUpdate::Cancelled
+            | AcpSessionUpdate::Finished { .. } => {}
+        }
+        if let Some(index) = index {
+            if self.delegate_entries[index].stats != stats
+                || self.delegate_entries[index].child_state != state
+            {
+                self.delegate_entries[index].stats = stats;
+                self.delegate_entries[index].child_state = state;
+                self.invalidate_delegate_render_cache();
+            }
+        } else if state != DelegateChildState::None || stats != DelegateStats::default() {
+            self.pending_delegate_child_states
+                .insert(session_id.to_string(), state);
+            self.pending_delegate_child_stats
+                .insert(session_id.to_string(), stats);
+        }
+    }
+
     fn apply_acp_session_update(
         &mut self,
         session_id: &str,
@@ -651,6 +1007,7 @@ impl crate::app::App {
     ) {
         if self.session_id.as_deref() != Some(session_id) {
             self.note_session_activity(session_id);
+            self.apply_acp_delegate_child_update(session_id, &update);
             return;
         }
         self.note_session_activity(session_id);
@@ -730,6 +1087,9 @@ impl crate::app::App {
                 self.activity = ActivityState::RunningTool { name: name.clone() };
                 self.set_status(LogLevel::Debug, "tool", format!("tool: {name}"));
                 self.finalize_streaming_segment();
+                if name == "delegate" {
+                    self.upsert_provisional_delegate(tool_call_id.as_deref(), arguments.as_ref());
+                }
                 if name != "question" {
                     let cwd = self.current_session_cwd();
                     let detail =
@@ -1560,6 +1920,24 @@ fn message_id_matches(left: Option<&String>, right: Option<&String>) -> bool {
     }
 }
 
+fn delegation_state_rank(state: DelegationUpdateState) -> u8 {
+    match state {
+        DelegationUpdateState::Requested => 1,
+        DelegationUpdateState::Forked => 2,
+        DelegationUpdateState::Completed
+        | DelegationUpdateState::Failed
+        | DelegationUpdateState::Cancelled => 3,
+    }
+}
+
+fn delegate_entry_lifecycle_rank(entry: &DelegateEntry) -> u8 {
+    match entry.status {
+        DelegateStatus::Completed | DelegateStatus::Failed | DelegateStatus::Cancelled => 3,
+        DelegateStatus::InProgress if entry.child_session_id.is_some() => 2,
+        DelegateStatus::InProgress => 1,
+    }
+}
+
 fn acp_content_to_string(value: &Value) -> String {
     match value {
         Value::String(s) => s.clone(),
@@ -1576,10 +1954,38 @@ fn acp_content_to_string(value: &Value) -> String {
 mod tests {
     use super::*;
     use crate::app::{App, ChatEntry, Screen};
-    use crate::protocol::SessionSummary;
+    use crate::protocol::{DelegateModelPreference, SessionSummary};
 
     const TEST_SESSION_ID: &str = "session-1";
     const TEST_ASSISTANT_ID: &str = "a1";
+
+    fn delegation_update(
+        state: DelegationUpdateState,
+        updated_at: i64,
+    ) -> DelegationUpdateNotification {
+        DelegationUpdateNotification {
+            version: 1,
+            session_id: TEST_SESSION_ID.into(),
+            delegation_id: "delegation-1".into(),
+            tool_call_id: Some("call-1".into()),
+            state,
+            target_agent_id: "coder".into(),
+            objective: "Implement the feature".into(),
+            child_session_id: (state != DelegationUpdateState::Requested).then(|| "child-1".into()),
+            requested_at: 100,
+            forked_at: (state != DelegationUpdateState::Requested).then_some(110),
+            finished_at: matches!(
+                state,
+                DelegationUpdateState::Completed
+                    | DelegationUpdateState::Failed
+                    | DelegationUpdateState::Cancelled
+            )
+            .then_some(120),
+            updated_at,
+            result_summary: (state == DelegationUpdateState::Completed).then(|| "done".into()),
+            error: (state == DelegationUpdateState::Failed).then(|| "boom".into()),
+        }
+    }
 
     fn app_with_active_session() -> App {
         let mut app = App::new();
@@ -1641,6 +2047,268 @@ mod tests {
             thinking: thinking.map(str::to_string),
             message_id: Some(TEST_ASSISTANT_ID.into()),
         }
+    }
+
+    fn profile(id: &str) -> ProfileInfo {
+        ProfileInfo {
+            id: id.into(),
+            name: id.into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn profile_catalog_preserves_valid_local_selection() {
+        let mut app = App::new();
+        app.active_profile_id = Some("deep".into());
+
+        app.handle_acp_event(AcpAppEvent::Profiles {
+            profiles: vec![profile("fast"), profile("deep")],
+            active_profile_id: Some("fast".into()),
+        });
+
+        assert_eq!(app.active_profile_id.as_deref(), Some("deep"));
+    }
+
+    #[test]
+    fn profile_catalog_falls_back_to_backend_default_then_first_profile() {
+        let mut app = App::new();
+        app.active_profile_id = Some("removed".into());
+
+        app.handle_acp_event(AcpAppEvent::Profiles {
+            profiles: vec![profile("fast"), profile("deep")],
+            active_profile_id: Some("deep".into()),
+        });
+        assert_eq!(app.active_profile_id.as_deref(), Some("deep"));
+
+        app.active_profile_id = Some("removed-again".into());
+        app.handle_acp_event(AcpAppEvent::Profiles {
+            profiles: vec![profile("fast"), profile("deep")],
+            active_profile_id: Some("missing".into()),
+        });
+        assert_eq!(app.active_profile_id.as_deref(), Some("fast"));
+    }
+
+    #[test]
+    fn empty_profile_catalog_clears_stale_selection() {
+        let mut app = App::new();
+        app.profiles = vec![profile("fast")];
+        app.active_profile_id = Some("fast".into());
+
+        app.handle_acp_event(AcpAppEvent::Profiles {
+            profiles: Vec::new(),
+            active_profile_id: None,
+        });
+
+        assert!(app.profiles.is_empty());
+        assert!(app.active_profile_id.is_none());
+    }
+
+    #[test]
+    fn loading_session_profile_does_not_replace_new_session_selection() {
+        let mut app = App::new();
+        app.active_profile_id = Some("deep".into());
+
+        app.handle_acp_event(AcpAppEvent::SessionLoaded {
+            agent_id: "agent-1".into(),
+            session_id: "session-1".into(),
+            profile_id: Some("fast".into()),
+        });
+
+        assert_eq!(app.active_profile_id.as_deref(), Some("deep"));
+        assert_eq!(app.current_session_profile_id(), Some("fast"));
+    }
+
+    #[test]
+    fn native_delegate_tool_start_creates_provisional_entry() {
+        let mut app = app_with_active_session();
+
+        app.handle_acp_event(AcpAppEvent::SessionUpdate {
+            session_id: TEST_SESSION_ID.into(),
+            update: AcpSessionUpdate::ToolCallStart {
+                tool_call_id: Some("call-1".into()),
+                name: "delegate".into(),
+                arguments: Some(serde_json::json!({
+                    "target_agent_id": "coder",
+                    "objective": "Implement the feature"
+                })),
+            },
+            is_replay: false,
+        });
+
+        assert_eq!(app.delegate_entries.len(), 1);
+        assert_eq!(app.delegate_entries[0].delegation_id, "tool:call-1");
+        assert_eq!(
+            app.delegate_entries[0].target_agent_id.as_deref(),
+            Some("coder")
+        );
+        assert_eq!(app.delegate_entries[0].status, DelegateStatus::InProgress);
+    }
+
+    #[test]
+    fn delegation_snapshots_reconcile_by_tool_id_and_ignore_stale_updates() {
+        let mut app = app_with_active_session();
+        app.upsert_provisional_delegate(
+            Some("call-1"),
+            Some(&serde_json::json!({
+                "target_agent_id": "coder",
+                "objective": "Implement the feature"
+            })),
+        );
+
+        app.handle_acp_event(AcpAppEvent::DelegationUpdate(delegation_update(
+            DelegationUpdateState::Completed,
+            120,
+        )));
+        app.handle_acp_event(AcpAppEvent::DelegationUpdate(delegation_update(
+            DelegationUpdateState::Forked,
+            110,
+        )));
+
+        assert_eq!(app.delegate_entries.len(), 1);
+        let entry = &app.delegate_entries[0];
+        assert_eq!(entry.delegation_id, "delegation-1");
+        assert_eq!(entry.child_session_id.as_deref(), Some("child-1"));
+        assert_eq!(entry.status, DelegateStatus::Completed);
+        assert_eq!(app.delegation_result_summaries["delegation-1"], "done");
+    }
+
+    #[test]
+    fn child_updates_before_fork_are_applied_when_lifecycle_links_child() {
+        let mut app = app_with_active_session();
+        app.handle_acp_event(AcpAppEvent::SessionUpdate {
+            session_id: "child-1".into(),
+            update: AcpSessionUpdate::ToolCallStart {
+                tool_call_id: Some("child-tool".into()),
+                name: "read_tool".into(),
+                arguments: None,
+            },
+            is_replay: false,
+        });
+        app.handle_acp_event(AcpAppEvent::SessionUpdate {
+            session_id: "child-1".into(),
+            update: AcpSessionUpdate::AssistantContentDelta {
+                content: "working".into(),
+                message_id: Some("child-message".into()),
+            },
+            is_replay: false,
+        });
+
+        app.handle_acp_event(AcpAppEvent::DelegationUpdate(delegation_update(
+            DelegationUpdateState::Forked,
+            110,
+        )));
+
+        let entry = &app.delegate_entries[0];
+        assert_eq!(entry.stats.tool_calls, 1);
+        assert_eq!(entry.stats.messages, 1);
+        assert_eq!(entry.child_state, DelegateChildState::AssistantMessage);
+    }
+
+    #[test]
+    fn delegation_completion_does_not_interrupt_parent_streaming() {
+        let mut app = app_with_active_session();
+        app.streaming_content = "partial".into();
+        app.activity = ActivityState::Streaming;
+
+        app.handle_acp_event(AcpAppEvent::DelegationUpdate(delegation_update(
+            DelegationUpdateState::Completed,
+            120,
+        )));
+
+        assert_eq!(app.streaming_content, "partial");
+        assert_eq!(app.activity, ActivityState::Streaming);
+    }
+
+    #[test]
+    fn profile_agents_populate_delegate_tabs_and_ignore_stale_responses() {
+        let mut app = App::new();
+        app.active_profile_id = Some("quorum".into());
+
+        app.handle_acp_event(AcpAppEvent::ProfileAgents {
+            profile_id: "old".into(),
+            agents: vec![AgentInfo {
+                id: "primary".into(),
+                name: "Session".into(),
+                description: None,
+                capabilities: Vec::new(),
+            }],
+        });
+        assert!(app.agents.is_empty());
+
+        app.handle_acp_event(AcpAppEvent::ProfileAgents {
+            profile_id: "quorum".into(),
+            agents: vec![
+                AgentInfo {
+                    id: "primary".into(),
+                    name: "Session".into(),
+                    description: None,
+                    capabilities: Vec::new(),
+                },
+                AgentInfo {
+                    id: "coder".into(),
+                    name: "Coder".into(),
+                    description: Some("Writes code".into()),
+                    capabilities: vec!["coding".into()],
+                },
+            ],
+        });
+        assert_eq!(app.agents_profile_id.as_deref(), Some("quorum"));
+        assert_eq!(app.model_popup_tab_count(), 2);
+        assert_eq!(app.model_popup_tab_agent_id(1), Some("coder"));
+    }
+
+    #[test]
+    fn profile_agents_reapply_profile_scoped_preferences_to_parent_session() {
+        let mut app = App::new();
+        app.session_id = Some("parent".into());
+        app.session_profiles
+            .insert("parent".into(), "quorum".into());
+        app.delegate_model_preferences.insert(
+            "quorum".into(),
+            [(
+                "coder".into(),
+                DelegateModelPreference {
+                    model_id: "openai/gpt-5".into(),
+                    provider: "openai".into(),
+                    model: "gpt-5".into(),
+                    node_id: Some("node-1".into()),
+                },
+            )]
+            .into_iter()
+            .collect(),
+        );
+
+        let commands = app.handle_acp_event(AcpAppEvent::ProfileAgents {
+            profile_id: "quorum".into(),
+            agents: vec![
+                AgentInfo {
+                    id: "primary".into(),
+                    name: "Session".into(),
+                    description: None,
+                    capabilities: Vec::new(),
+                },
+                AgentInfo {
+                    id: "coder".into(),
+                    name: "Coder".into(),
+                    description: None,
+                    capabilities: Vec::new(),
+                },
+            ],
+        });
+
+        assert!(matches!(
+            commands.as_slice(),
+            [ClientMsg::SetDelegateModel {
+                session_id,
+                agent_id,
+                model_id: Some(model_id),
+                node_id: Some(node_id),
+            }] if session_id == "parent"
+                && agent_id == "coder"
+                && model_id == "openai/gpt-5"
+                && node_id == "node-1"
+        ));
     }
 
     #[test]
@@ -1750,8 +2418,12 @@ mod tests {
         assert!(app.messages.is_empty());
         assert!(matches!(
             replies.as_slice(),
-            [ClientMsg::SubscribeSession { session_id, agent_id }]
-                if session_id == "session-1" && agent_id.as_deref() == Some("agent-1")
+            [
+                ClientMsg::SubscribeSession { session_id, agent_id },
+                ClientMsg::ListProfileAgents { profile_id },
+            ] if session_id == "session-1"
+                && agent_id.as_deref() == Some("agent-1")
+                && profile_id == "code"
         ));
     }
 

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -7,12 +7,13 @@ use crate::acp_client::{
 };
 use crate::app::{
     ActivityState, ChatEntry, DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus,
-    ElicitationState, LogLevel, Popup, Screen, ToolDetail,
+    ElicitationState, LogLevel, POPUP_SESSION_PAGE_TARGET, Popup, Screen, ToolDetail,
 };
 use crate::protocol::{
     AgentInfo, AuthProviderEntry, ClientMsg, ForkResultData, MeshInviteCreatedInfo, MeshNodesInfo,
     MeshStatusInfo, ModelEntry, OAuthFlowData, OAuthResultData, ProfileInfo, RedoResultData,
-    RemoteSessionAttachInfo, RemoteSessionListInfo, SessionGroup, UndoResultData, UndoStackFrame,
+    RemoteSessionAttachInfo, RemoteSessionListInfo, SessionGroup, SessionListRequest,
+    UndoResultData, UndoStackFrame,
 };
 use crate::tool_detail;
 
@@ -117,9 +118,13 @@ pub(crate) enum AcpAppEvent {
     RemoteSessions(RemoteSessionListInfo),
     RemoteSessionAttached(RemoteSessionAttachInfo),
     SessionList {
+        request: SessionListRequest,
         groups: Vec<SessionGroup>,
         next_cursor: Option<String>,
-        total_count: Option<u64>,
+    },
+    SessionListFailed {
+        request: SessionListRequest,
+        message: String,
     },
     SessionCreated {
         agent_id: String,
@@ -305,11 +310,14 @@ impl crate::app::App {
                 attached.attached,
             ),
             AcpAppEvent::SessionList {
+                request,
                 groups,
                 next_cursor,
-                total_count,
-            } => {
-                self.apply_acp_session_list(groups, next_cursor, total_count);
+            } => self.apply_acp_session_list(request, groups, next_cursor),
+            AcpAppEvent::SessionListFailed { request, message } => {
+                self.apply_acp_session_list_failure(&request);
+                self.push_acp_error(&message);
+                self.set_status(LogLevel::Error, "acp", format!("error: {message}"));
                 vec![]
             }
             AcpAppEvent::SessionCreated {
@@ -574,91 +582,156 @@ impl crate::app::App {
 
     fn apply_acp_session_list(
         &mut self,
+        request: SessionListRequest,
         mut groups: Vec<SessionGroup>,
-        _next_cursor: Option<String>,
-        total_count: Option<u64>,
-    ) {
-        let response_cwd = if groups.len() == 1 {
-            groups.first().and_then(|group| group.cwd.clone())
-        } else {
-            None
-        };
-        let is_group_page = response_cwd
-            .as_ref()
-            .map(|cwd| self.pending_session_group_loads.remove(&Some(cwd.clone())))
-            .unwrap_or_else(|| self.pending_session_group_loads.remove(&None));
-
-        groups.retain(|group| is_group_page || !group.sessions.is_empty());
+        next_cursor: Option<String>,
+    ) -> Vec<ClientMsg> {
         for group in &mut groups {
+            group.total_count = None;
             for session in &group.sessions {
                 if let Some(node_id) = session.node_id.as_deref() {
                     self.remember_remote_session_node(&session.session_id, node_id);
                 }
             }
-            group
+            group.sessions.sort_by(|a, b| {
+                b.updated_at
+                    .cmp(&a.updated_at)
+                    .then_with(|| b.session_id.cmp(&a.session_id))
+            });
+            group.latest_activity = group
                 .sessions
-                .sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+                .first()
+                .and_then(|session| session.updated_at.clone());
         }
 
-        if is_group_page {
-            for group in groups {
-                if let Some(existing) = self
+        let mut commands = Vec::new();
+        match request {
+            SessionListRequest::Discovery => {
+                self.session_discovery_in_progress = false;
+                for mut group in groups {
+                    group.next_cursor = None;
+                    match group.cwd.clone() {
+                        Some(cwd) => {
+                            let hydrated = self.hydrated_session_groups.contains(&cwd);
+                            if let Some(existing) = self
+                                .session_groups
+                                .iter_mut()
+                                .find(|existing| existing.cwd.as_deref() == Some(cwd.as_str()))
+                            {
+                                if !hydrated {
+                                    merge_session_page(
+                                        existing,
+                                        group.sessions,
+                                        Some(POPUP_SESSION_PAGE_TARGET),
+                                    );
+                                }
+                            } else {
+                                group.sessions.truncate(POPUP_SESSION_PAGE_TARGET);
+                                self.session_groups.push(group);
+                            }
+
+                            if !hydrated
+                                && self.pending_session_group_loads.insert(Some(cwd.clone()))
+                            {
+                                commands.push(ClientMsg::list_sessions_workspace(cwd));
+                            }
+                        }
+                        None => {
+                            if let Some(existing) = self
+                                .session_groups
+                                .iter_mut()
+                                .find(|existing| existing.cwd.is_none())
+                            {
+                                merge_session_page(
+                                    existing,
+                                    group.sessions,
+                                    Some(POPUP_SESSION_PAGE_TARGET),
+                                );
+                            } else {
+                                group.sessions.truncate(POPUP_SESSION_PAGE_TARGET);
+                                self.session_groups.push(group);
+                            }
+                        }
+                    }
+                }
+
+                if let Some(cursor) = next_cursor
+                    && self.session_discovery_cursors.insert(cursor.clone())
+                {
+                    self.session_discovery_in_progress = true;
+                    commands.push(ClientMsg::list_sessions_discovery(Some(cursor)));
+                }
+            }
+            SessionListRequest::WorkspaceFirstPage { cwd } => {
+                self.pending_session_group_loads.remove(&Some(cwd.clone()));
+                self.hydrated_session_groups.insert(cwd.clone());
+                let mut group = groups
+                    .into_iter()
+                    .find(|group| group.cwd.as_deref() == Some(cwd.as_str()))
+                    .unwrap_or_else(|| SessionGroup {
+                        cwd: Some(cwd.clone()),
+                        ..SessionGroup::default()
+                    });
+                group.cwd = Some(cwd.clone());
+                group.total_count = None;
+
+                if group.sessions.is_empty() {
+                    self.session_groups
+                        .retain(|existing| existing.cwd.as_deref() != Some(cwd.as_str()));
+                } else if let Some(existing) = self
                     .session_groups
                     .iter_mut()
-                    .find(|existing| existing.cwd == group.cwd)
+                    .find(|existing| existing.cwd.as_deref() == Some(cwd.as_str()))
                 {
-                    let mut seen = existing
-                        .sessions
-                        .iter()
-                        .map(|session| session.session_id.clone())
-                        .collect::<std::collections::HashSet<_>>();
-                    existing.sessions.extend(
-                        group
-                            .sessions
-                            .into_iter()
-                            .filter(|session| seen.insert(session.session_id.clone())),
-                    );
-                    existing
-                        .sessions
-                        .sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
-                    existing.latest_activity = existing
-                        .sessions
-                        .first()
-                        .and_then(|session| session.updated_at.clone())
-                        .or(group.latest_activity);
-                    existing.total_count = group.total_count;
-                    existing.next_cursor = group.next_cursor;
-                } else if !group.sessions.is_empty() {
+                    *existing = group;
+                } else {
                     self.session_groups.push(group);
                 }
             }
-        } else {
-            groups.sort_by(|a, b| {
-                let a_latest = a.sessions.first().and_then(|s| s.updated_at.as_deref());
-                let b_latest = b.sessions.first().and_then(|s| s.updated_at.as_deref());
-                b_latest.cmp(&a_latest)
-            });
-            self.session_groups = groups;
+            SessionListRequest::WorkspaceContinuation { cwd } => {
+                self.pending_session_group_loads.remove(&Some(cwd.clone()));
+                let page = groups
+                    .into_iter()
+                    .find(|group| group.cwd.as_deref() == Some(cwd.as_str()))
+                    .unwrap_or_else(|| SessionGroup {
+                        cwd: Some(cwd.clone()),
+                        ..SessionGroup::default()
+                    });
+                if let Some(existing) = self
+                    .session_groups
+                    .iter_mut()
+                    .find(|existing| existing.cwd.as_deref() == Some(cwd.as_str()))
+                {
+                    existing.next_cursor = page.next_cursor.clone();
+                    merge_session_page(existing, page.sessions, None);
+                } else if !page.sessions.is_empty() {
+                    self.session_groups.push(page);
+                }
+            }
         }
 
+        self.session_groups
+            .retain(|group| !group.sessions.is_empty());
         self.session_groups.sort_by(|a, b| {
-            let a_latest = a.sessions.first().and_then(|s| s.updated_at.as_deref());
-            let b_latest = b.sessions.first().and_then(|s| s.updated_at.as_deref());
-            b_latest.cmp(&a_latest)
+            b.latest_activity
+                .cmp(&a.latest_activity)
+                .then_with(|| a.cwd.cmp(&b.cwd))
         });
-
-        let total: usize = self.session_groups.iter().map(|g| g.sessions.len()).sum();
-        if !is_group_page && let Some(root_total) = total_count {
-            self.push_log(
-                LogLevel::Info,
-                "session",
-                format!("session list: total root sessions={root_total}, loaded={total}"),
-            );
-        }
 
         let visible_len = self.visible_start_items().len();
         if self.session_cursor >= visible_len && visible_len > 0 {
             self.session_cursor = visible_len - 1;
+        }
+        commands
+    }
+
+    fn apply_acp_session_list_failure(&mut self, request: &SessionListRequest) {
+        match request {
+            SessionListRequest::Discovery => self.session_discovery_in_progress = false,
+            SessionListRequest::WorkspaceFirstPage { cwd }
+            | SessionListRequest::WorkspaceContinuation { cwd } => {
+                self.pending_session_group_loads.remove(&Some(cwd.clone()));
+            }
         }
     }
 
@@ -1610,6 +1683,36 @@ impl crate::app::App {
     }
 }
 
+fn merge_session_page(
+    group: &mut SessionGroup,
+    sessions: Vec<crate::protocol::SessionSummary>,
+    cap: Option<usize>,
+) {
+    let mut seen = group
+        .sessions
+        .iter()
+        .map(|session| session.session_id.clone())
+        .collect::<HashSet<_>>();
+    group.sessions.extend(
+        sessions
+            .into_iter()
+            .filter(|session| seen.insert(session.session_id.clone())),
+    );
+    group.sessions.sort_by(|a, b| {
+        b.updated_at
+            .cmp(&a.updated_at)
+            .then_with(|| b.session_id.cmp(&a.session_id))
+    });
+    if let Some(cap) = cap {
+        group.sessions.truncate(cap);
+    }
+    group.latest_activity = group
+        .sessions
+        .first()
+        .and_then(|session| session.updated_at.clone());
+    group.total_count = None;
+}
+
 fn normalize_replay_updates(updates: Vec<AcpSessionUpdate>) -> Vec<AcpSessionUpdate> {
     let finalized_messages = finalized_assistant_messages(&updates);
     let mut normalized = Vec::with_capacity(updates.len());
@@ -2372,6 +2475,111 @@ mod tests {
     }
 
     #[test]
+    fn acp_discovery_hydrates_workspaces_and_replays_root_cursor() {
+        let mut app = App::new();
+        app.session_discovery_in_progress = true;
+
+        let replies = app.handle_acp_event(AcpAppEvent::SessionList {
+            request: SessionListRequest::Discovery,
+            groups: vec![session_group("/repo", &["s1", "s2"])],
+            next_cursor: Some("opaque-root-2".into()),
+        });
+
+        assert!(app.session_discovery_in_progress);
+        assert!(
+            app.pending_session_group_loads
+                .contains(&Some("/repo".into()))
+        );
+        assert_eq!(app.session_groups[0].next_cursor, None);
+        assert!(replies.iter().any(|reply| matches!(
+            reply,
+            ClientMsg::ListSessions {
+                request: SessionListRequest::WorkspaceFirstPage { cwd },
+                cursor: None,
+                ..
+            } if cwd == "/repo"
+        )));
+        assert!(replies.iter().any(|reply| matches!(
+            reply,
+            ClientMsg::ListSessions {
+                request: SessionListRequest::Discovery,
+                cursor: Some(cursor),
+                cwd: None,
+                ..
+            } if cursor == "opaque-root-2"
+        )));
+    }
+
+    #[test]
+    fn acp_workspace_first_page_replaces_discovery_preview() {
+        let mut app = App::new();
+        app.session_groups = vec![session_group("/repo", &["preview"])];
+        app.pending_session_group_loads.insert(Some("/repo".into()));
+        let mut page = session_group("/repo", &["new-1", "new-2"]);
+        page.next_cursor = Some("opaque-workspace-2".into());
+
+        app.handle_acp_event(AcpAppEvent::SessionList {
+            request: SessionListRequest::WorkspaceFirstPage {
+                cwd: "/repo".into(),
+            },
+            groups: vec![page],
+            next_cursor: Some("opaque-workspace-2".into()),
+        });
+
+        assert!(app.hydrated_session_groups.contains("/repo"));
+        assert!(app.pending_session_group_loads.is_empty());
+        assert_eq!(app.session_groups[0].total_count, None);
+        assert_eq!(
+            app.session_groups[0]
+                .sessions
+                .iter()
+                .map(|session| session.session_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["new-2", "new-1"]
+        );
+        assert_eq!(
+            app.session_groups[0].next_cursor.as_deref(),
+            Some("opaque-workspace-2")
+        );
+    }
+
+    #[test]
+    fn acp_discovery_merges_later_workspaces_without_overwriting_hydrated_groups() {
+        let mut app = App::new();
+        app.session_discovery_in_progress = true;
+        app.hydrated_session_groups.insert("/repo".into());
+        app.session_groups = vec![session_group("/repo", &["authoritative"])];
+
+        let replies = app.handle_acp_event(AcpAppEvent::SessionList {
+            request: SessionListRequest::Discovery,
+            groups: vec![
+                session_group("/repo", &["stale-discovery"]),
+                session_group("/later", &["later-1"]),
+            ],
+            next_cursor: None,
+        });
+
+        let repo = app
+            .session_groups
+            .iter()
+            .find(|group| group.cwd.as_deref() == Some("/repo"))
+            .unwrap();
+        assert_eq!(repo.sessions[0].session_id, "authoritative");
+        assert!(
+            app.session_groups
+                .iter()
+                .any(|group| group.cwd.as_deref() == Some("/later"))
+        );
+        assert!(replies.iter().any(|reply| matches!(
+            reply,
+            ClientMsg::ListSessions {
+                request: SessionListRequest::WorkspaceFirstPage { cwd },
+                ..
+            } if cwd == "/later"
+        )));
+    }
+
+    #[test]
     fn acp_group_session_page_merges_group_and_dedupes() {
         let mut app = App::new();
         app.session_groups = vec![session_group("/repo", &["s1"])];
@@ -2380,9 +2588,11 @@ mod tests {
         let mut group = session_group("/repo", &["s1", "s2"]);
         group.next_cursor = Some("cursor-2".into());
         app.handle_acp_event(AcpAppEvent::SessionList {
+            request: SessionListRequest::WorkspaceContinuation {
+                cwd: "/repo".into(),
+            },
             groups: vec![group],
-            next_cursor: None,
-            total_count: None,
+            next_cursor: Some("cursor-2".into()),
         });
 
         assert!(app.pending_session_group_loads.is_empty());
@@ -2397,8 +2607,23 @@ mod tests {
                 .iter()
                 .map(|session| session.session_id.as_str())
                 .collect::<Vec<_>>(),
-            vec!["s1", "s2"]
+            vec!["s2", "s1"]
         );
+    }
+
+    #[test]
+    fn acp_session_list_failure_clears_scoped_pending_state() {
+        let mut app = App::new();
+        app.pending_session_group_loads.insert(Some("/repo".into()));
+
+        app.handle_acp_event(AcpAppEvent::SessionListFailed {
+            request: SessionListRequest::WorkspaceContinuation {
+                cwd: "/repo".into(),
+            },
+            message: "failed".into(),
+        });
+
+        assert!(app.pending_session_group_loads.is_empty());
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1119,9 +1119,8 @@ pub enum StartPageItem {
 
 /// Maximum number of recent sessions shown per group on the start page.
 pub const MAX_RECENT_SESSIONS: usize = 3;
-/// Target visible sessions per group when auto-filling the sessions popup.
+/// Maximum discovery-preview sessions retained before the workspace page arrives.
 pub const POPUP_SESSION_PAGE_TARGET: usize = 10;
-pub const SESSION_GROUP_PAGE_LIMIT: u32 = 10;
 pub const SESSION_CHILD_PAGE_LIMIT: u32 = 10;
 
 /// Maximum number of workspace groups shown on the start page.
@@ -1214,8 +1213,14 @@ pub struct App {
     /// Groups whose header has been collapsed by the user in the session popup.
     /// Separate from `collapsed_groups` so start-page and popup states are independent.
     pub popup_collapsed_groups: HashSet<String>,
-    /// CWDs with an outstanding group-page session request.
+    /// Whether global ACP session discovery has another request in flight.
+    pub session_discovery_in_progress: bool,
+    /// Opaque global cursors already queued during the current discovery pass.
+    pub session_discovery_cursors: HashSet<String>,
+    /// CWDs with an outstanding first-page or continuation request.
     pub pending_session_group_loads: HashSet<Option<String>>,
+    /// CWDs whose authoritative first workspace page has been loaded.
+    pub hydrated_session_groups: HashSet<String>,
     /// Root session IDs expanded to show fork children.
     pub expanded_session_children: HashSet<String>,
     /// Parent session IDs with an outstanding child-page request.
@@ -1443,16 +1448,26 @@ fn move_wrapping_cursor(cursor: usize, len: usize, delta: isize) -> usize {
 }
 
 impl App {
+    pub fn begin_session_discovery(&mut self) -> Option<ClientMsg> {
+        if self.session_discovery_in_progress || !self.pending_session_group_loads.is_empty() {
+            return None;
+        }
+        self.session_groups.clear();
+        self.session_discovery_cursors.clear();
+        self.pending_session_group_loads.clear();
+        self.hydrated_session_groups.clear();
+        self.session_discovery_in_progress = true;
+        Some(ClientMsg::list_sessions_browse())
+    }
+
     pub fn session_group_page_request(&mut self, group_idx: usize) -> Option<ClientMsg> {
         let group = self.session_groups.get(group_idx)?;
         let cursor = group.next_cursor.clone()?;
-        let cwd = group.cwd.clone();
-        self.pending_session_group_loads.insert(cwd.clone());
-        Some(ClientMsg::list_sessions_group(
-            cwd,
-            cursor,
-            SESSION_GROUP_PAGE_LIMIT,
-        ))
+        let cwd = group.cwd.clone()?;
+        if !self.pending_session_group_loads.insert(Some(cwd.clone())) {
+            return None;
+        }
+        Some(ClientMsg::list_sessions_group(cwd, cursor))
     }
 
     pub fn session_child_page_request(
@@ -1485,7 +1500,10 @@ impl App {
             session_popup_tab: 0,
             collapsed_groups: HashSet::new(),
             popup_collapsed_groups: HashSet::new(),
+            session_discovery_in_progress: false,
+            session_discovery_cursors: HashSet::new(),
             pending_session_group_loads: HashSet::new(),
+            hydrated_session_groups: HashSet::new(),
             expanded_session_children: HashSet::new(),
             pending_session_child_loads: HashSet::new(),
             start_page_scroll: 0,
@@ -2393,6 +2411,8 @@ impl App {
             ConnectionEvent::Disconnected { reason } => {
                 self.conn = ConnState::Disconnected;
                 self.reconnect_delay_ms = None;
+                self.session_discovery_in_progress = false;
+                self.pending_session_group_loads.clear();
                 self.set_status(
                     LogLevel::Warn,
                     "connection",
@@ -10006,6 +10026,20 @@ mod popup_item_tests {
     }
 
     // ── no MAX_VISIBLE_GROUPS cap ─────────────────────────────────────────────
+
+    #[test]
+    fn popup_items_hide_group_load_more_while_request_is_pending() {
+        let mut app = App::new();
+        let mut group = make_group(Some("/workspace/project"), &["s1"]);
+        group.next_cursor = Some("opaque-workspace-2".to_string());
+        app.session_groups = vec![group];
+        app.pending_session_group_loads
+            .insert(Some("/workspace/project".to_string()));
+
+        assert!(!app.visible_popup_items().iter().any(
+            |item| matches!(item, PopupItem::LoadMore { parent_path, .. } if parent_path.is_empty())
+        ));
+    }
 
     #[test]
     fn popup_items_shows_all_groups_beyond_cap() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1298,15 +1298,13 @@ pub struct App {
     pub model_filter: String,
 
     // delegate agent model preferences
-    /// Known agents from the server's `state` message.
-    /// Single-element or empty in single-agent mode.
+    /// Agents for `agents_profile_id`. Index zero is the primary session agent.
     pub agents: Vec<crate::protocol::AgentInfo>,
-    /// Currently selected tab index in the model popup.
-    /// 0 = "Planner" (plan mode), 1 = "Build" (build mode), 2..N = delegate agents.
+    pub agents_profile_id: Option<String>,
+    /// Currently selected tab index: zero is the session, remaining tabs are delegates.
     pub model_popup_agent_tab: usize,
-    /// Per-agent-id model preferences: agent_id → (provider, model).
-    /// Applied automatically when `SessionForked` creates a child for that agent.
-    pub delegate_model_preferences: HashMap<String, (String, String)>,
+    /// Explicit model preferences scoped by profile ID and delegate agent ID.
+    pub delegate_model_preferences: HashMap<String, HashMap<String, DelegateModelPreference>>,
 
     // theme selector
     pub theme_cursor: usize,
@@ -1403,6 +1401,12 @@ pub struct App {
     pub pending_commands: Vec<ClientMsg>,
     /// Child-session state observed before a delegation entry can be linked.
     pub pending_delegate_child_states: HashMap<String, DelegateChildState>,
+    pub pending_delegate_child_stats: HashMap<String, DelegateStats>,
+    pub delegate_child_message_ids: HashMap<String, HashSet<String>>,
+    /// Latest lifecycle timestamp and bounded terminal metadata by delegation ID.
+    pub delegation_update_times: HashMap<String, i64>,
+    pub delegation_result_summaries: HashMap<String, String>,
+    pub delegation_errors: HashMap<String, String>,
     /// Parent delegate ToolCallStart records awaiting DelegationRequested linkage.
     pub pending_delegate_tool_calls: Vec<PendingDelegateToolCall>,
     /// While a reverted frontier turn is being suppressed, ignore any
@@ -1538,6 +1542,7 @@ impl App {
             model_cursor: 0,
             model_filter: String::new(),
             agents: Vec::new(),
+            agents_profile_id: None,
             model_popup_agent_tab: 0,
             delegate_model_preferences: HashMap::new(),
             theme_cursor: 0,
@@ -1597,6 +1602,11 @@ impl App {
             suppress_delegation_result: false,
             pending_commands: Vec::new(),
             pending_delegate_child_states: HashMap::new(),
+            pending_delegate_child_stats: HashMap::new(),
+            delegate_child_message_ids: HashMap::new(),
+            delegation_update_times: HashMap::new(),
+            delegation_result_summaries: HashMap::new(),
+            delegation_errors: HashMap::new(),
             pending_delegate_tool_calls: Vec::new(),
             suppress_turn_output: false,
             status: "connecting...".into(),
@@ -2606,23 +2616,85 @@ impl App {
         tab_idx == 0
     }
 
-    pub fn set_delegate_model_preference(&mut self, agent_id: &str, provider: &str, model: &str) {
-        self.delegate_model_preferences.insert(
-            agent_id.to_string(),
-            (provider.to_string(), model.to_string()),
-        );
+    pub fn delegate_preference_profile_id(&self) -> Option<&str> {
+        self.current_session_profile_id()
+            .or(self.active_profile_id.as_deref())
     }
 
-    pub fn get_delegate_model_preference(&self, agent_id: &str) -> Option<(&str, &str)> {
+    pub fn desired_agents_profile_id(&self) -> Option<&str> {
+        self.delegate_preference_profile_id()
+    }
+
+    pub fn set_delegate_model_preference(
+        &mut self,
+        profile_id: &str,
+        agent_id: &str,
+        model: &ModelEntry,
+    ) {
         self.delegate_model_preferences
-            .get(agent_id)
-            .map(|(p, m)| (p.as_str(), m.as_str()))
+            .entry(profile_id.to_string())
+            .or_default()
+            .insert(
+                agent_id.to_string(),
+                DelegateModelPreference {
+                    model_id: model.id.clone(),
+                    provider: model.provider.clone(),
+                    model: model.model.clone(),
+                    node_id: model.node_id.clone(),
+                },
+            );
+    }
+
+    pub fn clear_delegate_model_preference(&mut self, profile_id: &str, agent_id: &str) {
+        if let Some(preferences) = self.delegate_model_preferences.get_mut(profile_id) {
+            preferences.remove(agent_id);
+            if preferences.is_empty() {
+                self.delegate_model_preferences.remove(profile_id);
+            }
+        }
+    }
+
+    pub fn get_delegate_model_preference(
+        &self,
+        profile_id: &str,
+        agent_id: &str,
+    ) -> Option<&DelegateModelPreference> {
+        self.delegate_model_preferences
+            .get(profile_id)
+            .and_then(|preferences| preferences.get(agent_id))
+    }
+
+    pub fn delegate_model_commands_for_session(
+        &self,
+        session_id: &str,
+        profile_id: &str,
+    ) -> Vec<ClientMsg> {
+        let known_agents: HashSet<&str> =
+            self.agents.iter().skip(1).map(|a| a.id.as_str()).collect();
+        self.delegate_model_preferences
+            .get(profile_id)
+            .into_iter()
+            .flat_map(|preferences| preferences.iter())
+            .filter(|(agent_id, _)| known_agents.contains(agent_id.as_str()))
+            .map(|(agent_id, preference)| ClientMsg::SetDelegateModel {
+                session_id: session_id.to_string(),
+                agent_id: agent_id.clone(),
+                model_id: Some(preference.model_id.clone()),
+                node_id: preference.node_id.clone(),
+            })
+            .collect()
     }
 
     /// Cursor position for a delegate agent's preferred model in the popup list.
     pub fn delegate_model_cursor(&self, agent_id: &str) -> usize {
         let items = self.visible_model_popup_items();
-        let Some((provider, model)) = self.get_delegate_model_preference(agent_id) else {
+        let Some(profile_id) = self.delegate_preference_profile_id() else {
+            return items
+                .iter()
+                .position(|item| matches!(item, ModelPopupItem::Model { .. }))
+                .unwrap_or(0);
+        };
+        let Some(preference) = self.get_delegate_model_preference(profile_id, agent_id) else {
             return items
                 .iter()
                 .position(|item| matches!(item, ModelPopupItem::Model { .. }))
@@ -2632,8 +2704,8 @@ impl App {
             .iter()
             .position(|item| match item {
                 ModelPopupItem::Model { model_idx } => {
-                    let m = &self.models[*model_idx];
-                    m.provider == provider && m.model == model
+                    self.models[*model_idx].id == preference.model_id
+                        && self.models[*model_idx].node_id == preference.node_id
                 }
                 _ => false,
             })
@@ -4544,7 +4616,7 @@ mod delegate_entry_tests {
             family: None,
             quant: None,
         }];
-        app.set_delegate_model_preference("coder", "anthropic", "claude-sonnet");
+        app.set_delegate_model_preference("profile", "coder", &app.models[0].clone());
         app.delegate_entries.push(DelegateEntry {
             delegation_id: "del-1".into(),
             child_session_id: None,
@@ -10357,6 +10429,8 @@ mod delegate_model_preference_tests {
         AgentInfo {
             id: id.into(),
             name: name.into(),
+            description: None,
+            capabilities: Vec::new(),
         }
     }
 
@@ -10442,17 +10516,19 @@ mod delegate_model_preference_tests {
     #[test]
     fn delegate_pref_round_trip() {
         let mut app = App::new();
-        app.set_delegate_model_preference("coder", "anthropic", "claude-sonnet");
+        let model = make_model("anthropic", "claude-sonnet");
+        app.set_delegate_model_preference("profile", "coder", &model);
         assert_eq!(
-            app.get_delegate_model_preference("coder"),
-            Some(("anthropic", "claude-sonnet"))
+            app.get_delegate_model_preference("profile", "coder")
+                .map(|preference| preference.model_id.as_str()),
+            Some("anthropic/claude-sonnet")
         );
     }
 
     #[test]
     fn delegate_pref_missing_returns_none() {
         let app = App::new();
-        assert_eq!(app.get_delegate_model_preference("coder"), None);
+        assert_eq!(app.get_delegate_model_preference("profile", "coder"), None);
     }
 
     #[test]
@@ -10462,7 +10538,8 @@ mod delegate_model_preference_tests {
             make_model("openai", "gpt-4o"),
             make_model("anthropic", "claude-sonnet"),
         ];
-        app.set_delegate_model_preference("coder", "anthropic", "claude-sonnet");
+        app.active_profile_id = Some("profile".into());
+        app.set_delegate_model_preference("profile", "coder", &app.models[1].clone());
         let cursor = app.delegate_model_cursor("coder");
         // Should point to the second item (index 1 in models, but popup items
         // include provider headers — exact index depends on visible_model_popup_items).

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,8 @@ use std::sync::{Mutex, OnceLock};
 
 use serde::{Deserialize, Serialize};
 
+use crate::protocol::DelegateModelPreference;
+
 // ── path overrides for tests ─────────────────────────────────────────────────
 
 static CONFIG_PATH_OVERRIDE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
@@ -94,9 +96,11 @@ pub struct TuiConfig {
     pub theme: Option<String>,
     pub show_thinking: Option<bool>,
     pub acp: AcpConfig,
-    /// Per-agent-id model preferences: agent_id → "provider/model".
+    /// Legacy per-agent model preferences. Read for migration, no longer written.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub delegate_models: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub profile_delegate_models: HashMap<String, HashMap<String, DelegateModelPreference>>,
     pub profile: ProfileConfig,
 }
 
@@ -152,12 +156,15 @@ impl TuiConfig {
         let mut merged = self.clone();
         merged.theme = Some(crate::theme::Theme::current_id().to_string());
         merged.show_thinking = Some(app.show_thinking);
-        merged.delegate_models = app
-            .delegate_model_preferences
-            .iter()
-            .map(|(id, (p, m))| (id.clone(), format!("{p}/{m}")))
-            .collect();
+        merged.profile_delegate_models = app.delegate_model_preferences.clone();
         merged.profile.id = app.active_profile_id.clone();
+        if let Some(profile_id) = app.active_profile_id.as_deref()
+            && let Some(preferences) = app.delegate_model_preferences.get(profile_id)
+        {
+            merged
+                .delegate_models
+                .retain(|agent_id, _| !preferences.contains_key(agent_id));
+        }
         merged
     }
 
@@ -366,20 +373,42 @@ mod tests {
     fn config_round_trip_with_delegate_models() {
         let _guard = TestPathGuard::new("delegate-models-rt");
         let mut app = App::new();
-        app.set_delegate_model_preference("coder", "anthropic", "claude-sonnet");
-        app.set_delegate_model_preference("planner", "openai", "gpt-4o");
+        let coder = crate::protocol::ModelEntry {
+            id: "anthropic/claude-sonnet".into(),
+            label: "Claude Sonnet".into(),
+            provider: "anthropic".into(),
+            model: "claude-sonnet".into(),
+            node_id: None,
+            node_label: None,
+            family: None,
+            quant: None,
+        };
+        let planner = crate::protocol::ModelEntry {
+            id: "openai/gpt-4o".into(),
+            label: "GPT-4o".into(),
+            provider: "openai".into(),
+            model: "gpt-4o".into(),
+            node_id: None,
+            node_label: None,
+            family: None,
+            quant: None,
+        };
+        app.active_profile_id = Some("quorum".into());
+        app.set_delegate_model_preference("quorum", "coder", &coder);
+        app.set_delegate_model_preference("quorum", "planner", &planner);
 
         let cfg = TuiConfig::load().with_app_settings(&app);
         cfg.save();
         let loaded = TuiConfig::load();
 
+        assert!(loaded.delegate_models.is_empty());
         assert_eq!(
-            loaded.delegate_models.get("coder").map(String::as_str),
-            Some("anthropic/claude-sonnet")
+            loaded.profile_delegate_models["quorum"]["coder"].model_id,
+            "anthropic/claude-sonnet"
         );
         assert_eq!(
-            loaded.delegate_models.get("planner").map(String::as_str),
-            Some("openai/gpt-4o")
+            loaded.profile_delegate_models["quorum"]["planner"].model_id,
+            "openai/gpt-4o"
         );
     }
 
@@ -388,6 +417,39 @@ mod tests {
         let app = App::new();
         let cfg = TuiConfig::default().with_app_settings(&app);
         assert!(cfg.delegate_models.is_empty());
+        assert!(cfg.profile_delegate_models.is_empty());
+    }
+
+    #[test]
+    fn config_with_app_settings_preserves_unscoped_legacy_preferences() {
+        let cfg = TuiConfig {
+            delegate_models: [("coder".into(), "anthropic/claude-sonnet".into())]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+
+        let merged = cfg.with_app_settings(&App::new());
+
+        assert_eq!(
+            merged.delegate_models.get("coder").map(String::as_str),
+            Some("anthropic/claude-sonnet")
+        );
+    }
+
+    #[test]
+    fn config_profile_delegate_models_preserves_remote_identity() {
+        let toml_str = r#"
+[profile_delegate_models.quorum.coder]
+model_id = "openai/gpt-5"
+provider = "openai"
+model = "gpt-5"
+node_id = "node-1"
+"#;
+        let cfg: TuiConfig = toml::from_str(toml_str).unwrap();
+        let preference = &cfg.profile_delegate_models["quorum"]["coder"];
+        assert_eq!(preference.model_id, "openai/gpt-5");
+        assert_eq!(preference.node_id.as_deref(), Some("node-1"));
     }
 
     #[test]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -202,7 +202,9 @@ fn open_session_popup(
     app.session_popup_tab = 0;
     app.session_cursor = 0;
     app.session_filter.clear();
-    cmd_tx.send(ClientMsg::list_sessions_browse())?;
+    if let Some(request) = app.begin_session_discovery() {
+        cmd_tx.send(request)?;
+    }
     Ok(())
 }
 
@@ -2027,7 +2029,9 @@ fn try_execute_slash_command(
             app.session_popup_tab = 0;
             app.session_cursor = 0;
             app.session_filter.clear();
-            cmd_tx.send(ClientMsg::list_sessions_browse())?;
+            if let Some(request) = app.begin_session_discovery() {
+                cmd_tx.send(request)?;
+            }
         }
         "delegates" => {
             app.take_input();

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1445,8 +1445,20 @@ pub(crate) fn handle_profile_popup_key(
             }
             if let Some(profile_id) = app.selected_profile().map(|profile| profile.id.clone()) {
                 app.active_profile_id = Some(profile_id.clone());
-                cmd_tx.send(ClientMsg::SetActiveProfile { profile_id })?;
+                if app.current_session_profile_id().is_none() {
+                    app.agents.clear();
+                    app.agents_profile_id = None;
+                    app.model_popup_agent_tab = 0;
+                    cmd_tx.send(ClientMsg::ListProfileAgents {
+                        profile_id: profile_id.clone(),
+                    })?;
+                }
                 app.popup = Popup::None;
+                app.set_status(
+                    app::LogLevel::Info,
+                    "profile",
+                    format!("new sessions will use {profile_id}"),
+                );
                 save_config(app);
             } else {
                 app.set_status(app::LogLevel::Warn, "profile", "no matching profile");
@@ -1984,7 +1996,19 @@ fn try_execute_slash_command(
                 cmd_tx.send(ClientMsg::ListProfiles)?;
             } else if let Some(profile_id) = app.find_profile_id(&arg) {
                 app.active_profile_id = Some(profile_id.clone());
-                cmd_tx.send(ClientMsg::SetActiveProfile { profile_id })?;
+                if app.current_session_profile_id().is_none() {
+                    app.agents.clear();
+                    app.agents_profile_id = None;
+                    app.model_popup_agent_tab = 0;
+                    cmd_tx.send(ClientMsg::ListProfileAgents {
+                        profile_id: profile_id.clone(),
+                    })?;
+                }
+                app.set_status(
+                    app::LogLevel::Info,
+                    "profile",
+                    format!("new sessions will use {profile_id}"),
+                );
                 save_config(app);
             } else {
                 app.set_status(
@@ -2508,14 +2532,51 @@ pub(crate) fn handle_model_popup_key(
                 } else if let Some(agent_id) = app
                     .model_popup_tab_agent_id(app.model_popup_agent_tab)
                     .map(str::to_string)
+                    && let Some(profile_id) =
+                        app.delegate_preference_profile_id().map(str::to_string)
                 {
-                    app.set_delegate_model_preference(&agent_id, &model.provider, &model.model);
+                    app.set_delegate_model_preference(&profile_id, &agent_id, &model);
+                    if app.parent_session_id.is_none()
+                        && let Some(session_id) = app.session_id.clone()
+                    {
+                        cmd_tx.send(ClientMsg::SetDelegateModel {
+                            session_id,
+                            agent_id,
+                            model_id: Some(model.id.clone()),
+                            node_id: model.node_id.clone(),
+                        })?;
+                    }
                     app.set_status(
                         app::LogLevel::Info,
                         "model",
                         format!("{tab_label}: {}", model.label),
                     );
                 }
+                save_config(app);
+            }
+        }
+        KeyCode::Delete if !app.model_popup_is_session_tab(app.model_popup_agent_tab) => {
+            if let Some(agent_id) = app
+                .model_popup_tab_agent_id(app.model_popup_agent_tab)
+                .map(str::to_string)
+                && let Some(profile_id) = app.delegate_preference_profile_id().map(str::to_string)
+            {
+                app.clear_delegate_model_preference(&profile_id, &agent_id);
+                if app.parent_session_id.is_none()
+                    && let Some(session_id) = app.session_id.clone()
+                {
+                    cmd_tx.send(ClientMsg::SetDelegateModel {
+                        session_id,
+                        agent_id,
+                        model_id: None,
+                        node_id: None,
+                    })?;
+                }
+                app.set_status(
+                    app::LogLevel::Info,
+                    "model",
+                    "delegate model uses profile default",
+                );
                 save_config(app);
             }
         }
@@ -2725,6 +2786,8 @@ mod model_popup_tests {
         crate::protocol::AgentInfo {
             id: id.into(),
             name: name.into(),
+            description: None,
+            capabilities: Vec::new(),
         }
     }
 
@@ -3003,7 +3066,7 @@ mod model_popup_tests {
     }
 
     #[test]
-    fn slash_profile_with_arg_sends_set_active_profile_with_optimistic_update() {
+    fn slash_profile_with_arg_updates_local_new_session_profile() {
         let _guard = TestPersistenceGuard::new("slash-profile");
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
@@ -3018,13 +3081,13 @@ mod model_popup_tests {
 
         assert!(matches!(
             rx.try_recv(),
-            Ok(ClientMsg::SetActiveProfile { profile_id }) if profile_id == "fast"
+            Ok(ClientMsg::ListProfileAgents { profile_id }) if profile_id == "fast"
         ));
         assert_eq!(app.active_profile_id.as_deref(), Some("fast"));
     }
 
     #[test]
-    fn profile_popup_enter_sends_selected_profile() {
+    fn profile_popup_enter_updates_local_new_session_profile() {
         let _guard = TestPersistenceGuard::new("profile-popup-enter");
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
@@ -3038,7 +3101,27 @@ mod model_popup_tests {
         assert!(matches!(app.popup, Popup::None));
         assert!(matches!(
             rx.try_recv(),
-            Ok(ClientMsg::SetActiveProfile { profile_id }) if profile_id == "deep"
+            Ok(ClientMsg::ListProfileAgents { profile_id }) if profile_id == "deep"
+        ));
+        assert_eq!(app.active_profile_id.as_deref(), Some("deep"));
+    }
+
+    #[test]
+    fn new_session_uses_locally_selected_profile() {
+        let mut app = App::new();
+        app.conn = app::ConnState::Connected;
+        app.popup = Popup::NewSession;
+        app.new_session_path = "/repo".into();
+        app.new_session_cursor = app.new_session_path.len();
+        app.active_profile_id = Some("coder-delegate".into());
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        handle_new_session_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(ClientMsg::NewSession { profile_id: Some(profile_id), .. })
+                if profile_id == "coder-delegate"
         ));
     }
 
@@ -3048,6 +3131,8 @@ mod model_popup_tests {
         let mut app = App::new();
         app.popup = Popup::ModelSelect;
         app.session_id = Some("s1".into());
+        app.active_profile_id = Some("profile".into());
+        app.session_profiles.insert("s1".into(), "profile".into());
         app.agent_mode = "plan".into();
         app.current_provider = Some("openai".into());
         app.current_model = Some("gpt-4o".into());
@@ -3071,12 +3156,85 @@ mod model_popup_tests {
         let (tx, mut rx) = mpsc::unbounded_channel();
         handle_model_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
 
-        assert!(rx.try_recv().is_err());
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(ClientMsg::SetDelegateModel {
+                ref session_id,
+                ref agent_id,
+                ref model_id,
+                node_id: None,
+            }) if session_id == "s1"
+                && agent_id == "coder"
+                && model_id.as_deref() == Some("anthropic/claude-sonnet")
+        ));
         assert_eq!(app.current_provider.as_deref(), Some("openai"));
         assert_eq!(app.current_model.as_deref(), Some("gpt-4o"));
         assert_eq!(
-            app.get_delegate_model_preference("coder"),
-            Some(("anthropic", "claude-sonnet"))
+            app.get_delegate_model_preference("profile", "coder")
+                .map(|preference| preference.model_id.as_str()),
+            Some("anthropic/claude-sonnet")
+        );
+    }
+
+    #[test]
+    fn delete_on_delegate_tab_resets_parent_override() {
+        let _guard = TestPersistenceGuard::new("delegate-reset");
+        let mut app = App::new();
+        app.popup = Popup::ModelSelect;
+        app.session_id = Some("s1".into());
+        app.active_profile_id = Some("profile".into());
+        app.session_profiles.insert("s1".into(), "profile".into());
+        app.agents = vec![
+            make_agent("primary", "Session"),
+            make_agent("coder", "Coder"),
+        ];
+        app.model_popup_agent_tab = 1;
+        let model = make_model("anthropic", "claude-sonnet");
+        app.set_delegate_model_preference("profile", "coder", &model);
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        handle_model_popup_key(&mut app, key(KeyCode::Delete), &tx).unwrap();
+
+        assert!(
+            app.get_delegate_model_preference("profile", "coder")
+                .is_none()
+        );
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(ClientMsg::SetDelegateModel {
+                ref session_id,
+                ref agent_id,
+                model_id: None,
+                node_id: None,
+            }) if session_id == "s1" && agent_id == "coder"
+        ));
+    }
+
+    #[test]
+    fn delegate_child_model_selection_is_saved_without_mutating_child_session() {
+        let _guard = TestPersistenceGuard::new("delegate-child-model");
+        let mut app = App::new();
+        app.popup = Popup::ModelSelect;
+        app.session_id = Some("child".into());
+        app.parent_session_id = Some("parent".into());
+        app.active_profile_id = Some("profile".into());
+        app.session_profiles
+            .insert("child".into(), "profile".into());
+        app.agents = vec![
+            make_agent("primary", "Session"),
+            make_agent("coder", "Coder"),
+        ];
+        app.models = vec![make_model("anthropic", "claude-sonnet")];
+        app.model_popup_agent_tab = 1;
+        app.model_cursor = 1;
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        handle_model_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+
+        assert!(rx.try_recv().is_err());
+        assert!(
+            app.get_delegate_model_preference("profile", "coder")
+                .is_some()
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2164,7 +2164,9 @@ async fn run_loop(
                         app.handle_connection_event(state);
                         if app.conn == app::ConnState::Connected {
                             cmd_tx.send(ClientMsg::Init)?;
-                            cmd_tx.send(ClientMsg::list_sessions_browse())?;
+                            if let Some(request) = app.begin_session_discovery() {
+                                cmd_tx.send(request)?;
+                            }
                             cmd_tx.send(ClientMsg::ListAllModels { refresh: false })?;
                             if let Some(session_id) = app.session_id.clone() {
                                 if let Some(node_id) = app.session_remote_node_id(&session_id) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1889,9 +1889,28 @@ async fn main() -> anyhow::Result<()> {
     app.launch_cwd = detect_launch_cwd();
     app.active_profile_id = cfg.profile.id.clone();
     app.show_thinking = cfg.show_thinking.unwrap_or(true);
-    for (agent_id, model_key) in &cfg.delegate_models {
-        if let Some((provider, model)) = model_key.split_once('/') {
-            app.set_delegate_model_preference(agent_id, provider, model);
+    app.delegate_model_preferences = cfg.profile_delegate_models.clone();
+    if let Some(profile_id) = cfg.profile.id.as_deref() {
+        let legacy_preferences = app
+            .delegate_model_preferences
+            .entry(profile_id.to_string())
+            .or_default();
+        for (agent_id, model_key) in &cfg.delegate_models {
+            if legacy_preferences.contains_key(agent_id) {
+                continue;
+            }
+            let Some((provider, model)) = model_key.split_once('/') else {
+                continue;
+            };
+            legacy_preferences.insert(
+                agent_id.clone(),
+                protocol::DelegateModelPreference {
+                    model_id: model_key.clone(),
+                    provider: provider.to_string(),
+                    model: model.to_string(),
+                    node_id: None,
+                },
+            );
         }
     }
     if let Some(session_id) = cli.session.clone() {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -68,8 +68,14 @@ pub enum ClientMsg {
         reasoning_effort: String,
     },
     ListProfiles,
-    SetActiveProfile {
+    ListProfileAgents {
         profile_id: String,
+    },
+    SetDelegateModel {
+        session_id: String,
+        agent_id: String,
+        model_id: Option<String>,
+        node_id: Option<String>,
     },
     NewSession {
         cwd: Option<String>,
@@ -333,19 +339,42 @@ mod client_msg_tests {
     }
 
     #[test]
-    fn profile_messages_serialize() {
+    fn list_profiles_serializes() {
         let list = serde_json::to_value(ClientMsg::ListProfiles).unwrap();
         assert_eq!(list, json!({ "type": "list_profiles" }));
+    }
 
-        let set = serde_json::to_value(ClientMsg::SetActiveProfile {
-            profile_id: "fast".to_string(),
+    #[test]
+    fn delegate_profile_messages_serialize() {
+        let agents = serde_json::to_value(ClientMsg::ListProfileAgents {
+            profile_id: "quorum".into(),
+        })
+        .unwrap();
+        assert_eq!(
+            agents,
+            json!({
+                "type": "list_profile_agents",
+                "data": { "profile_id": "quorum" }
+            })
+        );
+
+        let set = serde_json::to_value(ClientMsg::SetDelegateModel {
+            session_id: "parent".into(),
+            agent_id: "coder".into(),
+            model_id: Some("openai/gpt-5".into()),
+            node_id: Some("node-1".into()),
         })
         .unwrap();
         assert_eq!(
             set,
             json!({
-                "type": "set_active_profile",
-                "data": { "profile_id": "fast" }
+                "type": "set_delegate_model",
+                "data": {
+                    "session_id": "parent",
+                    "agent_id": "coder",
+                    "model_id": "openai/gpt-5",
+                    "node_id": "node-1"
+                }
             })
         );
     }
@@ -459,12 +488,27 @@ pub struct ProfileInfo {
     pub source: Option<String>,
     #[serde(default)]
     pub config_kind: Option<String>,
+    #[serde(default)]
+    pub fingerprint: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct AgentInfo {
     pub id: String,
     pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DelegateModelPreference {
+    pub model_id: String,
+    pub provider: String,
+    pub model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -9,11 +9,29 @@ pub enum SessionScope {
     Forks,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionListRequest {
+    Discovery,
+    WorkspaceFirstPage { cwd: String },
+    WorkspaceContinuation { cwd: String },
+}
+
+impl SessionListRequest {
+    pub fn cwd(&self) -> Option<&str> {
+        match self {
+            Self::Discovery => None,
+            Self::WorkspaceFirstPage { cwd } | Self::WorkspaceContinuation { cwd } => Some(cwd),
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", content = "data", rename_all = "snake_case")]
 pub enum ClientMsg {
     Init,
     ListSessions {
+        #[serde(skip)]
+        request: SessionListRequest,
         #[serde(skip_serializing_if = "Option::is_none")]
         mode: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -155,9 +173,14 @@ pub enum ClientMsg {
 
 impl ClientMsg {
     pub fn list_sessions_browse() -> Self {
+        Self::list_sessions_discovery(None)
+    }
+
+    pub fn list_sessions_discovery(cursor: Option<String>) -> Self {
         Self::ListSessions {
+            request: SessionListRequest::Discovery,
             mode: None,
-            cursor: None,
+            cursor,
             limit: None,
             cwd: None,
             query: None,
@@ -166,12 +189,26 @@ impl ClientMsg {
         }
     }
 
-    pub fn list_sessions_group(cwd: Option<String>, cursor: String, limit: u32) -> Self {
+    pub fn list_sessions_workspace(cwd: String) -> Self {
         Self::ListSessions {
+            request: SessionListRequest::WorkspaceFirstPage { cwd: cwd.clone() },
+            mode: Some("group".to_string()),
+            cursor: None,
+            limit: Some(10),
+            cwd: Some(cwd),
+            query: None,
+            include_remote: None,
+            session_scope: SessionScope::Root,
+        }
+    }
+
+    pub fn list_sessions_group(cwd: String, cursor: String) -> Self {
+        Self::ListSessions {
+            request: SessionListRequest::WorkspaceContinuation { cwd: cwd.clone() },
             mode: Some("group".to_string()),
             cursor: Some(cursor),
-            limit: Some(limit),
-            cwd: Some(cwd.unwrap_or_else(|| "__none__".to_string())),
+            limit: Some(10),
+            cwd: Some(cwd),
             query: None,
             include_remote: None,
             session_scope: SessionScope::Root,
@@ -213,14 +250,52 @@ mod client_msg_tests {
     }
 
     #[test]
+    fn list_sessions_workspace_serializes_cwd_without_cursor() {
+        let value = serde_json::to_value(ClientMsg::list_sessions_workspace(
+            "/workspace/project".to_string(),
+        ))
+        .unwrap();
+        assert_eq!(
+            value,
+            json!({
+                "type": "list_sessions",
+                "data": {
+                    "mode": "group",
+                    "limit": 10,
+                    "cwd": "/workspace/project",
+                    "session_scope": "root"
+                }
+            })
+        );
+    }
+
+    #[test]
     fn list_sessions_group_omits_include_remote_for_pagination() {
         let value = serde_json::to_value(ClientMsg::list_sessions_group(
-            Some("/workspace/project".to_string()),
+            "/workspace/project".to_string(),
             "cursor-1".to_string(),
-            10,
         ))
         .unwrap();
         assert!(value["data"].get("include_remote").is_none());
+    }
+
+    #[test]
+    fn list_sessions_discovery_serializes_opaque_cursor() {
+        let value = serde_json::to_value(ClientMsg::list_sessions_discovery(Some(
+            "opaque-root-2".to_string(),
+        )))
+        .unwrap();
+        assert_eq!(
+            value,
+            json!({
+                "type": "list_sessions",
+                "data": {
+                    "cursor": "opaque-root-2",
+                    "include_remote": true,
+                    "session_scope": "root"
+                }
+            })
+        );
     }
 
     #[test]
@@ -279,9 +354,8 @@ mod client_msg_tests {
     #[test]
     fn list_sessions_group_serializes_backend_pagination_fields() {
         let value = serde_json::to_value(ClientMsg::list_sessions_group(
-            Some("/workspace/project".to_string()),
+            "/workspace/project".to_string(),
             "cursor-1".to_string(),
-            10,
         ))
         .unwrap();
         assert_eq!(

--- a/src/server_msg.rs
+++ b/src/server_msg.rs
@@ -4148,6 +4148,7 @@ mod session_list_pagination_tests {
                 ..
             }
         ));
+        assert!(app.session_group_page_request(0).is_none());
 
         let replies = app.handle_server_msg(list_msg(
             vec![

--- a/src/session.rs
+++ b/src/session.rs
@@ -402,7 +402,9 @@ impl App {
                         }
                     }
                 }
-                if group.next_cursor.is_some() {
+                if group.next_cursor.is_some()
+                    && !self.pending_session_group_loads.contains(&group.cwd)
+                {
                     items.push(PopupItem::LoadMore {
                         group_idx,
                         parent_path: Vec::new(),

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -9,8 +9,8 @@ use ratatui::{
 };
 
 use crate::app::{
-    ActivityState, App, ChatEntry, DelegateEntry, DiffPreviewSection, SessionOp, ShellOutputTail,
-    ToolDetail,
+    ActivityState, App, ChatEntry, DelegateEntry, DelegateStatus, DiffPreviewSection, SessionOp,
+    ShellOutputTail, ToolDetail,
 };
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -378,15 +378,21 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                 };
                 let sym = if *is_error { "x" } else { ">" };
 
-                // For delegate tool calls, compute duration and state from delegate_entries.
-                let (delegate_duration, delegate_awaiting_input) = if name == "delegate" {
+                // For delegate tool calls, compute duration and lifecycle from delegate entries.
+                let delegate_entry = if name == "delegate" {
                     let entry = delegate_entry_for_tool(tool_call_id.as_ref(), delegate_idx);
-                    let dur = entry.and_then(|e| {
-                        let start = e.started_at?;
-                        let end = e.ended_at.unwrap_or_else(|| {
+                    delegate_idx += 1;
+                    entry
+                } else {
+                    None
+                };
+                let delegate_duration = delegate_entry
+                    .and_then(|entry| {
+                        let start = entry.started_at?;
+                        let end = entry.ended_at.unwrap_or_else(|| {
                             std::time::SystemTime::now()
                                 .duration_since(std::time::UNIX_EPOCH)
-                                .map(|d| d.as_secs() as i64)
+                                .map(|duration| duration.as_secs() as i64)
                                 .unwrap_or(start)
                         });
                         let secs = (end - start).max(0) as u64;
@@ -395,14 +401,8 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                         } else {
                             format!(":{}m{}s", secs / 60, secs % 60)
                         })
-                    });
-                    let awaiting_input = entry.is_some_and(|e| e.awaiting_input());
-                    delegate_idx += 1;
-                    (dur.unwrap_or_default(), awaiting_input)
-                } else {
-                    (String::new(), false)
-                };
-
+                    })
+                    .unwrap_or_default();
                 let tool_style = style;
                 match detail {
                     ToolDetail::Edit {
@@ -503,14 +503,26 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                             } else {
                                 format!("({label_inner}{delegate_duration})")
                             };
+                            let (delegate_status, delegate_status_style) = match delegate_entry {
+                                Some(entry) if entry.awaiting_input() => {
+                                    ("awaiting input", Theme::mode_badge("plan"))
+                                }
+                                Some(entry) => match entry.status {
+                                    DelegateStatus::InProgress => {
+                                        ("running", Theme::status_accent())
+                                    }
+                                    DelegateStatus::Completed => ("done", Theme::status()),
+                                    DelegateStatus::Failed => ("failed", Theme::tool_error()),
+                                    DelegateStatus::Cancelled => ("cancelled", Theme::status()),
+                                },
+                                None => ("queued", Theme::status()),
+                            };
                             let mut spans = vec![Span::styled(format!("{sym} {name} "), style)];
                             spans.push(Span::styled(format!("{label} "), Theme::status_accent()));
-                            if delegate_awaiting_input {
-                                spans.push(Span::styled(
-                                    "awaiting input ",
-                                    Theme::mode_badge("plan"),
-                                ));
-                            }
+                            spans.push(Span::styled(
+                                format!("{delegate_status} "),
+                                delegate_status_style,
+                            ));
                             if !objective.is_empty() {
                                 spans.push(Span::styled(objective.to_string(), Theme::diff_file()));
                             }

--- a/src/ui/popups.rs
+++ b/src/ui/popups.rs
@@ -83,8 +83,11 @@ fn popup_log_level_style(level: LogLevel) -> ratatui::style::Style {
 
 /// Whether the given model matches a delegate agent's preferred model.
 fn popup_delegate_marker(app: &App, model: &crate::protocol::ModelEntry, agent_id: &str) -> bool {
-    app.get_delegate_model_preference(agent_id)
-        .is_some_and(|(p, m)| App::model_entry_matches_node(model, p, m, None))
+    app.delegate_preference_profile_id()
+        .and_then(|profile_id| app.get_delegate_model_preference(profile_id, agent_id))
+        .is_some_and(|preference| {
+            preference.model_id == model.id && preference.node_id == model.node_id
+        })
 }
 
 // ── Model popup ───────────────────────────────────────────────────────────────
@@ -330,6 +333,10 @@ pub(super) fn draw_model_popup(f: &mut Frame, app: &App) {
     if has_tabs {
         hint_spans.push(Span::styled("  tab ", Theme::status_accent()));
         hint_spans.push(Span::styled("agent", Theme::status()));
+        if !on_session_tab {
+            hint_spans.push(Span::styled("  del ", Theme::status_accent()));
+            hint_spans.push(Span::styled("default", Theme::status()));
+        }
     }
     f.render_widget(
         Paragraph::new(Line::from(hint_spans)).style(Theme::popup_bg()),


### PR DESCRIPTION
## What

Synchronize the current `main` line into `refactor/components` after Phase 3 slice 1.

This brings the already-landed product work onto the refactor integration line:

- profile support and profile-scoped delegate model selection from #52
- ACP workspace session pagination from #60
- legacy delegate-model config migration into the extracted runtime startup path

## Conflict resolution

- preserve the thin `src/main.rs` entry point and extracted `runtime/` architecture
- preserve Phase 3 activity and elicitation domain ownership
- keep `src/server_msg.rs`, `RawServerMsg`, and the legacy reducer permanently removed
- retain native/direct ACP coverage and add pending-pagination coverage to the native popup test owner
- preserve recursive parent-session discovery for nested session trees

## Validation

- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets` (718 passed)
- `git diff --check`
- no conflict markers or legacy reducer references
- no Ratatui, Tokio channel, UI, runtime, or ACP transport imports under `domain/`

## Target

This PR intentionally targets `refactor/components`, not `main`. The long-running refactor remains isolated from `main` until completion.