### PR TITLE
fix: align remote session contracts

### DIFF
--- a/src/acp_client.rs
+++ b/src/acp_client.rs
@@ -2646,25 +2646,6 @@ fn session_list_page_from_acp(
 
     for session in response.sessions {
         let cwd = session.cwd.to_string_lossy().to_string();
-        let metadata = session.meta.as_ref();
-        let node = metadata
-            .and_then(|meta| meta.get("node"))
-            .and_then(Value::as_str)
-            .map(str::to_string);
-        let node_id = metadata
-            .and_then(|meta| meta.get("nodeId").or_else(|| meta.get("node_id")))
-            .and_then(Value::as_str)
-            .map(str::to_string);
-        let attached = metadata
-            .and_then(|meta| meta.get("attached"))
-            .and_then(Value::as_bool);
-        let runtime_state = metadata
-            .and_then(|meta| {
-                meta.get("runtimeState")
-                    .or_else(|| meta.get("runtime_state"))
-            })
-            .and_then(Value::as_str)
-            .map(str::to_string);
         let group_key = request
             .cwd()
             .map(str::to_string)
@@ -2684,10 +2665,10 @@ fn session_list_page_from_acp(
             children: Vec::new(),
             children_next_cursor: None,
             children_total_count: None,
-            node,
-            node_id,
-            attached,
-            runtime_state,
+            node: None,
+            node_id: None,
+            attached: None,
+            runtime_state: None,
         });
     }
 
@@ -3374,27 +3355,6 @@ mod tests {
             }
             other => panic!("unexpected event: {other:?}"),
         }
-    }
-
-    #[test]
-    fn acp_session_list_preserves_remote_location_metadata() {
-        let mut metadata = acp::Meta::new();
-        metadata.insert("node".into(), Value::String("remote".into()));
-        metadata.insert("nodeId".into(), Value::String("node-1".into()));
-        metadata.insert("attached".into(), Value::Bool(false));
-        metadata.insert("runtimeState".into(), Value::String("stopped".into()));
-        let response = acp::ListSessionsResponse::new(vec![
-            acp::SessionInfo::new(acp::SessionId::from("remote-1"), Path::new("/remote/repo"))
-                .meta(metadata),
-        ]);
-
-        let page = session_list_page_from_acp(&SessionListRequest::Discovery, response);
-        let session = &page.groups[0].sessions[0];
-        assert_eq!(session.node.as_deref(), Some("remote"));
-        assert_eq!(session.node_id.as_deref(), Some("node-1"));
-        assert_eq!(session.cwd.as_deref(), Some("/remote/repo"));
-        assert_eq!(session.attached, Some(false));
-        assert_eq!(session.runtime_state.as_deref(), Some("stopped"));
     }
 
     #[test]

--- a/src/acp_client.rs
+++ b/src/acp_client.rs
@@ -2646,6 +2646,25 @@ fn session_list_page_from_acp(
 
     for session in response.sessions {
         let cwd = session.cwd.to_string_lossy().to_string();
+        let metadata = session.meta.as_ref();
+        let node = metadata
+            .and_then(|meta| meta.get("node"))
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let node_id = metadata
+            .and_then(|meta| meta.get("nodeId").or_else(|| meta.get("node_id")))
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let attached = metadata
+            .and_then(|meta| meta.get("attached"))
+            .and_then(Value::as_bool);
+        let runtime_state = metadata
+            .and_then(|meta| {
+                meta.get("runtimeState")
+                    .or_else(|| meta.get("runtime_state"))
+            })
+            .and_then(Value::as_str)
+            .map(str::to_string);
         let group_key = request
             .cwd()
             .map(str::to_string)
@@ -2665,10 +2684,10 @@ fn session_list_page_from_acp(
             children: Vec::new(),
             children_next_cursor: None,
             children_total_count: None,
-            node: None,
-            node_id: None,
-            attached: None,
-            runtime_state: None,
+            node,
+            node_id,
+            attached,
+            runtime_state,
         });
     }
 
