### PR TITLE
refactor: extract session domain types

### DIFF
--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -10,11 +10,12 @@ use crate::domain::activity::{
     ActivityState, DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus,
 };
 use crate::domain::elicitation::ElicitationState;
+use crate::domain::session::{SessionGroup, SessionSummary, UndoableTurn};
 use crate::protocol::{
     AgentInfo, AuthProviderEntry, ClientMsg, ForkResultData, MeshInviteCreatedInfo, MeshNodesInfo,
     MeshStatusInfo, ModelEntry, OAuthFlowData, OAuthResultData, ProfileInfo, RedoResultData,
-    RemoteSessionAttachInfo, RemoteSessionListInfo, SessionGroup, SessionListRequest,
-    UndoResultData, UndoStackFrame,
+    RemoteSessionAttachInfo, RemoteSessionListInfo, SessionListRequest, UndoResultData,
+    UndoStackFrame,
 };
 use crate::tool_detail;
 
@@ -1426,7 +1427,7 @@ impl crate::app::App {
             .iter()
             .any(|turn| turn.message_id == message_id)
         {
-            self.undoable_turns.push(crate::app::UndoableTurn {
+            self.undoable_turns.push(UndoableTurn {
                 turn_id: message_id.clone(),
                 message_id,
                 text,
@@ -1706,11 +1707,7 @@ impl crate::app::App {
     }
 }
 
-fn merge_session_page(
-    group: &mut SessionGroup,
-    sessions: Vec<crate::protocol::SessionSummary>,
-    cap: Option<usize>,
-) {
+fn merge_session_page(group: &mut SessionGroup, sessions: Vec<SessionSummary>, cap: Option<usize>) {
     let mut seen = group
         .sessions
         .iter()
@@ -2080,7 +2077,8 @@ fn acp_content_to_string(value: &Value) -> String {
 mod tests {
     use super::*;
     use crate::app::{App, ChatEntry, Screen};
-    use crate::protocol::{DelegateModelPreference, SessionSummary};
+    use crate::domain::session::UndoState;
+    use crate::protocol::DelegateModelPreference;
 
     const TEST_SESSION_ID: &str = "session-1";
     const TEST_ASSISTANT_ID: &str = "a1";
@@ -2664,7 +2662,7 @@ mod tests {
         app.messages.push(ChatEntry::Error("stale".into()));
         app.streaming_content = "stale stream".into();
         app.scroll_offset = 3;
-        app.undo_state = Some(crate::app::UndoState {
+        app.undo_state = Some(UndoState {
             stack: Vec::new(),
             frontier_message_id: Some("undo-1".into()),
         });
@@ -2728,7 +2726,7 @@ mod tests {
         app.streaming_thinking = "stale thinking".into();
         app.streaming_thinking_message_id = Some("thinking-1".into());
         app.scroll_offset = 4;
-        app.undo_state = Some(crate::app::UndoState {
+        app.undo_state = Some(UndoState {
             stack: Vec::new(),
             frontier_message_id: Some("undo-1".into()),
         });
@@ -3521,7 +3519,7 @@ mod tests {
         let mut app = App::new();
         app.session_id = Some("session-1".into());
         app.activity = ActivityState::SessionOp(crate::app::SessionOp::Undo);
-        app.undoable_turns.push(crate::app::UndoableTurn {
+        app.undoable_turns.push(UndoableTurn {
             turn_id: "u1".into(),
             message_id: "u1".into(),
             text: "change".into(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,6 +14,10 @@ pub(crate) use crate::domain::activity::{
 pub(crate) use crate::domain::elicitation::{
     ElicitationField, ElicitationFieldKind, ElicitationOption, ElicitationState,
 };
+use crate::domain::session::{
+    ForkBoundaryKind, ForkTurnItem, SessionGroup, UndoFrame, UndoFrameStatus, UndoState,
+    UndoableTurn,
+};
 use crate::highlight::Highlighter;
 use crate::markdown::CardBlock;
 use crate::mesh::{MeshFocus, MeshInviteFormField};
@@ -426,48 +430,6 @@ pub(crate) fn backfill_elicitation_outcomes(messages: &mut [ChatEntry], result_s
             .unwrap_or_default();
         *outcome = Some(labels.join("\n"));
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct UndoableTurn {
-    pub turn_id: String,
-    pub message_id: String,
-    pub text: String,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ForkBoundaryKind {
-    Assistant,
-    User,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ForkTurnItem {
-    pub turn_index: usize,
-    pub message_id: String,
-    pub boundary_kind: ForkBoundaryKind,
-    pub user_preview: String,
-    pub assistant_preview: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum UndoFrameStatus {
-    Pending,
-    Confirmed,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct UndoFrame {
-    pub turn_id: String,
-    pub message_id: String,
-    pub status: UndoFrameStatus,
-    pub reverted_files: Vec<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct UndoState {
-    pub stack: Vec<UndoFrame>,
-    pub frontier_message_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3797,6 +3759,7 @@ mod tests {
 #[cfg(test)]
 mod start_page_tests {
     use super::*;
+    use crate::domain::session::SessionSummary;
 
     fn make_group(cwd: Option<&str>, ids: &[(&str, Option<&str>)]) -> SessionGroup {
         SessionGroup {
@@ -4395,6 +4358,7 @@ mod start_page_tests {
 #[cfg(test)]
 mod popup_item_tests {
     use super::*;
+    use crate::domain::session::SessionSummary;
 
     fn make_group(cwd: Option<&str>, ids: &[&str]) -> SessionGroup {
         SessionGroup {

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -1,2 +1,3 @@
 pub(crate) mod activity;
 pub(crate) mod elicitation;
+pub(crate) mod session;

--- a/src/domain/session.rs
+++ b/src/domain/session.rs
@@ -1,0 +1,100 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct SessionGroup {
+    pub cwd: Option<String>,
+    #[serde(default)]
+    pub sessions: Vec<SessionSummary>,
+    /// ISO 8601 timestamp of the most recent activity in this group.
+    #[serde(default)]
+    pub latest_activity: Option<String>,
+    #[serde(default)]
+    pub total_count: Option<u64>,
+    #[serde(default)]
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct SessionSummary {
+    pub session_id: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub title: Option<String>,
+    /// Working directory for this session (may differ from group cwd for remote sessions).
+    #[serde(default)]
+    pub cwd: Option<String>,
+    #[serde(default)]
+    pub created_at: Option<String>,
+    #[serde(default)]
+    pub updated_at: Option<String>,
+    /// Parent session ID if this is a forked session.
+    #[serde(default)]
+    pub parent_session_id: Option<String>,
+    #[serde(default)]
+    pub fork_origin: Option<String>,
+    #[serde(default)]
+    pub session_kind: Option<String>,
+    /// Whether this session has child (forked) sessions.
+    #[serde(default)]
+    pub has_children: bool,
+    /// Number of direct forked child sessions.
+    #[serde(default)]
+    pub fork_count: u64,
+    #[serde(default)]
+    pub children: Vec<SessionSummary>,
+    #[serde(default)]
+    pub children_next_cursor: Option<String>,
+    #[serde(default)]
+    pub children_total_count: Option<u64>,
+    #[serde(default)]
+    pub node: Option<String>,
+    #[serde(default)]
+    pub node_id: Option<String>,
+    #[serde(default)]
+    pub attached: Option<bool>,
+    #[serde(default)]
+    pub runtime_state: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UndoableTurn {
+    pub turn_id: String,
+    pub message_id: String,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForkBoundaryKind {
+    Assistant,
+    User,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForkTurnItem {
+    pub turn_index: usize,
+    pub message_id: String,
+    pub boundary_kind: ForkBoundaryKind,
+    pub user_preview: String,
+    pub assistant_preview: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UndoFrameStatus {
+    Pending,
+    Confirmed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UndoFrame {
+    pub turn_id: String,
+    pub message_id: String,
+    pub status: UndoFrameStatus,
+    pub reverted_files: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct UndoState {
+    pub stack: Vec<UndoFrame>,
+    pub frontier_message_id: Option<String>,
+}

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+pub(crate) use crate::domain::session::{SessionGroup, SessionSummary};
+
 // --- Client → Server messages ---
 
 #[derive(Debug, Serialize)]
@@ -561,63 +563,6 @@ pub struct SessionChildrenData {
     pub next_cursor: Option<String>,
     #[serde(default)]
     pub total_count: Option<u64>,
-}
-
-#[derive(Debug, Clone, Default, Deserialize)]
-pub struct SessionGroup {
-    pub cwd: Option<String>,
-    #[serde(default)]
-    pub sessions: Vec<SessionSummary>,
-    /// ISO 8601 timestamp of the most recent activity in this group.
-    #[serde(default)]
-    pub latest_activity: Option<String>,
-    #[serde(default)]
-    pub total_count: Option<u64>,
-    #[serde(default)]
-    pub next_cursor: Option<String>,
-}
-
-#[derive(Debug, Clone, Default, Deserialize)]
-pub struct SessionSummary {
-    pub session_id: String,
-    #[serde(default)]
-    pub name: Option<String>,
-    #[serde(default)]
-    pub title: Option<String>,
-    /// Working directory for this session (may differ from group cwd for remote sessions).
-    #[serde(default)]
-    pub cwd: Option<String>,
-    #[serde(default)]
-    pub created_at: Option<String>,
-    #[serde(default)]
-    pub updated_at: Option<String>,
-    /// Parent session ID if this is a forked session.
-    #[serde(default)]
-    pub parent_session_id: Option<String>,
-    #[serde(default)]
-    pub fork_origin: Option<String>,
-    #[serde(default)]
-    pub session_kind: Option<String>,
-    /// Whether this session has child (forked) sessions.
-    #[serde(default)]
-    pub has_children: bool,
-    /// Number of direct forked child sessions.
-    #[serde(default)]
-    pub fork_count: u64,
-    #[serde(default)]
-    pub children: Vec<SessionSummary>,
-    #[serde(default)]
-    pub children_next_cursor: Option<String>,
-    #[serde(default)]
-    pub children_total_count: Option<u64>,
-    #[serde(default)]
-    pub node: Option<String>,
-    #[serde(default)]
-    pub node_id: Option<String>,
-    #[serde(default)]
-    pub attached: Option<bool>,
-    #[serde(default)]
-    pub runtime_state: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## summary

- add `src/domain/session.rs` for session-domain types
- move session grouping, summary, fork, and undo types into the domain module
- update app and acp state imports while retaining the temporary protocol re-export bridge

## validation

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`

all validation commands pass on commit `71cf6b3a29d9f8210f1e85c8b8465fc3f92aebba`.

## notes

- `AGENTS.md` and `CLAUDE.md` remain untracked locally and are not included in this pull request.
