### PR TITLE
refactor: extract semantic tool details

### DIFF
--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -5,12 +5,13 @@ use serde_json::Value;
 use crate::acp_client::{
     DelegateModelOverrideInfo, DelegationUpdateNotification, DelegationUpdateState,
 };
-use crate::app::{ChatEntry, LogLevel, POPUP_SESSION_PAGE_TARGET, Popup, Screen, ToolDetail};
+use crate::app::{ChatEntry, LogLevel, POPUP_SESSION_PAGE_TARGET, Popup, Screen};
 use crate::domain::activity::{
     ActivityState, DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus,
 };
 use crate::domain::elicitation::ElicitationState;
 use crate::domain::session::{SessionGroup, SessionSummary, UndoableTurn};
+use crate::domain::tool::ToolDetail;
 use crate::protocol::{
     AgentInfo, AuthProviderEntry, ClientMsg, ForkResultData, MeshInviteCreatedInfo, MeshNodesInfo,
     MeshStatusInfo, ModelEntry, OAuthFlowData, OAuthResultData, ProfileInfo, RedoResultData,

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,7 +3,6 @@ use std::time::{Duration, Instant};
 
 use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
-use ratatui::text::Line;
 
 #[allow(unused_imports)]
 pub(crate) use crate::domain::activity::{
@@ -18,6 +17,7 @@ use crate::domain::session::{
     ForkBoundaryKind, ForkTurnItem, SessionGroup, UndoFrame, UndoFrameStatus, UndoState,
     UndoableTurn,
 };
+use crate::domain::tool::ToolDetail;
 use crate::highlight::Highlighter;
 use crate::markdown::CardBlock;
 use crate::mesh::{MeshFocus, MeshInviteFormField};
@@ -459,71 +459,6 @@ pub struct PathCompletionState {
     pub query: String,
     pub selected_index: usize,
     pub results: Vec<FileIndexEntryLite>,
-}
-
-#[derive(Debug, Clone)]
-pub struct DiffPreviewSection {
-    pub header: String,
-    pub old: String,
-    pub new: String,
-    pub start_line: Option<usize>,
-}
-
-#[derive(Debug, Clone)]
-pub struct ShellOutputTail {
-    pub lines: Vec<String>,
-    pub hidden_line_count: usize,
-}
-
-#[derive(Debug, Clone)]
-pub enum ToolDetail {
-    None,
-    /// Compact one-liner info for display after tool name
-    Summary(String),
-    /// One-liner header + indented output lines below
-    SummaryWithOutput {
-        header: String,
-        output: String,
-    },
-    Edit {
-        file: String,
-        old: String,
-        new: String,
-        start_line: Option<usize>,
-        /// Pre-computed diff lines (avoids re-running TextDiff on every render).
-        cached_lines: Vec<Line<'static>>,
-    },
-    MultiEdit {
-        file: String,
-        edit_count: usize,
-        sections: Vec<DiffPreviewSection>,
-        /// Pre-computed sectioned diff lines for all requested edits.
-        cached_lines: Vec<Line<'static>>,
-    },
-    ReplaceSymbol {
-        title: String,
-        sections: Vec<DiffPreviewSection>,
-        /// Pre-computed best-effort symbol body diff lines.
-        cached_lines: Vec<Line<'static>>,
-    },
-    Shell {
-        command: String,
-        workdir: Option<String>,
-        output_tail: Option<ShellOutputTail>,
-        /// Pre-computed command and output-tail lines.
-        cached_lines: Vec<Line<'static>>,
-    },
-    ReadTool {
-        path: String,
-        start_line: Option<u64>,
-        end_line: Option<u64>,
-    },
-    WriteFile {
-        path: String,
-        content: String,
-        /// Pre-computed write preview lines.
-        cached_lines: Vec<Line<'static>>,
-    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -1,3 +1,4 @@
 pub(crate) mod activity;
 pub(crate) mod elicitation;
 pub(crate) mod session;
+pub(crate) mod tool;

--- a/src/domain/tool.rs
+++ b/src/domain/tool.rs
@@ -1,0 +1,54 @@
+#[derive(Debug, Clone)]
+pub struct DiffPreviewSection {
+    pub header: String,
+    pub old: String,
+    pub new: String,
+    pub start_line: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ShellOutputTail {
+    pub lines: Vec<String>,
+    pub hidden_line_count: usize,
+}
+
+#[derive(Debug, Clone)]
+pub enum ToolDetail {
+    None,
+    /// Compact one-liner info for display after the tool name.
+    Summary(String),
+    /// One-liner header with output displayed below it.
+    SummaryWithOutput {
+        header: String,
+        output: String,
+    },
+    Edit {
+        file: String,
+        old: String,
+        new: String,
+        start_line: Option<usize>,
+    },
+    MultiEdit {
+        file: String,
+        edit_count: usize,
+        sections: Vec<DiffPreviewSection>,
+    },
+    ReplaceSymbol {
+        title: String,
+        sections: Vec<DiffPreviewSection>,
+    },
+    Shell {
+        command: String,
+        workdir: Option<String>,
+        output_tail: Option<ShellOutputTail>,
+    },
+    ReadTool {
+        path: String,
+        start_line: Option<u64>,
+        end_line: Option<u64>,
+    },
+    WriteFile {
+        path: String,
+        content: String,
+    },
+}

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -10,7 +10,6 @@ fn popup_page_step(visible_rows: usize) -> usize {
 use crate::config;
 use crate::protocol::{self, ClientMsg, PromptBlock};
 use crate::theme;
-use crate::ui;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AppAction {
@@ -1590,63 +1589,10 @@ pub(crate) fn handle_new_session_popup_key(
 
 /// Invalidate every theme-dependent cache in `app` so that the next render
 /// frame rebuilds styled lines with the current palette.
-///
-/// Covers:
-/// - `card_cache` (finalized message cards)
-/// - `streaming_cache` / `streaming_thinking_cache`
-/// - cached tool preview lines (`edit`, `multiedit`, `replace_symbol`, `shell`, `write_file`)
 pub(crate) fn invalidate_theme_caches(app: &mut App) {
     app.card_cache.invalidate();
     app.streaming_cache.invalidate();
     app.streaming_thinking_cache.invalidate();
-
-    // Re-generate diff/write preview lines baked into ToolCall entries.
-    for entry in &mut app.messages {
-        if let app::ChatEntry::ToolCall { detail, .. } = entry {
-            match detail {
-                app::ToolDetail::Edit {
-                    old,
-                    new,
-                    start_line,
-                    cached_lines,
-                    ..
-                } => {
-                    *cached_lines = ui::build_diff_lines(old, new, *start_line);
-                }
-                app::ToolDetail::MultiEdit {
-                    sections,
-                    cached_lines,
-                    ..
-                } => {
-                    *cached_lines = ui::build_sectioned_diff_lines(sections, 6);
-                }
-                app::ToolDetail::ReplaceSymbol {
-                    sections,
-                    cached_lines,
-                    ..
-                } => {
-                    *cached_lines = ui::build_sectioned_diff_lines(sections, 4);
-                }
-                app::ToolDetail::Shell {
-                    command,
-                    workdir,
-                    output_tail,
-                    cached_lines,
-                } => {
-                    *cached_lines =
-                        ui::build_shell_lines(command, workdir.as_deref(), output_tail.as_ref());
-                }
-                app::ToolDetail::WriteFile {
-                    content,
-                    cached_lines,
-                    ..
-                } => {
-                    *cached_lines = ui::build_write_lines(content);
-                }
-                _ => {}
-            }
-        }
-    }
 }
 
 pub(crate) fn handle_theme_popup_key(app: &mut App, key: KeyEvent) -> anyhow::Result<()> {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -383,15 +383,34 @@ mod tests {
         Theme::begin_frame();
 
         let mut app = App::new();
-
-        // Populate card_cache
         app.messages.push(ChatEntry::User {
             text: "hello".into(),
             message_id: None,
         });
-        app.card_cache.processed_messages = 1;
+        app.messages.push(ChatEntry::ToolCall {
+            tool_call_id: None,
+            name: "edit".into(),
+            is_error: false,
+            detail: ToolDetail::Edit {
+                file: "f.rs".into(),
+                old: "aaa".into(),
+                new: "bbb".into(),
+                start_line: None,
+            },
+        });
 
-        // Populate streaming caches
+        let old_preview_fg = crate::ui::build_message_cards(&mut app)
+            .iter()
+            .find_map(|card| {
+                let lines = card.lines_for(120);
+                lines
+                    .iter()
+                    .flat_map(|line| line.spans.iter())
+                    .find(|span| span.content.as_ref() == "f.rs")
+                    .and_then(|span| span.style.fg)
+            })
+            .expect("edit preview should contain a styled file span");
+
         app.streaming_cache.store(
             5,
             vec![crate::markdown::CardBlock::Text(ratatui::text::Line::from(
@@ -405,30 +424,21 @@ mod tests {
             ))],
         );
 
-        app.messages.push(ChatEntry::ToolCall {
-            tool_call_id: None,
-            name: "edit".into(),
-            is_error: false,
-            detail: ToolDetail::Edit {
-                file: "f.rs".into(),
-                old: "aaa".into(),
-                new: "bbb".into(),
-                start_line: None,
-            },
-        });
-
-        // Confirm caches are populated
         assert!(app.streaming_cache.get(5).is_some());
         assert!(app.streaming_thinking_cache.get(3).is_some());
-        assert_eq!(app.card_cache.processed_messages, 1);
+        assert_eq!(
+            app.card_cache.processed_messages,
+            app.messages.len(),
+            "card_cache should be populated"
+        );
 
-        // Switch to a different theme and update the frame snapshot
-        // before invalidating — just as handle_theme_popup_key does.
+        // Match the production order: snapshot the selected theme, then clear styled caches.
         Theme::set_by_index(2);
         Theme::begin_frame();
+        let current_preview_fg = Theme::diff_file().fg.expect("diff_file should define fg");
+        assert_ne!(old_preview_fg, current_preview_fg);
         invalidate_theme_caches(&mut app);
 
-        // All caches cleared
         assert_eq!(
             app.card_cache.processed_messages, 0,
             "card_cache should be invalidated"
@@ -441,7 +451,6 @@ mod tests {
             app.streaming_thinking_cache.get(3).is_none(),
             "streaming_thinking_cache should be invalidated"
         );
-
         assert!(matches!(
             &app.messages[1],
             ChatEntry::ToolCall {
@@ -450,7 +459,20 @@ mod tests {
             } if old == "aaa" && new == "bbb"
         ));
 
-        // Reset
+        let rebuilt_preview_fg = crate::ui::build_message_cards(&mut app)
+            .iter()
+            .find_map(|card| {
+                let lines = card.lines_for(120);
+                lines
+                    .iter()
+                    .flat_map(|line| line.spans.iter())
+                    .find(|span| span.content.as_ref() == "f.rs")
+                    .and_then(|span| span.style.fg)
+            })
+            .expect("rebuilt edit preview should contain a styled file span");
+        assert_eq!(rebuilt_preview_fg, current_preview_fg);
+        assert_ne!(rebuilt_preview_fg, old_preview_fg);
+
         Theme::set_by_index(0);
         Theme::begin_frame();
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -39,6 +39,7 @@ mod tests {
     use crate::app::{
         ChatEntry, ElicitationField, ElicitationFieldKind, ElicitationOption, ElicitationState,
     };
+    use crate::domain::tool::ToolDetail;
     use crate::handlers::*;
     use crate::ui::OUTCOME_BULLET;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -377,9 +378,7 @@ mod tests {
     #[test]
     fn invalidate_theme_caches_clears_all_render_caches() {
         use crate::theme::Theme;
-        use crate::ui::build_diff_lines;
 
-        // Build cached_lines under theme 0
         Theme::set_by_index(0);
         Theme::begin_frame();
 
@@ -406,19 +405,15 @@ mod tests {
             ))],
         );
 
-        // Populate a ToolCall with cached_lines baked under theme 0
-        let old_lines = build_diff_lines("aaa", "bbb", None);
-        assert!(!old_lines.is_empty());
         app.messages.push(ChatEntry::ToolCall {
             tool_call_id: None,
             name: "edit".into(),
             is_error: false,
-            detail: app::ToolDetail::Edit {
+            detail: ToolDetail::Edit {
                 file: "f.rs".into(),
                 old: "aaa".into(),
                 new: "bbb".into(),
                 start_line: None,
-                cached_lines: old_lines.clone(),
             },
         });
 
@@ -447,24 +442,13 @@ mod tests {
             "streaming_thinking_cache should be invalidated"
         );
 
-        // Tool cached_lines rebuilt with the NEW theme's styles
-        if let ChatEntry::ToolCall {
-            detail: app::ToolDetail::Edit { cached_lines, .. },
-            ..
-        } = &app.messages[1]
-        {
-            assert!(
-                !cached_lines.is_empty(),
-                "tool cached_lines should be rebuilt"
-            );
-            // Lines must differ from the old theme — styles are theme-dependent
-            assert_ne!(
-                *cached_lines, old_lines,
-                "cached_lines should use the new theme's styles, not the old"
-            );
-        } else {
-            panic!("expected ToolCall with Edit detail");
-        }
+        assert!(matches!(
+            &app.messages[1],
+            ChatEntry::ToolCall {
+                detail: ToolDetail::Edit { old, new, .. },
+                ..
+            } if old == "aaa" && new == "bbb"
+        ));
 
         // Reset
         Theme::set_by_index(0);

--- a/src/tool_detail.rs
+++ b/src/tool_detail.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+
 use serde_json::Value;
 
 use crate::app::ChatEntry;
@@ -137,7 +139,19 @@ pub(crate) fn parse_tool_detail(
         }
         "question" => ToolDetail::Summary("asking...".into()),
         "apply_patch" => ToolDetail::Summary("patch".into()),
-        "replace_symbol" => ToolDetail::Summary(replace_symbol_title(&obj, cwd)),
+        "replace_symbol" => {
+            let Some(replacements) = obj.get("replacements").and_then(Value::as_array) else {
+                return ToolDetail::Summary("symbols".into());
+            };
+            if replacements.is_empty() {
+                return ToolDetail::Summary("symbols".into());
+            }
+            let root = string_field(&obj, "root");
+            ToolDetail::ReplaceSymbol {
+                title: replace_symbol_title(replacements, cwd),
+                sections: build_replace_symbol_sections(replacements, root.as_deref(), cwd),
+            }
+        }
         _ => ToolDetail::None,
     }
 }
@@ -448,10 +462,7 @@ fn delegate_summary(obj: &Value) -> ToolDetail {
     }
 }
 
-fn replace_symbol_title(obj: &Value, cwd: Option<&str>) -> String {
-    let Some(replacements) = obj.get("replacements").and_then(Value::as_array) else {
-        return "symbols".into();
-    };
+fn replace_symbol_title(replacements: &[Value], cwd: Option<&str>) -> String {
     let mut files = replacements
         .iter()
         .filter_map(|replacement| string_field(replacement, "path"))
@@ -464,6 +475,151 @@ fn replace_symbol_title(obj: &Value, cwd: Option<&str>) -> String {
         [one] => short_path(one).to_string(),
         [first, ..] => format!("{} (+{})", short_path(first), files.len() - 1),
     }
+}
+
+fn build_replace_symbol_sections(
+    replacements: &[Value],
+    root: Option<&str>,
+    cwd: Option<&str>,
+) -> Vec<DiffPreviewSection> {
+    replacements
+        .iter()
+        .filter_map(|replacement| {
+            let path = string_field(replacement, "path")?;
+            let symbol = string_field(replacement, "symbol")?;
+            let new = string_field(replacement, "newText")
+                .or_else(|| string_field(replacement, "new_text"))?;
+            let kind = string_field(replacement, "kind");
+            let occurrence = replacement
+                .get("occurrence")
+                .and_then(Value::as_u64)
+                .unwrap_or(0) as usize;
+            let resolved_path = resolve_preview_path(&path, root, cwd);
+            let preview = extract_symbol_body(&resolved_path, &symbol, kind.as_deref(), occurrence);
+            let display_path = strip_cwd(&path, cwd);
+            let mut header = if replacements.len() == 1 {
+                symbol.clone()
+            } else {
+                format!("{} {symbol}", short_path(&display_path))
+            };
+            if let Some(kind) = kind.filter(|kind| !kind.is_empty() && kind != "any") {
+                header.push_str(&format!(" ({kind})"));
+            }
+            Some(DiffPreviewSection {
+                header,
+                old: preview
+                    .as_ref()
+                    .map(|(old, _)| old.clone())
+                    .unwrap_or_default(),
+                new,
+                start_line: preview.map(|(_, start_line)| start_line),
+            })
+        })
+        .collect()
+}
+
+fn resolve_preview_path(path: &str, root: Option<&str>, cwd: Option<&str>) -> PathBuf {
+    let path_buf = PathBuf::from(path);
+    if path_buf.is_absolute() {
+        return path_buf;
+    }
+
+    let base = root
+        .filter(|root| !root.trim().is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| cwd.map(PathBuf::from).unwrap_or_else(|| PathBuf::from(".")));
+    let base = if base.is_absolute() {
+        base
+    } else if let Some(cwd) = cwd {
+        Path::new(cwd).join(base)
+    } else {
+        base
+    };
+
+    base.join(path_buf)
+}
+
+fn extract_symbol_body(
+    path: &Path,
+    symbol: &str,
+    kind: Option<&str>,
+    occurrence: usize,
+) -> Option<(String, usize)> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let lines = content.lines().collect::<Vec<_>>();
+    let leaf = symbol
+        .rsplit("::")
+        .next()
+        .unwrap_or(symbol)
+        .rsplit('.')
+        .next()
+        .unwrap_or(symbol);
+    let start = lines
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, line)| symbol_line_matches(line.trim_start(), leaf, kind).then_some(idx))
+        .nth(occurrence)?;
+    let end = symbol_block_end(&lines, start);
+
+    Some((lines[start..=end].join("\n"), start + 1))
+}
+
+fn symbol_line_matches(line: &str, name: &str, kind: Option<&str>) -> bool {
+    let function = || {
+        line.contains(&format!("fn {name}"))
+            || line.contains(&format!("function {name}"))
+            || line.starts_with(&format!("def {name}"))
+            || line.starts_with(&format!("async def {name}"))
+            || line.starts_with(&format!("{name}("))
+            || line.contains(&format!(" {name}("))
+    };
+    let matches = |keyword| line.contains(&format!("{keyword} {name}"));
+    match kind.unwrap_or("any") {
+        "function" | "method" | "test" => function(),
+        "struct" => matches("struct"),
+        "enum" => matches("enum"),
+        "trait" => matches("trait"),
+        "class" => matches("class"),
+        "type" => matches("type"),
+        "const" => matches("const"),
+        "impl" => matches("impl"),
+        "module" => matches("mod") || matches("module"),
+        _ => {
+            function()
+                || matches("struct")
+                || matches("enum")
+                || matches("trait")
+                || matches("class")
+                || matches("type")
+                || matches("const")
+                || matches("impl")
+                || matches("mod")
+                || matches("module")
+        }
+    }
+}
+
+fn symbol_block_end(lines: &[&str], start: usize) -> usize {
+    let mut seen_brace = false;
+    let mut balance = 0isize;
+    for (idx, line) in lines.iter().enumerate().skip(start) {
+        for ch in line.chars() {
+            match ch {
+                '{' => {
+                    seen_brace = true;
+                    balance += 1;
+                }
+                '}' if seen_brace => {
+                    balance -= 1;
+                    if balance <= 0 {
+                        return idx;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    lines.len().saturating_sub(1)
 }
 fn strip_cwd(path: &str, cwd: Option<&str>) -> String {
     cwd.and_then(|cwd| path.strip_prefix(cwd))
@@ -904,19 +1060,70 @@ mod tests {
     }
 
     #[test]
-    fn replace_symbol_summary_uses_replacement_paths_without_previewing_files() {
+    fn replace_symbol_builds_semantic_preview_sections() {
+        let path = std::env::current_dir()
+            .unwrap()
+            .join("src/tool_detail.rs")
+            .display()
+            .to_string();
+        let detail = parse_tool_detail(
+            "replace_symbol",
+            Some(&serde_json::json!({
+                "replacements": [{
+                    "path": path,
+                    "symbol": "parse_tool_detail",
+                    "kind": "function",
+                    "newText": "fn replacement() {}"
+                }]
+            })),
+            None,
+        );
+
+        match detail {
+            ToolDetail::ReplaceSymbol { title, sections } => {
+                assert_eq!(title, "src/tool_detail.rs");
+                assert_eq!(sections.len(), 1);
+                assert!(sections[0].header.contains("parse_tool_detail"));
+                assert!(sections[0].old.contains("fn parse_tool_detail"));
+                assert_eq!(sections[0].new, "fn replacement() {}");
+                assert!(sections[0].start_line.is_some());
+            }
+            other => panic!("expected ReplaceSymbol, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn replace_symbol_uses_path_title_and_sections_without_preview_files() {
         let detail = parse_tool_detail(
             "replace_symbol",
             Some(&serde_json::json!({
                 "replacements": [
-                    { "path": "/workspace/src/one.rs", "symbol": "one" },
-                    { "path": "/workspace/src/two.rs", "symbol": "two" }
+                    {
+                        "path": "/workspace/src/one.rs",
+                        "symbol": "one",
+                        "newText": "fn one() {}"
+                    },
+                    {
+                        "path": "/workspace/src/two.rs",
+                        "symbol": "two",
+                        "newText": "fn two() {}"
+                    }
                 ]
             })),
             Some("/workspace"),
         );
 
-        assert!(matches!(detail, ToolDetail::Summary(summary) if summary == "src/one.rs (+1)"));
+        match detail {
+            ToolDetail::ReplaceSymbol { title, sections } => {
+                assert_eq!(title, "src/one.rs (+1)");
+                assert_eq!(sections.len(), 2);
+                assert_eq!(sections[0].old, "");
+                assert_eq!(sections[0].start_line, None);
+                assert_eq!(sections[1].old, "");
+                assert_eq!(sections[1].start_line, None);
+            }
+            other => panic!("expected ReplaceSymbol, got: {other:?}"),
+        }
     }
 
     #[test]
@@ -995,5 +1202,57 @@ mod tests {
             other => panic!("expected ToolCall, got: {other:?}"),
         }
         assert!(matches!(messages[1], ChatEntry::Assistant { .. }));
+    }
+
+    #[test]
+    fn tool_start_reconciles_failed_fallback_in_place() {
+        let mut messages = vec![
+            ChatEntry::Assistant {
+                content: "before".into(),
+                thinking: None,
+                message_id: None,
+            },
+            ChatEntry::ToolCall {
+                tool_call_id: Some("missing-start".into()),
+                name: "shell (failed)".into(),
+                is_error: true,
+                detail: ToolDetail::None,
+            },
+        ];
+        let detail = parse_tool_detail(
+            "shell",
+            Some(&serde_json::json!({
+                "command": "cargo test tool_detail_tests"
+            })),
+            None,
+        );
+
+        assert!(reconcile_tool_call_start(
+            &mut messages,
+            Some("missing-start"),
+            "shell",
+            detail
+        ));
+        assert_eq!(
+            messages.len(),
+            2,
+            "start must not append a second tool entry"
+        );
+        match &messages[1] {
+            ChatEntry::ToolCall {
+                name,
+                is_error,
+                detail,
+                ..
+            } => {
+                assert_eq!(name, "shell");
+                assert!(*is_error);
+                assert!(matches!(
+                    detail,
+                    ToolDetail::Shell { command, .. } if command == "cargo test tool_detail_tests"
+                ));
+            }
+            other => panic!("expected ToolCall, got: {other:?}"),
+        }
     }
 }

--- a/src/tool_detail.rs
+++ b/src/tool_detail.rs
@@ -1,9 +1,7 @@
 use serde_json::Value;
 
-use crate::app::{ChatEntry, DiffPreviewSection, ShellOutputTail, ToolDetail};
-use crate::ui::{
-    build_diff_lines, build_sectioned_diff_lines, build_shell_lines, build_write_lines,
-};
+use crate::app::ChatEntry;
+use crate::domain::tool::{DiffPreviewSection, ShellOutputTail, ToolDetail};
 
 const DEFAULT_READ_TOOL_LIMIT: u64 = 2000;
 
@@ -18,17 +16,11 @@ pub(crate) fn parse_tool_detail(
     let obj = normalize_args(args);
 
     match tool_name {
-        "shell" => {
-            let command = shell_command_display(&obj);
-            let workdir = string_field(&obj, "workdir");
-            let cached_lines = build_shell_lines(&command, workdir.as_deref(), None);
-            ToolDetail::Shell {
-                command,
-                workdir,
-                output_tail: None,
-                cached_lines,
-            }
-        }
+        "shell" => ToolDetail::Shell {
+            command: shell_command_display(&obj),
+            workdir: string_field(&obj, "workdir"),
+            output_tail: None,
+        },
         "read_tool" => {
             let path = string_field(&obj, "path").unwrap_or_default();
             let offset = obj.get("offset").and_then(Value::as_u64).unwrap_or(0);
@@ -46,11 +38,7 @@ pub(crate) fn parse_tool_detail(
         "write_file" => {
             let path = string_field(&obj, "path").unwrap_or_default();
             let content = string_field(&obj, "content").unwrap_or_default();
-            ToolDetail::WriteFile {
-                path,
-                cached_lines: build_write_lines(&content),
-                content,
-            }
+            ToolDetail::WriteFile { path, content }
         }
         "edit" => {
             let file = string_field(&obj, "filePath")
@@ -64,7 +52,6 @@ pub(crate) fn parse_tool_detail(
                 .unwrap_or_default();
             ToolDetail::Edit {
                 file,
-                cached_lines: build_diff_lines(&old, &new, None),
                 old,
                 new,
                 start_line: None,
@@ -109,7 +96,6 @@ pub(crate) fn parse_tool_detail(
             ToolDetail::MultiEdit {
                 file,
                 edit_count: sections.len(),
-                cached_lines: build_sectioned_diff_lines(&sections, 6),
                 sections,
             }
         }
@@ -214,16 +200,9 @@ pub(crate) fn update_tool_detail(
         }
 
         match detail {
-            ToolDetail::Shell {
-                command,
-                workdir,
-                output_tail,
-                cached_lines,
-            } if name.starts_with("shell") => {
+            ToolDetail::Shell { output_tail, .. } if name.starts_with("shell") => {
                 if let Some(tail) = shell_output_tail_from_result(parsed.as_ref(), result) {
                     *output_tail = Some(tail);
-                    *cached_lines =
-                        build_shell_lines(command, workdir.as_deref(), output_tail.as_ref());
                 }
             }
             ToolDetail::ReadTool {
@@ -236,13 +215,7 @@ pub(crate) fn update_tool_detail(
                     *end_line = Some(last);
                 }
             }
-            ToolDetail::Edit {
-                old,
-                new,
-                start_line,
-                cached_lines,
-                ..
-            } => {
+            ToolDetail::Edit { start_line, .. } => {
                 let json_start = parsed
                     .as_ref()
                     .and_then(|value| value.get("startLineOld"))
@@ -252,20 +225,14 @@ pub(crate) fn update_tool_detail(
                     .or_else(|| compact_receipt_old_starts(&result_text).into_iter().next())
                 {
                     *start_line = Some(start);
-                    *cached_lines = build_diff_lines(old, new, Some(start));
                 }
             }
-            ToolDetail::MultiEdit {
-                sections,
-                cached_lines,
-                ..
-            } => {
+            ToolDetail::MultiEdit { sections, .. } => {
                 let starts = compact_receipt_old_starts(&result_text);
                 if !starts.is_empty() {
                     for (section, start) in sections.iter_mut().zip(starts) {
                         section.start_line = Some(start);
                     }
-                    *cached_lines = build_sectioned_diff_lines(sections, 6);
                 }
             }
             _ => {}
@@ -757,19 +724,12 @@ mod tests {
                 detail:
                     ToolDetail::Shell {
                         output_tail: Some(tail),
-                        cached_lines,
                         ..
                     },
                 ..
             } => {
                 assert_eq!(tail.hidden_line_count, 3);
                 assert_eq!(tail.lines, ["out4", "out5", "out6", "err1", "err2"]);
-                let rendered = cached_lines
-                    .iter()
-                    .flat_map(|line| line.spans.iter().map(|span| span.content.as_ref()))
-                    .collect::<String>();
-                assert!(rendered.contains("output tail:"));
-                assert!(rendered.contains("err2"));
             }
             other => panic!("expected shell tail, got: {other:?}"),
         }

--- a/src/tool_detail.rs
+++ b/src/tool_detail.rs
@@ -524,16 +524,18 @@ fn resolve_preview_path(path: &str, root: Option<&str>, cwd: Option<&str>) -> Pa
         return path_buf;
     }
 
-    let base = root
-        .filter(|root| !root.trim().is_empty())
-        .map(PathBuf::from)
-        .unwrap_or_else(|| cwd.map(PathBuf::from).unwrap_or_else(|| PathBuf::from(".")));
-    let base = if base.is_absolute() {
-        base
-    } else if let Some(cwd) = cwd {
-        Path::new(cwd).join(base)
-    } else {
-        base
+    let base = match root.filter(|root| !root.trim().is_empty()) {
+        Some(root) => {
+            let root = PathBuf::from(root);
+            if root.is_absolute() {
+                root
+            } else if let Some(cwd) = cwd {
+                Path::new(cwd).join(root)
+            } else {
+                root
+            }
+        }
+        None => cwd.map(PathBuf::from).unwrap_or_else(|| PathBuf::from(".")),
     };
 
     base.join(path_buf)
@@ -600,6 +602,10 @@ fn symbol_line_matches(line: &str, name: &str, kind: Option<&str>) -> bool {
 }
 
 fn symbol_block_end(lines: &[&str], start: usize) -> usize {
+    if lines[start].contains(';') && !lines[start].contains('{') {
+        return start;
+    }
+
     let mut seen_brace = false;
     let mut balance = 0isize;
     for (idx, line) in lines.iter().enumerate().skip(start) {
@@ -619,11 +625,17 @@ fn symbol_block_end(lines: &[&str], start: usize) -> usize {
             }
         }
     }
-    lines.len().saturating_sub(1)
+
+    if seen_brace {
+        lines.len().saturating_sub(1)
+    } else {
+        start
+    }
 }
+
 fn strip_cwd(path: &str, cwd: Option<&str>) -> String {
-    cwd.and_then(|cwd| path.strip_prefix(cwd))
-        .map(|path| path.trim_start_matches('/').to_string())
+    cwd.and_then(|cwd| Path::new(path).strip_prefix(cwd).ok())
+        .map(|path| path.to_string_lossy().into_owned())
         .unwrap_or_else(|| path.to_string())
 }
 
@@ -654,6 +666,19 @@ fn truncate_summary(value: &str, max_chars: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[allow(dead_code)]
+    mod replace_symbol_preview_fixtures {
+        fn target() -> &'static str {
+            "first"
+        }
+
+        mod nested {
+            fn target() -> &'static str {
+                "second"
+            }
+        }
+    }
 
     #[test]
     fn delegate_tool_shows_agent_and_objective() {
@@ -1061,8 +1086,7 @@ mod tests {
 
     #[test]
     fn replace_symbol_builds_semantic_preview_sections() {
-        let path = std::env::current_dir()
-            .unwrap()
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("src/tool_detail.rs")
             .display()
             .to_string();
@@ -1090,6 +1114,79 @@ mod tests {
             }
             other => panic!("expected ReplaceSymbol, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn replace_symbol_supports_snake_case_root_occurrence_and_qualified_leaf() {
+        let cwd = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let detail = parse_tool_detail(
+            "replace_symbol",
+            Some(&serde_json::json!({
+                "root": ".",
+                "replacements": [{
+                    "path": "src/tool_detail.rs",
+                    "symbol": "replace_symbol_preview_fixtures::nested::target",
+                    "kind": "function",
+                    "occurrence": 1,
+                    "new_text": "fn target() -> &'static str { \"replacement\" }"
+                }]
+            })),
+            cwd.to_str(),
+        );
+
+        match detail {
+            ToolDetail::ReplaceSymbol { title, sections } => {
+                assert_eq!(title, "src/tool_detail.rs");
+                assert_eq!(sections.len(), 1);
+                assert_eq!(
+                    sections[0].header,
+                    "replace_symbol_preview_fixtures::nested::target (function)"
+                );
+                assert!(sections[0].old.contains("\"second\""));
+                assert_eq!(
+                    sections[0].new,
+                    "fn target() -> &'static str { \"replacement\" }"
+                );
+                assert!(sections[0].start_line.is_some());
+            }
+            other => panic!("expected ReplaceSymbol, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn replace_symbol_preview_path_resolution_uses_root_and_cwd_once() {
+        let cwd = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let cwd_str = cwd.to_str().unwrap();
+        let relative_path = "src/tool_detail.rs";
+        let expected = cwd.join(relative_path);
+
+        assert_eq!(
+            resolve_preview_path(relative_path, Some(cwd_str), Some(cwd_str)),
+            expected
+        );
+        assert_eq!(
+            resolve_preview_path(relative_path, Some("."), Some(cwd_str)),
+            expected
+        );
+        assert_eq!(
+            resolve_preview_path(expected.to_str().unwrap(), Some("ignored"), Some(cwd_str)),
+            expected
+        );
+        assert_eq!(
+            resolve_preview_path(relative_path, None, Some("relative-cwd")),
+            Path::new("relative-cwd").join(relative_path)
+        );
+        assert_eq!(
+            strip_cwd("/workspace-other/src/lib.rs", Some("/workspace")),
+            "/workspace-other/src/lib.rs"
+        );
+    }
+
+    #[test]
+    fn symbol_preview_without_braces_does_not_consume_the_rest_of_the_file() {
+        let lines = ["const VALUE: usize = 1;", "fn unrelated() {}"];
+
+        assert_eq!(symbol_block_end(&lines, 0), 0);
     }
 
     #[test]

--- a/src/tool_detail.rs
+++ b/src/tool_detail.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use serde_json::Value;
 
@@ -139,19 +139,7 @@ pub(crate) fn parse_tool_detail(
         }
         "question" => ToolDetail::Summary("asking...".into()),
         "apply_patch" => ToolDetail::Summary("patch".into()),
-        "replace_symbol" => {
-            let Some(replacements) = obj.get("replacements").and_then(Value::as_array) else {
-                return ToolDetail::Summary("symbols".into());
-            };
-            if replacements.is_empty() {
-                return ToolDetail::Summary("symbols".into());
-            }
-            let root = string_field(&obj, "root");
-            ToolDetail::ReplaceSymbol {
-                title: replace_symbol_title(replacements, cwd),
-                sections: build_replace_symbol_sections(replacements, root.as_deref(), cwd),
-            }
-        }
+        "replace_symbol" => ToolDetail::Summary(replace_symbol_title(&obj, cwd)),
         _ => ToolDetail::None,
     }
 }
@@ -462,7 +450,10 @@ fn delegate_summary(obj: &Value) -> ToolDetail {
     }
 }
 
-fn replace_symbol_title(replacements: &[Value], cwd: Option<&str>) -> String {
+fn replace_symbol_title(obj: &Value, cwd: Option<&str>) -> String {
+    let Some(replacements) = obj.get("replacements").and_then(Value::as_array) else {
+        return "symbols".into();
+    };
     let mut files = replacements
         .iter()
         .filter_map(|replacement| string_field(replacement, "path"))
@@ -474,162 +465,6 @@ fn replace_symbol_title(replacements: &[Value], cwd: Option<&str>) -> String {
         [] => "symbols".into(),
         [one] => short_path(one).to_string(),
         [first, ..] => format!("{} (+{})", short_path(first), files.len() - 1),
-    }
-}
-
-fn build_replace_symbol_sections(
-    replacements: &[Value],
-    root: Option<&str>,
-    cwd: Option<&str>,
-) -> Vec<DiffPreviewSection> {
-    replacements
-        .iter()
-        .filter_map(|replacement| {
-            let path = string_field(replacement, "path")?;
-            let symbol = string_field(replacement, "symbol")?;
-            let new = string_field(replacement, "newText")
-                .or_else(|| string_field(replacement, "new_text"))?;
-            let kind = string_field(replacement, "kind");
-            let occurrence = replacement
-                .get("occurrence")
-                .and_then(Value::as_u64)
-                .unwrap_or(0) as usize;
-            let resolved_path = resolve_preview_path(&path, root, cwd);
-            let preview = extract_symbol_body(&resolved_path, &symbol, kind.as_deref(), occurrence);
-            let display_path = strip_cwd(&path, cwd);
-            let mut header = if replacements.len() == 1 {
-                symbol.clone()
-            } else {
-                format!("{} {symbol}", short_path(&display_path))
-            };
-            if let Some(kind) = kind.filter(|kind| !kind.is_empty() && kind != "any") {
-                header.push_str(&format!(" ({kind})"));
-            }
-            Some(DiffPreviewSection {
-                header,
-                old: preview
-                    .as_ref()
-                    .map(|(old, _)| old.clone())
-                    .unwrap_or_default(),
-                new,
-                start_line: preview.map(|(_, start_line)| start_line),
-            })
-        })
-        .collect()
-}
-
-fn resolve_preview_path(path: &str, root: Option<&str>, cwd: Option<&str>) -> PathBuf {
-    let path_buf = PathBuf::from(path);
-    if path_buf.is_absolute() {
-        return path_buf;
-    }
-
-    let base = match root.filter(|root| !root.trim().is_empty()) {
-        Some(root) => {
-            let root = PathBuf::from(root);
-            if root.is_absolute() {
-                root
-            } else if let Some(cwd) = cwd {
-                Path::new(cwd).join(root)
-            } else {
-                root
-            }
-        }
-        None => cwd.map(PathBuf::from).unwrap_or_else(|| PathBuf::from(".")),
-    };
-
-    base.join(path_buf)
-}
-
-fn extract_symbol_body(
-    path: &Path,
-    symbol: &str,
-    kind: Option<&str>,
-    occurrence: usize,
-) -> Option<(String, usize)> {
-    let content = std::fs::read_to_string(path).ok()?;
-    let lines = content.lines().collect::<Vec<_>>();
-    let leaf = symbol
-        .rsplit("::")
-        .next()
-        .unwrap_or(symbol)
-        .rsplit('.')
-        .next()
-        .unwrap_or(symbol);
-    let start = lines
-        .iter()
-        .enumerate()
-        .filter_map(|(idx, line)| symbol_line_matches(line.trim_start(), leaf, kind).then_some(idx))
-        .nth(occurrence)?;
-    let end = symbol_block_end(&lines, start);
-
-    Some((lines[start..=end].join("\n"), start + 1))
-}
-
-fn symbol_line_matches(line: &str, name: &str, kind: Option<&str>) -> bool {
-    let function = || {
-        line.contains(&format!("fn {name}"))
-            || line.contains(&format!("function {name}"))
-            || line.starts_with(&format!("def {name}"))
-            || line.starts_with(&format!("async def {name}"))
-            || line.starts_with(&format!("{name}("))
-            || line.contains(&format!(" {name}("))
-    };
-    let matches = |keyword| line.contains(&format!("{keyword} {name}"));
-    match kind.unwrap_or("any") {
-        "function" | "method" | "test" => function(),
-        "struct" => matches("struct"),
-        "enum" => matches("enum"),
-        "trait" => matches("trait"),
-        "class" => matches("class"),
-        "type" => matches("type"),
-        "const" => matches("const"),
-        "impl" => matches("impl"),
-        "module" => matches("mod") || matches("module"),
-        _ => {
-            function()
-                || matches("struct")
-                || matches("enum")
-                || matches("trait")
-                || matches("class")
-                || matches("type")
-                || matches("const")
-                || matches("impl")
-                || matches("mod")
-                || matches("module")
-        }
-    }
-}
-
-fn symbol_block_end(lines: &[&str], start: usize) -> usize {
-    if lines[start].contains(';') && !lines[start].contains('{') {
-        return start;
-    }
-
-    let mut seen_brace = false;
-    let mut balance = 0isize;
-    for (idx, line) in lines.iter().enumerate().skip(start) {
-        for ch in line.chars() {
-            match ch {
-                '{' => {
-                    seen_brace = true;
-                    balance += 1;
-                }
-                '}' if seen_brace => {
-                    balance -= 1;
-                    if balance <= 0 {
-                        return idx;
-                    }
-                }
-                _ => {}
-            }
-        }
-    }
-
-    if seen_brace {
-        lines.len().saturating_sub(1)
-    } else {
-        start
     }
 }
 
@@ -666,19 +501,6 @@ fn truncate_summary(value: &str, max_chars: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[allow(dead_code)]
-    mod replace_symbol_preview_fixtures {
-        fn target() -> &'static str {
-            "first"
-        }
-
-        mod nested {
-            fn target() -> &'static str {
-                "second"
-            }
-        }
-    }
 
     #[test]
     fn delegate_tool_shows_agent_and_objective() {
@@ -1085,97 +907,7 @@ mod tests {
     }
 
     #[test]
-    fn replace_symbol_builds_semantic_preview_sections() {
-        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("src/tool_detail.rs")
-            .display()
-            .to_string();
-        let detail = parse_tool_detail(
-            "replace_symbol",
-            Some(&serde_json::json!({
-                "replacements": [{
-                    "path": path,
-                    "symbol": "parse_tool_detail",
-                    "kind": "function",
-                    "newText": "fn replacement() {}"
-                }]
-            })),
-            None,
-        );
-
-        match detail {
-            ToolDetail::ReplaceSymbol { title, sections } => {
-                assert_eq!(title, "src/tool_detail.rs");
-                assert_eq!(sections.len(), 1);
-                assert!(sections[0].header.contains("parse_tool_detail"));
-                assert!(sections[0].old.contains("fn parse_tool_detail"));
-                assert_eq!(sections[0].new, "fn replacement() {}");
-                assert!(sections[0].start_line.is_some());
-            }
-            other => panic!("expected ReplaceSymbol, got: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn replace_symbol_supports_snake_case_root_occurrence_and_qualified_leaf() {
-        let cwd = Path::new(env!("CARGO_MANIFEST_DIR"));
-        let detail = parse_tool_detail(
-            "replace_symbol",
-            Some(&serde_json::json!({
-                "root": ".",
-                "replacements": [{
-                    "path": "src/tool_detail.rs",
-                    "symbol": "replace_symbol_preview_fixtures::nested::target",
-                    "kind": "function",
-                    "occurrence": 1,
-                    "new_text": "fn target() -> &'static str { \"replacement\" }"
-                }]
-            })),
-            cwd.to_str(),
-        );
-
-        match detail {
-            ToolDetail::ReplaceSymbol { title, sections } => {
-                assert_eq!(title, "src/tool_detail.rs");
-                assert_eq!(sections.len(), 1);
-                assert_eq!(
-                    sections[0].header,
-                    "replace_symbol_preview_fixtures::nested::target (function)"
-                );
-                assert!(sections[0].old.contains("\"second\""));
-                assert_eq!(
-                    sections[0].new,
-                    "fn target() -> &'static str { \"replacement\" }"
-                );
-                assert!(sections[0].start_line.is_some());
-            }
-            other => panic!("expected ReplaceSymbol, got: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn replace_symbol_preview_path_resolution_uses_root_and_cwd_once() {
-        let cwd = Path::new(env!("CARGO_MANIFEST_DIR"));
-        let cwd_str = cwd.to_str().unwrap();
-        let relative_path = "src/tool_detail.rs";
-        let expected = cwd.join(relative_path);
-
-        assert_eq!(
-            resolve_preview_path(relative_path, Some(cwd_str), Some(cwd_str)),
-            expected
-        );
-        assert_eq!(
-            resolve_preview_path(relative_path, Some("."), Some(cwd_str)),
-            expected
-        );
-        assert_eq!(
-            resolve_preview_path(expected.to_str().unwrap(), Some("ignored"), Some(cwd_str)),
-            expected
-        );
-        assert_eq!(
-            resolve_preview_path(relative_path, None, Some("relative-cwd")),
-            Path::new("relative-cwd").join(relative_path)
-        );
+    fn strip_cwd_requires_a_path_component_boundary() {
         assert_eq!(
             strip_cwd("/workspace-other/src/lib.rs", Some("/workspace")),
             "/workspace-other/src/lib.rs"
@@ -1183,14 +915,7 @@ mod tests {
     }
 
     #[test]
-    fn symbol_preview_without_braces_does_not_consume_the_rest_of_the_file() {
-        let lines = ["const VALUE: usize = 1;", "fn unrelated() {}"];
-
-        assert_eq!(symbol_block_end(&lines, 0), 0);
-    }
-
-    #[test]
-    fn replace_symbol_uses_path_title_and_sections_without_preview_files() {
+    fn replace_symbol_uses_multi_path_summary() {
         let detail = parse_tool_detail(
             "replace_symbol",
             Some(&serde_json::json!({
@@ -1210,17 +935,10 @@ mod tests {
             Some("/workspace"),
         );
 
-        match detail {
-            ToolDetail::ReplaceSymbol { title, sections } => {
-                assert_eq!(title, "src/one.rs (+1)");
-                assert_eq!(sections.len(), 2);
-                assert_eq!(sections[0].old, "");
-                assert_eq!(sections[0].start_line, None);
-                assert_eq!(sections[1].old, "");
-                assert_eq!(sections[1].start_line, None);
-            }
-            other => panic!("expected ReplaceSymbol, got: {other:?}"),
-        }
+        assert!(matches!(
+            detail,
+            ToolDetail::Summary(summary) if summary == "src/one.rs (+1)"
+        ));
     }
 
     #[test]

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -8,8 +8,9 @@ use ratatui::{
     widgets::{Block, List, ListItem, ListState, Padding, Paragraph, Wrap},
 };
 
-use crate::app::{App, ChatEntry, DiffPreviewSection, ShellOutputTail, ToolDetail};
+use crate::app::{App, ChatEntry};
 use crate::domain::activity::{ActivityState, DelegateEntry, DelegateStatus, SessionOp};
+use crate::domain::tool::{DiffPreviewSection, ShellOutputTail, ToolDetail};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::markdown;
@@ -404,42 +405,40 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                 let tool_style = style;
                 match detail {
                     ToolDetail::Edit {
-                        file, cached_lines, ..
+                        file,
+                        old,
+                        new,
+                        start_line,
                     } => {
                         pending_tools.push(Line::from(vec![
                             Span::styled(format!("{sym} {name} "), style),
                             Span::styled(short_path(file).to_string(), Theme::diff_file()),
                         ]));
-                        pending_tools.extend(cached_lines.iter().cloned());
+                        pending_tools.extend(build_diff_lines(old, new, *start_line));
                     }
                     ToolDetail::MultiEdit {
                         file,
                         edit_count,
-                        cached_lines,
-                        ..
+                        sections,
                     } => {
                         pending_tools.push(Line::from(vec![
                             Span::styled(format!("{sym} {name} "), style),
                             Span::styled(short_path(file).to_string(), Theme::diff_file()),
                             Span::styled(format!(" ({edit_count} edits)"), Theme::status_accent()),
                         ]));
-                        pending_tools.extend(cached_lines.iter().cloned());
+                        pending_tools.extend(build_sectioned_diff_lines(sections, 6));
                     }
-                    ToolDetail::ReplaceSymbol {
-                        title,
-                        cached_lines,
-                        ..
-                    } => {
+                    ToolDetail::ReplaceSymbol { title, sections } => {
                         pending_tools.push(Line::from(vec![
                             Span::styled(format!("{sym} {name} "), style),
                             Span::styled(title.clone(), Theme::diff_file()),
                         ]));
-                        pending_tools.extend(cached_lines.iter().cloned());
+                        pending_tools.extend(build_sectioned_diff_lines(sections, 4));
                     }
                     ToolDetail::Shell {
+                        command,
                         workdir,
-                        cached_lines,
-                        ..
+                        output_tail,
                     } => {
                         let mut spans = vec![Span::styled(format!("{sym} {name}"), style)];
                         if let Some(workdir) = workdir.as_deref().filter(|s| !s.trim().is_empty()) {
@@ -447,7 +446,11 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                             spans.push(Span::styled(workdir.to_string(), Theme::diff_file()));
                         }
                         pending_tools.push(Line::from(spans));
-                        pending_tools.extend(cached_lines.iter().cloned());
+                        pending_tools.extend(build_shell_lines(
+                            command,
+                            workdir.as_deref(),
+                            output_tail.as_ref(),
+                        ));
                     }
                     ToolDetail::ReadTool {
                         path,
@@ -468,14 +471,12 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                         }
                         pending_tools.push(Line::from(spans));
                     }
-                    ToolDetail::WriteFile {
-                        path, cached_lines, ..
-                    } => {
+                    ToolDetail::WriteFile { path, content } => {
                         pending_tools.push(Line::from(vec![
                             Span::styled(format!("{sym} {name} "), style),
                             Span::styled(short_path(path).to_string(), Theme::diff_file()),
                         ]));
-                        pending_tools.extend(cached_lines.iter().cloned());
+                        pending_tools.extend(build_write_lines(content));
                     }
                     ToolDetail::SummaryWithOutput { header, output } => {
                         pending_tools.push(Line::from(vec![

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2795,6 +2795,102 @@ mod tests {
     }
 
     #[test]
+    fn warm_shell_tool_card_rebuilds_with_output_tail_after_native_end_update() {
+        let mut app = App::new();
+        app.session_id = Some("test-session".into());
+        live_update(
+            &mut app,
+            "test-session",
+            AcpSessionUpdate::ToolCallStart {
+                tool_call_id: Some("shell-warm-cache".into()),
+                name: "shell".into(),
+                arguments: Some(serde_json::json!({ "command": "cargo test" })),
+            },
+        );
+
+        let warm_lines = rendered_card_lines(&mut app);
+        assert!(warm_lines.iter().any(|line| line.contains("$ cargo test")));
+        assert!(!warm_lines.iter().any(|line| line.contains("tail sentinel")));
+        assert_eq!(app.card_cache.processed_messages, app.messages.len());
+
+        live_update(
+            &mut app,
+            "test-session",
+            AcpSessionUpdate::ToolCallEnd {
+                tool_call_id: Some("shell-warm-cache".into()),
+                name: "shell".into(),
+                is_error: false,
+                result: Some("tail sentinel".into()),
+            },
+        );
+
+        assert_eq!(app.messages.len(), 1, "tool detail update should be in place");
+        assert_eq!(
+            app.card_cache.processed_messages, 0,
+            "semantic update should invalidate the warm card"
+        );
+        let rebuilt_lines = rendered_card_lines(&mut app);
+        assert!(rebuilt_lines.iter().any(|line| line.contains("output tail:")));
+        assert!(
+            rebuilt_lines
+                .iter()
+                .any(|line| line.contains("tail sentinel")),
+            "rebuilt card returned stale shell detail: {rebuilt_lines:?}"
+        );
+    }
+
+    #[test]
+    fn warm_edit_tool_card_rebuilds_with_start_line_after_native_end_update() {
+        let mut app = App::new();
+        app.session_id = Some("test-session".into());
+        live_update(
+            &mut app,
+            "test-session",
+            AcpSessionUpdate::ToolCallStart {
+                tool_call_id: Some("edit-warm-cache".into()),
+                name: "edit".into(),
+                arguments: Some(serde_json::json!({
+                    "filePath": "src/lib.rs",
+                    "oldString": "before\n",
+                    "newString": "after\n"
+                })),
+            },
+        );
+
+        let warm_lines = rendered_card_lines(&mut app);
+        assert!(
+            warm_lines
+                .iter()
+                .any(|line| line.contains("  1 ") && line.contains("- before"))
+        );
+        assert_eq!(app.card_cache.processed_messages, app.messages.len());
+
+        live_update(
+            &mut app,
+            "test-session",
+            AcpSessionUpdate::ToolCallEnd {
+                tool_call_id: Some("edit-warm-cache".into()),
+                name: "edit".into(),
+                is_error: false,
+                result: Some(r#"{"startLineOld":42}"#.into()),
+            },
+        );
+
+        assert_eq!(app.messages.len(), 1, "tool detail update should be in place");
+        assert_eq!(
+            app.card_cache.processed_messages, 0,
+            "semantic update should invalidate the warm card"
+        );
+        let rebuilt_lines = rendered_card_lines(&mut app);
+        assert!(
+            rebuilt_lines
+                .iter()
+                .any(|line| line.contains("  42 ") && line.contains("- before")),
+            "rebuilt card returned stale edit detail: {rebuilt_lines:?}"
+        );
+    }
+
+    #[test]
     fn failed_tool_end_before_start_reconciles_badge_without_stale_bottom_entry() {
         let mut app = App::new();
         app.session_id = Some("test-session".into());

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,9 +2,7 @@ mod chat;
 mod popups;
 mod start;
 
-pub(crate) use chat::{
-    CardCache, build_diff_lines, build_sectioned_diff_lines, build_shell_lines, build_write_lines,
-};
+pub(crate) use chat::CardCache;
 use chat::{draw_chat, draw_delegate_view};
 use popups::{
     draw_auth_popup, draw_command_palette_popup, draw_fork_turn_popup, draw_help_popup,
@@ -473,7 +471,8 @@ fn draw_header(
 mod tests {
     use super::*;
     use crate::acp_state::{AcpAppEvent, AcpSessionUpdate};
-    use crate::app::{App, ChatEntry, DiffPreviewSection, Screen, ShellOutputTail, ToolDetail};
+    use crate::app::{App, ChatEntry, Screen};
+    use crate::domain::tool::{DiffPreviewSection, ShellOutputTail, ToolDetail};
     use ratatui::backend::Backend;
     use ratatui::layout::Position;
     use ratatui::widgets::ListItem;
@@ -1364,7 +1363,7 @@ mod tests {
 
     #[test]
     fn delegate_tool_call_label_uses_accent_color() {
-        use crate::app::{ChatEntry, DelegateEntry, DelegateStats, DelegateStatus, ToolDetail};
+        use crate::app::{ChatEntry, DelegateEntry, DelegateStats, DelegateStatus};
         use crate::theme::Theme;
 
         let mut app = App::new();
@@ -1503,7 +1502,7 @@ mod tests {
     #[test]
     fn delegate_tool_call_shows_awaiting_input_marker() {
         use crate::app::{
-            ChatEntry, DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus, ToolDetail,
+            ChatEntry, DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus,
         };
 
         let mut app = App::new();
@@ -3121,41 +3120,6 @@ mod tests {
     }
 
     #[test]
-    fn tool_detail_edit_carries_precomputed_diff_lines() {
-        let detail = ToolDetail::Edit {
-            file: "src/main.rs".into(),
-            old: "hello".into(),
-            new: "world".into(),
-            start_line: None,
-            cached_lines: build_diff_lines("hello", "world", None),
-        };
-        match &detail {
-            ToolDetail::Edit { cached_lines, .. } => {
-                assert!(
-                    !cached_lines.is_empty(),
-                    "diff lines should be pre-computed"
-                );
-            }
-            _ => panic!("expected Edit"),
-        }
-    }
-
-    #[test]
-    fn tool_detail_write_carries_precomputed_lines() {
-        let detail = ToolDetail::WriteFile {
-            path: "out.txt".into(),
-            content: "line1\nline2\n".into(),
-            cached_lines: build_write_lines("line1\nline2\n"),
-        };
-        match &detail {
-            ToolDetail::WriteFile { cached_lines, .. } => {
-                assert_eq!(cached_lines.len(), 2);
-            }
-            _ => panic!("expected WriteFile"),
-        }
-    }
-
-    #[test]
     fn message_cards_edit_tool_includes_diff_lines() {
         let mut app = App::new();
         let old = "aaa\nbbb\n";
@@ -3169,7 +3133,6 @@ mod tests {
                 old: old.into(),
                 new: new.into(),
                 start_line: Some(1),
-                cached_lines: build_diff_lines(old, new, Some(1)),
             },
         });
 
@@ -3194,7 +3157,6 @@ mod tests {
             detail: ToolDetail::WriteFile {
                 path: "out.rs".into(),
                 content: content.into(),
-                cached_lines: build_write_lines(content),
             },
         });
 
@@ -3228,7 +3190,6 @@ mod tests {
             detail: ToolDetail::MultiEdit {
                 file: "src/lib.rs".into(),
                 edit_count: sections.len(),
-                cached_lines: build_sectioned_diff_lines(&sections, 6),
                 sections,
             },
         });
@@ -3288,7 +3249,6 @@ mod tests {
             is_error: false,
             detail: ToolDetail::ReplaceSymbol {
                 title: "src/ui/chat.rs build_message_cards".into(),
-                cached_lines: build_sectioned_diff_lines(&sections, 4),
                 sections,
             },
         });
@@ -3356,8 +3316,7 @@ mod tests {
             detail: ToolDetail::Shell {
                 command: command.into(),
                 workdir: Some("/repo".into()),
-                output_tail: Some(output_tail.clone()),
-                cached_lines: build_shell_lines(command, Some("/repo"), Some(&output_tail)),
+                output_tail: Some(output_tail),
             },
         });
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2824,13 +2824,21 @@ mod tests {
             },
         );
 
-        assert_eq!(app.messages.len(), 1, "tool detail update should be in place");
+        assert_eq!(
+            app.messages.len(),
+            1,
+            "tool detail update should be in place"
+        );
         assert_eq!(
             app.card_cache.processed_messages, 0,
             "semantic update should invalidate the warm card"
         );
         let rebuilt_lines = rendered_card_lines(&mut app);
-        assert!(rebuilt_lines.iter().any(|line| line.contains("output tail:")));
+        assert!(
+            rebuilt_lines
+                .iter()
+                .any(|line| line.contains("output tail:"))
+        );
         assert!(
             rebuilt_lines
                 .iter()
@@ -2876,7 +2884,11 @@ mod tests {
             },
         );
 
-        assert_eq!(app.messages.len(), 1, "tool detail update should be in place");
+        assert_eq!(
+            app.messages.len(),
+            1,
+            "tool detail update should be in place"
+        );
         assert_eq!(
             app.card_cache.processed_messages, 0,
             "semantic update should invalidate the warm card"


### PR DESCRIPTION
## summary
- extract semantic tool detail types into `src/domain/tool.rs`
- remove ui render caches from domain `ToolDetail` variants and render previews on demand in `src/ui/chat.rs`
- keep `ChatEntry` in `src/app.rs` for this slice while switching callers to `crate::domain::tool::ToolDetail`
- simplify theme cache invalidation in `src/handlers.rs` and validate rebuild behavior through runtime/ui tests
- keep `replace_symbol` semantic by storing preview sections instead of cached ratatui lines

## changed files
- `src/acp_state.rs`
- `src/app.rs`
- `src/domain.rs`
- `src/domain/tool.rs`
- `src/handlers.rs`
- `src/runtime/mod.rs`
- `src/tool_detail.rs`
- `src/ui/chat.rs`
- `src/ui/mod.rs`

## validation
- `cargo fmt --all -- --check` ✅
- `cargo check --all-targets` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --all-targets` ✅ (`720` tests passed)
- `git diff --check` ✅
- searched `src/domain` for forbidden imports (`ratatui`, `crate::ui`, `crate::runtime`, `tokio::sync::mpsc`) ✅
- searched for forbidden legacy symbols (`server_msg`, `RawServerMsg`, `handle_server_msg`) ✅

## notes
- pr base is `refactor/components`
- `main` remains untouched
- local untracked `AGENTS.md` and `CLAUDE.md` were left unstaged and uncommitted