@@ -3103,19 +3122,32 @@ mod tests {
         assert_eq!(session.model_id.as_deref(), Some("model-1"));
 
         let config_options = vec![json!({ "id": "profile", "value": { "nested": [1, 2] } })];
-        let snapshot = json!({ "events": [{ "kind": "message" }] });
+        let snapshot = json!({
+            "audit": [{ "kind": "message", "data": { "nested": [1, 2] } }],
+            "cursor": { "position": 1 },
+            "delegationUpdates": [{ "id": "delegate-1" }]
+        });
         let attached = remote_session_attach_from_wire(RemoteSessionAttachDto {
             session_id: "session-1".into(),
             node_id: "node-1".into(),
             attached: true,
             config_options: config_options.clone(),
-            snapshot: snapshot.clone(),
+            snapshot: Some(snapshot.clone()),
         });
         assert_eq!(attached.session_id, "session-1");
         assert_eq!(attached.node_id, "node-1");
         assert!(attached.attached);
         assert_eq!(attached.config_options, config_options);
-        assert_eq!(attached.snapshot, snapshot);
+        assert_eq!(attached.snapshot, Some(snapshot));
+
+        let detached = remote_session_attach_from_wire(RemoteSessionAttachDto {
+            session_id: "session-2".into(),
+            node_id: "node-1".into(),
+            attached: false,
+            config_options: Vec::new(),
+            snapshot: None,
+        });
+        assert_eq!(detached.snapshot, None);
 
         let invite = mesh_invite_created_from_wire(MeshInviteCreatedDto {
             invite_id: "invite-1".into(),
@@ -3342,6 +3374,27 @@ mod tests {
             }
             other => panic!("unexpected event: {other:?}"),
         }
+    }
+
+    #[test]
+    fn acp_session_list_preserves_remote_location_metadata() {
+        let mut metadata = acp::Meta::new();
+        metadata.insert("node".into(), Value::String("remote".into()));
+        metadata.insert("nodeId".into(), Value::String("node-1".into()));
+        metadata.insert("attached".into(), Value::Bool(false));
+        metadata.insert("runtimeState".into(), Value::String("stopped".into()));
+        let response = acp::ListSessionsResponse::new(vec![
+            acp::SessionInfo::new(acp::SessionId::from("remote-1"), Path::new("/remote/repo"))
+                .meta(metadata),
+        ]);
+
+        let page = session_list_page_from_acp(&SessionListRequest::Discovery, response);
+        let session = &page.groups[0].sessions[0];
+        assert_eq!(session.node.as_deref(), Some("remote"));
+        assert_eq!(session.node_id.as_deref(), Some("node-1"));
+        assert_eq!(session.cwd.as_deref(), Some("/remote/repo"));
+        assert_eq!(session.attached, Some(false));
+        assert_eq!(session.runtime_state.as_deref(), Some("stopped"));
     }
 
     #[test]

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -627,9 +627,24 @@ impl crate::app::App {
         } = page;
         for group in &mut groups {
             group.total_count = None;
-            for session in &group.sessions {
-                if let Some(node_id) = session.node_id.as_deref() {
-                    self.remember_remote_session_node(&session.session_id, node_id);
+            let session_metadata: Vec<(String, Option<String>, Option<String>)> = group
+                .sessions
+                .iter()
+                .map(|session| {
+                    (
+                        session.session_id.clone(),
+                        session.node_id.clone(),
+                        session.cwd.clone(),
+                    )
+                })
+                .collect();
+            for (session_id, node_id, cwd) in session_metadata {
+                if let Some(node_id) = node_id.or_else(|| {
+                    self.remote_session_locations
+                        .get(&session_id)
+                        .map(|location| location.node_id.clone())
+                }) {
+                    self.remember_remote_session_location(&session_id, &node_id, cwd);
                 }
             }
             group.sessions.sort_by(|a, b| {
@@ -2529,6 +2544,7 @@ mod tests {
                 id: "session-1".into(),
                 node_id: "node-1".into(),
                 title: Some("Boundary".into()),
+                cwd: Some("/remote/repo".into()),
                 ..Default::default()
             }],
             next_offset: Some(50),
@@ -2541,6 +2557,11 @@ mod tests {
         assert_eq!(
             app.selected_remote_sessions()[0].title.as_deref(),
             Some("Boundary")
+        );
+        assert_eq!(app.session_remote_node_id("session-1"), Some("node-1"));
+        assert_eq!(
+            app.session_remote_cwd("session-1"),
+            Some("/remote/repo".into())
         );
     }
 
@@ -2572,7 +2593,11 @@ mod tests {
                 node_id: "node-1".into(),
                 attached: true,
                 config_options: Vec::new(),
-                snapshot: Value::Null,
+                snapshot: Some(serde_json::json!({
+                    "audit": [{ "kind": "message" }],
+                    "cursor": { "position": 1 },
+                    "delegationUpdates": []
+                })),
             },
         ));
 
@@ -2580,7 +2605,7 @@ mod tests {
         assert!(matches!(
             replies.as_slice(),
             [
-                Command::LoadSession { session_id: load_id, .. },
+                Command::LoadSession { session_id: load_id, cwd: None },
                 Command::SubscribeSession { session_id: subscribe_id, agent_id },
             ] if load_id == "remote-1"
                 && subscribe_id == "remote-1"
@@ -2589,10 +2614,11 @@ mod tests {
     }
 
     #[test]
-    fn native_remote_attach_uses_current_cwd_and_detached_refreshes_sessions() {
+    fn native_remote_attach_uses_remote_cwd_and_detached_refreshes_sessions() {
         let mut app = App::new();
         app.agent_id = Some("agent-1".into());
         app.launch_cwd = Some("/launch".into());
+        app.remember_remote_session_location("remote-1", "node-1", Some("/remote/repo".into()));
 
         let attached = app.handle_acp_event(AcpAppEvent::RemoteSessionAttached(
             RemoteSessionAttachInfo {
@@ -2600,7 +2626,7 @@ mod tests {
                 node_id: "node-1".into(),
                 attached: true,
                 config_options: vec![Value::String("retained but unused".into())],
-                snapshot: serde_json::json!({ "retained": true }),
+                snapshot: Some(serde_json::json!({ "retained": true })),
             },
         ));
         assert!(matches!(
@@ -2609,7 +2635,7 @@ mod tests {
                 Command::LoadSession { session_id, cwd: Some(cwd) },
                 Command::SubscribeSession { session_id: subscribed_id, agent_id },
             ] if session_id == "remote-1"
-                && cwd == "/launch"
+                && cwd == "/remote/repo"
                 && subscribed_id == "remote-1"
                 && agent_id.as_deref() == Some("agent-1")
         ));
@@ -2620,15 +2646,51 @@ mod tests {
                 node_id: "node-2".into(),
                 attached: false,
                 config_options: Vec::new(),
-                snapshot: Value::Null,
+                snapshot: None,
             },
         ));
         assert_eq!(app.session_remote_node_id("remote-2"), Some("node-2"));
-        assert!(matches!(
-            detached.as_slice(),
-            [Command::ListRemoteSessions { node_id, offset: 0, limit: 50 }]
-                if node_id == "node-2"
-        ));
+        assert_eq!(app.session_remote_cwd("remote-2"), None);
+        assert_eq!(
+            detached,
+            vec![Command::ListRemoteSessions {
+                node_id: "node-2".into(),
+                offset: 0,
+                limit: 50,
+            }]
+        );
+    }
+
+    #[test]
+    fn acp_session_list_preserves_remote_summary_cwd() {
+        let mut app = App::new();
+        let replies = app.handle_acp_event(AcpAppEvent::SessionList {
+            request: SessionListRequest::Discovery,
+            page: session_list_page(
+                vec![SessionGroup {
+                    cwd: Some("/remote/repo".into()),
+                    sessions: vec![SessionSummary {
+                        session_id: "remote-1".into(),
+                        node_id: Some("node-1".into()),
+                        cwd: Some("/remote/repo".into()),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                None,
+            ),
+        });
+
+        assert!(
+            replies
+                .iter()
+                .any(|command| matches!(command, Command::ListSessions { .. }))
+        );
+        assert_eq!(app.session_remote_node_id("remote-1"), Some("node-1"));
+        assert_eq!(
+            app.session_remote_cwd("remote-1"),
+            Some("/remote/repo".into())
+        );
     }
 
     #[test]

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -627,24 +627,17 @@ impl crate::app::App {
         } = page;
         for group in &mut groups {
             group.total_count = None;
-            let session_metadata: Vec<(String, Option<String>, Option<String>)> = group
-                .sessions
-                .iter()
-                .map(|session| {
-                    (
-                        session.session_id.clone(),
-                        session.node_id.clone(),
+            for session in &group.sessions {
+                if let Some(node_id) = session
+                    .node_id
+                    .as_deref()
+                    .filter(|id| !id.trim().is_empty())
+                {
+                    self.remember_remote_session_location(
+                        &session.session_id,
+                        node_id,
                         session.cwd.clone(),
-                    )
-                })
-                .collect();
-            for (session_id, node_id, cwd) in session_metadata {
-                if let Some(node_id) = node_id.or_else(|| {
-                    self.remote_session_locations
-                        .get(&session_id)
-                        .map(|location| location.node_id.clone())
-                }) {
-                    self.remember_remote_session_location(&session_id, &node_id, cwd);
+                    );
                 }
             }
             group.sessions.sort_by(|a, b| {
@@ -2662,17 +2655,18 @@ mod tests {
     }
 
     #[test]
-    fn acp_session_list_preserves_remote_summary_cwd() {
+    fn acp_node_less_session_page_does_not_overwrite_remote_location() {
         let mut app = App::new();
-        let replies = app.handle_acp_event(AcpAppEvent::SessionList {
+        app.remember_remote_session_location("remote-1", "node-1", Some("/remote/repo".into()));
+
+        app.handle_acp_event(AcpAppEvent::SessionList {
             request: SessionListRequest::Discovery,
             page: session_list_page(
                 vec![SessionGroup {
-                    cwd: Some("/remote/repo".into()),
+                    cwd: Some("/local/repo".into()),
                     sessions: vec![SessionSummary {
                         session_id: "remote-1".into(),
-                        node_id: Some("node-1".into()),
-                        cwd: Some("/remote/repo".into()),
+                        cwd: Some("/local/repo".into()),
                         ..Default::default()
                     }],
                     ..Default::default()
@@ -2681,16 +2675,9 @@ mod tests {
             ),
         });
 
-        assert!(
-            replies
-                .iter()
-                .any(|command| matches!(command, Command::ListSessions { .. }))
-        );
-        assert_eq!(app.session_remote_node_id("remote-1"), Some("node-1"));
-        assert_eq!(
-            app.session_remote_cwd("remote-1"),
-            Some("/remote/repo".into())
-        );
+        let location = &app.remote_session_locations["remote-1"];
+        assert_eq!(location.node_id, "node-1");
+        assert_eq!(location.cwd.as_deref(), Some("/remote/repo"));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,7 +13,7 @@ use crate::domain::auth::{AuthProviderEntry, OAuthFlow, OAuthResult};
 use crate::domain::chat::{ChatEntry, format_outcome_labels};
 use crate::domain::elicitation::ElicitationState;
 use crate::domain::mesh::{
-    MeshInviteCreatedInfo, MeshStatusInfo, RemoteNodeInfo, RemoteSessionInfo,
+    MeshInviteCreatedInfo, MeshStatusInfo, RemoteNodeInfo, RemoteSessionInfo, RemoteSessionLocation,
 };
 use crate::domain::model::{DelegateModelPreference, ModelEntry};
 use crate::domain::profile::{AgentInfo, ProfileInfo};
@@ -606,8 +606,8 @@ pub struct App {
     pub new_session_cursor: usize,
     pub new_session_completion: Option<PathCompletionState>,
     pub session_activity: HashMap<String, SessionActivity>,
-    /// Remote sessions the user attached/dismissed before the refreshed list arrives.
-    pub remote_session_nodes: HashMap<String, String>,
+    /// Remote locations retained from ACP and mesh session metadata.
+    pub remote_session_locations: HashMap<String, RemoteSessionLocation>,
 
     // chat
     pub messages: Vec<ChatEntry>,
@@ -882,7 +882,7 @@ impl App {
             new_session_cursor: 0,
             new_session_completion: None,
             session_activity: HashMap::new(),
-            remote_session_nodes: HashMap::new(),
+            remote_session_locations: HashMap::new(),
             messages: Vec::new(),
             pending_prompt_seq: 0,
             input: String::new(),

--- a/src/domain/mesh.rs
+++ b/src/domain/mesh.rs
@@ -52,13 +52,19 @@ pub struct RemoteSessionListInfo {
     pub total_count: u32,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct RemoteSessionLocation {
+    pub node_id: String,
+    pub cwd: Option<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct RemoteSessionAttachInfo {
     pub session_id: String,
     pub node_id: String,
     pub attached: bool,
     pub config_options: Vec<Value>,
-    pub snapshot: Value,
+    pub snapshot: Option<Value>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -402,7 +402,7 @@ pub(crate) fn handle_mesh_popup_key(
             if let Some(node_id) = app.selected_mesh_node_id() {
                 cmd_tx.send(Command::CreateRemoteSession {
                     node_id: node_id.to_string(),
-                    cwd: app.current_session_cwd(),
+                    cwd: None,
                 })?;
             }
         }
@@ -2937,6 +2937,29 @@ mod model_popup_tests {
             Ok(Command::AttachRemoteSession { node_id, session_id })
                 if node_id == "node-1" && session_id == "remote-1"
         ));
+    }
+
+    #[test]
+    fn mesh_popup_create_remote_session_does_not_forward_local_cwd() {
+        let mut app = App::new();
+        app.popup = Popup::Mesh;
+        app.launch_cwd = Some("/local/launch".into());
+        app.mesh_nodes = vec![crate::domain::mesh::RemoteNodeInfo {
+            id: "node-1".into(),
+            label: "framework".into(),
+            ..Default::default()
+        }];
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        handle_mesh_popup_key(&mut app, key(KeyCode::Char('n')), &tx).unwrap();
+
+        assert_eq!(
+            rx.try_recv().unwrap(),
+            Command::CreateRemoteSession {
+                node_id: "node-1".into(),
+                cwd: None,
+            }
+        );
     }
 
     #[test]

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -176,6 +176,13 @@ impl App {
 
     pub fn apply_remote_sessions(&mut self, list: RemoteSessionListInfo) {
         let count = list.sessions.len();
+        for session in &list.sessions {
+            self.remember_remote_session_location(
+                &session.id,
+                &session.node_id,
+                session.cwd.clone(),
+            );
+        }
         self.remote_sessions_by_node
             .insert(list.node_id.clone(), list.sessions);
         if self.remote_session_cursor >= count {
@@ -192,13 +199,15 @@ impl App {
         &mut self,
         attached: RemoteSessionAttachInfo,
     ) -> Vec<Command> {
+        // ACP session/load is authoritative for history and typed config; applying this
+        // extension snapshot/config directly would duplicate replay or configuration.
         self.remember_remote_session_node(&attached.session_id, &attached.node_id);
         if attached.attached {
             self.popup = Popup::None;
             self.set_status(LogLevel::Info, "mesh", "remote session attached");
             Command::load_session_commands(
-                attached.session_id,
-                self.current_session_cwd(),
+                attached.session_id.clone(),
+                self.session_remote_cwd(&attached.session_id),
                 self.agent_id.clone(),
             )
             .into()

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -381,7 +381,7 @@ pub struct RemoteSessionAttachDto {
     #[serde(default)]
     pub config_options: Vec<serde_json::Value>,
     #[serde(default)]
-    pub snapshot: serde_json::Value,
+    pub snapshot: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -404,7 +404,7 @@ mod mesh_dto_tests {
         MeshInviteCreatedDto, MeshNodesDto, MeshStatusDto, RemoteNodeDto, RemoteSessionAttachDto,
         RemoteSessionDto, RemoteSessionListDto,
     };
-    use serde_json::{Value, json};
+    use serde_json::json;
 
     #[test]
     fn mesh_dtos_deserialize_representative_values_and_ignore_unknown_fields() {
@@ -481,12 +481,32 @@ mod mesh_dto_tests {
             "session_id": "session-1",
             "node_id": "node-1",
             "attached": true,
-            "config_options": [{ "id": "profile", "value": { "nested": [1, 2] } }],
-            "snapshot": { "events": [{ "kind": "message" }] }
+            "config_options": [],
+            "snapshot": {
+                "audit": [{ "kind": "message", "data": { "nested": [1, 2] } }],
+                "cursor": { "position": 1 },
+                "delegationUpdates": [{ "id": "delegate-1" }]
+            }
         }))
         .unwrap();
-        assert_eq!(attach.config_options[0]["value"]["nested"], json!([1, 2]));
-        assert_eq!(attach.snapshot["events"][0]["kind"], "message");
+        assert!(attach.config_options.is_empty());
+        assert_eq!(
+            attach.snapshot.as_ref().unwrap()["audit"][0]["data"]["nested"],
+            json!([1, 2])
+        );
+        assert_eq!(
+            attach.snapshot.as_ref().unwrap()["delegationUpdates"][0]["id"],
+            "delegate-1"
+        );
+
+        let detached: RemoteSessionAttachDto = serde_json::from_value(json!({
+            "session_id": "session-2",
+            "node_id": "node-1",
+            "attached": false,
+            "config_options": []
+        }))
+        .unwrap();
+        assert_eq!(detached.snapshot, None);
 
         let invite: MeshInviteCreatedDto = serde_json::from_value(json!({
             "invite_id": "invite-1",
@@ -520,7 +540,7 @@ mod mesh_dto_tests {
                 .unwrap();
         assert!(!attach.attached);
         assert!(attach.config_options.is_empty());
-        assert_eq!(attach.snapshot, Value::Null);
+        assert_eq!(attach.snapshot, None);
 
         let invite: MeshInviteCreatedDto = serde_json::from_value(json!({
             "invite_id": "invite-1",

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -508,6 +508,14 @@ mod mesh_dto_tests {
         .unwrap();
         assert_eq!(detached.snapshot, None);
 
+        let null_snapshot: RemoteSessionAttachDto = serde_json::from_value(json!({
+            "session_id": "session-3",
+            "node_id": "node-1",
+            "snapshot": null
+        }))
+        .unwrap();
+        assert_eq!(null_snapshot.snapshot, None);
+
         let invite: MeshInviteCreatedDto = serde_json::from_value(json!({
             "invite_id": "invite-1",
             "url": "qmt://mesh/join/token",

--- a/src/runtime/event_loop.rs
+++ b/src/runtime/event_loop.rs
@@ -28,6 +28,30 @@ fn send_command(cmd_tx: &mpsc::UnboundedSender<Command>, command: Command) -> an
     Ok(())
 }
 
+fn reconnect_session_commands(app: &mut App) -> Vec<Command> {
+    let Some(session_id) = app.session_id.clone() else {
+        return Vec::new();
+    };
+
+    if let Some(node_id) = app.session_remote_node_id(&session_id) {
+        return vec![Command::AttachRemoteSession {
+            node_id: node_id.to_string(),
+            session_id,
+        }];
+    }
+    if app.is_remote_session_id(&session_id) {
+        app.set_status(
+            app::LogLevel::Warn,
+            "session",
+            "remote session is missing node id; reconnect attach skipped",
+        );
+        return Vec::new();
+    }
+
+    Command::load_session_commands(session_id, app.current_session_cwd(), app.agent_id.clone())
+        .into()
+}
+
 pub(super) async fn run_loop(
     terminal: &mut AppTerminal,
     app: &mut App,
@@ -54,27 +78,8 @@ pub(super) async fn run_loop(
                             cmd_tx.send(Command::Init)?;
                             cmd_tx.send(Command::list_sessions_browse())?;
                             cmd_tx.send(Command::ListAllModels { refresh: false })?;
-                            if let Some(session_id) = app.session_id.clone() {
-                                if let Some(node_id) = app.session_remote_node_id(&session_id) {
-                                    cmd_tx.send(Command::AttachRemoteSession {
-                                        node_id: node_id.to_string(),
-                                        session_id,
-                                    })?;
-                                } else if app.is_remote_session_id(&session_id) {
-                                    app.set_status(
-                                        app::LogLevel::Warn,
-                                        "session",
-                                        "remote session is missing node id; reconnect attach skipped",
-                                    );
-                                } else {
-                                    for command in Command::load_session_commands(
-                                        session_id,
-                                        app.current_session_cwd(),
-                                        app.agent_id.clone(),
-                                    ) {
-                                        cmd_tx.send(command)?;
-                                    }
-                                }
+                            for command in reconnect_session_commands(app) {
+                                cmd_tx.send(command)?;
                             }
                         } else if was_connected && app.conn == app::ConnState::Disconnected {
                             app.set_status(
@@ -182,7 +187,8 @@ mod tests {
 
     use tokio::sync::mpsc;
 
-    use super::{send_command, tick_from_elapsed};
+    use super::{reconnect_session_commands, send_command, tick_from_elapsed};
+    use crate::app::App;
     use crate::command::Command;
 
     #[test]
@@ -206,6 +212,65 @@ mod tests {
             } if session_id == "session-1" && cwd == "/repo"
         ));
         assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn reconnect_attaches_remembered_remote_session_without_loading() {
+        let mut app = App::new();
+        app.session_id = Some("remote-1".into());
+        app.remember_remote_session_location("remote-1", "node-1", Some("/remote/repo".into()));
+
+        assert_eq!(
+            reconnect_session_commands(&mut app),
+            vec![Command::AttachRemoteSession {
+                node_id: "node-1".into(),
+                session_id: "remote-1".into(),
+            }]
+        );
+    }
+
+    #[test]
+    fn reconnect_warns_for_remote_session_missing_node() {
+        let mut app = App::new();
+        app.session_id = Some("remote-1".into());
+        app.session_groups = vec![crate::domain::session::SessionGroup {
+            sessions: vec![crate::domain::session::SessionSummary {
+                session_id: "remote-1".into(),
+                node: Some("remote".into()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }];
+
+        assert!(reconnect_session_commands(&mut app).is_empty());
+        assert!(app.status.contains("missing node id"));
+    }
+
+    #[test]
+    fn reconnect_loads_and_subscribes_local_session() {
+        let mut app = App::new();
+        app.session_id = Some("local-1".into());
+        app.agent_id = Some("agent-1".into());
+        app.launch_cwd = Some("/local/repo".into());
+
+        assert_eq!(
+            reconnect_session_commands(&mut app),
+            vec![
+                Command::LoadSession {
+                    session_id: "local-1".into(),
+                    cwd: Some("/local/repo".into()),
+                },
+                Command::SubscribeSession {
+                    session_id: "local-1".into(),
+                    agent_id: Some("agent-1".into()),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn reconnect_without_active_session_does_nothing() {
+        assert!(reconnect_session_commands(&mut App::new()).is_empty());
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -96,18 +96,48 @@ impl App {
             .and_then(|session| session.parent_session_id.as_deref())
     }
 
+    pub fn remember_remote_session_location(
+        &mut self,
+        session_id: &str,
+        node_id: &str,
+        cwd: Option<String>,
+    ) {
+        let location = self
+            .remote_session_locations
+            .entry(session_id.to_string())
+            .or_default();
+        location.node_id = node_id.to_string();
+        if let Some(cwd) = cwd.filter(|cwd| !cwd.trim().is_empty()) {
+            location.cwd = Some(cwd);
+        }
+    }
+
     pub fn remember_remote_session_node(&mut self, session_id: &str, node_id: &str) {
-        self.remote_session_nodes
-            .insert(session_id.to_string(), node_id.to_string());
+        self.remember_remote_session_location(session_id, node_id, None);
     }
 
     pub fn session_remote_node_id(&self, session_id: &str) -> Option<&str> {
         self.session_summary_by_id(session_id)
             .and_then(|session| session.node_id.as_deref())
             .or_else(|| {
-                self.remote_session_nodes
+                self.remote_session_locations
                     .get(session_id)
-                    .map(String::as_str)
+                    .map(|location| location.node_id.as_str())
+            })
+    }
+
+    pub fn session_remote_cwd(&self, session_id: &str) -> Option<String> {
+        self.session_summary_by_id(session_id)
+            .filter(|session| session.node_id.is_some() || session.node.is_some())
+            .and_then(|session| session.cwd.as_deref())
+            .filter(|cwd| !cwd.trim().is_empty())
+            .map(str::to_string)
+            .or_else(|| {
+                self.remote_session_locations
+                    .get(session_id)
+                    .and_then(|location| location.cwd.as_deref())
+                    .filter(|cwd| !cwd.trim().is_empty())
+                    .map(str::to_string)
             })
     }
 
@@ -194,6 +224,21 @@ impl App {
     }
 
     pub fn merge_session_children(&mut self, data: SessionChildrenPage) {
+        let remote_locations: Vec<(String, String, Option<String>)> = data
+            .sessions
+            .iter()
+            .filter_map(|session| {
+                Some((
+                    session.session_id.clone(),
+                    session.node_id.clone()?,
+                    session.cwd.clone(),
+                ))
+            })
+            .collect();
+        for (session_id, node_id, cwd) in remote_locations {
+            self.remember_remote_session_location(&session_id, &node_id, cwd);
+        }
+
         let had_pending_request = self
             .pending_session_child_loads
             .remove(&data.parent_session_id);
@@ -207,18 +252,6 @@ impl App {
                 .into_iter()
                 .filter(fork_browsing_child)
                 .collect();
-            let remote_nodes: Vec<(String, String)> = sessions
-                .iter()
-                .filter_map(|session| {
-                    Some((
-                        session.session_id.clone(),
-                        session.node_id.as_ref()?.clone(),
-                    ))
-                })
-                .collect();
-            for (session_id, node_id) in remote_nodes {
-                self.remote_session_nodes.insert(session_id, node_id);
-            }
             let append = had_pending_request
                 && !parent.children.is_empty()
                 && parent.children_next_cursor.is_some();
@@ -731,6 +764,19 @@ mod tests {
     }
 
     #[test]
+    fn remote_session_location_preserves_cwd_across_node_only_refreshes() {
+        let mut app = App::new();
+        app.remember_remote_session_location("remote-1", "node-1", Some("/remote/repo".into()));
+        app.remember_remote_session_node("remote-1", "node-2");
+
+        assert_eq!(app.session_remote_node_id("remote-1"), Some("node-2"));
+        assert_eq!(
+            app.session_remote_cwd("remote-1"),
+            Some("/remote/repo".into())
+        );
+    }
+
+    #[test]
     fn session_parent_id_finds_explicit_parent_at_any_depth() {
         let mut app = App::new();
         let mut grandchild = session("grandchild");
@@ -775,6 +821,7 @@ mod tests {
 
         let mut remote = session("remote-child");
         remote.node_id = Some("node-1".into());
+        remote.cwd = Some("/remote/repo".into());
         let mut delegated = session("delegated-child");
         delegated.fork_origin = Some("delegation".into());
         app.merge_session_children(SessionChildrenPage {
@@ -798,6 +845,10 @@ mod tests {
         assert_eq!(parent.fork_count, 3);
         assert!(parent.has_children);
         assert_eq!(app.session_remote_node_id("remote-child"), Some("node-1"));
+        assert_eq!(
+            app.session_remote_cwd("remote-child"),
+            Some("/remote/repo".into())
+        );
         assert!(app.pending_session_child_loads.is_empty());
 
         app.pending_session_child_loads.insert("parent".into());


### PR DESCRIPTION
Aligns qmtui with QueryMT backend commit 9121cb04747eb99cb8f5425c581c4d2bc52b0754. Evidence: `crates/agent/src/control/remote.rs` defines create/attach response semantics and optional snapshots; `crates/agent/src/agent/remote/node_manager.rs` persists remote cwd and resumes stopped sessions; `crates/agent/src/agent/handle/ext_remote.rs` performs attach lookup/resume; `crates/agent/src/agent/handle/model_registry.rs` supplies the session-history snapshot shape.

Changes:
- Replaces node-only remote bookkeeping with `RemoteSessionLocation { node_id, cwd }`, populated from mesh remote-session lists, child metadata, and remembered attach mapping. Attached loads use known authoritative remote cwd; unknown remote cwd remains `None`, never the local launch/current cwd. ACP `session/list` does not supply remote identity and never populates or refreshes that mapping.
- Mesh new-session key sends `cwd: None`; qmtui does not guess a remote-machine path.
- Makes attach snapshots optional through wire/domain conversion. Attached responses keep load-then-subscribe ordering; detached creation remembers the mapping and emits only node-scoped remote-session refresh. Attach snapshot/config remain opaque and are intentionally not applied because subsequent ACP `session/load` is the sole authoritative history/config hydration path.
- Extracts reconnect decision logic: remembered/summary remote identity emits attach only, missing remote node warns without local load, local sessions retain load+subscribe behavior. Backend attach remains responsible for DHT lookup and stopped-session resume.

Validation:
- `cargo fmt --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --all-targets --all-features`
- `cargo test --all-features` (746 passed)
- `git diff --check`; boundary searches confirm no speculative ACP remote metadata aliases or ACP-page inheritance, no mesh remote create using `current_session_cwd`, no protocol DTO leakage into application code, and no direct attach snapshot/config hydration.

Deferred:
- Remote cwd UI input; the create flow continues to omit cwd rather than guessing it.
- Semantics for future non-empty attach `config_options`.
- Direct attach snapshot hydration unless the ACP load contract changes.
- Backend bookmark cwd gap.
- MeshState/state decomposition.
- Stale remote-map/local-id collision semantics, pending an explicit backend identity contract.
