### PR TITLE
refactor: complete phase 3 acceptance

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3845,31 +3845,6 @@ mod start_page_tests {
         ));
     }
 
-    // ── filtered_sessions still works (for popup compat) ─────────────────────
-
-    #[test]
-    fn filtered_sessions_returns_flat_list_for_popup() {
-        let mut app = App::new();
-        app.session_groups = vec![
-            make_group(Some("/a"), &[("s1", None)]),
-            make_group(Some("/b"), &[("s2", None), ("s3", None)]),
-        ];
-
-        let flat = app.filtered_sessions();
-        assert_eq!(flat.len(), 3);
-    }
-
-    #[test]
-    fn filtered_sessions_applies_filter() {
-        let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &[("aaa", None), ("bbb", None)])];
-        app.session_filter = "aaa".to_string();
-
-        let flat = app.filtered_sessions();
-        assert_eq!(flat.len(), 1);
-        assert_eq!(flat[0].session_id, "aaa");
-    }
-
     // ── GroupHeader carries correct session_count ─────────────────────────────
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -280,21 +280,6 @@ impl App {
         }
     }
 
-    /// Flat list of sessions that match the current filter, across all groups.
-    ///
-    /// Used by the session popup (which shows a flat list) for backward compatibility.
-    pub fn filtered_sessions(&self) -> Vec<&SessionSummary> {
-        let q = self.session_filter.to_lowercase();
-        self.session_groups
-            .iter()
-            .flat_map(|g| {
-                matching_session_indices(g, &q)
-                    .into_iter()
-                    .map(move |i| &g.sessions[i])
-            })
-            .collect()
-    }
-
     /// Build the flat list of visible rows for the start-page session list.
     ///
     /// Each call re-evaluates the current `session_filter` and `collapsed_groups`.


### PR DESCRIPTION
## cleanup
- remove production-dead `App::filtered_sessions`
- remove the two tests that existed only to preserve that compatibility API
- leave session popup/start-page behavior and all deferred Phase 4 work unchanged

## phase 3 acceptance
- focused protocol owner imports: pass; no flat `crate::protocol::{...}` imports
- wire/domain separation: pass; no DTOs in `domain` or `acp_state`, no protocol re-exports, and no forbidden domain dependencies
- internal commands: pass; no legacy reducer/command wire names or serialization traits on `Command`
- serde compatibility: pass; no `deny_unknown_fields`
- compatibility cleanup: pass; no remaining `filtered_sessions` reference or strict Phase 3 compatibility item
- broad Phase 3 source gates pass and source review is approved, but Phase 3 remains `acceptance implemented; integration pending` until this PR is integrated

## post-cleanup metrics
- 44 tracked Rust files; 41,442 physical lines
- largest complete source: `src/app.rs`, 4,750 lines including inline tests
- largest source prefix before a single trailing top-level test module: `src/ui/popups.rs`, 2,990 lines; `src/acp_client.rs` is second at 2,988; this procedure applies only to files whose tests are one trailing top-level `#[cfg(test)]` module and does not estimate mixed/interleaved files
- `App`: 142 top-level fields; 5 files containing an `App` impl: `src/app.rs`, `src/input.rs`, `src/mesh.rs`, `src/session.rs`, and `src/acp_state.rs` (`impl crate::app::App`), with the latter retained as later Phase 7 residue
- production handlers accepting `cmd_tx: &mpsc::UnboundedSender<Command>`: 23
- protocol: 5 owner files plus `mod.rs`, 24 public types, 1,015 owner LOC (1,020 including `mod.rs`)
- forbidden domain imports: 0; strict Phase 3 compatibility items: 0; legacy names: 0
- tests: 756 declarations; 756 passed, 0 failed, 0 ignored; harness 1.90s, warm command wall 2.007s
- `dead_code` allowances: 2 occurrences, intentionally deferred

## validation
- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --all-targets --all-features`
- `cargo test --all-targets --all-features -- --quiet`
- `git diff --check`

## accepted later-phase residuals
- retain `EventKind` until its owning reducer boundary exists
- retain same-shape auth/profile/model serde dependencies
- defer crate-wide `#![allow(dead_code)]` removal to Phase 11
- defer mesh attach snapshot/config semantics, remote cwd UI, and stale remote-map identity collisions
- defer `App` state decomposition, command-channel refactors, and rendering ownership; Phase 4 does not begin here