### PR TITLE
refactor: remove domain compatibility bridges

### DIFF
--- a/src/acp_client.rs
+++ b/src/acp_client.rs
@@ -21,11 +21,11 @@ use crate::ServerChannelMsg;
 use crate::acp_state::{AcpAppEvent, AcpModelsMetaInfo, AcpSessionUpdate};
 use crate::domain::model::ModelEntry;
 use crate::domain::profile::{AgentInfo, ProfileInfo};
+use crate::domain::session::{SessionGroup, SessionSummary};
 use crate::protocol::{
     AuthProvidersData, ClientMsg, ForkResultData, MeshInviteCreatedInfo, MeshNodesInfo,
     MeshStatusInfo, OAuthFlowData, OAuthResultData, RedoResultData, RemoteSessionAttachInfo,
-    RemoteSessionListInfo, SessionGroup, SessionListRequest, SessionSummary, UndoResultData,
-    UndoStackFrame,
+    RemoteSessionListInfo, SessionListRequest, UndoResultData, UndoStackFrame,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -2080,6 +2080,7 @@ fn acp_content_to_string(value: &Value) -> String {
 mod tests {
     use super::*;
     use crate::app::{App, Screen};
+    use crate::domain::activity::{PendingDelegateToolCall, SessionOp};
     use crate::domain::model::DelegateModelPreference;
     use crate::domain::session::UndoState;
 
@@ -2737,17 +2738,17 @@ mod tests {
         app.elicitation = Some(ElicitationState::new_for_test(Vec::new()));
         app.elicitation_ui = Some(crate::ui::ElicitationUiState::default());
         app.session_stats.total_tool_calls = 2;
-        app.delegate_entries.push(crate::app::DelegateEntry {
+        app.delegate_entries.push(DelegateEntry {
             delegation_id: "delegate-1".into(),
             child_session_id: Some("child".into()),
             delegate_tool_call_id: None,
             target_agent_id: None,
             objective: "keep".into(),
-            status: crate::app::DelegateStatus::InProgress,
-            stats: crate::app::DelegateStats::default(),
+            status: DelegateStatus::InProgress,
+            stats: DelegateStats::default(),
             started_at: None,
             ended_at: None,
-            child_state: crate::app::DelegateChildState::None,
+            child_state: DelegateChildState::None,
         });
 
         let replies = app.handle_acp_event(AcpAppEvent::SessionLoaded {
@@ -2780,24 +2781,22 @@ mod tests {
     fn native_session_loaded_root_clears_delegate_state() {
         let mut app = App::new();
         app.parent_session_id = Some("old-parent".into());
-        app.delegate_entries.push(crate::app::DelegateEntry {
+        app.delegate_entries.push(DelegateEntry {
             delegation_id: "delegate-1".into(),
             child_session_id: None,
             delegate_tool_call_id: None,
             target_agent_id: None,
             objective: "clear".into(),
-            status: crate::app::DelegateStatus::InProgress,
-            stats: crate::app::DelegateStats::default(),
+            status: DelegateStatus::InProgress,
+            stats: DelegateStats::default(),
             started_at: None,
             ended_at: None,
-            child_state: crate::app::DelegateChildState::None,
+            child_state: DelegateChildState::None,
         });
-        app.pending_delegate_child_states.insert(
-            "child".into(),
-            crate::app::DelegateChildState::OtherProgress,
-        );
+        app.pending_delegate_child_states
+            .insert("child".into(), DelegateChildState::OtherProgress);
         app.pending_delegate_tool_calls
-            .push(crate::app::PendingDelegateToolCall {
+            .push(PendingDelegateToolCall {
                 tool_call_id: "tool-1".into(),
                 target_agent_id: None,
                 objective: "clear".into(),
@@ -3521,7 +3520,7 @@ mod tests {
     fn native_undo_result_success_updates_state_and_reloads_session() {
         let mut app = App::new();
         app.session_id = Some("session-1".into());
-        app.activity = ActivityState::SessionOp(crate::app::SessionOp::Undo);
+        app.activity = ActivityState::SessionOp(SessionOp::Undo);
         app.undoable_turns.push(UndoableTurn {
             turn_id: "u1".into(),
             message_id: "u1".into(),
@@ -3550,7 +3549,7 @@ mod tests {
     #[test]
     fn native_redo_result_failure_clears_pending_state_and_logs_warning() {
         let mut app = App::new();
-        app.activity = ActivityState::SessionOp(crate::app::SessionOp::Redo);
+        app.activity = ActivityState::SessionOp(SessionOp::Redo);
 
         let replies = app.handle_acp_event(AcpAppEvent::RedoResult(RedoResultData {
             success: false,

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,16 +4,12 @@ use std::time::{Duration, Instant};
 use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
 
-#[allow(unused_imports)]
-pub(crate) use crate::domain::activity::{
-    ActivityState, DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus,
-    PendingDelegateToolCall, SessionActivity, SessionOp, SessionStatsLite,
+use crate::domain::activity::{
+    ActivityState, DelegateChildState, DelegateEntry, DelegateStats, PendingDelegateToolCall,
+    SessionActivity, SessionOp, SessionStatsLite,
 };
 use crate::domain::chat::{ChatEntry, format_outcome_labels};
-#[allow(unused_imports)]
-pub(crate) use crate::domain::elicitation::{
-    ElicitationField, ElicitationFieldKind, ElicitationOption, ElicitationState,
-};
+use crate::domain::elicitation::ElicitationState;
 use crate::domain::model::{DelegateModelPreference, ModelEntry};
 use crate::domain::profile::{AgentInfo, ProfileInfo};
 use crate::domain::session::{
@@ -23,7 +19,10 @@ use crate::domain::session::{
 use crate::highlight::Highlighter;
 use crate::markdown::CardBlock;
 use crate::mesh::{MeshFocus, MeshInviteFormField};
-use crate::protocol::*;
+use crate::protocol::{
+    ClientMsg, EventKind, MeshInviteCreatedInfo, MeshStatusInfo, RemoteNodeInfo, RemoteSessionInfo,
+    UndoStackFrame,
+};
 use crate::ui::{CardCache, ElicitationUiState};
 
 /// Cache for rendered streaming markdown to avoid re-parsing every frame.
@@ -2098,6 +2097,7 @@ impl App {
 #[cfg(test)]
 mod reasoning_effort_tests {
     use super::*;
+    use crate::domain::session::SessionSummary;
 
     // ── reasoning_effort_label ────────────────────────────────────────────────
 
@@ -2485,6 +2485,7 @@ mod reasoning_effort_tests {
 #[cfg(test)]
 mod delegate_entry_tests {
     use super::*;
+    use crate::domain::activity::DelegateStatus;
 
     fn make_entry(delegation_id: &str, objective: &str, status: DelegateStatus) -> DelegateEntry {
         DelegateEntry {
@@ -2850,6 +2851,7 @@ mod session_mode_tests {
 mod tests {
     use super::*;
     use crate::domain::chat::OUTCOME_BULLET;
+    use crate::protocol::{AgentEvent, ProgressKind};
 
     fn make_turn(message_id: &str) -> UndoableTurn {
         UndoableTurn {
@@ -3654,6 +3656,7 @@ mod tests {
 mod start_page_tests {
     use super::*;
     use crate::domain::session::SessionSummary;
+    use crate::protocol::SessionListData;
 
     fn make_group(cwd: Option<&str>, ids: &[(&str, Option<&str>)]) -> SessionGroup {
         SessionGroup {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -2767,7 +2767,7 @@ mod model_popup_tests {
     use crate::config::TestPersistenceGuard;
     use crate::domain::model::ModelEntry;
     use crate::domain::profile::{AgentInfo, ProfileInfo};
-    use crate::protocol;
+    use crate::domain::session::{SessionGroup, SessionSummary};
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use tokio::sync::mpsc;
 
@@ -2808,8 +2808,8 @@ mod model_popup_tests {
     #[test]
     fn start_page_enter_on_remote_session_attaches_instead_of_loading() {
         let mut app = App::new();
-        app.session_groups = vec![protocol::SessionGroup {
-            sessions: vec![protocol::SessionSummary {
+        app.session_groups = vec![SessionGroup {
+            sessions: vec![SessionSummary {
                 session_id: "remote-1".into(),
                 node_id: Some("node-1".into()),
                 attached: Some(false),
@@ -2834,8 +2834,8 @@ mod model_popup_tests {
     fn popup_enter_on_remote_session_attaches_instead_of_loading() {
         let mut app = App::new();
         app.popup = Popup::SessionSelect;
-        app.session_groups = vec![protocol::SessionGroup {
-            sessions: vec![protocol::SessionSummary {
+        app.session_groups = vec![SessionGroup {
+            sessions: vec![SessionSummary {
                 session_id: "remote-1".into(),
                 node_id: Some("node-1".into()),
                 attached: Some(true),
@@ -3346,8 +3346,8 @@ mod model_popup_tests {
         app.popup = Popup::ModelSelect;
         app.session_id = Some("remote-1".into());
         app.agent_mode = "build".into();
-        app.session_groups = vec![protocol::SessionGroup {
-            sessions: vec![protocol::SessionSummary {
+        app.session_groups = vec![SessionGroup {
+            sessions: vec![SessionSummary {
                 session_id: "remote-1".into(),
                 node_id: Some("node-1".into()),
                 ..Default::default()
@@ -3439,7 +3439,10 @@ mod model_popup_tests {
 
     #[test]
     fn delegate_popup_subscribes_with_child_target_agent() {
-        use crate::app::{DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus, Popup};
+        use crate::app::Popup;
+        use crate::domain::activity::{
+            DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus,
+        };
 
         let mut app = App::new();
         app.agent_id = Some("planner".into());

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-pub(crate) use crate::domain::session::{SessionGroup, SessionSummary};
+use crate::domain::session::{SessionGroup, SessionSummary};
 
 // --- Client → Server messages ---
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -37,8 +37,10 @@ pub(crate) enum ServerChannelMsg {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::{ElicitationField, ElicitationFieldKind, ElicitationOption, ElicitationState};
     use crate::domain::chat::{ChatEntry, OUTCOME_BULLET};
+    use crate::domain::elicitation::{
+        ElicitationField, ElicitationFieldKind, ElicitationOption, ElicitationState,
+    };
     use crate::domain::tool::ToolDetail;
     use crate::handlers::*;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -480,8 +482,9 @@ mod tests {
 #[cfg(test)]
 mod external_editor_tests {
     use super::*;
-    use crate::app::{ActivityState, App};
+    use crate::app::App;
     use crate::config::{AcpConfig, TestPersistenceGuard, TuiConfig};
+    use crate::domain::activity::{ActivityState, SessionOp};
     use crate::domain::chat::ChatEntry;
     use crate::handlers::*;
     use crate::protocol::PromptBlock;
@@ -1329,7 +1332,7 @@ mod external_editor_tests {
         let mut app = App::new();
         app.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
-        app.activity = ActivityState::SessionOp(app::SessionOp::Undo);
+        app.activity = ActivityState::SessionOp(SessionOp::Undo);
         app.input = "draft".into();
         app.input_cursor = app.input.len();
 
@@ -1613,8 +1616,9 @@ impl PersistenceGuard {
 #[cfg(test)]
 mod sessions_key_tests {
     use super::*;
+    use crate::domain::session::{SessionGroup, SessionSummary};
     use crate::handlers::*;
-    use crate::protocol::{ClientMsg, SessionGroup, SessionSummary};
+    use crate::protocol::ClientMsg;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use tokio::sync::mpsc;
 
@@ -2051,8 +2055,9 @@ mod sessions_key_tests {
 mod session_popup_key_tests {
     use super::*;
     use crate::app::Popup;
+    use crate::domain::session::{SessionGroup, SessionSummary};
     use crate::handlers::*;
-    use crate::protocol::{ClientMsg, SessionGroup, SessionSummary};
+    use crate::protocol::ClientMsg;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
     fn make_group(cwd: Option<&str>, ids: &[&str]) -> SessionGroup {
@@ -2793,7 +2798,10 @@ mod session_popup_key_tests {
 #[cfg(test)]
 mod delegate_popup_key_tests {
     use super::*;
-    use crate::app::{DelegateEntry, DelegateStatus, Popup};
+    use crate::app::Popup;
+    use crate::domain::activity::{
+        DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus,
+    };
     use crate::handlers::*;
     use crossterm::event::KeyCode;
 
@@ -2805,10 +2813,10 @@ mod delegate_popup_key_tests {
             target_agent_id: Some("coder".into()),
             objective: objective.into(),
             status: DelegateStatus::Completed,
-            stats: app::DelegateStats::default(),
+            stats: DelegateStats::default(),
             started_at: None,
             ended_at: None,
-            child_state: app::DelegateChildState::None,
+            child_state: DelegateChildState::None,
         }
     }
 
@@ -2916,10 +2924,10 @@ mod delegate_popup_key_tests {
             target_agent_id: None,
             objective: "pending task".into(),
             status: DelegateStatus::InProgress,
-            stats: app::DelegateStats::default(),
+            stats: DelegateStats::default(),
             started_at: None,
             ended_at: None,
-            child_state: app::DelegateChildState::None,
+            child_state: DelegateChildState::None,
         }];
         let action = apply_delegate_popup_key(&mut app, KeyCode::Enter);
         assert_eq!(action, SessionKeyAction::None);
@@ -2957,7 +2965,7 @@ mod delegate_popup_key_tests {
     fn delegate_enter_loads_awaiting_input_child_session() {
         let mut app = setup_delegate_app();
         app.delegate_entries[0].status = DelegateStatus::InProgress;
-        app.delegate_entries[0].child_state = app::DelegateChildState::PendingElicitation {
+        app.delegate_entries[0].child_state = DelegateChildState::PendingElicitation {
             elicitation_id: "elic-1".into(),
             message: "Need approval".into(),
             requested_schema: serde_json::json!({ "properties": {} }),
@@ -3344,7 +3352,10 @@ mod runtime_tests {
 mod auth_tests {
     use super::*;
     use crate::handlers::*;
-    use crate::protocol::*;
+    use crate::protocol::{
+        AuthMethod, AuthProviderEntry, AuthProvidersData, ClientMsg, OAuthFlowData, OAuthFlowKind,
+        OAuthResultData, OAuthStatus,
+    };
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
     fn key(code: KeyCode) -> KeyEvent {

--- a/src/session.rs
+++ b/src/session.rs
@@ -5,9 +5,13 @@ use std::time::{Duration, Instant};
 use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
 
-use crate::app::*;
+use crate::app::{
+    App, FileIndexEntryLite, MAX_RECENT_SESSIONS, MAX_VISIBLE_GROUPS, PathCompletionState, Popup,
+    PopupItem, StartPageItem,
+};
 use crate::domain::activity::{DelegateEntry, SessionActivity};
-use crate::protocol::*;
+use crate::domain::session::{SessionGroup, SessionSummary};
+use crate::protocol::SessionChildrenData;
 
 /// Returns indices of sessions in `group` whose title or ID matches `q`.
 /// When `q` is empty every session matches in original order.

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -471,8 +471,15 @@ mod tests {
     use super::*;
     use crate::acp_state::{AcpAppEvent, AcpSessionUpdate};
     use crate::app::{App, Screen};
+    use crate::domain::activity::{
+        DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus, SessionActivity,
+    };
     use crate::domain::chat::ChatEntry;
+    use crate::domain::elicitation::{
+        ElicitationField, ElicitationFieldKind, ElicitationOption, ElicitationState,
+    };
     use crate::domain::model::ModelEntry;
+    use crate::domain::session::{SessionGroup, SessionSummary};
     use crate::domain::tool::{DiffPreviewSection, ShellOutputTail, ToolDetail};
     use ratatui::backend::Backend;
     use ratatui::layout::Position;
@@ -744,7 +751,7 @@ mod tests {
         app.current_model = Some("claude-sonnet".into());
         app.session_activity.insert(
             "session-a".into(),
-            crate::app::SessionActivity {
+            SessionActivity {
                 last_event_at: Instant::now(),
             },
         );
@@ -759,7 +766,7 @@ mod tests {
 
         app.session_activity.insert(
             "session-b".into(),
-            crate::app::SessionActivity {
+            SessionActivity {
                 last_event_at: Instant::now(),
             },
         );
@@ -774,7 +781,7 @@ mod tests {
 
         app.session_activity.insert(
             "session-c".into(),
-            crate::app::SessionActivity {
+            SessionActivity {
                 last_event_at: Instant::now(),
             },
         );
@@ -788,7 +795,7 @@ mod tests {
 
         app.session_activity.insert(
             "session-c".into(),
-            crate::app::SessionActivity {
+            SessionActivity {
                 last_event_at: Instant::now() - Duration::from_secs(6),
             },
         );
@@ -804,8 +811,6 @@ mod tests {
 
     #[test]
     fn draw_chat_shows_delegate_badge_when_entries_exist() {
-        use crate::app::{DelegateEntry, DelegateStatus};
-
         let mut app = App::new();
         app.screen = Screen::Chat;
         app.session_id = Some("s1".into());
@@ -827,10 +832,10 @@ mod tests {
                 target_agent_id: None,
                 objective: "a".into(),
                 status: DelegateStatus::Completed,
-                stats: crate::app::DelegateStats::default(),
+                stats: DelegateStats::default(),
                 started_at: None,
                 ended_at: None,
-                child_state: crate::app::DelegateChildState::None,
+                child_state: DelegateChildState::None,
             },
             DelegateEntry {
                 delegation_id: "d2".into(),
@@ -839,10 +844,10 @@ mod tests {
                 target_agent_id: None,
                 objective: "b".into(),
                 status: DelegateStatus::Completed,
-                stats: crate::app::DelegateStats::default(),
+                stats: DelegateStats::default(),
                 started_at: None,
                 ended_at: None,
-                child_state: crate::app::DelegateChildState::None,
+                child_state: DelegateChildState::None,
             },
             DelegateEntry {
                 delegation_id: "d3".into(),
@@ -851,10 +856,10 @@ mod tests {
                 target_agent_id: None,
                 objective: "c".into(),
                 status: DelegateStatus::InProgress,
-                stats: crate::app::DelegateStats::default(),
+                stats: DelegateStats::default(),
                 started_at: None,
                 ended_at: None,
-                child_state: crate::app::DelegateChildState::None,
+                child_state: DelegateChildState::None,
             },
         ];
         let buffer = render_chat_buffer(&mut app, 100, 8);
@@ -867,8 +872,6 @@ mod tests {
 
     #[test]
     fn draw_chat_shows_delegate_awaiting_input_badge() {
-        use crate::app::{DelegateChildState, DelegateEntry, DelegateStatus};
-
         let mut app = App::new();
         app.screen = Screen::Chat;
         app.session_id = Some("s1".into());
@@ -882,7 +885,7 @@ mod tests {
             target_agent_id: Some("coder".into()),
             objective: "a".into(),
             status: DelegateStatus::InProgress,
-            stats: crate::app::DelegateStats::default(),
+            stats: DelegateStats::default(),
             started_at: None,
             ended_at: None,
             child_state: DelegateChildState::PendingElicitation {
@@ -910,7 +913,6 @@ mod tests {
 
     #[test]
     fn draw_chat_failed_delegate_badge_uses_dim_surface_background() {
-        use crate::app::{DelegateEntry, DelegateStatus};
         use crate::theme::Theme;
 
         let mut app = App::new();
@@ -926,10 +928,10 @@ mod tests {
             target_agent_id: None,
             objective: "a".into(),
             status: DelegateStatus::Failed,
-            stats: crate::app::DelegateStats::default(),
+            stats: DelegateStats::default(),
             started_at: None,
             ended_at: None,
-            child_state: crate::app::DelegateChildState::None,
+            child_state: DelegateChildState::None,
         }];
 
         let buffer = render_chat_buffer(&mut app, 100, 8);
@@ -943,7 +945,7 @@ mod tests {
 
     #[test]
     fn draw_delegate_popup_uses_aligned_stat_columns_without_header() {
-        use crate::app::{DelegateEntry, DelegateStats, DelegateStatus, Popup};
+        use crate::app::Popup;
 
         let mut app = App::new();
         app.screen = Screen::Chat;
@@ -967,7 +969,7 @@ mod tests {
                 },
                 started_at: None,
                 ended_at: None,
-                child_state: crate::app::DelegateChildState::None,
+                child_state: DelegateChildState::None,
             },
             DelegateEntry {
                 delegation_id: "del-2".into(),
@@ -985,7 +987,7 @@ mod tests {
                 },
                 started_at: None,
                 ended_at: None,
-                child_state: crate::app::DelegateChildState::None,
+                child_state: DelegateChildState::None,
             },
         ];
 
@@ -1008,7 +1010,7 @@ mod tests {
 
     #[test]
     fn draw_delegate_popup_shows_question_pending_marker_and_hint() {
-        use crate::app::{DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus, Popup};
+        use crate::app::Popup;
 
         let mut app = App::new();
         app.screen = Screen::Chat;
@@ -1058,7 +1060,7 @@ mod tests {
 
     #[test]
     fn draw_delegate_popup_hides_cost_column_when_all_rows_have_zero_cost() {
-        use crate::app::{DelegateEntry, DelegateStats, DelegateStatus, Popup};
+        use crate::app::Popup;
 
         let mut app = App::new();
         app.screen = Screen::Chat;
@@ -1081,7 +1083,7 @@ mod tests {
                 },
                 started_at: None,
                 ended_at: None,
-                child_state: crate::app::DelegateChildState::None,
+                child_state: DelegateChildState::None,
             },
             DelegateEntry {
                 delegation_id: "del-2".into(),
@@ -1099,7 +1101,7 @@ mod tests {
                 },
                 started_at: None,
                 ended_at: None,
-                child_state: crate::app::DelegateChildState::None,
+                child_state: DelegateChildState::None,
             },
         ];
 
@@ -1127,7 +1129,7 @@ mod tests {
 
     #[test]
     fn draw_delegate_popup_truncates_long_objectives_with_unicode_ellipsis() {
-        use crate::app::{DelegateEntry, DelegateStats, DelegateStatus, Popup};
+        use crate::app::Popup;
 
         let mut app = App::new();
         app.screen = Screen::Chat;
@@ -1149,7 +1151,7 @@ mod tests {
             },
             started_at: None,
             ended_at: None,
-            child_state: crate::app::DelegateChildState::None,
+            child_state: DelegateChildState::None,
         }];
 
         let backend = ratatui::backend::TestBackend::new(70, 12);
@@ -1169,7 +1171,7 @@ mod tests {
 
     #[test]
     fn draw_delegate_popup_failed_symbol_uses_dim_surface_background() {
-        use crate::app::{DelegateEntry, DelegateStats, DelegateStatus, Popup};
+        use crate::app::Popup;
         use crate::theme::Theme;
 
         let mut app = App::new();
@@ -1188,7 +1190,7 @@ mod tests {
                 stats: DelegateStats::default(),
                 started_at: None,
                 ended_at: None,
-                child_state: crate::app::DelegateChildState::None,
+                child_state: DelegateChildState::None,
             },
             DelegateEntry {
                 delegation_id: "del-1".into(),
@@ -1200,7 +1202,7 @@ mod tests {
                 stats: DelegateStats::default(),
                 started_at: None,
                 ended_at: None,
-                child_state: crate::app::DelegateChildState::None,
+                child_state: DelegateChildState::None,
             },
         ];
 
@@ -1218,7 +1220,7 @@ mod tests {
 
     #[test]
     fn draw_delegate_popup_highlights_full_selected_row() {
-        use crate::app::{DelegateEntry, DelegateStats, DelegateStatus, Popup};
+        use crate::app::Popup;
         use crate::theme::Theme;
 
         let mut app = App::new();
@@ -1243,7 +1245,7 @@ mod tests {
                 },
                 started_at: None,
                 ended_at: None,
-                child_state: crate::app::DelegateChildState::None,
+                child_state: DelegateChildState::None,
             },
             DelegateEntry {
                 delegation_id: "del-2".into(),
@@ -1261,7 +1263,7 @@ mod tests {
                 },
                 started_at: None,
                 ended_at: None,
-                child_state: crate::app::DelegateChildState::None,
+                child_state: DelegateChildState::None,
             },
         ];
 
@@ -1307,7 +1309,7 @@ mod tests {
 
     #[test]
     fn draw_delegate_popup_shows_agent_name_column() {
-        use crate::app::{DelegateEntry, DelegateStats, DelegateStatus, Popup};
+        use crate::app::Popup;
 
         let mut app = App::new();
         app.screen = Screen::Chat;
@@ -1325,7 +1327,7 @@ mod tests {
                 stats: DelegateStats::default(),
                 started_at: None,
                 ended_at: None,
-                child_state: crate::app::DelegateChildState::None,
+                child_state: DelegateChildState::None,
             },
             DelegateEntry {
                 delegation_id: "del-2".into(),
@@ -1337,7 +1339,7 @@ mod tests {
                 stats: DelegateStats::default(),
                 started_at: None,
                 ended_at: None,
-                child_state: crate::app::DelegateChildState::None,
+                child_state: DelegateChildState::None,
             },
         ];
 
@@ -1364,7 +1366,6 @@ mod tests {
 
     #[test]
     fn delegate_tool_call_label_uses_accent_color() {
-        use crate::app::{DelegateEntry, DelegateStats, DelegateStatus};
         use crate::theme::Theme;
 
         let mut app = App::new();
@@ -1386,7 +1387,7 @@ mod tests {
             stats: DelegateStats::default(),
             started_at: Some(1700000000),
             ended_at: Some(1700000045),
-            child_state: crate::app::DelegateChildState::None,
+            child_state: DelegateChildState::None,
         });
 
         let buffer = render_chat_buffer(&mut app, 60, 10);
@@ -1502,8 +1503,6 @@ mod tests {
 
     #[test]
     fn delegate_tool_call_shows_awaiting_input_marker() {
-        use crate::app::{DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus};
-
         let mut app = App::new();
         app.screen = Screen::Chat;
         app.agent_mode = "build".into();
@@ -1619,7 +1618,7 @@ mod tests {
         let mut app = App::new();
         app.screen = Screen::Chat;
         app.agent_mode = "build".into();
-        app.elicitation = Some(crate::app::ElicitationState::new_for_test(vec![]));
+        app.elicitation = Some(ElicitationState::new_for_test(vec![]));
         app.elicitation_ui = Some(ElicitationUiState::default());
 
         let _buffer = render_chat_buffer(&mut app, 80, 12);
@@ -1627,10 +1626,6 @@ mod tests {
 
     #[test]
     fn draw_chat_custom_elicitation_wraps_and_expands_with_prefix() {
-        use crate::app::{
-            ElicitationField, ElicitationFieldKind, ElicitationOption, ElicitationState,
-        };
-
         let mut app = App::new();
         app.screen = Screen::Chat;
         app.agent_mode = "build".into();
@@ -1672,10 +1667,6 @@ mod tests {
 
     #[test]
     fn draw_chat_wraps_long_elicitation_question() {
-        use crate::app::{
-            ElicitationField, ElicitationFieldKind, ElicitationOption, ElicitationState,
-        };
-
         let mut app = App::new();
         app.screen = Screen::Chat;
         let mut state = ElicitationState::new_for_test(vec![ElicitationField {
@@ -1708,10 +1699,6 @@ mod tests {
 
     #[test]
     fn draw_chat_wraps_long_elicitation_answers() {
-        use crate::app::{
-            ElicitationField, ElicitationFieldKind, ElicitationOption, ElicitationState,
-        };
-
         let mut app = App::new();
         app.screen = Screen::Chat;
         app.elicitation = Some(ElicitationState::new_for_test(vec![ElicitationField {
@@ -1741,10 +1728,6 @@ mod tests {
 
     #[test]
     fn draw_delegate_view_shows_elicitation_popup_and_input_hint() {
-        use crate::app::{
-            ElicitationField, ElicitationFieldKind, ElicitationOption, ElicitationState,
-        };
-
         let mut app = App::new();
         app.screen = Screen::Delegate;
         app.agent_mode = "build".into();
@@ -2400,8 +2383,6 @@ mod tests {
 
     #[test]
     fn delegate_row_fixture_marks_parent_awaiting_input() {
-        use crate::app::{DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus};
-
         let mut app = App::new();
         app.messages.push(delegate_tool_call(
             "tool-delegate-1",
@@ -2559,8 +2540,6 @@ mod tests {
 
     #[test]
     fn delegate_row_updates_after_child_state_change_without_message_append() {
-        use crate::app::{DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus};
-
         let mut app = App::new();
         app.messages
             .push(delegate_tool_call("tool-1", "coder", "Fix cache bug"));
@@ -2603,8 +2582,6 @@ mod tests {
 
     #[test]
     fn delegate_row_awaiting_marker_uses_tool_call_identity_not_sequence() {
-        use crate::app::{DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus};
-
         let mut app = App::new();
         app.messages.push(ChatEntry::User {
             text: "first".into(),
@@ -3061,8 +3038,6 @@ mod tests {
 
     #[test]
     fn child_session_group_replays_elicitation_as_durable_card() {
-        use crate::protocol::{SessionGroup, SessionSummary};
-
         let mut app = App::new();
         app.session_groups = vec![SessionGroup {
             cwd: None,
@@ -3095,8 +3070,6 @@ mod tests {
 
     #[test]
     fn direct_elicitation_fixture_renders_active_popup() {
-        use crate::app::{ElicitationField, ElicitationFieldKind, ElicitationState};
-
         // Legacy envelope parsing is covered outside the UI; render an active popup directly.
         let mut app = App::new();
         app.screen = Screen::Delegate;
@@ -3858,7 +3831,6 @@ mod tests {
     // ── start-page session list row builder ───────────────────────────────────
 
     use crate::app::StartPageItem;
-    use crate::protocol::{SessionGroup, SessionSummary};
 
     fn make_group(cwd: Option<&str>, ids: &[&str]) -> SessionGroup {
         SessionGroup {


### PR DESCRIPTION
## changes
- remove the activity and elicitation compatibility reexports from `app`
- make the session domain imports in `protocol` private while retaining them in the session wire dtos
- migrate production and test consumers to `domain::activity`, `domain::elicitation`, and `domain::session`
- replace the remaining `app::*` and `protocol::*` imports with explicit imports

## validation
- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all-targets` (723 passed)
- `git diff --check`
- ownership, wildcard, forbidden domain dependency, and legacy server searches are clean

## caveat
- session wire dtos in `protocol` still privately contain the domain `SessionGroup` and `SessionSummary` types