### PR TITLE
refactor: separate session page wire types

### DIFF
--- a/src/acp_client.rs
+++ b/src/acp_client.rs
@@ -21,11 +21,12 @@ use crate::ServerChannelMsg;
 use crate::acp_state::{AcpAppEvent, AcpModelsMetaInfo, AcpSessionUpdate};
 use crate::domain::model::ModelEntry;
 use crate::domain::profile::{AgentInfo, ProfileInfo};
-use crate::domain::session::{SessionGroup, SessionSummary};
+use crate::domain::session::{SessionChildrenPage, SessionGroup, SessionListPage, SessionSummary};
 use crate::protocol::{
     AuthProvidersData, ClientMsg, ForkResultData, MeshInviteCreatedInfo, MeshNodesInfo,
     MeshStatusInfo, OAuthFlowData, OAuthResultData, RedoResultData, RemoteSessionAttachInfo,
-    RemoteSessionListInfo, SessionListRequest, UndoResultData, UndoStackFrame,
+    RemoteSessionListInfo, SessionChildrenData, SessionGroupData, SessionListData,
+    SessionListRequest, SessionSummaryData, UndoResultData, UndoStackFrame,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2467,11 +2468,76 @@ fn flatten_select_entries(option: &Value) -> Vec<&Value> {
         .collect()
 }
 
-fn send_session_list(
-    srv_tx: &mpsc::UnboundedSender<ServerChannelMsg>,
-    request: SessionListRequest,
+fn session_summary_from_wire(data: SessionSummaryData) -> SessionSummary {
+    SessionSummary {
+        session_id: data.session_id,
+        name: data.name,
+        title: data.title,
+        cwd: data.cwd,
+        created_at: data.created_at,
+        updated_at: data.updated_at,
+        parent_session_id: data.parent_session_id,
+        fork_origin: data.fork_origin,
+        session_kind: data.session_kind,
+        has_children: data.has_children,
+        fork_count: data.fork_count,
+        children: data
+            .children
+            .into_iter()
+            .map(session_summary_from_wire)
+            .collect(),
+        children_next_cursor: data.children_next_cursor,
+        children_total_count: data.children_total_count,
+        node: data.node,
+        node_id: data.node_id,
+        attached: data.attached,
+        runtime_state: data.runtime_state,
+    }
+}
+
+fn session_group_from_wire(data: SessionGroupData) -> SessionGroup {
+    SessionGroup {
+        cwd: data.cwd,
+        sessions: data
+            .sessions
+            .into_iter()
+            .map(session_summary_from_wire)
+            .collect(),
+        latest_activity: data.latest_activity,
+        total_count: data.total_count,
+        next_cursor: data.next_cursor,
+    }
+}
+
+fn session_list_page_from_wire(data: SessionListData) -> SessionListPage {
+    SessionListPage {
+        groups: data
+            .groups
+            .into_iter()
+            .map(session_group_from_wire)
+            .collect(),
+        next_cursor: data.next_cursor,
+        total_count: data.total_count,
+    }
+}
+
+fn session_children_page_from_wire(data: SessionChildrenData) -> SessionChildrenPage {
+    SessionChildrenPage {
+        parent_session_id: data.parent_session_id,
+        sessions: data
+            .sessions
+            .into_iter()
+            .map(session_summary_from_wire)
+            .collect(),
+        next_cursor: data.next_cursor,
+        total_count: data.total_count,
+    }
+}
+
+fn session_list_page_from_acp(
+    request: &SessionListRequest,
     response: acp::ListSessionsResponse,
-) {
+) -> SessionListPage {
     let mut groups: BTreeMap<Option<String>, Vec<SessionSummary>> = BTreeMap::new();
     let response_cursor = response.next_cursor.map(|cursor| cursor.to_string());
 
@@ -2525,14 +2591,20 @@ fn send_session_list(
         })
         .collect::<Vec<_>>();
 
-    send_acp(
-        srv_tx,
-        AcpAppEvent::SessionList {
-            request,
-            groups,
-            next_cursor: response_cursor,
-        },
-    );
+    SessionListPage {
+        groups,
+        next_cursor: response_cursor,
+        total_count: None,
+    }
+}
+
+fn send_session_list(
+    srv_tx: &mpsc::UnboundedSender<ServerChannelMsg>,
+    request: SessionListRequest,
+    response: acp::ListSessionsResponse,
+) {
+    let page = session_list_page_from_acp(&request, response);
+    send_acp(srv_tx, AcpAppEvent::SessionList { request, page });
 }
 
 fn send_state(
@@ -2885,8 +2957,95 @@ mod tests {
     }
 
     #[test]
+    fn wire_session_pages_map_recursively_to_domain() {
+        let list = session_list_page_from_wire(SessionListData {
+            groups: vec![SessionGroupData {
+                cwd: Some("/repo".into()),
+                latest_activity: Some("2024-02-01T00:00:00Z".into()),
+                total_count: Some(2),
+                next_cursor: Some("group-next".into()),
+                sessions: vec![SessionSummaryData {
+                    session_id: "root".into(),
+                    name: Some("Root name".into()),
+                    title: Some("Root title".into()),
+                    cwd: Some("/repo".into()),
+                    created_at: Some("2024-01-01T00:00:00Z".into()),
+                    updated_at: Some("2024-02-01T00:00:00Z".into()),
+                    parent_session_id: None,
+                    fork_origin: Some("manual".into()),
+                    session_kind: Some("interactive".into()),
+                    has_children: true,
+                    fork_count: 1,
+                    children: vec![SessionSummaryData {
+                        session_id: "child".into(),
+                        parent_session_id: Some("root".into()),
+                        node_id: Some("node-child".into()),
+                        ..Default::default()
+                    }],
+                    children_next_cursor: Some("child-next".into()),
+                    children_total_count: Some(1),
+                    node: Some("remote".into()),
+                    node_id: Some("node-root".into()),
+                    attached: Some(true),
+                    runtime_state: Some("running".into()),
+                }],
+            }],
+            next_cursor: Some("list-next".into()),
+            total_count: Some(7),
+        });
+
+        assert_eq!(list.next_cursor.as_deref(), Some("list-next"));
+        assert_eq!(list.total_count, Some(7));
+        let group = &list.groups[0];
+        assert_eq!(group.cwd.as_deref(), Some("/repo"));
+        assert_eq!(
+            group.latest_activity.as_deref(),
+            Some("2024-02-01T00:00:00Z")
+        );
+        assert_eq!(group.total_count, Some(2));
+        assert_eq!(group.next_cursor.as_deref(), Some("group-next"));
+        let root = &group.sessions[0];
+        assert_eq!(root.name.as_deref(), Some("Root name"));
+        assert_eq!(root.title.as_deref(), Some("Root title"));
+        assert_eq!(root.cwd.as_deref(), Some("/repo"));
+        assert_eq!(root.created_at.as_deref(), Some("2024-01-01T00:00:00Z"));
+        assert_eq!(root.updated_at.as_deref(), Some("2024-02-01T00:00:00Z"));
+        assert_eq!(root.parent_session_id, None);
+        assert_eq!(root.fork_origin.as_deref(), Some("manual"));
+        assert_eq!(root.session_kind.as_deref(), Some("interactive"));
+        assert!(root.has_children);
+        assert_eq!(root.fork_count, 1);
+        assert_eq!(root.children[0].session_id, "child");
+        assert_eq!(root.children[0].parent_session_id.as_deref(), Some("root"));
+        assert_eq!(root.children[0].node_id.as_deref(), Some("node-child"));
+        assert_eq!(root.children_next_cursor.as_deref(), Some("child-next"));
+        assert_eq!(root.children_total_count, Some(1));
+        assert_eq!(root.node.as_deref(), Some("remote"));
+        assert_eq!(root.node_id.as_deref(), Some("node-root"));
+        assert_eq!(root.attached, Some(true));
+        assert_eq!(root.runtime_state.as_deref(), Some("running"));
+
+        let children = session_children_page_from_wire(SessionChildrenData {
+            parent_session_id: "root".into(),
+            sessions: vec![SessionSummaryData {
+                session_id: "child".into(),
+                children: vec![SessionSummaryData {
+                    session_id: "grandchild".into(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            next_cursor: Some("children-next".into()),
+            total_count: Some(3),
+        });
+        assert_eq!(children.parent_session_id, "root");
+        assert_eq!(children.sessions[0].children[0].session_id, "grandchild");
+        assert_eq!(children.next_cursor.as_deref(), Some("children-next"));
+        assert_eq!(children.total_count, Some(3));
+    }
+
+    #[test]
     fn acp_root_session_list_preserves_only_the_global_cursor() {
-        let (tx, mut rx) = mpsc::unbounded_channel();
         let response = acp::ListSessionsResponse::new(vec![
             acp::SessionInfo::new(acp::SessionId::from("s1"), Path::new("/repo")),
             acp::SessionInfo::new(acp::SessionId::from("s2"), Path::new("/repo")),
@@ -2894,53 +3053,37 @@ mod tests {
         ])
         .next_cursor(Some("100".to_string()));
 
-        send_session_list(&tx, SessionListRequest::Discovery, response);
+        let page = session_list_page_from_acp(&SessionListRequest::Discovery, response);
 
-        let ServerChannelMsg::Acp(event) = rx.try_recv().expect("session list event");
-        assert!(matches!(
-            event,
-            AcpAppEvent::SessionList {
-                request: SessionListRequest::Discovery,
-                groups,
-                next_cursor: Some(cursor),
-            } if cursor == "100"
-                && groups.len() == 2
-                && groups.iter().all(|group| group.next_cursor.is_none())
-        ));
+        assert_eq!(page.next_cursor.as_deref(), Some("100"));
+        assert_eq!(page.total_count, None);
+        assert_eq!(page.groups.len(), 2);
+        assert!(page.groups.iter().all(|group| group.next_cursor.is_none()));
     }
 
     #[test]
     fn acp_cwd_session_list_maps_next_cursor_to_group_cursor() {
-        let (tx, mut rx) = mpsc::unbounded_channel();
         let response = acp::ListSessionsResponse::new(vec![
-            acp::SessionInfo::new(acp::SessionId::from("s1"), Path::new("/repo"))
+            acp::SessionInfo::new(acp::SessionId::from("s1"), Path::new("/from-response"))
                 .title(Some("One".to_string()))
                 .updated_at(Some("2024-01-01T00:00:00Z".to_string())),
         ])
         .next_cursor(Some("cursor-2".to_string()));
+        let request = SessionListRequest::WorkspaceContinuation {
+            cwd: "/repo".to_string(),
+        };
 
-        send_session_list(
-            &tx,
-            SessionListRequest::WorkspaceContinuation {
-                cwd: "/repo".to_string(),
-            },
-            response,
+        let page = session_list_page_from_acp(&request, response);
+
+        assert_eq!(page.next_cursor.as_deref(), Some("cursor-2"));
+        assert_eq!(page.groups.len(), 1);
+        assert_eq!(page.groups[0].cwd.as_deref(), Some("/repo"));
+        assert_eq!(page.groups[0].next_cursor.as_deref(), Some("cursor-2"));
+        assert_eq!(page.groups[0].sessions[0].session_id, "s1");
+        assert_eq!(
+            page.groups[0].sessions[0].cwd.as_deref(),
+            Some("/from-response")
         );
-
-        let ServerChannelMsg::Acp(event) = rx.try_recv().expect("session list event");
-        assert!(matches!(
-            event,
-            AcpAppEvent::SessionList {
-                request: SessionListRequest::WorkspaceContinuation { cwd },
-                groups,
-                next_cursor: Some(root_cursor),
-            } if cwd == "/repo"
-                && root_cursor == "cursor-2"
-                && groups.len() == 1
-                && groups[0].cwd.as_deref() == Some("/repo")
-                && groups[0].next_cursor.as_deref() == Some("cursor-2")
-                && groups[0].sessions[0].session_id == "s1"
-        ));
     }
 
     #[test]

--- a/src/acp_client.rs
+++ b/src/acp_client.rs
@@ -21,12 +21,11 @@ use crate::ServerChannelMsg;
 use crate::acp_state::{AcpAppEvent, AcpModelsMetaInfo, AcpSessionUpdate};
 use crate::domain::model::ModelEntry;
 use crate::domain::profile::{AgentInfo, ProfileInfo};
-use crate::domain::session::{SessionChildrenPage, SessionGroup, SessionListPage, SessionSummary};
+use crate::domain::session::{SessionGroup, SessionListPage, SessionSummary};
 use crate::protocol::{
     AuthProvidersData, ClientMsg, ForkResultData, MeshInviteCreatedInfo, MeshNodesInfo,
     MeshStatusInfo, OAuthFlowData, OAuthResultData, RedoResultData, RemoteSessionAttachInfo,
-    RemoteSessionListInfo, SessionChildrenData, SessionGroupData, SessionListData,
-    SessionListRequest, SessionSummaryData, UndoResultData, UndoStackFrame,
+    RemoteSessionListInfo, SessionListRequest, UndoResultData, UndoStackFrame,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2468,72 +2467,6 @@ fn flatten_select_entries(option: &Value) -> Vec<&Value> {
         .collect()
 }
 
-fn session_summary_from_wire(data: SessionSummaryData) -> SessionSummary {
-    SessionSummary {
-        session_id: data.session_id,
-        name: data.name,
-        title: data.title,
-        cwd: data.cwd,
-        created_at: data.created_at,
-        updated_at: data.updated_at,
-        parent_session_id: data.parent_session_id,
-        fork_origin: data.fork_origin,
-        session_kind: data.session_kind,
-        has_children: data.has_children,
-        fork_count: data.fork_count,
-        children: data
-            .children
-            .into_iter()
-            .map(session_summary_from_wire)
-            .collect(),
-        children_next_cursor: data.children_next_cursor,
-        children_total_count: data.children_total_count,
-        node: data.node,
-        node_id: data.node_id,
-        attached: data.attached,
-        runtime_state: data.runtime_state,
-    }
-}
-
-fn session_group_from_wire(data: SessionGroupData) -> SessionGroup {
-    SessionGroup {
-        cwd: data.cwd,
-        sessions: data
-            .sessions
-            .into_iter()
-            .map(session_summary_from_wire)
-            .collect(),
-        latest_activity: data.latest_activity,
-        total_count: data.total_count,
-        next_cursor: data.next_cursor,
-    }
-}
-
-fn session_list_page_from_wire(data: SessionListData) -> SessionListPage {
-    SessionListPage {
-        groups: data
-            .groups
-            .into_iter()
-            .map(session_group_from_wire)
-            .collect(),
-        next_cursor: data.next_cursor,
-        total_count: data.total_count,
-    }
-}
-
-fn session_children_page_from_wire(data: SessionChildrenData) -> SessionChildrenPage {
-    SessionChildrenPage {
-        parent_session_id: data.parent_session_id,
-        sessions: data
-            .sessions
-            .into_iter()
-            .map(session_summary_from_wire)
-            .collect(),
-        next_cursor: data.next_cursor,
-        total_count: data.total_count,
-    }
-}
-
 fn session_list_page_from_acp(
     request: &SessionListRequest,
     response: acp::ListSessionsResponse,
@@ -2957,131 +2890,33 @@ mod tests {
     }
 
     #[test]
-    fn wire_session_list_page_maps_recursively_to_domain() {
-        let list = session_list_page_from_wire(SessionListData {
-            groups: vec![SessionGroupData {
-                cwd: Some("/repo".into()),
-                latest_activity: Some("2024-02-01T00:00:00Z".into()),
-                total_count: Some(2),
-                next_cursor: Some("group-next".into()),
-                sessions: vec![SessionSummaryData {
-                    session_id: "root".into(),
-                    name: Some("Root name".into()),
-                    title: Some("Root title".into()),
-                    cwd: Some("/repo".into()),
-                    created_at: Some("2024-01-01T00:00:00Z".into()),
-                    updated_at: Some("2024-02-01T00:00:00Z".into()),
-                    parent_session_id: Some("source".into()),
-                    fork_origin: Some("manual".into()),
-                    session_kind: Some("interactive".into()),
-                    has_children: true,
-                    fork_count: 1,
-                    children: vec![SessionSummaryData {
-                        session_id: "child".into(),
-                        parent_session_id: Some("root".into()),
-                        children: vec![SessionSummaryData {
-                            session_id: "grandchild".into(),
-                            ..Default::default()
-                        }],
-                        children_next_cursor: Some("grandchild-next".into()),
-                        children_total_count: Some(1),
-                        node_id: Some("node-child".into()),
-                        ..Default::default()
-                    }],
-                    children_next_cursor: Some("child-next".into()),
-                    children_total_count: Some(1),
-                    node: Some("remote".into()),
-                    node_id: Some("node-root".into()),
-                    attached: Some(true),
-                    runtime_state: Some("running".into()),
-                }],
-            }],
-            next_cursor: Some("list-next".into()),
-            total_count: Some(7),
-        });
+    fn send_session_list_emits_request_and_domain_page() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let request = SessionListRequest::WorkspaceContinuation {
+            cwd: "/repo".to_string(),
+        };
+        let response = acp::ListSessionsResponse::new(vec![acp::SessionInfo::new(
+            acp::SessionId::from("session-1"),
+            Path::new("/from-response"),
+        )])
+        .next_cursor(Some("cursor-2".to_string()));
 
-        assert_eq!(list.next_cursor.as_deref(), Some("list-next"));
-        assert_eq!(list.total_count, Some(7));
-        let group = &list.groups[0];
-        assert_eq!(group.cwd.as_deref(), Some("/repo"));
-        assert_eq!(
-            group.latest_activity.as_deref(),
-            Some("2024-02-01T00:00:00Z")
-        );
-        assert_eq!(group.total_count, Some(2));
-        assert_eq!(group.next_cursor.as_deref(), Some("group-next"));
-        let root = &group.sessions[0];
-        assert_eq!(root.session_id, "root");
-        assert_eq!(root.name.as_deref(), Some("Root name"));
-        assert_eq!(root.title.as_deref(), Some("Root title"));
-        assert_eq!(root.cwd.as_deref(), Some("/repo"));
-        assert_eq!(root.created_at.as_deref(), Some("2024-01-01T00:00:00Z"));
-        assert_eq!(root.updated_at.as_deref(), Some("2024-02-01T00:00:00Z"));
-        assert_eq!(root.parent_session_id.as_deref(), Some("source"));
-        assert_eq!(root.fork_origin.as_deref(), Some("manual"));
-        assert_eq!(root.session_kind.as_deref(), Some("interactive"));
-        assert!(root.has_children);
-        assert_eq!(root.fork_count, 1);
-        assert_eq!(root.children_next_cursor.as_deref(), Some("child-next"));
-        assert_eq!(root.children_total_count, Some(1));
-        assert_eq!(root.node.as_deref(), Some("remote"));
-        assert_eq!(root.node_id.as_deref(), Some("node-root"));
-        assert_eq!(root.attached, Some(true));
-        assert_eq!(root.runtime_state.as_deref(), Some("running"));
-        let child = &root.children[0];
-        assert_eq!(child.session_id, "child");
-        assert_eq!(child.parent_session_id.as_deref(), Some("root"));
-        assert_eq!(child.node_id.as_deref(), Some("node-child"));
-        assert_eq!(
-            child.children_next_cursor.as_deref(),
-            Some("grandchild-next")
-        );
-        assert_eq!(child.children_total_count, Some(1));
-        assert_eq!(child.children[0].session_id, "grandchild");
-    }
+        send_session_list(&tx, request.clone(), response);
 
-    #[test]
-    fn wire_session_children_page_maps_recursively_to_domain() {
-        let children = session_children_page_from_wire(SessionChildrenData {
-            parent_session_id: "root".into(),
-            sessions: vec![SessionSummaryData {
-                session_id: "child".into(),
-                parent_session_id: Some("root".into()),
-                node_id: Some("node-child".into()),
-                children: vec![SessionSummaryData {
-                    session_id: "grandchild".into(),
-                    parent_session_id: Some("child".into()),
-                    node_id: Some("node-grandchild".into()),
-                    ..Default::default()
-                }],
-                children_next_cursor: Some("grandchild-next".into()),
-                children_total_count: Some(1),
-                ..Default::default()
-            }],
-            next_cursor: Some("children-next".into()),
-            total_count: Some(3),
-        });
-
-        assert_eq!(children.parent_session_id, "root");
-        assert_eq!(children.next_cursor.as_deref(), Some("children-next"));
-        assert_eq!(children.total_count, Some(3));
-        let child = &children.sessions[0];
-        assert_eq!(child.parent_session_id.as_deref(), Some("root"));
-        assert_eq!(child.node_id.as_deref(), Some("node-child"));
-        assert_eq!(
-            child.children_next_cursor.as_deref(),
-            Some("grandchild-next")
-        );
-        assert_eq!(child.children_total_count, Some(1));
-        assert_eq!(child.children[0].session_id, "grandchild");
-        assert_eq!(
-            child.children[0].parent_session_id.as_deref(),
-            Some("child")
-        );
-        assert_eq!(
-            child.children[0].node_id.as_deref(),
-            Some("node-grandchild")
-        );
+        match rx.try_recv().expect("session list event") {
+            ServerChannelMsg::Acp(AcpAppEvent::SessionList {
+                request: emitted_request,
+                page,
+            }) => {
+                assert_eq!(emitted_request, request);
+                assert_eq!(page.next_cursor.as_deref(), Some("cursor-2"));
+                assert_eq!(page.groups.len(), 1);
+                assert_eq!(page.groups[0].cwd.as_deref(), Some("/repo"));
+                assert_eq!(page.groups[0].next_cursor.as_deref(), Some("cursor-2"));
+                assert_eq!(page.groups[0].sessions.len(), 1);
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
     }
 
     #[test]

--- a/src/acp_client.rs
+++ b/src/acp_client.rs
@@ -2957,7 +2957,7 @@ mod tests {
     }
 
     #[test]
-    fn wire_session_pages_map_recursively_to_domain() {
+    fn wire_session_list_page_maps_recursively_to_domain() {
         let list = session_list_page_from_wire(SessionListData {
             groups: vec![SessionGroupData {
                 cwd: Some("/repo".into()),
@@ -2971,7 +2971,7 @@ mod tests {
                     cwd: Some("/repo".into()),
                     created_at: Some("2024-01-01T00:00:00Z".into()),
                     updated_at: Some("2024-02-01T00:00:00Z".into()),
-                    parent_session_id: None,
+                    parent_session_id: Some("source".into()),
                     fork_origin: Some("manual".into()),
                     session_kind: Some("interactive".into()),
                     has_children: true,
@@ -2979,6 +2979,12 @@ mod tests {
                     children: vec![SessionSummaryData {
                         session_id: "child".into(),
                         parent_session_id: Some("root".into()),
+                        children: vec![SessionSummaryData {
+                            session_id: "grandchild".into(),
+                            ..Default::default()
+                        }],
+                        children_next_cursor: Some("grandchild-next".into()),
+                        children_total_count: Some(1),
                         node_id: Some("node-child".into()),
                         ..Default::default()
                     }],
@@ -3005,43 +3011,77 @@ mod tests {
         assert_eq!(group.total_count, Some(2));
         assert_eq!(group.next_cursor.as_deref(), Some("group-next"));
         let root = &group.sessions[0];
+        assert_eq!(root.session_id, "root");
         assert_eq!(root.name.as_deref(), Some("Root name"));
         assert_eq!(root.title.as_deref(), Some("Root title"));
         assert_eq!(root.cwd.as_deref(), Some("/repo"));
         assert_eq!(root.created_at.as_deref(), Some("2024-01-01T00:00:00Z"));
         assert_eq!(root.updated_at.as_deref(), Some("2024-02-01T00:00:00Z"));
-        assert_eq!(root.parent_session_id, None);
+        assert_eq!(root.parent_session_id.as_deref(), Some("source"));
         assert_eq!(root.fork_origin.as_deref(), Some("manual"));
         assert_eq!(root.session_kind.as_deref(), Some("interactive"));
         assert!(root.has_children);
         assert_eq!(root.fork_count, 1);
-        assert_eq!(root.children[0].session_id, "child");
-        assert_eq!(root.children[0].parent_session_id.as_deref(), Some("root"));
-        assert_eq!(root.children[0].node_id.as_deref(), Some("node-child"));
         assert_eq!(root.children_next_cursor.as_deref(), Some("child-next"));
         assert_eq!(root.children_total_count, Some(1));
         assert_eq!(root.node.as_deref(), Some("remote"));
         assert_eq!(root.node_id.as_deref(), Some("node-root"));
         assert_eq!(root.attached, Some(true));
         assert_eq!(root.runtime_state.as_deref(), Some("running"));
+        let child = &root.children[0];
+        assert_eq!(child.session_id, "child");
+        assert_eq!(child.parent_session_id.as_deref(), Some("root"));
+        assert_eq!(child.node_id.as_deref(), Some("node-child"));
+        assert_eq!(
+            child.children_next_cursor.as_deref(),
+            Some("grandchild-next")
+        );
+        assert_eq!(child.children_total_count, Some(1));
+        assert_eq!(child.children[0].session_id, "grandchild");
+    }
 
+    #[test]
+    fn wire_session_children_page_maps_recursively_to_domain() {
         let children = session_children_page_from_wire(SessionChildrenData {
             parent_session_id: "root".into(),
             sessions: vec![SessionSummaryData {
                 session_id: "child".into(),
+                parent_session_id: Some("root".into()),
+                node_id: Some("node-child".into()),
                 children: vec![SessionSummaryData {
                     session_id: "grandchild".into(),
+                    parent_session_id: Some("child".into()),
+                    node_id: Some("node-grandchild".into()),
                     ..Default::default()
                 }],
+                children_next_cursor: Some("grandchild-next".into()),
+                children_total_count: Some(1),
                 ..Default::default()
             }],
             next_cursor: Some("children-next".into()),
             total_count: Some(3),
         });
+
         assert_eq!(children.parent_session_id, "root");
-        assert_eq!(children.sessions[0].children[0].session_id, "grandchild");
         assert_eq!(children.next_cursor.as_deref(), Some("children-next"));
         assert_eq!(children.total_count, Some(3));
+        let child = &children.sessions[0];
+        assert_eq!(child.parent_session_id.as_deref(), Some("root"));
+        assert_eq!(child.node_id.as_deref(), Some("node-child"));
+        assert_eq!(
+            child.children_next_cursor.as_deref(),
+            Some("grandchild-next")
+        );
+        assert_eq!(child.children_total_count, Some(1));
+        assert_eq!(child.children[0].session_id, "grandchild");
+        assert_eq!(
+            child.children[0].parent_session_id.as_deref(),
+            Some("child")
+        );
+        assert_eq!(
+            child.children[0].node_id.as_deref(),
+            Some("node-grandchild")
+        );
     }
 
     #[test]

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -14,7 +14,7 @@ use crate::domain::chat::ChatEntry;
 use crate::domain::elicitation::ElicitationState;
 use crate::domain::model::ModelEntry;
 use crate::domain::profile::{AgentInfo, ProfileInfo};
-use crate::domain::session::{SessionGroup, SessionSummary, UndoableTurn};
+use crate::domain::session::{SessionGroup, SessionListPage, SessionSummary, UndoableTurn};
 use crate::domain::tool::ToolDetail;
 use crate::protocol::{
     ClientMsg, ForkResultData, MeshInviteCreatedInfo, MeshNodesInfo, MeshStatusInfo, OAuthFlowData,
@@ -125,8 +125,7 @@ pub(crate) enum AcpAppEvent {
     RemoteSessionAttached(RemoteSessionAttachInfo),
     SessionList {
         request: SessionListRequest,
-        groups: Vec<SessionGroup>,
-        next_cursor: Option<String>,
+        page: SessionListPage,
     },
     SessionListFailed {
         request: SessionListRequest,
@@ -315,11 +314,9 @@ impl crate::app::App {
                 &attached.node_id,
                 attached.attached,
             ),
-            AcpAppEvent::SessionList {
-                request,
-                groups,
-                next_cursor,
-            } => self.apply_acp_session_list(request, groups, next_cursor),
+            AcpAppEvent::SessionList { request, page } => {
+                self.apply_acp_session_list(request, page)
+            }
             AcpAppEvent::SessionListFailed { request, message } => {
                 self.apply_acp_session_list_failure(&request);
                 self.push_acp_error(&message);
@@ -589,9 +586,13 @@ impl crate::app::App {
     fn apply_acp_session_list(
         &mut self,
         request: SessionListRequest,
-        mut groups: Vec<SessionGroup>,
-        next_cursor: Option<String>,
+        page: SessionListPage,
     ) -> Vec<ClientMsg> {
+        let SessionListPage {
+            mut groups,
+            next_cursor,
+            total_count: _,
+        } = page;
         for group in &mut groups {
             group.total_count = None;
             for session in &group.sessions {
@@ -2083,7 +2084,7 @@ mod tests {
     use crate::app::{App, Screen};
     use crate::domain::activity::{PendingDelegateToolCall, SessionOp};
     use crate::domain::model::DelegateModelPreference;
-    use crate::domain::session::UndoState;
+    use crate::domain::session::{SessionListPage, UndoState};
 
     const TEST_SESSION_ID: &str = "session-1";
     const TEST_ASSISTANT_ID: &str = "a1";
@@ -2137,6 +2138,14 @@ mod tests {
                     ..Default::default()
                 })
                 .collect(),
+        }
+    }
+
+    fn session_list_page(groups: Vec<SessionGroup>, next_cursor: Option<&str>) -> SessionListPage {
+        SessionListPage {
+            groups,
+            next_cursor: next_cursor.map(str::to_string),
+            total_count: None,
         }
     }
 
@@ -2516,8 +2525,10 @@ mod tests {
 
         let replies = app.handle_acp_event(AcpAppEvent::SessionList {
             request: SessionListRequest::Discovery,
-            groups: vec![session_group("/repo", &["s1", "s2"])],
-            next_cursor: Some("opaque-root-2".into()),
+            page: session_list_page(
+                vec![session_group("/repo", &["s1", "s2"])],
+                Some("opaque-root-2"),
+            ),
         });
 
         assert!(app.session_discovery_in_progress);
@@ -2557,8 +2568,7 @@ mod tests {
             request: SessionListRequest::WorkspaceFirstPage {
                 cwd: "/repo".into(),
             },
-            groups: vec![page],
-            next_cursor: Some("opaque-workspace-2".into()),
+            page: session_list_page(vec![page], Some("opaque-workspace-2")),
         });
 
         assert!(app.hydrated_session_groups.contains("/repo"));
@@ -2587,11 +2597,13 @@ mod tests {
 
         let replies = app.handle_acp_event(AcpAppEvent::SessionList {
             request: SessionListRequest::Discovery,
-            groups: vec![
-                session_group("/repo", &["stale-discovery"]),
-                session_group("/later", &["later-1"]),
-            ],
-            next_cursor: None,
+            page: session_list_page(
+                vec![
+                    session_group("/repo", &["stale-discovery"]),
+                    session_group("/later", &["later-1"]),
+                ],
+                None,
+            ),
         });
 
         let repo = app
@@ -2626,8 +2638,7 @@ mod tests {
             request: SessionListRequest::WorkspaceContinuation {
                 cwd: "/repo".into(),
             },
-            groups: vec![group],
-            next_cursor: Some("cursor-2".into()),
+            page: session_list_page(vec![group], Some("cursor-2")),
         });
 
         assert!(app.pending_session_group_loads.is_empty());

--- a/src/app.rs
+++ b/src/app.rs
@@ -3657,7 +3657,6 @@ mod tests {
 mod start_page_tests {
     use super::*;
     use crate::domain::session::SessionSummary;
-    use crate::protocol::SessionListData;
 
     fn make_group(cwd: Option<&str>, ids: &[(&str, Option<&str>)]) -> SessionGroup {
         SessionGroup {
@@ -3849,68 +3848,6 @@ mod start_page_tests {
                 depth: 0,
             } if path == &vec![0]
         ));
-    }
-
-    // ── session_list message preserves group structure ────────────────────────
-
-    #[test]
-    fn session_summary_defaults_missing_fork_count_to_zero() {
-        let session: SessionSummary = serde_json::from_value(serde_json::json!({
-            "session_id": "s1",
-            "title": "Session One"
-        }))
-        .expect("session summary without fork_count should parse");
-
-        assert_eq!(session.fork_count, 0);
-    }
-
-    #[test]
-    fn backend_shaped_session_list_deserializes_with_new_fields() {
-        let list: SessionListData = serde_json::from_value(serde_json::json!({
-            "groups": [
-                {
-                    "cwd": "/workspace/project",
-                    "latest_activity": "2024-02-01T00:00:00Z",
-                    "total_count": 1,
-                    "next_cursor": "group-next",
-                    "sessions": [
-                        {
-                            "session_id": "s1",
-                            "name": "Session One",
-                            "cwd": "/workspace/project",
-                            "title": "T1",
-                            "created_at": "2024-01-01T00:00:00Z",
-                            "updated_at": "2024-02-01T00:00:00Z",
-                            "parent_session_id": null,
-                            "fork_origin": null,
-                            "session_kind": "interactive",
-                            "has_children": true,
-                            "fork_count": 3,
-                            "node": "local",
-                            "node_id": "node-1",
-                            "attached": true,
-                            "runtime_state": "running"
-                        }
-                    ]
-                }
-            ],
-            "next_cursor": "list-next",
-            "total_count": 1
-        }))
-        .expect("backend session_list shape should parse");
-
-        assert_eq!(list.next_cursor.as_deref(), Some("list-next"));
-        assert_eq!(list.total_count, Some(1));
-        assert_eq!(list.groups[0].total_count, Some(1));
-        assert_eq!(list.groups[0].next_cursor.as_deref(), Some("group-next"));
-        let session = &list.groups[0].sessions[0];
-        assert_eq!(session.name.as_deref(), Some("Session One"));
-        assert_eq!(session.session_kind.as_deref(), Some("interactive"));
-        assert_eq!(session.fork_count, 3);
-        assert_eq!(session.node.as_deref(), Some("local"));
-        assert_eq!(session.node_id.as_deref(), Some("node-1"));
-        assert_eq!(session.attached, Some(true));
-        assert_eq!(session.runtime_state.as_deref(), Some("running"));
     }
 
     #[test]

--- a/src/domain/session.rs
+++ b/src/domain/session.rs
@@ -1,60 +1,52 @@
-use serde::Deserialize;
-
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default)]
 pub struct SessionGroup {
     pub cwd: Option<String>,
-    #[serde(default)]
     pub sessions: Vec<SessionSummary>,
     /// ISO 8601 timestamp of the most recent activity in this group.
-    #[serde(default)]
     pub latest_activity: Option<String>,
-    #[serde(default)]
     pub total_count: Option<u64>,
-    #[serde(default)]
     pub next_cursor: Option<String>,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default)]
 pub struct SessionSummary {
     pub session_id: String,
-    #[serde(default)]
     pub name: Option<String>,
-    #[serde(default)]
     pub title: Option<String>,
     /// Working directory for this session (may differ from group cwd for remote sessions).
-    #[serde(default)]
     pub cwd: Option<String>,
-    #[serde(default)]
     pub created_at: Option<String>,
-    #[serde(default)]
     pub updated_at: Option<String>,
     /// Parent session ID if this is a forked session.
-    #[serde(default)]
     pub parent_session_id: Option<String>,
-    #[serde(default)]
     pub fork_origin: Option<String>,
-    #[serde(default)]
     pub session_kind: Option<String>,
     /// Whether this session has child (forked) sessions.
-    #[serde(default)]
     pub has_children: bool,
     /// Number of direct forked child sessions.
-    #[serde(default)]
     pub fork_count: u64,
-    #[serde(default)]
     pub children: Vec<SessionSummary>,
-    #[serde(default)]
     pub children_next_cursor: Option<String>,
-    #[serde(default)]
     pub children_total_count: Option<u64>,
-    #[serde(default)]
     pub node: Option<String>,
-    #[serde(default)]
     pub node_id: Option<String>,
-    #[serde(default)]
     pub attached: Option<bool>,
-    #[serde(default)]
     pub runtime_state: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SessionListPage {
+    pub groups: Vec<SessionGroup>,
+    pub next_cursor: Option<String>,
+    pub total_count: Option<u64>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SessionChildrenPage {
+    pub parent_session_id: String,
+    pub sessions: Vec<SessionSummary>,
+    pub next_cursor: Option<String>,
+    pub total_count: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 
 use crate::domain::auth::{AuthMethod, AuthProviderEntry, OAuthFlowKind};
-use crate::domain::session::{SessionGroup, SessionSummary};
 
 // --- Client → Server messages ---
 
@@ -624,7 +623,7 @@ pub struct SessionCreatedData {
 #[derive(Debug, Default, Deserialize)]
 pub struct SessionListData {
     #[serde(default)]
-    pub groups: Vec<SessionGroup>,
+    pub groups: Vec<SessionGroupData>,
     #[serde(default)]
     pub next_cursor: Option<String>,
     #[serde(default)]
@@ -632,10 +631,67 @@ pub struct SessionListData {
 }
 
 #[derive(Debug, Default, Deserialize)]
+pub struct SessionGroupData {
+    pub cwd: Option<String>,
+    #[serde(default)]
+    pub sessions: Vec<SessionSummaryData>,
+    /// ISO 8601 timestamp of the most recent activity in this group.
+    #[serde(default)]
+    pub latest_activity: Option<String>,
+    #[serde(default)]
+    pub total_count: Option<u64>,
+    #[serde(default)]
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct SessionSummaryData {
+    pub session_id: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub title: Option<String>,
+    /// Working directory for this session (may differ from group cwd for remote sessions).
+    #[serde(default)]
+    pub cwd: Option<String>,
+    #[serde(default)]
+    pub created_at: Option<String>,
+    #[serde(default)]
+    pub updated_at: Option<String>,
+    /// Parent session ID if this is a forked session.
+    #[serde(default)]
+    pub parent_session_id: Option<String>,
+    #[serde(default)]
+    pub fork_origin: Option<String>,
+    #[serde(default)]
+    pub session_kind: Option<String>,
+    /// Whether this session has child (forked) sessions.
+    #[serde(default)]
+    pub has_children: bool,
+    /// Number of direct forked child sessions.
+    #[serde(default)]
+    pub fork_count: u64,
+    #[serde(default)]
+    pub children: Vec<SessionSummaryData>,
+    #[serde(default)]
+    pub children_next_cursor: Option<String>,
+    #[serde(default)]
+    pub children_total_count: Option<u64>,
+    #[serde(default)]
+    pub node: Option<String>,
+    #[serde(default)]
+    pub node_id: Option<String>,
+    #[serde(default)]
+    pub attached: Option<bool>,
+    #[serde(default)]
+    pub runtime_state: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
 pub struct SessionChildrenData {
     pub parent_session_id: String,
     #[serde(default)]
-    pub sessions: Vec<SessionSummary>,
+    pub sessions: Vec<SessionSummaryData>,
     #[serde(default)]
     pub next_cursor: Option<String>,
     #[serde(default)]
@@ -698,6 +754,104 @@ pub struct ForkResultData {
     pub forked_session_id: Option<String>,
     #[serde(default)]
     pub message: Option<String>,
+}
+
+#[cfg(test)]
+mod session_page_data_tests {
+    use super::{SessionChildrenData, SessionListData};
+    use serde_json::json;
+
+    #[test]
+    fn session_pages_deserialize_recursive_wire_fields_and_defaults() {
+        let list: SessionListData = serde_json::from_value(json!({
+            "groups": [{
+                "cwd": "/workspace/project",
+                "latest_activity": "2024-02-01T00:00:00Z",
+                "total_count": 4,
+                "next_cursor": "group-next",
+                "unknown_group_field": true,
+                "sessions": [{
+                    "session_id": "root",
+                    "name": "Session One",
+                    "title": "Root",
+                    "cwd": "/workspace/project",
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "updated_at": "2024-02-01T00:00:00Z",
+                    "parent_session_id": null,
+                    "fork_origin": null,
+                    "session_kind": "interactive",
+                    "has_children": true,
+                    "fork_count": 1,
+                    "children_next_cursor": "child-next",
+                    "children_total_count": 2,
+                    "node": "remote",
+                    "node_id": "node-1",
+                    "attached": true,
+                    "runtime_state": "running",
+                    "unknown_session_field": "ignored",
+                    "children": [{
+                        "session_id": "child",
+                        "parent_session_id": "root",
+                        "fork_origin": "manual"
+                    }]
+                }]
+            }],
+            "next_cursor": "list-next",
+            "total_count": 9,
+            "unknown_page_field": null
+        }))
+        .expect("session list wire shape should deserialize");
+
+        assert_eq!(list.next_cursor.as_deref(), Some("list-next"));
+        assert_eq!(list.total_count, Some(9));
+        let group = &list.groups[0];
+        assert_eq!(group.cwd.as_deref(), Some("/workspace/project"));
+        assert_eq!(
+            group.latest_activity.as_deref(),
+            Some("2024-02-01T00:00:00Z")
+        );
+        assert_eq!(group.total_count, Some(4));
+        assert_eq!(group.next_cursor.as_deref(), Some("group-next"));
+        let root = &group.sessions[0];
+        assert_eq!(root.name.as_deref(), Some("Session One"));
+        assert_eq!(root.title.as_deref(), Some("Root"));
+        assert_eq!(root.cwd.as_deref(), Some("/workspace/project"));
+        assert_eq!(root.created_at.as_deref(), Some("2024-01-01T00:00:00Z"));
+        assert_eq!(root.updated_at.as_deref(), Some("2024-02-01T00:00:00Z"));
+        assert_eq!(root.parent_session_id, None);
+        assert_eq!(root.fork_origin, None);
+        assert_eq!(root.session_kind.as_deref(), Some("interactive"));
+        assert!(root.has_children);
+        assert_eq!(root.fork_count, 1);
+        assert_eq!(root.children_next_cursor.as_deref(), Some("child-next"));
+        assert_eq!(root.children_total_count, Some(2));
+        assert_eq!(root.node.as_deref(), Some("remote"));
+        assert_eq!(root.node_id.as_deref(), Some("node-1"));
+        assert_eq!(root.attached, Some(true));
+        assert_eq!(root.runtime_state.as_deref(), Some("running"));
+        assert_eq!(root.children[0].session_id, "child");
+        assert_eq!(root.children[0].parent_session_id.as_deref(), Some("root"));
+        assert_eq!(root.children[0].fork_origin.as_deref(), Some("manual"));
+        assert_eq!(root.children[0].fork_count, 0);
+        assert!(root.children[0].children.is_empty());
+
+        let children: SessionChildrenData = serde_json::from_value(json!({
+            "parent_session_id": "root",
+            "sessions": [{ "session_id": "child" }]
+        }))
+        .expect("session children defaults should deserialize");
+        assert_eq!(children.parent_session_id, "root");
+        assert_eq!(children.sessions[0].fork_count, 0);
+        assert!(children.sessions[0].children.is_empty());
+        assert_eq!(children.next_cursor, None);
+        assert_eq!(children.total_count, None);
+
+        let empty_list: SessionListData =
+            serde_json::from_value(json!({})).expect("session list defaults should deserialize");
+        assert!(empty_list.groups.is_empty());
+        assert_eq!(empty_list.next_cursor, None);
+        assert_eq!(empty_list.total_count, None);
+    }
 }
 
 #[cfg(test)]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -778,7 +778,7 @@ mod session_page_data_tests {
                     "created_at": "2024-01-01T00:00:00Z",
                     "updated_at": "2024-02-01T00:00:00Z",
                     "parent_session_id": null,
-                    "fork_origin": null,
+                    "fork_origin": "manual",
                     "session_kind": "interactive",
                     "has_children": true,
                     "fork_count": 1,
@@ -792,7 +792,11 @@ mod session_page_data_tests {
                     "children": [{
                         "session_id": "child",
                         "parent_session_id": "root",
-                        "fork_origin": "manual"
+                        "fork_origin": "manual",
+                        "children_next_cursor": "grandchild-next",
+                        "children_total_count": 1,
+                        "node_id": "node-2",
+                        "children": [{ "session_id": "grandchild" }]
                     }]
                 }]
             }],
@@ -813,13 +817,14 @@ mod session_page_data_tests {
         assert_eq!(group.total_count, Some(4));
         assert_eq!(group.next_cursor.as_deref(), Some("group-next"));
         let root = &group.sessions[0];
+        assert_eq!(root.session_id, "root");
         assert_eq!(root.name.as_deref(), Some("Session One"));
         assert_eq!(root.title.as_deref(), Some("Root"));
         assert_eq!(root.cwd.as_deref(), Some("/workspace/project"));
         assert_eq!(root.created_at.as_deref(), Some("2024-01-01T00:00:00Z"));
         assert_eq!(root.updated_at.as_deref(), Some("2024-02-01T00:00:00Z"));
         assert_eq!(root.parent_session_id, None);
-        assert_eq!(root.fork_origin, None);
+        assert_eq!(root.fork_origin.as_deref(), Some("manual"));
         assert_eq!(root.session_kind.as_deref(), Some("interactive"));
         assert!(root.has_children);
         assert_eq!(root.fork_count, 1);
@@ -829,22 +834,55 @@ mod session_page_data_tests {
         assert_eq!(root.node_id.as_deref(), Some("node-1"));
         assert_eq!(root.attached, Some(true));
         assert_eq!(root.runtime_state.as_deref(), Some("running"));
-        assert_eq!(root.children[0].session_id, "child");
-        assert_eq!(root.children[0].parent_session_id.as_deref(), Some("root"));
-        assert_eq!(root.children[0].fork_origin.as_deref(), Some("manual"));
-        assert_eq!(root.children[0].fork_count, 0);
-        assert!(root.children[0].children.is_empty());
+
+        let child = &root.children[0];
+        assert_eq!(child.session_id, "child");
+        assert_eq!(child.parent_session_id.as_deref(), Some("root"));
+        assert_eq!(child.fork_origin.as_deref(), Some("manual"));
+        assert_eq!(
+            child.children_next_cursor.as_deref(),
+            Some("grandchild-next")
+        );
+        assert_eq!(child.children_total_count, Some(1));
+        assert_eq!(child.node_id.as_deref(), Some("node-2"));
+        assert_eq!(child.children[0].session_id, "grandchild");
+        assert_eq!(child.children[0].fork_count, 0);
+        assert!(child.children[0].children.is_empty());
 
         let children: SessionChildrenData = serde_json::from_value(json!({
+            "parent_session_id": "root",
+            "sessions": [{
+                "session_id": "child",
+                "node_id": "node-2",
+                "children_next_cursor": "nested-next",
+                "children_total_count": 1,
+                "children": [{ "session_id": "grandchild" }]
+            }],
+            "next_cursor": "children-next",
+            "total_count": 3
+        }))
+        .expect("session children wire shape should deserialize");
+        assert_eq!(children.parent_session_id, "root");
+        assert_eq!(children.next_cursor.as_deref(), Some("children-next"));
+        assert_eq!(children.total_count, Some(3));
+        assert_eq!(children.sessions[0].node_id.as_deref(), Some("node-2"));
+        assert_eq!(
+            children.sessions[0].children_next_cursor.as_deref(),
+            Some("nested-next")
+        );
+        assert_eq!(children.sessions[0].children_total_count, Some(1));
+        assert_eq!(children.sessions[0].children[0].session_id, "grandchild");
+
+        let defaulted_children: SessionChildrenData = serde_json::from_value(json!({
             "parent_session_id": "root",
             "sessions": [{ "session_id": "child" }]
         }))
         .expect("session children defaults should deserialize");
-        assert_eq!(children.parent_session_id, "root");
-        assert_eq!(children.sessions[0].fork_count, 0);
-        assert!(children.sessions[0].children.is_empty());
-        assert_eq!(children.next_cursor, None);
-        assert_eq!(children.total_count, None);
+        assert_eq!(defaulted_children.sessions[0].fork_count, 0);
+        assert!(!defaulted_children.sessions[0].has_children);
+        assert!(defaulted_children.sessions[0].children.is_empty());
+        assert_eq!(defaulted_children.next_cursor, None);
+        assert_eq!(defaulted_children.total_count, None);
 
         let empty_list: SessionListData =
             serde_json::from_value(json!({})).expect("session list defaults should deserialize");

--- a/src/session.rs
+++ b/src/session.rs
@@ -10,8 +10,7 @@ use crate::app::{
     PopupItem, StartPageItem,
 };
 use crate::domain::activity::{DelegateEntry, SessionActivity};
-use crate::domain::session::{SessionGroup, SessionSummary};
-use crate::protocol::SessionChildrenData;
+use crate::domain::session::{SessionChildrenPage, SessionGroup, SessionSummary};
 
 /// Returns indices of sessions in `group` whose title or ID matches `q`.
 /// When `q` is empty every session matches in original order.
@@ -194,7 +193,7 @@ impl App {
         false
     }
 
-    pub fn merge_session_children(&mut self, data: SessionChildrenData) {
+    pub fn merge_session_children(&mut self, data: SessionChildrenPage) {
         let had_pending_request = self
             .pending_session_child_loads
             .remove(&data.parent_session_id);
@@ -778,7 +777,7 @@ mod tests {
         remote.node_id = Some("node-1".into());
         let mut delegated = session("delegated-child");
         delegated.fork_origin = Some("delegation".into());
-        app.merge_session_children(SessionChildrenData {
+        app.merge_session_children(SessionChildrenPage {
             parent_session_id: "parent".into(),
             sessions: vec![session("child-1"), remote, delegated, session("child-1")],
             next_cursor: Some("cursor-2".into()),
@@ -802,7 +801,7 @@ mod tests {
         assert!(app.pending_session_child_loads.is_empty());
 
         app.pending_session_child_loads.insert("parent".into());
-        app.merge_session_children(SessionChildrenData {
+        app.merge_session_children(SessionChildrenPage {
             parent_session_id: "parent".into(),
             sessions: vec![session("remote-child"), session("child-2")],
             next_cursor: None,
@@ -823,7 +822,7 @@ mod tests {
 
         app.pending_session_child_loads
             .insert("missing-parent".into());
-        app.merge_session_children(SessionChildrenData {
+        app.merge_session_children(SessionChildrenPage {
             parent_session_id: "missing-parent".into(),
             ..Default::default()
         });


### PR DESCRIPTION
## changes
- move session list/children serde records into protocol-only wire dtos
- add an explicit native acp adapter that produces domain session pages
- carry domain pages through acp events, reducers, and child merging
- cover wire serde fields/defaults, native cursor mapping, and the session-list event envelope

## validation
- cargo fmt --all -- --check
- cargo check --all-targets
- cargo clippy --all-targets -- -D warnings
- cargo build --all-targets
- cargo test --all-targets (728 tests)
- git diff --check
- stale-shape searches for removed wire mappers/tests and acp_client wire dto imports

## caveats
- the wire dto serde contract remains; conversion will be introduced with real ingress. session children transport remains unsupported in the current acp subset
- total_count handling is unchanged: pages preserve it at the boundary, while the existing list reducer intentionally does not store it