### PR TITLE
refactor: extract chat domain entries

### DIFF
--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -5,10 +5,11 @@ use serde_json::Value;
 use crate::acp_client::{
     DelegateModelOverrideInfo, DelegationUpdateNotification, DelegationUpdateState,
 };
-use crate::app::{ChatEntry, LogLevel, POPUP_SESSION_PAGE_TARGET, Popup, Screen};
+use crate::app::{LogLevel, POPUP_SESSION_PAGE_TARGET, Popup, Screen};
 use crate::domain::activity::{
     ActivityState, DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus,
 };
+use crate::domain::chat::ChatEntry;
 use crate::domain::elicitation::ElicitationState;
 use crate::domain::session::{SessionGroup, SessionSummary, UndoableTurn};
 use crate::domain::tool::ToolDetail;
@@ -2077,7 +2078,7 @@ fn acp_content_to_string(value: &Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::{App, ChatEntry, Screen};
+    use crate::app::{App, Screen};
     use crate::domain::session::UndoState;
     use crate::protocol::DelegateModelPreference;
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,6 +9,7 @@ pub(crate) use crate::domain::activity::{
     ActivityState, DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus,
     PendingDelegateToolCall, SessionActivity, SessionOp, SessionStatsLite,
 };
+use crate::domain::chat::{ChatEntry, format_outcome_labels};
 #[allow(unused_imports)]
 pub(crate) use crate::domain::elicitation::{
     ElicitationField, ElicitationFieldKind, ElicitationOption, ElicitationState,
@@ -17,12 +18,11 @@ use crate::domain::session::{
     ForkBoundaryKind, ForkTurnItem, SessionGroup, UndoFrame, UndoFrameStatus, UndoState,
     UndoableTurn,
 };
-use crate::domain::tool::ToolDetail;
 use crate::highlight::Highlighter;
 use crate::markdown::CardBlock;
 use crate::mesh::{MeshFocus, MeshInviteFormField};
 use crate::protocol::*;
-use crate::ui::{CardCache, ElicitationUiState, OUTCOME_BULLET};
+use crate::ui::{CardCache, ElicitationUiState};
 
 /// Cache for rendered streaming markdown to avoid re-parsing every frame.
 /// Invalidated when `streaming_content` grows or is cleared.
@@ -359,46 +359,6 @@ pub(crate) fn update_delegate_child_state(state: &mut DelegateChildState, kind: 
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum ChatEntry {
-    User {
-        text: String,
-        message_id: Option<String>,
-    },
-    Assistant {
-        content: String,
-        thinking: Option<String>,
-        message_id: Option<String>,
-    },
-    Thinking {
-        content: String,
-        message_id: Option<String>,
-    },
-    ToolCall {
-        tool_call_id: Option<String>,
-        name: String,
-        is_error: bool,
-        detail: ToolDetail,
-    },
-    CompactionStart {
-        token_estimate: u32,
-    },
-    CompactionEnd {
-        token_estimate: Option<u32>,
-        summary: String,
-        summary_len: u32,
-    },
-    Info(String),
-    Error(String),
-    Elicitation {
-        elicitation_id: String,
-        message: String,
-        source: String,
-        /// None = pending; Some = responded with this outcome label.
-        outcome: Option<String>,
-    },
-}
-
 pub(crate) fn backfill_elicitation_outcomes(messages: &mut [ChatEntry], result_str: &str) {
     let Ok(val) = serde_json::from_str::<serde_json::Value>(result_str) else {
         return;
@@ -418,17 +378,13 @@ pub(crate) fn backfill_elicitation_outcomes(messages: &mut [ChatEntry], result_s
         let Some(answer_entry) = answer_iter.next() else {
             break;
         };
-        let labels: Vec<String> = answer_entry
+        let labels = answer_entry
             .get("answers")
             .and_then(|a| a.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str())
-                    .map(|s| format!("{OUTCOME_BULLET}{s}"))
-                    .collect()
-            })
-            .unwrap_or_default();
-        *outcome = Some(labels.join("\n"));
+            .map(|answers| answers.iter().filter_map(|answer| answer.as_str()))
+            .into_iter()
+            .flatten();
+        *outcome = Some(format_outcome_labels(labels));
     }
 }
 
@@ -2891,6 +2847,7 @@ mod session_mode_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::chat::OUTCOME_BULLET;
 
     fn make_turn(message_id: &str) -> UndoableTurn {
         UndoableTurn {

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -1,4 +1,5 @@
 pub(crate) mod activity;
+pub(crate) mod chat;
 pub(crate) mod elicitation;
 pub(crate) mod session;
 pub(crate) mod tool;

--- a/src/domain/chat.rs
+++ b/src/domain/chat.rs
@@ -1,0 +1,91 @@
+use crate::domain::tool::ToolDetail;
+
+pub const OUTCOME_BULLET: &str = "\u{25B8} ";
+
+#[derive(Debug, Clone)]
+pub enum ChatEntry {
+    User {
+        text: String,
+        message_id: Option<String>,
+    },
+    Assistant {
+        content: String,
+        thinking: Option<String>,
+        message_id: Option<String>,
+    },
+    Thinking {
+        content: String,
+        message_id: Option<String>,
+    },
+    ToolCall {
+        tool_call_id: Option<String>,
+        name: String,
+        is_error: bool,
+        detail: ToolDetail,
+    },
+    CompactionStart {
+        token_estimate: u32,
+    },
+    CompactionEnd {
+        token_estimate: Option<u32>,
+        summary: String,
+        summary_len: u32,
+    },
+    Info(String),
+    Error(String),
+    Elicitation {
+        elicitation_id: String,
+        message: String,
+        source: String,
+        /// None = pending; Some = responded with this outcome label.
+        outcome: Option<String>,
+    },
+}
+
+pub fn format_outcome_label(label: &str) -> String {
+    let mut formatted = String::with_capacity(OUTCOME_BULLET.len() + label.len());
+    formatted.push_str(OUTCOME_BULLET);
+    formatted.push_str(label);
+    formatted
+}
+
+pub fn format_outcome_labels<'a>(labels: impl IntoIterator<Item = &'a str>) -> String {
+    let mut labels = labels.into_iter();
+    let Some(first) = labels.next() else {
+        return String::new();
+    };
+
+    let mut formatted = format_outcome_label(first);
+    for label in labels {
+        formatted.push('\n');
+        formatted.push_str(OUTCOME_BULLET);
+        formatted.push_str(label);
+    }
+    formatted
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OUTCOME_BULLET, format_outcome_label, format_outcome_labels};
+
+    #[test]
+    fn format_outcome_label_prefixes_single_label() {
+        assert_eq!(
+            format_outcome_label("Beta"),
+            format!("{OUTCOME_BULLET}Beta")
+        );
+    }
+
+    #[test]
+    fn format_outcome_labels_joins_multiple_labels_with_newlines() {
+        assert_eq!(
+            format_outcome_labels(["Alpha", "Beta", "Gamma"]),
+            format!("{OUTCOME_BULLET}Alpha\n{OUTCOME_BULLET}Beta\n{OUTCOME_BULLET}Gamma"),
+        );
+    }
+
+    #[test]
+    fn format_outcome_labels_returns_empty_for_no_labels() {
+        assert!(format_outcome_labels(std::iter::empty()).is_empty());
+    }
+}

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -3,6 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::app::{self, App, CommandPaletteAction, LogLevel, Popup, Screen};
 use crate::domain::activity::{ActivityState, SessionOp};
+use crate::domain::chat::{ChatEntry, format_outcome_labels};
 
 fn popup_page_step(visible_rows: usize) -> usize {
     visible_rows.saturating_sub(1).max(1)
@@ -40,7 +41,6 @@ pub(crate) fn handle_elicitation_key(
     cmd_tx: &mpsc::UnboundedSender<ClientMsg>,
 ) -> anyhow::Result<()> {
     use crate::domain::elicitation::ElicitationFieldKind;
-    use crate::ui::OUTCOME_BULLET;
 
     let (Some(state), Some(ui)) = (app.elicitation.as_mut(), app.elicitation_ui.as_mut()) else {
         return Ok(());
@@ -53,25 +53,25 @@ pub(crate) fn handle_elicitation_key(
                             custom_active: bool| {
         let field = &state.fields[field_index];
         if custom_active {
-            return format!("{OUTCOME_BULLET}{}", state.custom_input.trim());
+            return format_outcome_labels([state.custom_input.trim()]);
         }
         match &field.kind {
             ElicitationFieldKind::SingleSelect { options } => options
                 .iter()
                 .find(|option| state.selected.get(&field.name) == Some(&option.value))
-                .map(|option| format!("{OUTCOME_BULLET}{}", option.label))
+                .map(|option| format_outcome_labels([option.label.as_str()]))
                 .unwrap_or_default(),
             ElicitationFieldKind::MultiSelect { options } => state
                 .selected
                 .get(&field.name)
                 .and_then(serde_json::Value::as_array)
                 .map(|values| {
-                    options
-                        .iter()
-                        .filter(|option| values.contains(&option.value))
-                        .map(|option| format!("{OUTCOME_BULLET}{}", option.label))
-                        .collect::<Vec<_>>()
-                        .join("\n")
+                    format_outcome_labels(
+                        options
+                            .iter()
+                            .filter(|option| values.contains(&option.value))
+                            .map(|option| option.label.as_str()),
+                    )
                 })
                 .unwrap_or_default(),
             ElicitationFieldKind::TextInput | ElicitationFieldKind::NumberInput { .. } => {
@@ -1729,7 +1729,7 @@ pub(crate) fn handle_chat_key(
                     app.messages.retain(|entry| {
                         !matches!(
                             entry,
-                            crate::app::ChatEntry::User {
+                            ChatEntry::User {
                                 message_id: Some(message_id),
                                 ..
                             } if message_id == &local_id

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -36,12 +36,10 @@ pub(crate) enum ServerChannelMsg {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::{
-        ChatEntry, ElicitationField, ElicitationFieldKind, ElicitationOption, ElicitationState,
-    };
+    use crate::app::{ElicitationField, ElicitationFieldKind, ElicitationOption, ElicitationState};
+    use crate::domain::chat::{ChatEntry, OUTCOME_BULLET};
     use crate::domain::tool::ToolDetail;
     use crate::handlers::*;
-    use crate::ui::OUTCOME_BULLET;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use tokio::sync::mpsc;
 
@@ -481,8 +479,9 @@ mod tests {
 #[cfg(test)]
 mod external_editor_tests {
     use super::*;
-    use crate::app::{ActivityState, App, ChatEntry};
+    use crate::app::{ActivityState, App};
     use crate::config::{AcpConfig, TestPersistenceGuard, TuiConfig};
+    use crate::domain::chat::ChatEntry;
     use crate::handlers::*;
     use crate::protocol::PromptBlock;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -1097,16 +1096,16 @@ mod external_editor_tests {
         app.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
         app.messages = vec![
-            app::ChatEntry::User {
+            ChatEntry::User {
                 text: "alpha prompt".into(),
                 message_id: Some("user-1".into()),
             },
-            app::ChatEntry::Assistant {
+            ChatEntry::Assistant {
                 content: "alpha reply".into(),
                 thinking: None,
                 message_id: Some("asst-1".into()),
             },
-            app::ChatEntry::User {
+            ChatEntry::User {
                 text: "beta prompt".into(),
                 message_id: Some("user-2".into()),
             },

--- a/src/tool_detail.rs
+++ b/src/tool_detail.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use serde_json::Value;
 
-use crate::app::ChatEntry;
+use crate::domain::chat::ChatEntry;
 use crate::domain::tool::{DiffPreviewSection, ShellOutputTail, ToolDetail};
 
 const DEFAULT_READ_TOOL_LIMIT: u64 = 2000;

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -8,8 +8,9 @@ use ratatui::{
     widgets::{Block, List, ListItem, ListState, Padding, Paragraph, Wrap},
 };
 
-use crate::app::{App, ChatEntry};
+use crate::app::App;
 use crate::domain::activity::{ActivityState, DelegateEntry, DelegateStatus, SessionOp};
+use crate::domain::chat::{ChatEntry, OUTCOME_BULLET};
 use crate::domain::tool::{DiffPreviewSection, ShellOutputTail, ToolDetail};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -17,9 +18,7 @@ use crate::markdown;
 use crate::theme::Theme;
 
 use super::start::short_cwd;
-use super::{
-    INPUT_OVERLINE, InputVisualLayout, OUTCOME_BULLET, build_input_visual_layout, draw_header,
-};
+use super::{INPUT_OVERLINE, InputVisualLayout, build_input_visual_layout, draw_header};
 
 // ── Spinner ───────────────────────────────────────────────────────────────────
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -281,7 +281,6 @@ pub(crate) fn build_input_visual_layout(
 }
 
 // ── Symbols shared across sub-modules ──────────────────────────────────────────
-pub(crate) const OUTCOME_BULLET: &str = "\u{25B8} "; // ▸ prefix for each selected option in resolved card
 pub(super) const COLOR_SWATCH: &str = "\u{25A0}"; // ■ black square  – theme palette colour preview
 pub(crate) const ELLIPSIS: &str = "\u{2026}"; // … horizontal ellipsis – truncation marker
 pub(super) const ARROW_UP: &str = "\u{2191}"; // ↑ upwards arrow
@@ -471,7 +470,8 @@ fn draw_header(
 mod tests {
     use super::*;
     use crate::acp_state::{AcpAppEvent, AcpSessionUpdate};
-    use crate::app::{App, ChatEntry, Screen};
+    use crate::app::{App, Screen};
+    use crate::domain::chat::ChatEntry;
     use crate::domain::tool::{DiffPreviewSection, ShellOutputTail, ToolDetail};
     use ratatui::backend::Backend;
     use ratatui::layout::Position;
@@ -1363,7 +1363,7 @@ mod tests {
 
     #[test]
     fn delegate_tool_call_label_uses_accent_color() {
-        use crate::app::{ChatEntry, DelegateEntry, DelegateStats, DelegateStatus};
+        use crate::app::{DelegateEntry, DelegateStats, DelegateStatus};
         use crate::theme::Theme;
 
         let mut app = App::new();
@@ -1501,9 +1501,7 @@ mod tests {
 
     #[test]
     fn delegate_tool_call_shows_awaiting_input_marker() {
-        use crate::app::{
-            ChatEntry, DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus,
-        };
+        use crate::app::{DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus};
 
         let mut app = App::new();
         app.screen = Screen::Chat;


### PR DESCRIPTION
## summary
- move the semantic `ChatEntry` enum from app ownership into `domain::chat`
- move elicitation outcome bullet formatting into chat-domain helpers
- update app, ACP state, handlers, runtime tests, tool reconciliation, and UI to import `ChatEntry` directly from the domain
- keep streaming render caches and legacy elicitation-result parsing in the app/UI layers

## validation
- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets` (723 passed)
- `git diff --check`
- verified no `crate::app::ChatEntry` or `app::ChatEntry` remains
- verified no `crate::ui::OUTCOME_BULLET` remains
- verified `src/domain` has no rendering, runtime, terminal, protocol, transport, or tokio dependencies
- verified no `server_msg`, `RawServerMsg`, or `handle_server_msg` remains