### PR TITLE
refactor: extract model and profile domain types

### DIFF
--- a/src/acp_client.rs
+++ b/src/acp_client.rs
@@ -19,11 +19,13 @@ use tokio_tungstenite::{connect_async, tungstenite::Message};
 
 use crate::ServerChannelMsg;
 use crate::acp_state::{AcpAppEvent, AcpModelsMetaInfo, AcpSessionUpdate};
+use crate::domain::model::ModelEntry;
+use crate::domain::profile::{AgentInfo, ProfileInfo};
 use crate::protocol::{
-    AgentInfo, AuthProvidersData, ClientMsg, ForkResultData, MeshInviteCreatedInfo, MeshNodesInfo,
-    MeshStatusInfo, OAuthFlowData, OAuthResultData, ProfileInfo, RedoResultData,
-    RemoteSessionAttachInfo, RemoteSessionListInfo, SessionGroup, SessionListRequest,
-    SessionSummary, UndoResultData, UndoStackFrame,
+    AuthProvidersData, ClientMsg, ForkResultData, MeshInviteCreatedInfo, MeshNodesInfo,
+    MeshStatusInfo, OAuthFlowData, OAuthResultData, RedoResultData, RemoteSessionAttachInfo,
+    RemoteSessionListInfo, SessionGroup, SessionListRequest, SessionSummary, UndoResultData,
+    UndoStackFrame,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -66,8 +68,8 @@ struct AcpModelEntry {
 }
 
 impl AcpModelEntry {
-    fn to_app_model(&self) -> crate::protocol::ModelEntry {
-        crate::protocol::ModelEntry {
+    fn to_app_model(&self) -> ModelEntry {
+        ModelEntry {
             id: self.id.clone(),
             label: self.label.clone(),
             provider: self.provider.clone(),

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -11,13 +11,14 @@ use crate::domain::activity::{
 };
 use crate::domain::chat::ChatEntry;
 use crate::domain::elicitation::ElicitationState;
+use crate::domain::model::ModelEntry;
+use crate::domain::profile::{AgentInfo, ProfileInfo};
 use crate::domain::session::{SessionGroup, SessionSummary, UndoableTurn};
 use crate::domain::tool::ToolDetail;
 use crate::protocol::{
-    AgentInfo, AuthProviderEntry, ClientMsg, ForkResultData, MeshInviteCreatedInfo, MeshNodesInfo,
-    MeshStatusInfo, ModelEntry, OAuthFlowData, OAuthResultData, ProfileInfo, RedoResultData,
-    RemoteSessionAttachInfo, RemoteSessionListInfo, SessionListRequest, UndoResultData,
-    UndoStackFrame,
+    AuthProviderEntry, ClientMsg, ForkResultData, MeshInviteCreatedInfo, MeshNodesInfo,
+    MeshStatusInfo, OAuthFlowData, OAuthResultData, RedoResultData, RemoteSessionAttachInfo,
+    RemoteSessionListInfo, SessionListRequest, UndoResultData, UndoStackFrame,
 };
 use crate::tool_detail;
 
@@ -2079,8 +2080,8 @@ fn acp_content_to_string(value: &Value) -> String {
 mod tests {
     use super::*;
     use crate::app::{App, Screen};
+    use crate::domain::model::DelegateModelPreference;
     use crate::domain::session::UndoState;
-    use crate::protocol::DelegateModelPreference;
 
     const TEST_SESSION_ID: &str = "session-1";
     const TEST_ASSISTANT_ID: &str = "a1";

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,6 +14,8 @@ use crate::domain::chat::{ChatEntry, format_outcome_labels};
 pub(crate) use crate::domain::elicitation::{
     ElicitationField, ElicitationFieldKind, ElicitationOption, ElicitationState,
 };
+use crate::domain::model::{DelegateModelPreference, ModelEntry};
+use crate::domain::profile::{AgentInfo, ProfileInfo};
 use crate::domain::session::{
     ForkBoundaryKind, ForkTurnItem, SessionGroup, UndoFrame, UndoFrameStatus, UndoState,
     UndoableTurn,
@@ -660,7 +662,7 @@ pub struct App {
 
     // delegate agent model preferences
     /// Agents for `agents_profile_id`. Index zero is the primary session agent.
-    pub agents: Vec<crate::protocol::AgentInfo>,
+    pub agents: Vec<AgentInfo>,
     pub agents_profile_id: Option<String>,
     /// Currently selected tab index: zero is the session, remaining tabs are delegates.
     pub model_popup_agent_tab: usize,
@@ -4764,7 +4766,8 @@ mod popup_item_tests {
 #[cfg(test)]
 mod delegate_model_preference_tests {
     use super::*;
-    use crate::protocol::{AgentInfo, ModelEntry};
+    use crate::domain::model::ModelEntry;
+    use crate::domain::profile::AgentInfo;
 
     fn make_agent(id: &str, name: &str) -> AgentInfo {
         AgentInfo {

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ use std::sync::{Mutex, OnceLock};
 
 use serde::{Deserialize, Serialize};
 
-use crate::protocol::DelegateModelPreference;
+use crate::domain::model::DelegateModelPreference;
 
 // ── path overrides for tests ─────────────────────────────────────────────────
 
@@ -182,6 +182,7 @@ impl TuiConfig {
 mod tests {
     use super::*;
     use crate::app::App;
+    use crate::domain::model::ModelEntry;
     use serial_test::serial;
 
     fn unique_temp_dir(label: &str) -> std::path::PathBuf {
@@ -373,7 +374,7 @@ mod tests {
     fn config_round_trip_with_delegate_models() {
         let _guard = TestPathGuard::new("delegate-models-rt");
         let mut app = App::new();
-        let coder = crate::protocol::ModelEntry {
+        let coder = ModelEntry {
             id: "anthropic/claude-sonnet".into(),
             label: "Claude Sonnet".into(),
             provider: "anthropic".into(),
@@ -383,7 +384,7 @@ mod tests {
             family: None,
             quant: None,
         };
-        let planner = crate::protocol::ModelEntry {
+        let planner = ModelEntry {
             id: "openai/gpt-4o".into(),
             label: "GPT-4o".into(),
             provider: "openai".into(),

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -1,5 +1,7 @@
 pub(crate) mod activity;
 pub(crate) mod chat;
 pub(crate) mod elicitation;
+pub(crate) mod model;
+pub(crate) mod profile;
 pub(crate) mod session;
 pub(crate) mod tool;

--- a/src/domain/model.rs
+++ b/src/domain/model.rs
@@ -1,0 +1,23 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DelegateModelPreference {
+    pub model_id: String,
+    pub provider: String,
+    pub model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ModelEntry {
+    pub id: String,
+    pub label: String,
+    pub provider: String,
+    pub model: String,
+    pub node_id: Option<String>,
+    #[serde(default)]
+    pub node_label: Option<String>,
+    pub family: Option<String>,
+    pub quant: Option<String>,
+}

--- a/src/domain/profile.rs
+++ b/src/domain/profile.rs
@@ -1,0 +1,27 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ProfileInfo {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub config_kind: Option<String>,
+    #[serde(default)]
+    pub fingerprint: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AgentInfo {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+}

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -4,12 +4,13 @@ use tokio::sync::mpsc;
 use crate::app::{self, App, CommandPaletteAction, LogLevel, Popup, Screen};
 use crate::domain::activity::{ActivityState, SessionOp};
 use crate::domain::chat::{ChatEntry, format_outcome_labels};
+use crate::domain::model::ModelEntry;
 
 fn popup_page_step(visible_rows: usize) -> usize {
     visible_rows.saturating_sub(1).max(1)
 }
 use crate::config;
-use crate::protocol::{self, ClientMsg, PromptBlock};
+use crate::protocol::{ClientMsg, PromptBlock};
 use crate::theme;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2498,7 +2499,7 @@ pub(crate) fn handle_model_popup_key(
             app.model_cursor = (app.model_cursor + 1).min(max);
         }
         KeyCode::Enter => {
-            let selected: Option<protocol::ModelEntry> = app
+            let selected: Option<ModelEntry> = app
                 .visible_model_popup_items()
                 .get(app.model_cursor)
                 .and_then(|item| match item {
@@ -2764,7 +2765,9 @@ mod model_popup_tests {
     use super::*;
     use crate::app::{App, Popup};
     use crate::config::TestPersistenceGuard;
-    use crate::protocol::{ModelEntry, ProfileInfo};
+    use crate::domain::model::ModelEntry;
+    use crate::domain::profile::{AgentInfo, ProfileInfo};
+    use crate::protocol;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use tokio::sync::mpsc;
 
@@ -2785,8 +2788,8 @@ mod model_popup_tests {
         }
     }
 
-    fn make_agent(id: &str, name: &str) -> crate::protocol::AgentInfo {
-        crate::protocol::AgentInfo {
+    fn make_agent(id: &str, name: &str) -> AgentInfo {
+        AgentInfo {
             id: id.into(),
             name: name.into(),
             description: None,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,10 +1,5 @@
 use serde::{Deserialize, Serialize};
 
-// Temporary compatibility bridges for protocol-path consumers.
-#[allow(unused_imports)]
-pub(crate) use crate::domain::model::{DelegateModelPreference, ModelEntry};
-#[allow(unused_imports)]
-pub(crate) use crate::domain::profile::{AgentInfo, ProfileInfo};
 pub(crate) use crate::domain::session::{SessionGroup, SessionSummary};
 
 // --- Client → Server messages ---

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,5 +1,10 @@
 use serde::{Deserialize, Serialize};
 
+// Temporary compatibility bridges for protocol-path consumers.
+#[allow(unused_imports)]
+pub(crate) use crate::domain::model::{DelegateModelPreference, ModelEntry};
+#[allow(unused_imports)]
+pub(crate) use crate::domain::profile::{AgentInfo, ProfileInfo};
 pub(crate) use crate::domain::session::{SessionGroup, SessionSummary};
 
 // --- Client → Server messages ---
@@ -500,41 +505,6 @@ pub struct ReasoningEffortData {
     pub reasoning_effort: Option<String>,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
-pub struct ProfileInfo {
-    pub id: String,
-    pub name: String,
-    #[serde(default)]
-    pub description: Option<String>,
-    #[serde(default)]
-    pub tags: Vec<String>,
-    #[serde(default)]
-    pub source: Option<String>,
-    #[serde(default)]
-    pub config_kind: Option<String>,
-    #[serde(default)]
-    pub fingerprint: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct AgentInfo {
-    pub id: String,
-    pub name: String,
-    #[serde(default)]
-    pub description: Option<String>,
-    #[serde(default)]
-    pub capabilities: Vec<String>,
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct DelegateModelPreference {
-    pub model_id: String,
-    pub provider: String,
-    pub model: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub node_id: Option<String>,
-}
-
 #[derive(Debug, Deserialize)]
 pub struct SessionCreatedData {
     pub agent_id: String,
@@ -917,19 +887,6 @@ pub struct DelegationData {
     pub target_agent_id: Option<String>,
     #[serde(default)]
     pub objective: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct ModelEntry {
-    pub id: String,
-    pub label: String,
-    pub provider: String,
-    pub model: String,
-    pub node_id: Option<String>,
-    #[serde(default)]
-    pub node_label: Option<String>,
-    pub family: Option<String>,
-    pub quant: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -11,6 +11,7 @@ use crate::{
     acp_state::AcpAppEvent,
     app::{self, App, Screen},
     config,
+    domain::model::DelegateModelPreference,
     protocol::ClientMsg,
     server_manager, theme,
 };
@@ -1481,7 +1482,7 @@ pub async fn run() -> anyhow::Result<()> {
             };
             legacy_preferences.insert(
                 agent_id.clone(),
-                crate::protocol::DelegateModelPreference {
+                DelegateModelPreference {
                     model_id: model_key.clone(),
                     provider: provider.to_string(),
                     model: model.to_string(),
@@ -3090,12 +3091,13 @@ mod chord_reasoning_effort_tests {
 #[cfg(test)]
 mod reasoning_effort_integration_tests {
     use super::*;
+    use crate::domain::model::ModelEntry;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use serial_test::serial;
     use tokio::sync::mpsc;
 
-    fn make_model(provider: &str, model: &str) -> crate::protocol::ModelEntry {
-        crate::protocol::ModelEntry {
+    fn make_model(provider: &str, model: &str) -> ModelEntry {
+        ModelEntry {
             id: format!("{provider}/{model}"),
             label: model.into(),
             provider: provider.into(),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -472,6 +472,7 @@ mod tests {
     use crate::acp_state::{AcpAppEvent, AcpSessionUpdate};
     use crate::app::{App, Screen};
     use crate::domain::chat::ChatEntry;
+    use crate::domain::model::ModelEntry;
     use crate::domain::tool::{DiffPreviewSection, ShellOutputTail, ToolDetail};
     use ratatui::backend::Backend;
     use ratatui::layout::Position;
@@ -1926,7 +1927,7 @@ mod tests {
         app.current_provider = Some("anthropic".into());
         app.current_model = Some("claude-sonnet".into());
         app.models = vec![
-            crate::protocol::ModelEntry {
+            ModelEntry {
                 id: "anthropic/claude-sonnet".into(),
                 label: "Claude Sonnet".into(),
                 provider: "anthropic".into(),
@@ -1936,7 +1937,7 @@ mod tests {
                 family: None,
                 quant: None,
             },
-            crate::protocol::ModelEntry {
+            ModelEntry {
                 id: "openai/gpt-4o".into(),
                 label: "GPT-4o".into(),
                 provider: "openai".into(),
@@ -2004,7 +2005,7 @@ mod tests {
         app.current_provider = Some("anthropic".into());
         app.current_model = Some("claude-sonnet".into());
         app.models = vec![
-            crate::protocol::ModelEntry {
+            ModelEntry {
                 id: "anthropic/claude-sonnet".into(),
                 label: "Claude Sonnet".into(),
                 provider: "anthropic".into(),
@@ -2014,7 +2015,7 @@ mod tests {
                 family: None,
                 quant: None,
             },
-            crate::protocol::ModelEntry {
+            ModelEntry {
                 id: "openai/gpt-4o".into(),
                 label: "GPT-4o".into(),
                 provider: "openai".into(),
@@ -2054,7 +2055,7 @@ mod tests {
         app.current_model = Some("gpt-5".into());
         app.current_model_node_id = Some("node-1".into());
         app.models = vec![
-            crate::protocol::ModelEntry {
+            ModelEntry {
                 id: "codex/gpt-5".into(),
                 label: "gpt-5".into(),
                 provider: "codex".into(),
@@ -2064,7 +2065,7 @@ mod tests {
                 family: None,
                 quant: None,
             },
-            crate::protocol::ModelEntry {
+            ModelEntry {
                 id: "codex@node-1/gpt-5".into(),
                 label: "gpt-5".into(),
                 provider: "codex".into(),
@@ -2234,7 +2235,7 @@ mod tests {
         app.popup = Popup::ModelSelect;
         app.agent_mode = "build".into();
         app.models = (0..12)
-            .map(|i| crate::protocol::ModelEntry {
+            .map(|i| ModelEntry {
                 id: format!("anthropic/model-{i}"),
                 label: format!("Model {i}"),
                 provider: "anthropic".into(),

--- a/src/ui/popups.rs
+++ b/src/ui/popups.rs
@@ -9,7 +9,9 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::app::{App, AuthPanel, LogLevel, session_group_count_text};
 use crate::domain::activity::DelegateStats;
-use crate::protocol::{OAuthStatus, ProfileInfo};
+use crate::domain::model::ModelEntry;
+use crate::domain::profile::ProfileInfo;
+use crate::protocol::OAuthStatus;
 use crate::theme::Theme;
 
 use super::chat::{CHECK_CHECKED, CHECK_FAILED, SpinnerKind, spinner};
@@ -83,7 +85,7 @@ fn popup_log_level_style(level: LogLevel) -> ratatui::style::Style {
 }
 
 /// Whether the given model matches a delegate agent's preferred model.
-fn popup_delegate_marker(app: &App, model: &crate::protocol::ModelEntry, agent_id: &str) -> bool {
+fn popup_delegate_marker(app: &App, model: &ModelEntry, agent_id: &str) -> bool {
     app.delegate_preference_profile_id()
         .and_then(|profile_id| app.get_delegate_model_preference(profile_id, agent_id))
         .is_some_and(|preference| {
@@ -2989,7 +2991,7 @@ fn draw_auth_clipboard_fallback(f: &mut Frame, area: Rect, url: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::ProfileInfo;
+    use crate::domain::profile::ProfileInfo;
 
     fn profile(id: &str, name: &str) -> ProfileInfo {
         ProfileInfo {


### PR DESCRIPTION
## changes
- move `ModelEntry` and `DelegateModelPreference` into `domain::model`
- move `ProfileInfo` and `AgentInfo` into `domain::profile`
- migrate app, acp, config, handlers, runtime, and ui consumers to direct domain imports
- retain temporary protocol reexports while keeping acp wire response adapters in `acp_client`

## validation
- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets` (723 passed)
- `git diff --check`
- verified exactly one definition for each extracted type
- verified production code has no protocol-path references to the extracted types
- verified domain modules have no forbidden transport/app dependencies
- verified no legacy server symbols are present