### PR TITLE
refactor: separate delegation notification values

### DIFF
--- a/src/acp_client.rs
+++ b/src/acp_client.rs
@@ -20,6 +20,7 @@ use tokio_tungstenite::{connect_async, tungstenite::Message};
 use crate::ServerChannelMsg;
 use crate::acp_state::{AcpAppEvent, AcpModelsMetaInfo, AcpSessionUpdate};
 use crate::command::{Command, PromptBlock, SessionListRequest};
+use crate::domain::activity::{DelegationState, DelegationUpdate};
 use crate::domain::auth::{OAuthFlow, OAuthResult, OAuthResultStatus};
 use crate::domain::mesh::{
     MeshInviteCreatedInfo, MeshNodesInfo, MeshScopeInfo, MeshStatusInfo, RemoteNodeInfo,
@@ -32,9 +33,10 @@ use crate::domain::session::{
     UndoStackSnapshot,
 };
 use crate::protocol::{
-    AuthProvidersData, MeshInviteCreatedDto, MeshNodesDto, MeshScopeDto, MeshStatusDto,
-    OAuthFlowDto, OAuthResultDto, RedoResultData, RemoteNodeDto, RemoteSessionAttachDto,
-    RemoteSessionDto, RemoteSessionListDto, UndoResultData, UndoStackFrame,
+    AuthProvidersData, DelegationUpdateDto, DelegationUpdateStateDto, MeshInviteCreatedDto,
+    MeshNodesDto, MeshScopeDto, MeshStatusDto, OAuthFlowDto, OAuthResultDto, RedoResultData,
+    RemoteNodeDto, RemoteSessionAttachDto, RemoteSessionDto, RemoteSessionListDto, UndoResultData,
+    UndoStackFrame,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -135,41 +137,6 @@ struct AcpDelegateModelResponse {
     agent_id: String,
     #[serde(default)]
     model: Option<DelegateModelOverrideInfo>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub(crate) enum DelegationUpdateState {
-    Requested,
-    Forked,
-    Completed,
-    Failed,
-    Cancelled,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct DelegationUpdateNotification {
-    pub version: u32,
-    pub session_id: String,
-    pub delegation_id: String,
-    #[serde(default)]
-    pub tool_call_id: Option<String>,
-    pub state: DelegationUpdateState,
-    pub target_agent_id: String,
-    pub objective: String,
-    #[serde(default)]
-    pub child_session_id: Option<String>,
-    pub requested_at: i64,
-    #[serde(default)]
-    pub forked_at: Option<i64>,
-    #[serde(default)]
-    pub finished_at: Option<i64>,
-    pub updated_at: i64,
-    #[serde(default)]
-    pub result_summary: Option<String>,
-    #[serde(default)]
-    pub error: Option<String>,
 }
 
 fn normalize_profile_agents_response(
@@ -699,17 +666,20 @@ fn is_delegation_notification_method(method: &str) -> bool {
 }
 
 fn handle_delegation_notification(srv_tx: &mpsc::UnboundedSender<ServerChannelMsg>, params: Value) {
-    match serde_json::from_value::<DelegationUpdateNotification>(params) {
-        Ok(update) if update.version == 1 => {
-            send_acp(srv_tx, AcpAppEvent::DelegationUpdate(update));
+    match serde_json::from_value::<DelegationUpdateDto>(params) {
+        Ok(update) => {
+            let version = update.version;
+            match delegation_update_from_wire(update) {
+                Some(update) => send_acp(srv_tx, AcpAppEvent::DelegationUpdate(update)),
+                None => send_acp(
+                    srv_tx,
+                    AcpAppEvent::InfoLog {
+                        target: "delegation",
+                        message: format!("ignored delegation notification version {version}"),
+                    },
+                ),
+            }
         }
-        Ok(update) => send_acp(
-            srv_tx,
-            AcpAppEvent::InfoLog {
-                target: "delegation",
-                message: format!("ignored delegation notification version {}", update.version),
-            },
-        ),
         Err(err) => send_acp(
             srv_tx,
             AcpAppEvent::InfoLog {
@@ -1625,6 +1595,34 @@ fn mesh_invite_created_from_wire(invite: MeshInviteCreatedDto) -> MeshInviteCrea
     }
 }
 
+fn delegation_update_from_wire(update: DelegationUpdateDto) -> Option<DelegationUpdate> {
+    if update.version != 1 {
+        return None;
+    }
+
+    Some(DelegationUpdate {
+        session_id: update.session_id,
+        delegation_id: update.delegation_id,
+        tool_call_id: update.tool_call_id,
+        state: match update.state {
+            DelegationUpdateStateDto::Requested => DelegationState::Requested,
+            DelegationUpdateStateDto::Forked => DelegationState::Forked,
+            DelegationUpdateStateDto::Completed => DelegationState::Completed,
+            DelegationUpdateStateDto::Failed => DelegationState::Failed,
+            DelegationUpdateStateDto::Cancelled => DelegationState::Cancelled,
+        },
+        target_agent_id: update.target_agent_id,
+        objective: update.objective,
+        child_session_id: update.child_session_id,
+        requested_at: update.requested_at,
+        forked_at: update.forked_at,
+        finished_at: update.finished_at,
+        updated_at: update.updated_at,
+        result_summary: update.result_summary,
+        error: update.error,
+    })
+}
+
 fn oauth_flow_from_wire(flow: OAuthFlowDto) -> OAuthFlow {
     OAuthFlow {
         flow_id: flow.flow_id,
@@ -1811,14 +1809,14 @@ fn session_load_audit_from_load_value(response: &Value) -> Value {
     }
 }
 
-fn delegation_updates_from_load_value(response: &Value) -> Vec<DelegationUpdateNotification> {
+fn delegation_updates_from_load_value(response: &Value) -> Vec<DelegationUpdate> {
     session_load_snapshot_from_load_value(response)
         .and_then(|snapshot| snapshot.get("delegationUpdates"))
         .and_then(Value::as_array)
         .into_iter()
         .flatten()
-        .filter_map(|update| serde_json::from_value(update.clone()).ok())
-        .filter(|update: &DelegationUpdateNotification| update.version == 1)
+        .filter_map(|update| serde_json::from_value::<DelegationUpdateDto>(update.clone()).ok())
+        .filter_map(delegation_update_from_wire)
         .collect()
 }
 
@@ -3010,6 +3008,43 @@ mod tests {
             .collect()
     }
 
+    fn delegation_wire_value(version: u32) -> Value {
+        json!({
+            "version": version,
+            "sessionId": "parent",
+            "delegationId": "delegation-1",
+            "toolCallId": "call-1",
+            "state": "completed",
+            "targetAgentId": "coder",
+            "objective": "Implement it",
+            "childSessionId": "child-1",
+            "requestedAt": 100,
+            "forkedAt": 110,
+            "finishedAt": 120,
+            "updatedAt": 120,
+            "resultSummary": "done",
+            "error": "reported after completion"
+        })
+    }
+
+    fn expected_delegation_update() -> DelegationUpdate {
+        DelegationUpdate {
+            session_id: "parent".into(),
+            delegation_id: "delegation-1".into(),
+            tool_call_id: Some("call-1".into()),
+            state: DelegationState::Completed,
+            target_agent_id: "coder".into(),
+            objective: "Implement it".into(),
+            child_session_id: Some("child-1".into()),
+            requested_at: 100,
+            forked_at: Some(110),
+            finished_at: Some(120),
+            updated_at: 120,
+            result_summary: Some("done".into()),
+            error: Some("reported after completion".into()),
+        }
+    }
+
     #[test]
     fn prompt_blocks_convert_semantic_text_and_resource_links() {
         let blocks = prompt_blocks(vec![
@@ -3144,6 +3179,22 @@ mod tests {
         assert_eq!(invite.expires_at, 123);
         assert_eq!(invite.max_uses, 2);
         assert_eq!(invite.mesh_name.as_deref(), Some("Team"));
+    }
+
+    #[test]
+    fn delegation_update_from_wire_maps_every_semantic_field() {
+        let wire = serde_json::from_value(delegation_wire_value(1)).expect("wire update");
+
+        let update = delegation_update_from_wire(wire).expect("supported update");
+
+        assert_eq!(update, expected_delegation_update());
+    }
+
+    #[test]
+    fn delegation_update_from_wire_rejects_unsupported_version() {
+        let wire = serde_json::from_value(delegation_wire_value(2)).expect("wire update");
+
+        assert_eq!(delegation_update_from_wire(wire), None);
     }
 
     #[test]
@@ -3490,36 +3541,23 @@ mod tests {
     }
 
     #[test]
-    fn session_load_delegation_updates_parse_latest_snapshots() {
+    fn session_load_delegation_updates_skip_malformed_and_unsupported_snapshots() {
         let response = json!({
             "_meta": {
                 "querymt/sessionLoadSnapshot.v1": {
                     "audit": { "events": [] },
-                    "delegationUpdates": [{
-                        "version": 1,
-                        "sessionId": "parent",
-                        "delegationId": "delegation-1",
-                        "toolCallId": "call-1",
-                        "state": "completed",
-                        "targetAgentId": "coder",
-                        "objective": "Implement it",
-                        "childSessionId": "child-1",
-                        "requestedAt": 100,
-                        "forkedAt": 110,
-                        "finishedAt": 120,
-                        "updatedAt": 120,
-                        "resultSummary": "done",
-                        "error": null
-                    }]
+                    "delegationUpdates": [
+                        delegation_wire_value(1),
+                        { "version": 1, "sessionId": "malformed" },
+                        delegation_wire_value(2)
+                    ]
                 }
             }
         });
 
         let updates = delegation_updates_from_load_value(&response);
 
-        assert_eq!(updates.len(), 1);
-        assert_eq!(updates[0].state, DelegationUpdateState::Completed);
-        assert_eq!(updates[0].tool_call_id.as_deref(), Some("call-1"));
+        assert_eq!(updates, [expected_delegation_update()]);
     }
 
     #[test]
@@ -3531,6 +3569,47 @@ mod tests {
             "_querymt/session/delegationUpdate"
         ));
         assert!(!is_delegation_notification_method("session/update"));
+    }
+
+    #[test]
+    fn delegation_notification_handler_emits_domain_update() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        handle_delegation_notification(&tx, delegation_wire_value(1));
+
+        assert!(matches!(
+            rx.try_recv().expect("delegation event"),
+            ServerChannelMsg::Acp(AcpAppEvent::DelegationUpdate(update))
+                if update == expected_delegation_update()
+        ));
+    }
+
+    #[test]
+    fn delegation_notification_handler_logs_unsupported_version() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        handle_delegation_notification(&tx, delegation_wire_value(2));
+
+        assert!(matches!(
+            rx.try_recv().expect("delegation version log"),
+            ServerChannelMsg::Acp(AcpAppEvent::InfoLog { target, message })
+                if target == "delegation"
+                    && message == "ignored delegation notification version 2"
+        ));
+    }
+
+    #[test]
+    fn delegation_notification_handler_logs_malformed_payload() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        handle_delegation_notification(&tx, json!({ "version": 1 }));
+
+        assert!(matches!(
+            rx.try_recv().expect("invalid delegation log"),
+            ServerChannelMsg::Acp(AcpAppEvent::InfoLog { target, message })
+                if target == "delegation"
+                    && message.starts_with("invalid delegation notification: ")
+        ));
     }
 
     #[test]
@@ -3980,30 +4059,6 @@ mod tests {
         assert!(empty.profiles.is_empty());
         assert!(empty.active_profile_id.is_none());
         assert!(normalize_profiles_response(json!({})).is_err());
-    }
-
-    #[test]
-    fn delegation_update_payload_uses_camel_case_contract() {
-        let update: DelegationUpdateNotification = serde_json::from_value(json!({
-            "version": 1,
-            "sessionId": "parent",
-            "delegationId": "delegation-1",
-            "toolCallId": "call-1",
-            "state": "forked",
-            "targetAgentId": "coder",
-            "objective": "Implement it",
-            "childSessionId": "child-1",
-            "requestedAt": 100,
-            "forkedAt": 110,
-            "finishedAt": null,
-            "updatedAt": 110,
-            "resultSummary": null,
-            "error": null
-        }))
-        .expect("delegation update");
-
-        assert_eq!(update.state, DelegationUpdateState::Forked);
-        assert_eq!(update.child_session_id.as_deref(), Some("child-1"));
     }
 
     #[test]

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -2,13 +2,12 @@ use std::collections::HashSet;
 
 use serde_json::Value;
 
-use crate::acp_client::{
-    DelegateModelOverrideInfo, DelegationUpdateNotification, DelegationUpdateState,
-};
+use crate::acp_client::DelegateModelOverrideInfo;
 use crate::app::{LogLevel, POPUP_SESSION_PAGE_TARGET, Popup, Screen};
 use crate::command::{Command, SessionListRequest};
 use crate::domain::activity::{
     ActivityState, DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus,
+    DelegationState, DelegationUpdate,
 };
 use crate::domain::auth::{AuthProviderEntry, OAuthFlow, OAuthResult};
 use crate::domain::chat::ChatEntry;
@@ -153,10 +152,10 @@ pub(crate) enum AcpAppEvent {
         session_id: String,
         updates: Vec<AcpSessionUpdate>,
     },
-    DelegationUpdate(DelegationUpdateNotification),
+    DelegationUpdate(DelegationUpdate),
     DelegationReplay {
         session_id: String,
-        updates: Vec<DelegationUpdateNotification>,
+        updates: Vec<DelegationUpdate>,
     },
     Models {
         models: Vec<ModelEntry>,
@@ -921,8 +920,8 @@ impl crate::app::App {
         self.invalidate_delegate_render_cache();
     }
 
-    fn apply_acp_delegation_update(&mut self, update: DelegationUpdateNotification) {
-        if update.version != 1 || self.session_id.as_deref() != Some(update.session_id.as_str()) {
+    fn apply_acp_delegation_update(&mut self, update: DelegationUpdate) {
+        if self.session_id.as_deref() != Some(update.session_id.as_str()) {
             return;
         }
         let existing_index = self
@@ -948,12 +947,10 @@ impl crate::app::App {
             })
         });
         let status = match update.state {
-            DelegationUpdateState::Requested | DelegationUpdateState::Forked => {
-                DelegateStatus::InProgress
-            }
-            DelegationUpdateState::Completed => DelegateStatus::Completed,
-            DelegationUpdateState::Failed => DelegateStatus::Failed,
-            DelegationUpdateState::Cancelled => DelegateStatus::Cancelled,
+            DelegationState::Requested | DelegationState::Forked => DelegateStatus::InProgress,
+            DelegationState::Completed => DelegateStatus::Completed,
+            DelegationState::Failed => DelegateStatus::Failed,
+            DelegationState::Cancelled => DelegateStatus::Cancelled,
         };
         let index = if let Some(index) = index {
             index
@@ -2088,13 +2085,11 @@ fn message_id_matches(left: Option<&String>, right: Option<&String>) -> bool {
     }
 }
 
-fn delegation_state_rank(state: DelegationUpdateState) -> u8 {
+fn delegation_state_rank(state: DelegationState) -> u8 {
     match state {
-        DelegationUpdateState::Requested => 1,
-        DelegationUpdateState::Forked => 2,
-        DelegationUpdateState::Completed
-        | DelegationUpdateState::Failed
-        | DelegationUpdateState::Cancelled => 3,
+        DelegationState::Requested => 1,
+        DelegationState::Forked => 2,
+        DelegationState::Completed | DelegationState::Failed | DelegationState::Cancelled => 3,
     }
 }
 
@@ -2130,31 +2125,25 @@ mod tests {
     const TEST_SESSION_ID: &str = "session-1";
     const TEST_ASSISTANT_ID: &str = "a1";
 
-    fn delegation_update(
-        state: DelegationUpdateState,
-        updated_at: i64,
-    ) -> DelegationUpdateNotification {
-        DelegationUpdateNotification {
-            version: 1,
+    fn delegation_update(state: DelegationState, updated_at: i64) -> DelegationUpdate {
+        DelegationUpdate {
             session_id: TEST_SESSION_ID.into(),
             delegation_id: "delegation-1".into(),
             tool_call_id: Some("call-1".into()),
             state,
             target_agent_id: "coder".into(),
             objective: "Implement the feature".into(),
-            child_session_id: (state != DelegationUpdateState::Requested).then(|| "child-1".into()),
+            child_session_id: (state != DelegationState::Requested).then(|| "child-1".into()),
             requested_at: 100,
-            forked_at: (state != DelegationUpdateState::Requested).then_some(110),
+            forked_at: (state != DelegationState::Requested).then_some(110),
             finished_at: matches!(
                 state,
-                DelegationUpdateState::Completed
-                    | DelegationUpdateState::Failed
-                    | DelegationUpdateState::Cancelled
+                DelegationState::Completed | DelegationState::Failed | DelegationState::Cancelled
             )
             .then_some(120),
             updated_at,
-            result_summary: (state == DelegationUpdateState::Completed).then(|| "done".into()),
-            error: (state == DelegationUpdateState::Failed).then(|| "boom".into()),
+            result_summary: (state == DelegationState::Completed).then(|| "done".into()),
+            error: (state == DelegationState::Failed).then(|| "boom".into()),
         }
     }
 
@@ -2345,11 +2334,11 @@ mod tests {
         );
 
         app.handle_acp_event(AcpAppEvent::DelegationUpdate(delegation_update(
-            DelegationUpdateState::Completed,
+            DelegationState::Completed,
             120,
         )));
         app.handle_acp_event(AcpAppEvent::DelegationUpdate(delegation_update(
-            DelegationUpdateState::Forked,
+            DelegationState::Forked,
             110,
         )));
 
@@ -2359,6 +2348,78 @@ mod tests {
         assert_eq!(entry.child_session_id.as_deref(), Some("child-1"));
         assert_eq!(entry.status, DelegateStatus::Completed);
         assert_eq!(app.delegation_result_summaries["delegation-1"], "done");
+    }
+
+    #[test]
+    fn delegation_equal_timestamp_does_not_regress_lifecycle_rank() {
+        let mut app = app_with_active_session();
+
+        app.handle_acp_event(AcpAppEvent::DelegationUpdate(delegation_update(
+            DelegationState::Completed,
+            120,
+        )));
+        app.handle_acp_event(AcpAppEvent::DelegationUpdate(delegation_update(
+            DelegationState::Forked,
+            120,
+        )));
+
+        assert_eq!(app.delegate_entries[0].status, DelegateStatus::Completed);
+        assert_eq!(app.delegation_result_summaries["delegation-1"], "done");
+    }
+
+    #[test]
+    fn delegation_updates_insert_and_remove_summary_and_error() {
+        let mut app = app_with_active_session();
+
+        app.handle_acp_event(AcpAppEvent::DelegationUpdate(delegation_update(
+            DelegationState::Completed,
+            120,
+        )));
+        assert_eq!(app.delegation_result_summaries["delegation-1"], "done");
+        assert!(!app.delegation_errors.contains_key("delegation-1"));
+
+        app.handle_acp_event(AcpAppEvent::DelegationUpdate(delegation_update(
+            DelegationState::Failed,
+            130,
+        )));
+        assert_eq!(app.delegate_entries[0].status, DelegateStatus::Failed);
+        assert!(!app.delegation_result_summaries.contains_key("delegation-1"));
+        assert_eq!(app.delegation_errors["delegation-1"], "boom");
+
+        app.handle_acp_event(AcpAppEvent::DelegationUpdate(delegation_update(
+            DelegationState::Cancelled,
+            140,
+        )));
+        assert_eq!(app.delegate_entries[0].status, DelegateStatus::Cancelled);
+        assert!(!app.delegation_errors.contains_key("delegation-1"));
+    }
+
+    #[test]
+    fn delegation_live_and_replay_updates_filter_inactive_parent_sessions() {
+        let mut app = app_with_active_session();
+        let valid_update = delegation_update(DelegationState::Requested, 100);
+
+        app.handle_acp_event(AcpAppEvent::DelegationReplay {
+            session_id: "session-2".into(),
+            updates: vec![valid_update.clone()],
+        });
+        assert!(app.delegate_entries.is_empty());
+
+        let mut wrong_parent_update = valid_update.clone();
+        wrong_parent_update.session_id = "session-2".into();
+        app.handle_acp_event(AcpAppEvent::DelegationReplay {
+            session_id: TEST_SESSION_ID.into(),
+            updates: vec![wrong_parent_update.clone()],
+        });
+        app.handle_acp_event(AcpAppEvent::DelegationUpdate(wrong_parent_update));
+        assert!(app.delegate_entries.is_empty());
+
+        app.handle_acp_event(AcpAppEvent::DelegationReplay {
+            session_id: TEST_SESSION_ID.into(),
+            updates: vec![valid_update],
+        });
+        assert_eq!(app.delegate_entries.len(), 1);
+        assert_eq!(app.delegate_entries[0].status, DelegateStatus::InProgress);
     }
 
     #[test]
@@ -2383,7 +2444,7 @@ mod tests {
         });
 
         app.handle_acp_event(AcpAppEvent::DelegationUpdate(delegation_update(
-            DelegationUpdateState::Forked,
+            DelegationState::Forked,
             110,
         )));
 
@@ -2400,7 +2461,7 @@ mod tests {
         app.activity = ActivityState::Streaming;
 
         app.handle_acp_event(AcpAppEvent::DelegationUpdate(delegation_update(
-            DelegationUpdateState::Completed,
+            DelegationState::Completed,
             120,
         )));
 

--- a/src/domain/activity.rs
+++ b/src/domain/activity.rs
@@ -43,6 +43,32 @@ pub enum DelegateChildState {
     OtherProgress,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DelegationState {
+    Requested,
+    Forked,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DelegationUpdate {
+    pub session_id: String,
+    pub delegation_id: String,
+    pub tool_call_id: Option<String>,
+    pub state: DelegationState,
+    pub target_agent_id: String,
+    pub objective: String,
+    pub child_session_id: Option<String>,
+    pub requested_at: i64,
+    pub forked_at: Option<i64>,
+    pub finished_at: Option<i64>,
+    pub updated_at: i64,
+    pub result_summary: Option<String>,
+    pub error: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct DelegateEntry {
     pub delegation_id: String,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -300,6 +300,121 @@ pub struct DelegationData {
     pub objective: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DelegationUpdateStateDto {
+    Requested,
+    Forked,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DelegationUpdateDto {
+    pub version: u32,
+    pub session_id: String,
+    pub delegation_id: String,
+    #[serde(default)]
+    pub tool_call_id: Option<String>,
+    pub state: DelegationUpdateStateDto,
+    pub target_agent_id: String,
+    pub objective: String,
+    #[serde(default)]
+    pub child_session_id: Option<String>,
+    pub requested_at: i64,
+    #[serde(default)]
+    pub forked_at: Option<i64>,
+    #[serde(default)]
+    pub finished_at: Option<i64>,
+    pub updated_at: i64,
+    #[serde(default)]
+    pub result_summary: Option<String>,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+#[cfg(test)]
+mod delegation_update_dto_tests {
+    use super::{DelegationUpdateDto, DelegationUpdateStateDto};
+    use serde_json::json;
+
+    #[test]
+    fn delegation_update_dto_deserializes_camel_case_fields_and_ignores_unknown_fields() {
+        let update: DelegationUpdateDto = serde_json::from_value(json!({
+            "version": 1,
+            "sessionId": "parent",
+            "delegationId": "delegation-1",
+            "toolCallId": "call-1",
+            "state": "forked",
+            "targetAgentId": "coder",
+            "objective": "Implement it",
+            "childSessionId": "child-1",
+            "requestedAt": 100,
+            "forkedAt": 110,
+            "finishedAt": null,
+            "updatedAt": 110,
+            "resultSummary": null,
+            "error": null,
+            "unknownField": "ignored"
+        }))
+        .expect("delegation update");
+
+        assert_eq!(update.version, 1);
+        assert_eq!(update.session_id, "parent");
+        assert_eq!(update.delegation_id, "delegation-1");
+        assert_eq!(update.tool_call_id.as_deref(), Some("call-1"));
+        assert_eq!(update.state, DelegationUpdateStateDto::Forked);
+        assert_eq!(update.target_agent_id, "coder");
+        assert_eq!(update.objective, "Implement it");
+        assert_eq!(update.child_session_id.as_deref(), Some("child-1"));
+        assert_eq!(update.requested_at, 100);
+        assert_eq!(update.forked_at, Some(110));
+        assert_eq!(update.finished_at, None);
+        assert_eq!(update.updated_at, 110);
+        assert_eq!(update.result_summary, None);
+        assert_eq!(update.error, None);
+    }
+
+    #[test]
+    fn delegation_update_dto_defaults_optional_fields() {
+        let update: DelegationUpdateDto = serde_json::from_value(json!({
+            "version": 1,
+            "sessionId": "parent",
+            "delegationId": "delegation-1",
+            "state": "requested",
+            "targetAgentId": "coder",
+            "objective": "Implement it",
+            "requestedAt": 100,
+            "updatedAt": 100
+        }))
+        .expect("delegation update defaults");
+
+        assert_eq!(update.tool_call_id, None);
+        assert_eq!(update.child_session_id, None);
+        assert_eq!(update.forked_at, None);
+        assert_eq!(update.finished_at, None);
+        assert_eq!(update.result_summary, None);
+        assert_eq!(update.error, None);
+    }
+
+    #[test]
+    fn delegation_update_state_dto_accepts_every_snake_case_lifecycle_state() {
+        for (wire_state, expected) in [
+            ("requested", DelegationUpdateStateDto::Requested),
+            ("forked", DelegationUpdateStateDto::Forked),
+            ("completed", DelegationUpdateStateDto::Completed),
+            ("failed", DelegationUpdateStateDto::Failed),
+            ("cancelled", DelegationUpdateStateDto::Cancelled),
+        ] {
+            let state: DelegationUpdateStateDto =
+                serde_json::from_value(json!(wire_state)).expect("delegation state");
+            assert_eq!(state, expected);
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct MeshStatusDto {
     pub enabled: bool,


### PR DESCRIPTION
## behavior

- move delegation notification serde shapes into protocol DTOs and add semantic delegation values under domain activity
- validate notification version 1 and convert every semantic field at the ACP boundary for live and replay paths
- keep malformed or unsupported live notifications logged and ignored, and skip malformed or unsupported replay entries
- preserve active-parent filtering, lifecycle ordering, provisional tool-call reconciliation, child hydration, summary/error updates, and parent streaming
- retain persisted `EventKind::Delegation*` audit variants unchanged

## validation

- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --all-targets --all-features`
- `cargo test --all-features` (756 passed)
- `git diff --check`
- boundary searches confirm old local notification types are removed, DTOs remain in protocol/ACP adapter code, and version validation occurs at the adapter

## deferred

- stack PR8 owns surviving protocol DTO modularization, orphan re-inventory, and broader fixtures
- `EventKind` remains audit input until it has an owning reducer boundary
