### PR TITLE
refactor: separate session mutation results

### DIFF
--- a/src/acp_client.rs
+++ b/src/acp_client.rs
@@ -21,11 +21,14 @@ use crate::ServerChannelMsg;
 use crate::acp_state::{AcpAppEvent, AcpModelsMetaInfo, AcpSessionUpdate};
 use crate::domain::model::ModelEntry;
 use crate::domain::profile::{AgentInfo, ProfileInfo};
-use crate::domain::session::{SessionGroup, SessionListPage, SessionSummary};
+use crate::domain::session::{
+    ForkResult, RedoResult, SessionGroup, SessionListPage, SessionSummary, UndoResult,
+    UndoStackSnapshot,
+};
 use crate::protocol::{
-    AuthProvidersData, ClientMsg, ForkResultData, MeshInviteCreatedInfo, MeshNodesInfo,
-    MeshStatusInfo, OAuthFlowData, OAuthResultData, RedoResultData, RemoteSessionAttachInfo,
-    RemoteSessionListInfo, SessionListRequest, UndoResultData, UndoStackFrame,
+    AuthProvidersData, ClientMsg, MeshInviteCreatedInfo, MeshNodesInfo, MeshStatusInfo,
+    OAuthFlowData, OAuthResultData, RedoResultData, RemoteSessionAttachInfo, RemoteSessionListInfo,
+    SessionListRequest, UndoResultData, UndoStackFrame,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1260,10 +1263,8 @@ async fn handle_client_msg<C: AcpConnection>(
             let Some(session_id) = state.current_session_id().await else {
                 send_acp(
                     srv_tx,
-                    AcpAppEvent::ForkResult(ForkResultData {
-                        success: false,
+                    AcpAppEvent::ForkResult(ForkResult::Failed {
                         source_session_id: None,
-                        forked_session_id: None,
                         message: Some("cannot fork before a session is loaded".to_string()),
                     }),
                 );
@@ -1274,8 +1275,7 @@ async fn handle_client_msg<C: AcpConnection>(
             match connection.request(req).await {
                 Ok(response) => send_acp(
                     srv_tx,
-                    AcpAppEvent::ForkResult(ForkResultData {
-                        success: true,
+                    AcpAppEvent::ForkResult(ForkResult::Succeeded {
                         source_session_id: Some(session_id),
                         forked_session_id: Some(response.session_id.to_string()),
                         message: None,
@@ -1283,10 +1283,8 @@ async fn handle_client_msg<C: AcpConnection>(
                 ),
                 Err(err) => send_acp(
                     srv_tx,
-                    AcpAppEvent::ForkResult(ForkResultData {
-                        success: false,
+                    AcpAppEvent::ForkResult(ForkResult::Failed {
                         source_session_id: Some(session_id),
-                        forked_session_id: None,
                         message: Some(format!("ACP fork failed: {err:?}")),
                     }),
                 ),
@@ -1316,7 +1314,10 @@ async fn handle_client_msg<C: AcpConnection>(
             if let Ok(result) =
                 serde_json::from_value::<UndoResultData>(ext_payload(&response).clone())
             {
-                send_acp(srv_tx, AcpAppEvent::UndoResult(result));
+                send_acp(
+                    srv_tx,
+                    AcpAppEvent::UndoResult(undo_result_from_wire(result)),
+                );
             }
         }
         ClientMsg::Redo => {
@@ -1333,7 +1334,10 @@ async fn handle_client_msg<C: AcpConnection>(
             if let Ok(result) =
                 serde_json::from_value::<RedoResultData>(ext_payload(&response).clone())
             {
-                send_acp(srv_tx, AcpAppEvent::RedoResult(result));
+                send_acp(
+                    srv_tx,
+                    AcpAppEvent::RedoResult(redo_result_from_wire(result)),
+                );
             }
         }
         ClientMsg::ListRemoteNodes => {
@@ -1514,17 +1518,55 @@ fn load_session_cwd(cwd: Option<&str>, default_cwd: PathBuf) -> PathBuf {
         .unwrap_or(default_cwd)
 }
 
+fn undo_stack_snapshot_from_wire(frames: Vec<UndoStackFrame>) -> UndoStackSnapshot {
+    UndoStackSnapshot {
+        message_ids: frames.into_iter().map(|frame| frame.message_id).collect(),
+    }
+}
+
+fn undo_result_from_wire(result: UndoResultData) -> UndoResult {
+    let stack = undo_stack_snapshot_from_wire(result.undo_stack);
+    if result.success {
+        UndoResult::Applied {
+            target_message_id: result.message_id,
+            reverted_files: result.reverted_files,
+            message: result.message,
+            stack,
+        }
+    } else {
+        UndoResult::Rejected {
+            message: result.message,
+            stack,
+        }
+    }
+}
+
+fn redo_result_from_wire(result: RedoResultData) -> RedoResult {
+    let stack = undo_stack_snapshot_from_wire(result.undo_stack);
+    if result.success {
+        RedoResult::Applied {
+            message: result.message,
+            stack,
+        }
+    } else {
+        RedoResult::Rejected {
+            message: result.message,
+            stack,
+        }
+    }
+}
+
 async fn fetch_undo_stack<C: AcpConnection>(
     connection: &C,
     session_id: &str,
-) -> Result<Vec<UndoStackFrame>, acp_sdk::Error> {
+) -> Result<UndoStackSnapshot, acp_sdk::Error> {
     let response = call_querymt_ext(
         connection,
         "querymt/session/undoStack",
         json!({ "session_id": session_id }),
     )
     .await?;
-    Ok(ext_payload(&response)
+    let frames = ext_payload(&response)
         .get("undo_stack")
         .and_then(Value::as_array)
         .map(|items| {
@@ -1533,7 +1575,8 @@ async fn fetch_undo_stack<C: AcpConnection>(
                 .filter_map(|item| serde_json::from_value::<UndoStackFrame>(item.clone()).ok())
                 .collect()
         })
-        .unwrap_or_default())
+        .unwrap_or_default();
+    Ok(undo_stack_snapshot_from_wire(frames))
 }
 
 async fn post_connect_diagnostics<C: AcpConnection>(
@@ -2830,6 +2873,98 @@ mod tests {
             "provider": provider,
             "model": model,
         })
+    }
+
+    fn wire_stack(ids: &[&str]) -> Vec<UndoStackFrame> {
+        ids.iter()
+            .map(|message_id| UndoStackFrame {
+                message_id: (*message_id).into(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn undo_stack_snapshot_from_wire_preserves_message_order() {
+        let snapshot = undo_stack_snapshot_from_wire(wire_stack(&["message-2", "message-1"]));
+
+        assert_eq!(snapshot.message_ids, ["message-2", "message-1"]);
+    }
+
+    #[test]
+    fn undo_result_from_wire_maps_applied_details() {
+        let result = undo_result_from_wire(UndoResultData {
+            success: true,
+            message_id: Some("message-2".into()),
+            reverted_files: vec!["src/a.rs".into()],
+            message: Some("undone".into()),
+            undo_stack: wire_stack(&["message-1", "message-2"]),
+        });
+
+        assert_eq!(
+            result,
+            UndoResult::Applied {
+                target_message_id: Some("message-2".into()),
+                reverted_files: vec!["src/a.rs".into()],
+                message: Some("undone".into()),
+                stack: UndoStackSnapshot {
+                    message_ids: vec!["message-1".into(), "message-2".into()],
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn undo_result_from_wire_rejects_and_discards_reverted_files() {
+        let result = undo_result_from_wire(UndoResultData {
+            success: false,
+            message_id: Some("ignored".into()),
+            reverted_files: vec!["ignored.rs".into()],
+            message: Some("undo rejected".into()),
+            undo_stack: wire_stack(&["message-1"]),
+        });
+
+        assert_eq!(
+            result,
+            UndoResult::Rejected {
+                message: Some("undo rejected".into()),
+                stack: UndoStackSnapshot {
+                    message_ids: vec!["message-1".into()],
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn redo_result_from_wire_maps_applied_and_rejected_results() {
+        let applied = redo_result_from_wire(RedoResultData {
+            success: true,
+            message: Some("redone".into()),
+            undo_stack: wire_stack(&["message-1", "message-2"]),
+        });
+        assert_eq!(
+            applied,
+            RedoResult::Applied {
+                message: Some("redone".into()),
+                stack: UndoStackSnapshot {
+                    message_ids: vec!["message-1".into(), "message-2".into()],
+                },
+            }
+        );
+
+        let rejected = redo_result_from_wire(RedoResultData {
+            success: false,
+            message: Some("redo rejected".into()),
+            undo_stack: wire_stack(&["message-1"]),
+        });
+        assert_eq!(
+            rejected,
+            RedoResult::Rejected {
+                message: Some("redo rejected".into()),
+                stack: UndoStackSnapshot {
+                    message_ids: vec!["message-1".into()],
+                },
+            }
+        );
     }
 
     #[tokio::test]

--- a/src/acp_client.rs
+++ b/src/acp_client.rs
@@ -1535,6 +1535,7 @@ fn undo_result_from_wire(result: UndoResultData) -> UndoResult {
         }
     } else {
         UndoResult::Rejected {
+            target_message_id: result.message_id,
             message: result.message,
             stack,
         }
@@ -2914,10 +2915,10 @@ mod tests {
     }
 
     #[test]
-    fn undo_result_from_wire_rejects_and_discards_reverted_files() {
+    fn undo_result_from_wire_preserves_rejected_target_and_discards_files() {
         let result = undo_result_from_wire(UndoResultData {
             success: false,
-            message_id: Some("ignored".into()),
+            message_id: Some("message-1".into()),
             reverted_files: vec!["ignored.rs".into()],
             message: Some("undo rejected".into()),
             undo_stack: wire_stack(&["message-1"]),
@@ -2926,6 +2927,7 @@ mod tests {
         assert_eq!(
             result,
             UndoResult::Rejected {
+                target_message_id: Some("message-1".into()),
                 message: Some("undo rejected".into()),
                 stack: UndoStackSnapshot {
                     message_ids: vec!["message-1".into()],

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -14,12 +14,14 @@ use crate::domain::chat::ChatEntry;
 use crate::domain::elicitation::ElicitationState;
 use crate::domain::model::ModelEntry;
 use crate::domain::profile::{AgentInfo, ProfileInfo};
-use crate::domain::session::{SessionGroup, SessionListPage, SessionSummary, UndoableTurn};
+use crate::domain::session::{
+    ForkResult, RedoResult, SessionGroup, SessionListPage, SessionSummary, UndoResult,
+    UndoStackSnapshot, UndoableTurn,
+};
 use crate::domain::tool::ToolDetail;
 use crate::protocol::{
-    ClientMsg, ForkResultData, MeshInviteCreatedInfo, MeshNodesInfo, MeshStatusInfo, OAuthFlowData,
-    OAuthResultData, RedoResultData, RemoteSessionAttachInfo, RemoteSessionListInfo,
-    SessionListRequest, UndoResultData, UndoStackFrame,
+    ClientMsg, MeshInviteCreatedInfo, MeshNodesInfo, MeshStatusInfo, OAuthFlowData,
+    OAuthResultData, RemoteSessionAttachInfo, RemoteSessionListInfo, SessionListRequest,
 };
 use crate::tool_detail;
 
@@ -159,10 +161,10 @@ pub(crate) enum AcpAppEvent {
         models: Vec<ModelEntry>,
         meta: Option<AcpModelsMetaInfo>,
     },
-    UndoStack(Vec<UndoStackFrame>),
-    UndoResult(UndoResultData),
-    RedoResult(RedoResultData),
-    ForkResult(ForkResultData),
+    UndoStack(UndoStackSnapshot),
+    UndoResult(UndoResult),
+    RedoResult(RedoResult),
+    ForkResult(ForkResult),
     AuthProviders(Vec<AuthProviderEntry>),
     OAuthFlowStarted(OAuthFlowData),
     OAuthResult(OAuthResultData),
@@ -360,67 +362,80 @@ impl crate::app::App {
                 self.undo_state = self.build_undo_state_from_server_stack(&undo_stack, None, None);
                 vec![]
             }
-            AcpAppEvent::UndoResult(ur) => {
+            AcpAppEvent::UndoResult(result) => {
                 self.activity = ActivityState::Idle;
-                let message_id_for_files = ur
-                    .message_id
-                    .clone()
-                    .or_else(|| ur.undo_stack.last().map(|frame| frame.message_id.clone()));
-                self.undo_state = self.build_undo_state_from_server_stack(
-                    &ur.undo_stack,
-                    message_id_for_files.as_deref(),
-                    if ur.success {
-                        Some(ur.reverted_files.as_slice())
-                    } else {
-                        None
-                    },
-                );
-                if ur.success {
-                    self.recent_prompt_text = None;
-                    self.streaming_content.clear();
-                    self.streaming_content_message_id = None;
-                    self.streaming_cache.invalidate();
-                    self.set_status(LogLevel::Info, "session", "undone - reloading session");
-                    if let Some(ref sid) = self.session_id {
-                        return vec![ClientMsg::LoadSession {
-                            session_id: sid.clone(),
-                            cwd: self.current_session_cwd(),
-                        }];
+                match result {
+                    UndoResult::Applied {
+                        target_message_id,
+                        reverted_files,
+                        message: _,
+                        stack,
+                    } => {
+                        let message_id_for_files =
+                            target_message_id.or_else(|| stack.message_ids.last().cloned());
+                        self.undo_state = self.build_undo_state_from_server_stack(
+                            &stack,
+                            message_id_for_files.as_deref(),
+                            Some(&reverted_files),
+                        );
+                        self.recent_prompt_text = None;
+                        self.streaming_content.clear();
+                        self.streaming_content_message_id = None;
+                        self.streaming_cache.invalidate();
+                        self.set_status(LogLevel::Info, "session", "undone - reloading session");
+                        if let Some(ref sid) = self.session_id {
+                            return vec![ClientMsg::LoadSession {
+                                session_id: sid.clone(),
+                                cwd: self.current_session_cwd(),
+                            }];
+                        }
                     }
-                } else {
-                    self.set_status(
-                        LogLevel::Warn,
-                        "session",
-                        ur.message.unwrap_or_else(|| "undo failed".into()),
-                    );
+                    UndoResult::Rejected { message, stack } => {
+                        self.undo_state =
+                            self.build_undo_state_from_server_stack(&stack, None, None);
+                        self.set_status(
+                            LogLevel::Warn,
+                            "session",
+                            message.unwrap_or_else(|| "undo failed".into()),
+                        );
+                    }
                 }
                 vec![]
             }
-            AcpAppEvent::RedoResult(rr) => {
+            AcpAppEvent::RedoResult(result) => {
                 self.activity = ActivityState::Idle;
-                self.undo_state =
-                    self.build_undo_state_from_server_stack(&rr.undo_stack, None, None);
-                if rr.success {
-                    self.set_status(LogLevel::Info, "session", "redone - reloading session");
-                    if let Some(ref sid) = self.session_id {
-                        return vec![ClientMsg::LoadSession {
-                            session_id: sid.clone(),
-                            cwd: self.current_session_cwd(),
-                        }];
+                match result {
+                    RedoResult::Applied { message: _, stack } => {
+                        self.undo_state =
+                            self.build_undo_state_from_server_stack(&stack, None, None);
+                        self.set_status(LogLevel::Info, "session", "redone - reloading session");
+                        if let Some(ref sid) = self.session_id {
+                            return vec![ClientMsg::LoadSession {
+                                session_id: sid.clone(),
+                                cwd: self.current_session_cwd(),
+                            }];
+                        }
                     }
-                } else {
-                    self.set_status(
-                        LogLevel::Warn,
-                        "session",
-                        rr.message.unwrap_or_else(|| "redo failed".into()),
-                    );
+                    RedoResult::Rejected { message, stack } => {
+                        self.undo_state =
+                            self.build_undo_state_from_server_stack(&stack, None, None);
+                        self.set_status(
+                            LogLevel::Warn,
+                            "session",
+                            message.unwrap_or_else(|| "redo failed".into()),
+                        );
+                    }
                 }
                 vec![]
             }
-            AcpAppEvent::ForkResult(fr) => {
+            AcpAppEvent::ForkResult(result) => {
                 self.pending_fork_message_id = None;
-                if fr.success {
-                    if let Some(forked_session_id) = fr.forked_session_id {
+                match result {
+                    ForkResult::Succeeded {
+                        source_session_id: _,
+                        forked_session_id: Some(forked_session_id),
+                        message: _,
+                    } => {
                         self.popup = Popup::None;
                         self.set_status(LogLevel::Info, "fork", "forked - loading session");
                         return vec![
@@ -434,18 +449,23 @@ impl crate::app::App {
                             },
                         ];
                     }
-                    self.set_status(
+                    ForkResult::Succeeded {
+                        source_session_id: _,
+                        forked_session_id: None,
+                        message,
+                    } => self.set_status(
                         LogLevel::Warn,
                         "fork",
-                        fr.message
-                            .unwrap_or_else(|| "fork succeeded without session id".into()),
-                    );
-                } else {
-                    self.set_status(
+                        message.unwrap_or_else(|| "fork succeeded without session id".into()),
+                    ),
+                    ForkResult::Failed {
+                        source_session_id: _,
+                        message,
+                    } => self.set_status(
                         LogLevel::Warn,
                         "fork",
-                        fr.message.unwrap_or_else(|| "fork failed".into()),
-                    );
+                        message.unwrap_or_else(|| "fork failed".into()),
+                    ),
                 }
                 vec![]
             }
@@ -3539,18 +3559,66 @@ mod tests {
             text: "change".into(),
         });
 
-        let replies = app.handle_acp_event(AcpAppEvent::UndoResult(UndoResultData {
-            success: true,
-            message_id: Some("u1".into()),
+        let replies = app.handle_acp_event(AcpAppEvent::UndoResult(UndoResult::Applied {
+            target_message_id: None,
             reverted_files: vec!["src/main.rs".into()],
             message: None,
-            undo_stack: vec![UndoStackFrame {
-                message_id: "u1".into(),
-            }],
+            stack: UndoStackSnapshot {
+                message_ids: vec!["u1".into()],
+            },
         }));
 
         assert!(matches!(app.activity, ActivityState::Idle));
         assert_eq!(app.status, "undone - reloading session");
+        assert!(app.can_redo());
+        assert_eq!(
+            app.undo_state.as_ref().unwrap().stack[0].reverted_files,
+            ["src/main.rs"]
+        );
+        assert!(matches!(
+            replies.as_slice(),
+            [ClientMsg::LoadSession { session_id, cwd }] if session_id == "session-1" && cwd.is_none()
+        ));
+    }
+
+    #[test]
+    fn native_undo_result_failure_rebuilds_state_without_reload() {
+        let mut app = App::new();
+        app.session_id = Some("session-1".into());
+        app.activity = ActivityState::SessionOp(SessionOp::Undo);
+        app.streaming_content = "keep streaming content".into();
+
+        let replies = app.handle_acp_event(AcpAppEvent::UndoResult(UndoResult::Rejected {
+            message: Some("Undo rejected".into()),
+            stack: UndoStackSnapshot {
+                message_ids: vec!["u1".into()],
+            },
+        }));
+
+        assert!(matches!(app.activity, ActivityState::Idle));
+        assert_eq!(app.status, "Undo rejected");
+        assert_eq!(app.streaming_content, "keep streaming content");
+        assert!(replies.is_empty());
+        let frame = &app.undo_state.as_ref().unwrap().stack[0];
+        assert_eq!(frame.message_id, "u1");
+        assert!(frame.reverted_files.is_empty());
+    }
+
+    #[test]
+    fn native_redo_result_success_rebuilds_state_and_reloads_session() {
+        let mut app = App::new();
+        app.session_id = Some("session-1".into());
+        app.activity = ActivityState::SessionOp(SessionOp::Redo);
+
+        let replies = app.handle_acp_event(AcpAppEvent::RedoResult(RedoResult::Applied {
+            message: Some("redone".into()),
+            stack: UndoStackSnapshot {
+                message_ids: vec!["u1".into()],
+            },
+        }));
+
+        assert!(matches!(app.activity, ActivityState::Idle));
+        assert_eq!(app.status, "redone - reloading session");
         assert!(app.can_redo());
         assert!(matches!(
             replies.as_slice(),
@@ -3563,14 +3631,16 @@ mod tests {
         let mut app = App::new();
         app.activity = ActivityState::SessionOp(SessionOp::Redo);
 
-        let replies = app.handle_acp_event(AcpAppEvent::RedoResult(RedoResultData {
-            success: false,
+        let replies = app.handle_acp_event(AcpAppEvent::RedoResult(RedoResult::Rejected {
             message: Some("Nothing to redo".into()),
-            undo_stack: Vec::new(),
+            stack: UndoStackSnapshot {
+                message_ids: vec!["u1".into()],
+            },
         }));
 
         assert!(matches!(app.activity, ActivityState::Idle));
         assert_eq!(app.status, "Nothing to redo");
+        assert!(app.can_redo());
         assert!(replies.is_empty());
         assert!(matches!(
             app.logs.last(),
@@ -3585,8 +3655,7 @@ mod tests {
         app.popup = Popup::ForkTurnSelect;
         app.pending_fork_message_id = Some("msg-1".into());
 
-        let replies = app.handle_acp_event(AcpAppEvent::ForkResult(ForkResultData {
-            success: true,
+        let replies = app.handle_acp_event(AcpAppEvent::ForkResult(ForkResult::Succeeded {
             source_session_id: Some("source-1".into()),
             forked_session_id: Some("fork-1".into()),
             message: None,
@@ -3605,15 +3674,31 @@ mod tests {
     }
 
     #[test]
+    fn native_fork_result_success_without_id_warns_and_keeps_popup() {
+        let mut app = App::new();
+        app.popup = Popup::ForkTurnSelect;
+        app.pending_fork_message_id = Some("msg-1".into());
+
+        let replies = app.handle_acp_event(AcpAppEvent::ForkResult(ForkResult::Succeeded {
+            source_session_id: Some("source-1".into()),
+            forked_session_id: None,
+            message: None,
+        }));
+
+        assert!(replies.is_empty());
+        assert_eq!(app.pending_fork_message_id, None);
+        assert_eq!(app.popup, Popup::ForkTurnSelect);
+        assert_eq!(app.status, "fork succeeded without session id");
+    }
+
+    #[test]
     fn native_fork_result_failure_clears_pending_and_keeps_popup() {
         let mut app = App::new();
         app.popup = Popup::ForkTurnSelect;
         app.pending_fork_message_id = Some("msg-1".into());
 
-        let replies = app.handle_acp_event(AcpAppEvent::ForkResult(ForkResultData {
-            success: false,
+        let replies = app.handle_acp_event(AcpAppEvent::ForkResult(ForkResult::Failed {
             source_session_id: Some("source-1".into()),
-            forked_session_id: None,
             message: Some("fork failed".into()),
         }));
 
@@ -3627,9 +3712,9 @@ mod tests {
     fn native_undo_stack_hydrates_redo_state() {
         let mut app = App::new();
 
-        app.handle_acp_event(AcpAppEvent::UndoStack(vec![UndoStackFrame {
-            message_id: "u1".into(),
-        }]));
+        app.handle_acp_event(AcpAppEvent::UndoStack(UndoStackSnapshot {
+            message_ids: vec!["u1".into()],
+        }));
 
         assert!(app.can_redo());
     }

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -390,9 +390,18 @@ impl crate::app::App {
                             }];
                         }
                     }
-                    UndoResult::Rejected { message, stack } => {
-                        self.undo_state =
-                            self.build_undo_state_from_server_stack(&stack, None, None);
+                    UndoResult::Rejected {
+                        target_message_id,
+                        message,
+                        stack,
+                    } => {
+                        let preferred =
+                            target_message_id.or_else(|| stack.message_ids.last().cloned());
+                        self.undo_state = self.build_undo_state_from_server_stack(
+                            &stack,
+                            preferred.as_deref(),
+                            None,
+                        );
                         self.set_status(
                             LogLevel::Warn,
                             "session",
@@ -2104,7 +2113,7 @@ mod tests {
     use crate::app::{App, Screen};
     use crate::domain::activity::{PendingDelegateToolCall, SessionOp};
     use crate::domain::model::DelegateModelPreference;
-    use crate::domain::session::{SessionListPage, UndoState};
+    use crate::domain::session::{SessionListPage, UndoFrame, UndoFrameStatus, UndoState};
 
     const TEST_SESSION_ID: &str = "session-1";
     const TEST_ASSISTANT_ID: &str = "a1";
@@ -3560,7 +3569,7 @@ mod tests {
         });
 
         let replies = app.handle_acp_event(AcpAppEvent::UndoResult(UndoResult::Applied {
-            target_message_id: None,
+            target_message_id: Some("u1".into()),
             reverted_files: vec!["src/main.rs".into()],
             message: None,
             stack: UndoStackSnapshot {
@@ -3582,16 +3591,38 @@ mod tests {
     }
 
     #[test]
-    fn native_undo_result_failure_rebuilds_state_without_reload() {
+    fn native_undo_rejection_without_target_uses_stack_tail_without_reload() {
         let mut app = App::new();
         app.session_id = Some("session-1".into());
         app.activity = ActivityState::SessionOp(SessionOp::Undo);
         app.streaming_content = "keep streaming content".into();
+        app.undoable_turns = vec![
+            UndoableTurn {
+                turn_id: "turn-1".into(),
+                message_id: "msg-1".into(),
+                text: "first".into(),
+            },
+            UndoableTurn {
+                turn_id: "turn-2".into(),
+                message_id: "msg-2".into(),
+                text: "second".into(),
+            },
+        ];
+        app.undo_state = Some(UndoState {
+            stack: vec![UndoFrame {
+                turn_id: "turn-1".into(),
+                message_id: "msg-1".into(),
+                status: UndoFrameStatus::Confirmed,
+                reverted_files: vec![],
+            }],
+            frontier_message_id: Some("msg-1".into()),
+        });
 
         let replies = app.handle_acp_event(AcpAppEvent::UndoResult(UndoResult::Rejected {
+            target_message_id: None,
             message: Some("Undo rejected".into()),
             stack: UndoStackSnapshot {
-                message_ids: vec!["u1".into()],
+                message_ids: vec!["msg-1".into(), "msg-2".into()],
             },
         }));
 
@@ -3599,9 +3630,52 @@ mod tests {
         assert_eq!(app.status, "Undo rejected");
         assert_eq!(app.streaming_content, "keep streaming content");
         assert!(replies.is_empty());
-        let frame = &app.undo_state.as_ref().unwrap().stack[0];
-        assert_eq!(frame.message_id, "u1");
-        assert!(frame.reverted_files.is_empty());
+        let undo_state = app.undo_state.as_ref().expect("undo state");
+        assert_eq!(undo_state.frontier_message_id.as_deref(), Some("msg-2"));
+        assert!(
+            undo_state
+                .stack
+                .iter()
+                .all(|frame| frame.reverted_files.is_empty())
+        );
+        assert_eq!(
+            app.current_undo_target()
+                .map(|turn| turn.message_id.as_str()),
+            Some("msg-1")
+        );
+    }
+
+    #[test]
+    fn native_undo_rejection_prefers_explicit_target() {
+        let mut app = App::new();
+        app.undoable_turns = vec![
+            UndoableTurn {
+                turn_id: "turn-1".into(),
+                message_id: "msg-1".into(),
+                text: "first".into(),
+            },
+            UndoableTurn {
+                turn_id: "turn-2".into(),
+                message_id: "msg-2".into(),
+                text: "second".into(),
+            },
+        ];
+
+        let replies = app.handle_acp_event(AcpAppEvent::UndoResult(UndoResult::Rejected {
+            target_message_id: Some("msg-1".into()),
+            message: None,
+            stack: UndoStackSnapshot {
+                message_ids: vec!["msg-1".into(), "msg-2".into()],
+            },
+        }));
+
+        assert!(replies.is_empty());
+        assert_eq!(
+            app.undo_state
+                .as_ref()
+                .and_then(|state| state.frontier_message_id.as_deref()),
+            Some("msg-1")
+        );
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,15 +14,14 @@ use crate::domain::elicitation::ElicitationState;
 use crate::domain::model::{DelegateModelPreference, ModelEntry};
 use crate::domain::profile::{AgentInfo, ProfileInfo};
 use crate::domain::session::{
-    ForkBoundaryKind, ForkTurnItem, SessionGroup, UndoFrame, UndoFrameStatus, UndoState,
-    UndoableTurn,
+    ForkBoundaryKind, ForkTurnItem, SessionGroup, UndoFrame, UndoFrameStatus, UndoStackSnapshot,
+    UndoState, UndoableTurn,
 };
 use crate::highlight::Highlighter;
 use crate::markdown::CardBlock;
 use crate::mesh::{MeshFocus, MeshInviteFormField};
 use crate::protocol::{
     ClientMsg, EventKind, MeshInviteCreatedInfo, MeshStatusInfo, RemoteNodeInfo, RemoteSessionInfo,
-    UndoStackFrame,
 };
 use crate::ui::{CardCache, ElicitationUiState};
 
@@ -1850,11 +1849,11 @@ impl App {
 
     pub fn build_undo_state_from_server_stack(
         &self,
-        undo_stack: &[UndoStackFrame],
+        undo_stack: &UndoStackSnapshot,
         preferred_frontier_message_id: Option<&str>,
         reverted_files: Option<&[String]>,
     ) -> Option<UndoState> {
-        if undo_stack.is_empty() {
+        if undo_stack.message_ids.is_empty() {
             return None;
         }
 
@@ -1867,32 +1866,32 @@ impl App {
         }
 
         let stack: Vec<UndoFrame> = undo_stack
+            .message_ids
             .iter()
-            .map(|frame| {
-                let previous = previous_by_message_id.get(&frame.message_id);
-                let reverted_files =
-                    if preferred_frontier_message_id == Some(frame.message_id.as_str()) {
-                        reverted_files
-                            .map(|files| files.to_vec())
-                            .or_else(|| previous.map(|frame| frame.reverted_files.clone()))
-                            .unwrap_or_default()
-                    } else {
-                        previous
-                            .map(|frame| frame.reverted_files.clone())
-                            .unwrap_or_default()
-                    };
+            .map(|message_id| {
+                let previous = previous_by_message_id.get(message_id);
+                let reverted_files = if preferred_frontier_message_id == Some(message_id.as_str()) {
+                    reverted_files
+                        .map(|files| files.to_vec())
+                        .or_else(|| previous.map(|frame| frame.reverted_files.clone()))
+                        .unwrap_or_default()
+                } else {
+                    previous
+                        .map(|frame| frame.reverted_files.clone())
+                        .unwrap_or_default()
+                };
                 let turn_id = previous
                     .map(|frame| frame.turn_id.clone())
                     .or_else(|| {
                         self.undoable_turns
                             .iter()
-                            .find(|turn| turn.message_id == frame.message_id)
+                            .find(|turn| turn.message_id == *message_id)
                             .map(|turn| turn.turn_id.clone())
                     })
-                    .unwrap_or_else(|| frame.message_id.clone());
+                    .unwrap_or_else(|| message_id.clone());
                 UndoFrame {
                     turn_id,
-                    message_id: frame.message_id.clone(),
+                    message_id: message_id.clone(),
                     status: UndoFrameStatus::Confirmed,
                     reverted_files,
                 }
@@ -2862,12 +2861,10 @@ mod tests {
         }
     }
 
-    fn make_stack(ids: &[&str]) -> Vec<UndoStackFrame> {
-        ids.iter()
-            .map(|id| UndoStackFrame {
-                message_id: (*id).into(),
-            })
-            .collect()
+    fn make_stack(ids: &[&str]) -> UndoStackSnapshot {
+        UndoStackSnapshot {
+            message_ids: ids.iter().map(|id| (*id).into()).collect(),
+        }
     }
 
     #[test]
@@ -3168,10 +3165,35 @@ mod tests {
     }
 
     #[test]
+    fn build_undo_state_preserves_order_previous_turn_and_unknown_fallback() {
+        let mut app = App::new();
+        app.undo_state = Some(UndoState {
+            stack: vec![UndoFrame {
+                turn_id: "previous-turn".into(),
+                message_id: "msg-1".into(),
+                status: UndoFrameStatus::Pending,
+                reverted_files: vec!["preserved.rs".into()],
+            }],
+            frontier_message_id: Some("msg-1".into()),
+        });
+
+        let state = app
+            .build_undo_state_from_server_stack(&make_stack(&["msg-1", "unknown"]), None, None)
+            .expect("undo state");
+
+        assert_eq!(state.stack[0].message_id, "msg-1");
+        assert_eq!(state.stack[0].turn_id, "previous-turn");
+        assert_eq!(state.stack[0].status, UndoFrameStatus::Confirmed);
+        assert_eq!(state.stack[0].reverted_files, ["preserved.rs"]);
+        assert_eq!(state.stack[1].message_id, "unknown");
+        assert_eq!(state.stack[1].turn_id, "unknown");
+    }
+
+    #[test]
     fn build_undo_state_returns_none_for_empty_stack() {
         let app = App::new();
         assert_eq!(
-            app.build_undo_state_from_server_stack(&[], None, None),
+            app.build_undo_state_from_server_stack(&UndoStackSnapshot::default(), None, None),
             None
         );
     }

--- a/src/domain/session.rs
+++ b/src/domain/session.rs
@@ -63,6 +63,7 @@ pub enum UndoResult {
         stack: UndoStackSnapshot,
     },
     Rejected {
+        target_message_id: Option<String>,
         message: Option<String>,
         stack: UndoStackSnapshot,
     },

--- a/src/domain/session.rs
+++ b/src/domain/session.rs
@@ -49,6 +49,50 @@ pub struct SessionChildrenPage {
     pub total_count: Option<u64>,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UndoStackSnapshot {
+    pub message_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UndoResult {
+    Applied {
+        target_message_id: Option<String>,
+        reverted_files: Vec<String>,
+        message: Option<String>,
+        stack: UndoStackSnapshot,
+    },
+    Rejected {
+        message: Option<String>,
+        stack: UndoStackSnapshot,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RedoResult {
+    Applied {
+        message: Option<String>,
+        stack: UndoStackSnapshot,
+    },
+    Rejected {
+        message: Option<String>,
+        stack: UndoStackSnapshot,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ForkResult {
+    Succeeded {
+        source_session_id: Option<String>,
+        forked_session_id: Option<String>,
+        message: Option<String>,
+    },
+    Failed {
+        source_session_id: Option<String>,
+        message: Option<String>,
+    },
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UndoableTurn {
     pub turn_id: String,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -893,24 +893,97 @@ mod session_page_data_tests {
 }
 
 #[cfg(test)]
-mod fork_result_tests {
-    use super::*;
+mod session_mutation_data_tests {
+    use super::{ForkResultData, RedoResultData, UndoResultData};
     use serde_json::json;
 
     #[test]
-    fn fork_result_deserializes_optional_fields() {
-        let result: ForkResultData = serde_json::from_value(json!({
+    fn undo_result_deserializes_success_fields_and_stack_order() {
+        let result: UndoResultData = serde_json::from_value(json!({
+            "success": true,
+            "message_id": "message-2",
+            "reverted_files": ["src/a.rs", "src/b.rs"],
+            "message": "undone",
+            "undo_stack": [
+                { "message_id": "message-1" },
+                { "message_id": "message-2" }
+            ]
+        }))
+        .unwrap();
+
+        assert!(result.success);
+        assert_eq!(result.message_id.as_deref(), Some("message-2"));
+        assert_eq!(result.reverted_files, ["src/a.rs", "src/b.rs"]);
+        assert_eq!(result.message.as_deref(), Some("undone"));
+        assert_eq!(result.undo_stack[0].message_id, "message-1");
+        assert_eq!(result.undo_stack[1].message_id, "message-2");
+    }
+
+    #[test]
+    fn undo_result_deserializes_failure_with_default_collections() {
+        let result: UndoResultData = serde_json::from_value(json!({
+            "success": false,
+            "message_id": null,
+            "message": "undo rejected"
+        }))
+        .unwrap();
+
+        assert!(!result.success);
+        assert!(result.reverted_files.is_empty());
+        assert!(result.undo_stack.is_empty());
+        assert_eq!(result.message.as_deref(), Some("undo rejected"));
+    }
+
+    #[test]
+    fn redo_result_deserializes_success_fields_and_stack_order() {
+        let result: RedoResultData = serde_json::from_value(json!({
+            "success": true,
+            "message": "redone",
+            "undo_stack": [
+                { "message_id": "message-1" },
+                { "message_id": "message-2" }
+            ]
+        }))
+        .unwrap();
+
+        assert!(result.success);
+        assert_eq!(result.message.as_deref(), Some("redone"));
+        assert_eq!(result.undo_stack[0].message_id, "message-1");
+        assert_eq!(result.undo_stack[1].message_id, "message-2");
+    }
+
+    #[test]
+    fn redo_result_deserializes_failure_with_default_stack() {
+        let result: RedoResultData = serde_json::from_value(json!({
+            "success": false,
+            "message": "redo rejected"
+        }))
+        .unwrap();
+
+        assert!(!result.success);
+        assert!(result.undo_stack.is_empty());
+        assert_eq!(result.message.as_deref(), Some("redo rejected"));
+    }
+
+    #[test]
+    fn fork_result_deserializes_present_and_missing_optional_fields() {
+        let succeeded: ForkResultData = serde_json::from_value(json!({
             "success": true,
             "source_session_id": "source-1",
             "forked_session_id": "fork-1",
             "message": "forked"
         }))
         .unwrap();
+        assert!(succeeded.success);
+        assert_eq!(succeeded.source_session_id.as_deref(), Some("source-1"));
+        assert_eq!(succeeded.forked_session_id.as_deref(), Some("fork-1"));
+        assert_eq!(succeeded.message.as_deref(), Some("forked"));
 
-        assert!(result.success);
-        assert_eq!(result.source_session_id.as_deref(), Some("source-1"));
-        assert_eq!(result.forked_session_id.as_deref(), Some("fork-1"));
-        assert_eq!(result.message.as_deref(), Some("forked"));
+        let failed: ForkResultData = serde_json::from_value(json!({ "success": false })).unwrap();
+        assert!(!failed.success);
+        assert_eq!(failed.source_session_id, None);
+        assert_eq!(failed.forked_session_id, None);
+        assert_eq!(failed.message, None);
     }
 }
 


### PR DESCRIPTION
## changes
- add semantic undo stack, undo, redo, and fork result types to the session domain
- convert wire mutation payloads at the acp client boundary and return domain snapshots from undo stack fetches
- update acp events, reducer matching, and app undo projection to use semantic variants
- expand protocol, conversion, reducer, and projection coverage for success, rejection, ordering, and missing-id cases

## validation
- cargo check
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test --all-targets --quiet (740 passed)
- verified wire mutation types occur only in protocol and acp_client