### PR TITLE
refactor: extract diagnostics state

### DIFF
--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -3,8 +3,9 @@ use std::collections::HashSet;
 use serde_json::Value;
 
 use crate::acp_client::DelegateModelOverrideInfo;
-use crate::app::{LogLevel, POPUP_SESSION_PAGE_TARGET, Popup, Screen};
+use crate::app::{POPUP_SESSION_PAGE_TARGET, Popup, Screen};
 use crate::command::{Command, SessionListRequest};
+use crate::diagnostics::LogLevel;
 use crate::domain::activity::{
     ActivityState, DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus,
     DelegationState, DelegationUpdate,
@@ -3551,7 +3552,7 @@ mod tests {
         assert_eq!(app.context_limit, 8192);
         assert_eq!(app.cumulative_cost, Some(0.0123));
         assert!(matches!(
-            app.logs.last(),
+            app.diagnostics.logs.last(),
             Some(entry)
                 if entry.level == LogLevel::Info
                     && entry.target == "usage"
@@ -3575,7 +3576,7 @@ mod tests {
             Some(std::time::Duration::from_secs(42))
         );
         assert!(matches!(
-            app.logs.last(),
+            app.diagnostics.logs.last(),
             Some(entry)
                 if entry.level == LogLevel::Info
                     && entry.target == "usage"
@@ -3771,7 +3772,7 @@ mod tests {
         }));
 
         assert!(matches!(app.activity, ActivityState::Idle));
-        assert_eq!(app.status, "undone - reloading session");
+        assert_eq!(app.diagnostics.status, "undone - reloading session");
         assert!(app.can_redo());
         assert_eq!(
             app.undo_state.as_ref().unwrap().stack[0].reverted_files,
@@ -3826,7 +3827,7 @@ mod tests {
         }));
 
         assert!(matches!(app.activity, ActivityState::Idle));
-        assert_eq!(app.status, "Undo rejected");
+        assert_eq!(app.diagnostics.status, "Undo rejected");
         assert_eq!(app.streaming_content, "keep streaming content");
         assert!(replies.is_empty());
         let undo_state = app.undo_state.as_ref().expect("undo state");
@@ -3892,7 +3893,7 @@ mod tests {
         }));
 
         assert!(matches!(app.activity, ActivityState::Idle));
-        assert_eq!(app.status, "redone - reloading session");
+        assert_eq!(app.diagnostics.status, "redone - reloading session");
         assert!(app.can_redo());
         assert!(matches!(
             replies.as_slice(),
@@ -3919,11 +3920,11 @@ mod tests {
         }));
 
         assert!(matches!(app.activity, ActivityState::Idle));
-        assert_eq!(app.status, "Nothing to redo");
+        assert_eq!(app.diagnostics.status, "Nothing to redo");
         assert!(app.can_redo());
         assert!(replies.is_empty());
         assert!(matches!(
-            app.logs.last(),
+            app.diagnostics.logs.last(),
             Some(entry) if entry.level == LogLevel::Warn && entry.target == "session"
         ));
     }
@@ -3943,7 +3944,7 @@ mod tests {
 
         assert_eq!(app.pending_fork_message_id, None);
         assert_eq!(app.popup, Popup::None);
-        assert_eq!(app.status, "forked - loading session");
+        assert_eq!(app.diagnostics.status, "forked - loading session");
         assert_eq!(replies.len(), 2);
         assert!(matches!(
             replies.as_slice(),
@@ -3969,7 +3970,7 @@ mod tests {
         assert!(replies.is_empty());
         assert_eq!(app.pending_fork_message_id, None);
         assert_eq!(app.popup, Popup::ForkTurnSelect);
-        assert_eq!(app.status, "fork succeeded without session id");
+        assert_eq!(app.diagnostics.status, "fork succeeded without session id");
     }
 
     #[test]
@@ -3986,7 +3987,7 @@ mod tests {
         assert!(replies.is_empty());
         assert_eq!(app.pending_fork_message_id, None);
         assert_eq!(app.popup, Popup::ForkTurnSelect);
-        assert_eq!(app.status, "fork failed");
+        assert_eq!(app.diagnostics.status, "fork failed");
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,6 +5,7 @@ use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
 
 use crate::command::Command;
+use crate::diagnostics::{AppLogEntry, DiagnosticsState, LogLevel};
 use crate::domain::activity::{
     ActivityState, DelegateChildState, DelegateEntry, DelegateStats, PendingDelegateToolCall,
     SessionActivity, SessionOp, SessionStatsLite,
@@ -219,45 +220,6 @@ pub const COMMAND_PALETTE_COMMANDS: &[CommandPaletteCommand] = &[
         chat_only: false,
     },
 ];
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum LogLevel {
-    Trace,
-    Debug,
-    Info,
-    Warn,
-    Error,
-}
-
-impl LogLevel {
-    pub fn label(self) -> &'static str {
-        match self {
-            Self::Trace => "TRACE",
-            Self::Debug => "DEBUG",
-            Self::Info => "INFO",
-            Self::Warn => "WARN",
-            Self::Error => "ERROR",
-        }
-    }
-
-    pub fn next(self) -> Self {
-        match self {
-            Self::Trace => Self::Debug,
-            Self::Debug => Self::Info,
-            Self::Info => Self::Warn,
-            Self::Warn => Self::Error,
-            Self::Error => Self::Trace,
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AppLogEntry {
-    pub elapsed: Duration,
-    pub level: LogLevel,
-    pub target: &'static str,
-    pub message: String,
-}
 
 // ── Delegation tracking ───────────────────────────────────────────────────────
 
@@ -684,12 +646,8 @@ pub struct App {
     // help popup
     pub help_scroll: usize,
 
-    // in-memory logs popup
-    pub started_at: Instant,
-    pub logs: Vec<AppLogEntry>,
-    pub log_cursor: usize,
-    pub log_filter: String,
-    pub log_level_filter: LogLevel,
+    // in-memory logs popup and status line
+    pub(crate) diagnostics: DiagnosticsState,
 
     // Undo/redo state mirrors the web UI semantics: a server-authoritative stack
     // of reverted turns plus a frontier that marks the current branch point.
@@ -704,9 +662,6 @@ pub struct App {
     pub context_limit: u64,
     pub session_stats: SessionStatsLite,
     pub pending_cancel_confirm_until: Option<Instant>,
-
-    // status line
-    pub status: String,
 
     // mesh / remote (from ACP extensions)
     /// Count of mesh nodes from the last `querymt/mesh/nodes` fetch.
@@ -931,11 +886,7 @@ impl App {
             theme_cursor: 0,
             theme_filter: String::new(),
             help_scroll: 0,
-            started_at: Instant::now(),
-            logs: Vec::new(),
-            log_cursor: 0,
-            log_filter: String::new(),
-            log_level_filter: LogLevel::Info,
+            diagnostics: DiagnosticsState::new(),
             undo_state: None,
             undoable_turns: Vec::new(),
             recent_prompt_text: None,
@@ -992,7 +943,6 @@ impl App {
             delegation_errors: HashMap::new(),
             pending_delegate_tool_calls: Vec::new(),
             suppress_turn_output: false,
-            status: "connecting...".into(),
             tick: 0,
             should_quit: false,
         }
@@ -1432,48 +1382,29 @@ impl App {
         }
     }
 
+    // phase 11 compatibility forward
     pub fn push_log(&mut self, level: LogLevel, target: &'static str, message: impl Into<String>) {
-        let message = message.into();
-        if self.logs.last().is_some_and(|entry| {
-            entry.level == level && entry.target == target && entry.message == message
-        }) {
-            return;
-        }
-        self.logs.push(AppLogEntry {
-            elapsed: self.started_at.elapsed(),
-            level,
-            target,
-            message,
-        });
+        self.diagnostics.push_log(level, target, message);
     }
 
+    // phase 11 compatibility forward
     pub fn set_status(
         &mut self,
         level: LogLevel,
         target: &'static str,
         message: impl Into<String>,
     ) {
-        let message = message.into();
-        self.status = message.clone();
-        self.push_log(level, target, message);
+        self.diagnostics.set_status(level, target, message);
     }
 
+    // phase 11 compatibility forward
     pub fn filtered_logs(&self) -> Vec<&AppLogEntry> {
-        let query = self.log_filter.to_lowercase();
-        self.logs
-            .iter()
-            .filter(|entry| entry.level >= self.log_level_filter)
-            .filter(|entry| {
-                query.is_empty()
-                    || entry.message.to_lowercase().contains(&query)
-                    || entry.target.to_lowercase().contains(&query)
-                    || entry.level.label().to_lowercase().contains(&query)
-            })
-            .collect()
+        self.diagnostics.filtered_logs()
     }
 
+    // phase 11 compatibility forward
     pub fn cycle_log_level_filter(&mut self) {
-        self.log_level_filter = self.log_level_filter.next();
+        self.diagnostics.cycle_log_level_filter();
     }
 
     pub fn cancel_confirm_active(&self) -> bool {
@@ -3137,68 +3068,24 @@ mod tests {
     }
 
     #[test]
-    fn push_log_deduplicates_consecutive_entries() {
-        let mut app = App::new();
-
-        app.push_log(LogLevel::Info, "server", "starting local server");
-        app.push_log(LogLevel::Info, "server", "starting local server");
-        app.push_log(LogLevel::Warn, "server", "waiting for lock");
-
-        assert_eq!(app.logs.len(), 2);
-        assert_eq!(app.logs[0].level, LogLevel::Info);
-        assert_eq!(app.logs[0].target, "server");
-        assert_eq!(app.logs[0].message, "starting local server");
-        assert_eq!(app.logs[1].level, LogLevel::Warn);
-    }
-
-    #[test]
-    fn set_status_updates_visible_status_and_appends_log() {
-        let mut app = App::new();
-
-        app.set_status(LogLevel::Info, "connection", "connected");
-
-        assert_eq!(app.status, "connected");
-        let last = app.logs.last().expect("missing log entry");
-        assert_eq!(last.level, LogLevel::Info);
-        assert_eq!(last.target, "connection");
-        assert_eq!(last.message, "connected");
-    }
-
-    #[test]
-    fn filtered_logs_apply_level_threshold_and_text_filter() {
-        let mut app = App::new();
-        app.push_log(LogLevel::Debug, "activity", "ready");
-        app.push_log(LogLevel::Warn, "server", "waiting for lock");
-        app.push_log(LogLevel::Error, "server", "start failed");
-
-        app.log_level_filter = LogLevel::Warn;
-        let filtered = app.filtered_logs();
-        assert_eq!(filtered.len(), 2);
-        assert!(filtered.iter().all(|entry| entry.level >= LogLevel::Warn));
-
-        app.log_filter = "failed".into();
-        let filtered = app.filtered_logs();
-        assert_eq!(filtered.len(), 1);
-        assert_eq!(filtered[0].message, "start failed");
-    }
-
-    #[test]
     fn cancel_confirm_arms_expires_and_restores_status() {
         let mut app = App::new();
         app.activity = ActivityState::Thinking;
 
         app.arm_cancel_confirm();
         assert!(app.cancel_confirm_active());
-        assert_eq!(app.status, "press Esc again to stop");
+        assert_eq!(app.diagnostics.status, "press Esc again to stop");
         assert!(
-            matches!(app.logs.last(), Some(entry) if entry.message == "press Esc again to stop")
+            matches!(app.diagnostics.logs.last(), Some(entry) if entry.message == "press Esc again to stop")
         );
 
         app.pending_cancel_confirm_until = Some(Instant::now() - Duration::from_millis(1));
         app.clear_expired_cancel_confirm();
         assert!(!app.cancel_confirm_active());
-        assert_eq!(app.status, "thinking...");
-        assert!(matches!(app.logs.last(), Some(entry) if entry.message == "thinking..."));
+        assert_eq!(app.diagnostics.status, "thinking...");
+        assert!(
+            matches!(app.diagnostics.logs.last(), Some(entry) if entry.message == "thinking...")
+        );
     }
 
     #[test]
@@ -3207,22 +3094,22 @@ mod tests {
         app.conn = ConnState::Disconnected;
         app.set_status(LogLevel::Warn, "connection", "connection lost - retrying");
         app.refresh_transient_status();
-        assert_eq!(app.status, "connection lost - retrying");
+        assert_eq!(app.diagnostics.status, "connection lost - retrying");
 
         app.conn = ConnState::Connected;
         app.activity = ActivityState::Thinking;
         app.refresh_transient_status();
-        assert_eq!(app.status, "thinking...");
+        assert_eq!(app.diagnostics.status, "thinking...");
 
         app.activity = ActivityState::Compacting {
             token_estimate: 2048,
         };
         app.refresh_transient_status();
-        assert_eq!(app.status, "compacting context (~2048 tokens)");
+        assert_eq!(app.diagnostics.status, "compacting context (~2048 tokens)");
 
         app.activity = ActivityState::SessionOp(SessionOp::Redo);
         app.refresh_transient_status();
-        assert_eq!(app.status, "redoing...");
+        assert_eq!(app.diagnostics.status, "redoing...");
     }
 
     #[test]
@@ -3459,9 +3346,12 @@ mod tests {
         assert_eq!(app.conn, ConnState::Connecting);
         assert_eq!(app.reconnect_attempt, 3);
         assert_eq!(app.reconnect_delay_ms, Some(2000));
-        assert_eq!(app.status, "waiting for server - retry 3 in 2.0s");
+        assert_eq!(
+            app.diagnostics.status,
+            "waiting for server - retry 3 in 2.0s"
+        );
         assert!(
-            matches!(app.logs.last(), Some(entry) if entry.target == "connection" && entry.level == LogLevel::Warn)
+            matches!(app.diagnostics.logs.last(), Some(entry) if entry.target == "connection" && entry.level == LogLevel::Warn)
         );
 
         app.handle_connection_event(ConnectionEvent::Disconnected {
@@ -3469,9 +3359,9 @@ mod tests {
         });
         assert_eq!(app.conn, ConnState::Disconnected);
         assert_eq!(app.reconnect_delay_ms, None);
-        assert_eq!(app.status, "connection lost - socket closed");
+        assert_eq!(app.diagnostics.status, "connection lost - socket closed");
         assert!(
-            matches!(app.logs.last(), Some(entry) if entry.message == "connection lost - socket closed")
+            matches!(app.diagnostics.logs.last(), Some(entry) if entry.message == "connection lost - socket closed")
         );
 
         app.session_id = Some("session-1".into());
@@ -3479,9 +3369,9 @@ mod tests {
         assert_eq!(app.conn, ConnState::Connected);
         assert_eq!(app.reconnect_attempt, 0);
         assert_eq!(app.reconnect_delay_ms, None);
-        assert_eq!(app.status, "reconnected");
+        assert_eq!(app.diagnostics.status, "reconnected");
         assert!(
-            matches!(app.logs.last(), Some(entry) if entry.level == LogLevel::Info && entry.message == "reconnected")
+            matches!(app.diagnostics.logs.last(), Some(entry) if entry.level == LogLevel::Info && entry.message == "reconnected")
         );
     }
 

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,0 +1,233 @@
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl LogLevel {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Trace => "TRACE",
+            Self::Debug => "DEBUG",
+            Self::Info => "INFO",
+            Self::Warn => "WARN",
+            Self::Error => "ERROR",
+        }
+    }
+
+    pub(crate) fn next(self) -> Self {
+        match self {
+            Self::Trace => Self::Debug,
+            Self::Debug => Self::Info,
+            Self::Info => Self::Warn,
+            Self::Warn => Self::Error,
+            Self::Error => Self::Trace,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AppLogEntry {
+    pub(crate) elapsed: Duration,
+    pub(crate) level: LogLevel,
+    pub(crate) target: &'static str,
+    pub(crate) message: String,
+}
+
+pub(crate) struct DiagnosticsState {
+    pub(crate) started_at: Instant,
+    pub(crate) logs: Vec<AppLogEntry>,
+    pub(crate) log_cursor: usize,
+    pub(crate) log_filter: String,
+    pub(crate) log_level_filter: LogLevel,
+    pub(crate) status: String,
+}
+
+impl DiagnosticsState {
+    pub(crate) fn new() -> Self {
+        Self {
+            started_at: Instant::now(),
+            logs: Vec::new(),
+            log_cursor: 0,
+            log_filter: String::new(),
+            log_level_filter: LogLevel::Info,
+            status: "connecting...".into(),
+        }
+    }
+
+    pub(crate) fn push_log(
+        &mut self,
+        level: LogLevel,
+        target: &'static str,
+        message: impl Into<String>,
+    ) {
+        let message = message.into();
+        if self.logs.last().is_some_and(|entry| {
+            entry.level == level && entry.target == target && entry.message == message
+        }) {
+            return;
+        }
+        self.logs.push(AppLogEntry {
+            elapsed: self.started_at.elapsed(),
+            level,
+            target,
+            message,
+        });
+    }
+
+    pub(crate) fn set_status(
+        &mut self,
+        level: LogLevel,
+        target: &'static str,
+        message: impl Into<String>,
+    ) {
+        let message = message.into();
+        self.status = message.clone();
+        self.push_log(level, target, message);
+    }
+
+    pub(crate) fn filtered_logs(&self) -> Vec<&AppLogEntry> {
+        let query = self.log_filter.to_lowercase();
+        self.logs
+            .iter()
+            .filter(|entry| entry.level >= self.log_level_filter)
+            .filter(|entry| {
+                query.is_empty()
+                    || entry.message.to_lowercase().contains(&query)
+                    || entry.target.to_lowercase().contains(&query)
+                    || entry.level.label().to_lowercase().contains(&query)
+            })
+            .collect()
+    }
+
+    pub(crate) fn cycle_log_level_filter(&mut self) {
+        self.log_level_filter = self.log_level_filter.next();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use super::{DiagnosticsState, LogLevel};
+
+    #[test]
+    fn constructor_uses_expected_defaults() {
+        let before = Instant::now();
+        let diagnostics = DiagnosticsState::new();
+        let after = Instant::now();
+
+        assert!(diagnostics.started_at >= before);
+        assert!(diagnostics.started_at <= after);
+        assert!(diagnostics.logs.is_empty());
+        assert_eq!(diagnostics.log_cursor, 0);
+        assert!(diagnostics.log_filter.is_empty());
+        assert_eq!(diagnostics.log_level_filter, LogLevel::Info);
+        assert_eq!(diagnostics.status, "connecting...");
+    }
+
+    #[test]
+    fn push_log_suppresses_only_consecutive_exact_duplicates() {
+        let mut diagnostics = DiagnosticsState::new();
+
+        diagnostics.push_log(LogLevel::Info, "server", "starting local server");
+        diagnostics.push_log(LogLevel::Info, "server", "starting local server");
+        diagnostics.push_log(LogLevel::Warn, "server", "starting local server");
+        diagnostics.push_log(LogLevel::Warn, "runtime", "starting local server");
+        diagnostics.push_log(LogLevel::Warn, "runtime", "ready");
+        diagnostics.push_log(LogLevel::Info, "server", "starting local server");
+
+        assert_eq!(diagnostics.logs.len(), 5);
+        assert_eq!(diagnostics.logs[0].level, LogLevel::Info);
+        assert_eq!(diagnostics.logs[1].level, LogLevel::Warn);
+        assert_eq!(diagnostics.logs[2].target, "runtime");
+        assert_eq!(diagnostics.logs[3].message, "ready");
+        assert_eq!(diagnostics.logs[4].level, diagnostics.logs[0].level);
+        assert_eq!(diagnostics.logs[4].target, diagnostics.logs[0].target);
+        assert_eq!(diagnostics.logs[4].message, diagnostics.logs[0].message);
+    }
+
+    #[test]
+    fn set_status_updates_visible_status_and_appends_log() {
+        let mut diagnostics = DiagnosticsState::new();
+
+        diagnostics.set_status(LogLevel::Info, "connection", "connected");
+
+        assert_eq!(diagnostics.status, "connected");
+        let last = diagnostics.logs.last().expect("missing log entry");
+        assert_eq!(last.level, LogLevel::Info);
+        assert_eq!(last.target, "connection");
+        assert_eq!(last.message, "connected");
+    }
+
+    #[test]
+    fn filtered_logs_match_message_target_and_level_case_insensitively() {
+        let mut diagnostics = DiagnosticsState::new();
+        diagnostics.push_log(LogLevel::Debug, "activity", "ready");
+        diagnostics.push_log(LogLevel::Warn, "Server", "waiting for lock");
+        diagnostics.push_log(LogLevel::Error, "runtime", "START FAILED");
+        diagnostics.log_level_filter = LogLevel::Trace;
+
+        diagnostics.log_filter = "READY".into();
+        assert_eq!(diagnostics.filtered_logs()[0].target, "activity");
+
+        diagnostics.log_filter = "server".into();
+        assert_eq!(diagnostics.filtered_logs()[0].level, LogLevel::Warn);
+
+        diagnostics.log_filter = "wArN".into();
+        assert_eq!(diagnostics.filtered_logs()[0].message, "waiting for lock");
+
+        diagnostics.log_filter = "failed".into();
+        assert_eq!(diagnostics.filtered_logs()[0].level, LogLevel::Error);
+    }
+
+    #[test]
+    fn filtered_logs_apply_minimum_level_threshold() {
+        let mut diagnostics = DiagnosticsState::new();
+        diagnostics.push_log(LogLevel::Debug, "activity", "ready");
+        diagnostics.push_log(LogLevel::Warn, "server", "waiting for lock");
+        diagnostics.push_log(LogLevel::Error, "server", "start failed");
+
+        diagnostics.log_level_filter = LogLevel::Warn;
+        let filtered = diagnostics.filtered_logs();
+
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered.iter().all(|entry| entry.level >= LogLevel::Warn));
+    }
+
+    #[test]
+    fn cycle_log_level_filter_wraps_in_display_order() {
+        let mut diagnostics = DiagnosticsState::new();
+        diagnostics.log_level_filter = LogLevel::Trace;
+
+        for expected in [
+            LogLevel::Debug,
+            LogLevel::Info,
+            LogLevel::Warn,
+            LogLevel::Error,
+            LogLevel::Trace,
+        ] {
+            diagnostics.cycle_log_level_filter();
+            assert_eq!(diagnostics.log_level_filter, expected);
+        }
+    }
+
+    #[test]
+    fn log_elapsed_uses_diagnostics_started_at() {
+        let mut diagnostics = DiagnosticsState::new();
+        let started_at = diagnostics.started_at;
+        let elapsed_before = started_at.elapsed();
+
+        diagnostics.push_log(LogLevel::Info, "server", "ready");
+
+        let elapsed = diagnostics.logs[0].elapsed;
+        let elapsed_after = started_at.elapsed();
+        assert!(elapsed >= elapsed_before);
+        assert!(elapsed <= elapsed_after);
+    }
+}

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,7 +1,8 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use tokio::sync::mpsc;
 
-use crate::app::{self, App, AuthUiNotice, CommandPaletteAction, LogLevel, Popup, Screen};
+use crate::app::{self, App, AuthUiNotice, CommandPaletteAction, Popup, Screen};
+use crate::diagnostics::LogLevel;
 use crate::domain::activity::{ActivityState, SessionOp};
 use crate::domain::auth::{OAuthFlowKind, OAuthStatus};
 use crate::domain::chat::{ChatEntry, format_outcome_labels};
@@ -25,7 +26,7 @@ pub(crate) fn can_send_server_commands(app: &mut App) -> bool {
         true
     } else {
         app.set_status(
-            app::LogLevel::Warn,
+            LogLevel::Warn,
             "connection",
             "not connected - waiting to reconnect",
         );
@@ -237,7 +238,7 @@ pub(crate) fn handle_elicitation_key(
 fn open_model_popup(app: &mut App, cmd_tx: &mpsc::UnboundedSender<Command>) -> anyhow::Result<()> {
     if app.screen != Screen::Chat {
         app.set_status(
-            app::LogLevel::Warn,
+            LogLevel::Warn,
             "model",
             "model select is only available in chat",
         );
@@ -273,8 +274,8 @@ fn open_session_popup(
 
 fn open_log_popup(app: &mut App) {
     app.popup = Popup::Log;
-    app.log_cursor = app.filtered_logs().len().saturating_sub(1);
-    app.log_filter.clear();
+    app.diagnostics.log_cursor = app.filtered_logs().len().saturating_sub(1);
+    app.diagnostics.log_filter.clear();
 }
 
 fn execute_command_palette_action(
@@ -455,7 +456,7 @@ pub(crate) fn handle_mesh_invite_popup_key(
         KeyCode::Enter => {
             if let Some(msg) = app.mesh_invite_form_command() {
                 cmd_tx.send(msg)?;
-                app.set_status(app::LogLevel::Info, "mesh", "creating invite...");
+                app.set_status(LogLevel::Info, "mesh", "creating invite...");
             }
         }
         KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -489,7 +490,7 @@ pub(crate) fn handle_mesh_invite_qr_popup_key(app: &mut App, key: KeyEvent) -> a
         KeyCode::Char('y') if key.modifiers.contains(KeyModifiers::CONTROL) => {
             if let Some(url) = app.mesh_invite_url().map(str::to_string) {
                 if copy_text_to_clipboard(&url) {
-                    app.set_status(app::LogLevel::Info, "mesh", "invite URL copied");
+                    app.set_status(LogLevel::Info, "mesh", "invite URL copied");
                 } else {
                     app.mesh_clipboard_fallback = Some(url);
                 }
@@ -557,11 +558,11 @@ pub(crate) fn handle_key(
     // chord second key: ctrl+x was pressed, now handle the follow-up
     if app.chord {
         app.chord = false;
-        app.set_status(app::LogLevel::Debug, "input", "ready");
+        app.set_status(LogLevel::Debug, "input", "ready");
         if key.code == KeyCode::Char('e') {
             if app.screen != Screen::Chat {
                 app.set_status(
-                    app::LogLevel::Warn,
+                    LogLevel::Warn,
                     "editor",
                     "external editor is only available in chat",
                 );
@@ -588,14 +589,14 @@ pub(crate) fn handle_key(
             Some(msg) => {
                 cmd_tx.send(msg)?;
                 app.set_status(
-                    app::LogLevel::Info,
+                    LogLevel::Info,
                     "model",
                     format!("thinking: {}", app.reasoning_effort_label()),
                 );
             }
             None => {
                 app.set_status(
-                    app::LogLevel::Warn,
+                    LogLevel::Warn,
                     "model",
                     format!(
                         "unknown reasoning effort {:?}; cannot cycle",
@@ -618,7 +619,7 @@ pub(crate) fn handle_key(
     // chord start: ctrl+x
     if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('x') {
         app.chord = true;
-        app.set_status(app::LogLevel::Debug, "input", "C-x ...");
+        app.set_status(LogLevel::Debug, "input", "C-x ...");
         return Ok(AppAction::None);
     }
 
@@ -747,11 +748,7 @@ pub(crate) fn handle_chord(
             app.should_quit = true;
         }
         KeyCode::Char('e') => {
-            app.set_status(
-                app::LogLevel::Warn,
-                "editor",
-                "external editor unavailable here",
-            );
+            app.set_status(LogLevel::Warn, "editor", "external editor unavailable here");
         }
 
         KeyCode::Char('t') => {
@@ -780,7 +777,7 @@ pub(crate) fn handle_chord(
         KeyCode::Char('j') => {
             if !matches!(app.screen, Screen::Chat | Screen::Delegate) {
                 app.set_status(
-                    app::LogLevel::Warn,
+                    LogLevel::Warn,
                     "session",
                     "parent jump only available in chat",
                 );
@@ -797,7 +794,7 @@ pub(crate) fn handle_chord(
                     app.agent_id.clone(),
                 )?;
             } else {
-                app.set_status(app::LogLevel::Info, "session", "no parent session");
+                app.set_status(LogLevel::Info, "session", "no parent session");
             }
         }
         KeyCode::Char('?') => {
@@ -807,7 +804,7 @@ pub(crate) fn handle_chord(
         KeyCode::Char('f') => {
             if app.screen != Screen::Chat {
                 app.set_status(
-                    app::LogLevel::Warn,
+                    LogLevel::Warn,
                     "fork",
                     "fork selector is only available in chat",
                 );
@@ -821,12 +818,12 @@ pub(crate) fn handle_chord(
             }
             if app.is_turn_active() {
                 app.set_status(
-                    app::LogLevel::Warn,
+                    LogLevel::Warn,
                     "session",
                     "cannot undo while agent is active",
                 );
             } else if app.has_pending_session_op() || app.has_pending_undo() {
-                app.set_status(app::LogLevel::Warn, "session", "undo already pending");
+                app.set_status(LogLevel::Warn, "session", "undo already pending");
             } else if let Some(turn) = app.current_undo_target().cloned() {
                 if app.input.trim().is_empty() && !turn.text.is_empty() {
                     app.input = turn.text.clone();
@@ -835,12 +832,12 @@ pub(crate) fn handle_chord(
                 }
                 app.push_pending_undo(&turn);
                 app.activity = ActivityState::SessionOp(SessionOp::Undo);
-                app.set_status(app::LogLevel::Info, "session", "undoing...");
+                app.set_status(LogLevel::Info, "session", "undoing...");
                 cmd_tx.send(Command::Undo {
                     message_id: turn.message_id,
                 })?;
             } else {
-                app.set_status(app::LogLevel::Warn, "session", "nothing to undo");
+                app.set_status(LogLevel::Warn, "session", "nothing to undo");
             }
         }
         KeyCode::Char('r') => {
@@ -849,22 +846,22 @@ pub(crate) fn handle_chord(
             }
             if app.is_turn_active() {
                 app.set_status(
-                    app::LogLevel::Warn,
+                    LogLevel::Warn,
                     "session",
                     "cannot redo while agent is active",
                 );
             } else if app.has_pending_session_op() || app.has_pending_undo() {
-                app.set_status(app::LogLevel::Warn, "session", "undo already pending");
+                app.set_status(LogLevel::Warn, "session", "undo already pending");
             } else if app.can_redo() {
                 app.activity = ActivityState::SessionOp(SessionOp::Redo);
-                app.set_status(app::LogLevel::Info, "session", "redoing...");
+                app.set_status(LogLevel::Info, "session", "redoing...");
                 cmd_tx.send(Command::Redo)?;
             } else {
-                app.set_status(app::LogLevel::Warn, "session", "nothing to redo");
+                app.set_status(LogLevel::Warn, "session", "nothing to redo");
             }
         }
         _ => {
-            app.set_status(app::LogLevel::Debug, "input", "unknown chord");
+            app.set_status(LogLevel::Debug, "input", "unknown chord");
         }
     }
     Ok(())
@@ -1111,7 +1108,7 @@ pub(crate) fn apply_popup_session_key(
                             }
                             if app.is_remote_session_id(&session_id) {
                                 app.set_status(
-                                    app::LogLevel::Warn,
+                                    LogLevel::Warn,
                                     "session",
                                     "remote session is missing node id; refresh sessions and try again",
                                 );
@@ -1359,7 +1356,7 @@ pub(crate) fn apply_delegate_popup_key(
                     };
                 } else {
                     app.set_status(
-                        app::LogLevel::Warn,
+                        LogLevel::Warn,
                         "delegates",
                         "delegation still pending — no session to load",
                     );
@@ -1438,36 +1435,36 @@ pub(crate) fn handle_log_popup_key(app: &mut App, key: KeyEvent) -> anyhow::Resu
             app.popup = Popup::None;
         }
         KeyCode::Up => {
-            app.log_cursor = app.log_cursor.saturating_sub(1);
+            app.diagnostics.log_cursor = app.diagnostics.log_cursor.saturating_sub(1);
         }
         KeyCode::Down => {
             let max = app.filtered_logs().len().saturating_sub(1);
-            app.log_cursor = (app.log_cursor + 1).min(max);
+            app.diagnostics.log_cursor = (app.diagnostics.log_cursor + 1).min(max);
         }
         KeyCode::PageUp => {
-            app.log_cursor = app.log_cursor.saturating_sub(10);
+            app.diagnostics.log_cursor = app.diagnostics.log_cursor.saturating_sub(10);
         }
         KeyCode::PageDown => {
             let max = app.filtered_logs().len().saturating_sub(1);
-            app.log_cursor = (app.log_cursor + 10).min(max);
+            app.diagnostics.log_cursor = (app.diagnostics.log_cursor + 10).min(max);
         }
         KeyCode::Home => {
-            app.log_cursor = 0;
+            app.diagnostics.log_cursor = 0;
         }
         KeyCode::End => {
-            app.log_cursor = app.filtered_logs().len().saturating_sub(1);
+            app.diagnostics.log_cursor = app.filtered_logs().len().saturating_sub(1);
         }
         KeyCode::Backspace => {
-            app.log_filter.pop();
-            app.log_cursor = app.filtered_logs().len().saturating_sub(1);
+            app.diagnostics.log_filter.pop();
+            app.diagnostics.log_cursor = app.filtered_logs().len().saturating_sub(1);
         }
         KeyCode::Tab => {
             app.cycle_log_level_filter();
-            app.log_cursor = app.filtered_logs().len().saturating_sub(1);
+            app.diagnostics.log_cursor = app.filtered_logs().len().saturating_sub(1);
         }
         KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
-            app.log_filter.push(c);
-            app.log_cursor = 0;
+            app.diagnostics.log_filter.push(c);
+            app.diagnostics.log_cursor = 0;
         }
         _ => {}
     }
@@ -1509,13 +1506,13 @@ pub(crate) fn handle_profile_popup_key(
                 }
                 app.popup = Popup::None;
                 app.set_status(
-                    app::LogLevel::Info,
+                    LogLevel::Info,
                     "profile",
                     format!("new sessions will use {profile_id}"),
                 );
                 save_config(app);
             } else {
-                app.set_status(app::LogLevel::Warn, "profile", "no matching profile");
+                app.set_status(LogLevel::Warn, "profile", "no matching profile");
             }
         }
         _ => {}
@@ -1673,7 +1670,7 @@ pub(crate) fn handle_chat_key(
             } else if app.has_cancellable_activity() {
                 if app.cancel_confirm_active() {
                     app.clear_cancel_confirm();
-                    app.set_status(app::LogLevel::Warn, "activity", "stopping...");
+                    app.set_status(LogLevel::Warn, "activity", "stopping...");
                     cmd_tx.send(Command::CancelSession)?;
                 } else {
                     app.arm_cancel_confirm();
@@ -1886,7 +1883,7 @@ fn try_execute_slash_command(
             app.take_input();
             if app.screen != crate::app::Screen::Chat {
                 app.set_status(
-                    app::LogLevel::Warn,
+                    LogLevel::Warn,
                     "model",
                     "model select is only available in chat",
                 );
@@ -1918,7 +1915,7 @@ fn try_execute_slash_command(
                     "build" | "plan" => {
                         if app.agent_mode == arg {
                             app.set_status(
-                                app::LogLevel::Info,
+                                LogLevel::Info,
                                 "mode",
                                 format!("already in {} mode", arg),
                             );
@@ -1928,7 +1925,7 @@ fn try_execute_slash_command(
                     }
                     _ => {
                         app.set_status(
-                            app::LogLevel::Warn,
+                            LogLevel::Warn,
                             "mode",
                             format!("unknown mode: {} (try build or plan)", arg),
                         );
@@ -1942,7 +1939,7 @@ fn try_execute_slash_command(
                 return Ok(SlashResult::Handled);
             }
             if app.agent_mode == "review" {
-                app.set_status(app::LogLevel::Info, "mode", "already in review mode");
+                app.set_status(LogLevel::Info, "mode", "already in review mode");
             } else {
                 switch_mode(app, cmd_tx, "review")?;
             }
@@ -1951,7 +1948,7 @@ fn try_execute_slash_command(
             app.take_input();
             if arg.is_empty() {
                 app.set_status(
-                    app::LogLevel::Info,
+                    LogLevel::Info,
                     "model",
                     format!("thinking: {}", app.reasoning_effort_label()),
                 );
@@ -1959,7 +1956,7 @@ fn try_execute_slash_command(
                 let level = arg.to_lowercase();
                 if app::validate_reasoning_effort(Some(&level)).is_none() {
                     app.set_status(
-                        app::LogLevel::Warn,
+                        LogLevel::Warn,
                         "model",
                         format!(
                             "unknown level: {} (try auto, low, medium, high, max)",
@@ -1973,7 +1970,7 @@ fn try_execute_slash_command(
                     let msg = app.set_reasoning_effort(Some(&level)).unwrap();
                     cmd_tx.send(msg)?;
                     app.set_status(
-                        app::LogLevel::Info,
+                        LogLevel::Info,
                         "model",
                         format!("thinking: {}", app.reasoning_effort_label()),
                     );
@@ -2005,14 +2002,14 @@ fn try_execute_slash_command(
                     })?;
                 }
                 app.set_status(
-                    app::LogLevel::Info,
+                    LogLevel::Info,
                     "profile",
                     format!("new sessions will use {profile_id}"),
                 );
                 save_config(app);
             } else {
                 app.set_status(
-                    app::LogLevel::Warn,
+                    LogLevel::Warn,
                     "profile",
                     format!("unknown profile: {}", arg),
                 );
@@ -2035,7 +2032,7 @@ fn try_execute_slash_command(
             app.take_input();
             if app.screen != crate::app::Screen::Chat {
                 app.set_status(
-                    app::LogLevel::Warn,
+                    LogLevel::Warn,
                     "delegates",
                     "delegates only available in chat",
                 );
@@ -2061,8 +2058,8 @@ fn try_execute_slash_command(
         "logs" => {
             app.take_input();
             app.popup = crate::app::Popup::Log;
-            app.log_cursor = app.filtered_logs().len().saturating_sub(1);
-            app.log_filter.clear();
+            app.diagnostics.log_cursor = app.filtered_logs().len().saturating_sub(1);
+            app.diagnostics.log_filter.clear();
         }
         "auth" => {
             app.take_input();
@@ -2075,34 +2072,22 @@ fn try_execute_slash_command(
         "fork" => {
             app.take_input();
             if app.screen != crate::app::Screen::Chat {
-                app.set_status(
-                    app::LogLevel::Warn,
-                    "fork",
-                    "forking is only available in chat",
-                );
+                app.set_status(LogLevel::Warn, "fork", "forking is only available in chat");
                 return Ok(SlashResult::Handled);
             }
             if !can_send_server_commands(app) {
                 return Ok(SlashResult::Handled);
             }
             if app.pending_fork_message_id.is_some() {
-                app.set_status(app::LogLevel::Warn, "fork", "fork already pending");
+                app.set_status(LogLevel::Warn, "fork", "fork already pending");
             } else if app.has_pending_session_op() {
-                app.set_status(
-                    app::LogLevel::Warn,
-                    "fork",
-                    "session operation already pending",
-                );
+                app.set_status(LogLevel::Warn, "fork", "session operation already pending");
             } else if app.is_turn_active() {
-                app.set_status(
-                    app::LogLevel::Warn,
-                    "fork",
-                    "cannot fork while agent is active",
-                );
+                app.set_status(LogLevel::Warn, "fork", "cannot fork while agent is active");
             } else if let Some(turn) = app.latest_fork_boundary() {
                 begin_fork_session(app, turn.message_id, cmd_tx)?;
             } else {
-                app.set_status(app::LogLevel::Warn, "fork", "no forkable turns");
+                app.set_status(LogLevel::Warn, "fork", "no forkable turns");
             }
         }
         "undo" => {
@@ -2114,12 +2099,12 @@ fn try_execute_slash_command(
             }
             if app.is_turn_active() {
                 app.set_status(
-                    app::LogLevel::Warn,
+                    LogLevel::Warn,
                     "session",
                     "cannot undo while agent is active",
                 );
             } else if app.has_pending_session_op() || app.has_pending_undo() {
-                app.set_status(app::LogLevel::Warn, "session", "undo already pending");
+                app.set_status(LogLevel::Warn, "session", "undo already pending");
             } else if let Some(turn) = app.current_undo_target().cloned() {
                 if app.input.trim().is_empty() && !turn.text.is_empty() {
                     app.input = turn.text.clone();
@@ -2128,12 +2113,12 @@ fn try_execute_slash_command(
                 }
                 app.push_pending_undo(&turn);
                 app.activity = ActivityState::SessionOp(SessionOp::Undo);
-                app.set_status(app::LogLevel::Info, "session", "undoing...");
+                app.set_status(LogLevel::Info, "session", "undoing...");
                 cmd_tx.send(Command::Undo {
                     message_id: turn.message_id,
                 })?;
             } else {
-                app.set_status(app::LogLevel::Warn, "session", "nothing to undo");
+                app.set_status(LogLevel::Warn, "session", "nothing to undo");
             }
         }
         "redo" => {
@@ -2143,18 +2128,18 @@ fn try_execute_slash_command(
             }
             if app.is_turn_active() {
                 app.set_status(
-                    app::LogLevel::Warn,
+                    LogLevel::Warn,
                     "session",
                     "cannot redo while agent is active",
                 );
             } else if app.has_pending_session_op() || app.has_pending_undo() {
-                app.set_status(app::LogLevel::Warn, "session", "redo already pending");
+                app.set_status(LogLevel::Warn, "session", "redo already pending");
             } else if app.can_redo() {
                 app.activity = ActivityState::SessionOp(SessionOp::Redo);
-                app.set_status(app::LogLevel::Info, "session", "redoing...");
+                app.set_status(LogLevel::Info, "session", "redoing...");
                 cmd_tx.send(Command::Redo)?;
             } else {
-                app.set_status(app::LogLevel::Warn, "session", "nothing to redo");
+                app.set_status(LogLevel::Warn, "session", "nothing to redo");
             }
         }
         "editor" => {
@@ -2165,10 +2150,10 @@ fn try_execute_slash_command(
             app.take_input();
             if app.has_cancellable_activity() {
                 app.clear_cancel_confirm();
-                app.set_status(app::LogLevel::Warn, "activity", "stopping...");
+                app.set_status(LogLevel::Warn, "activity", "stopping...");
                 cmd_tx.send(Command::CancelSession)?;
             } else {
-                app.set_status(app::LogLevel::Warn, "activity", "nothing to cancel");
+                app.set_status(LogLevel::Warn, "activity", "nothing to cancel");
             }
         }
         "quit" => {
@@ -2536,11 +2521,7 @@ pub(crate) fn handle_model_popup_key(
                             })?;
                         }
                     }
-                    app.set_status(
-                        app::LogLevel::Info,
-                        "model",
-                        format!("session: {}", model.label),
-                    );
+                    app.set_status(LogLevel::Info, "model", format!("session: {}", model.label));
                 } else if let Some(agent_id) = app
                     .model_popup_tab_agent_id(app.model_popup_agent_tab)
                     .map(str::to_string)
@@ -2559,7 +2540,7 @@ pub(crate) fn handle_model_popup_key(
                         })?;
                     }
                     app.set_status(
-                        app::LogLevel::Info,
+                        LogLevel::Info,
                         "model",
                         format!("{tab_label}: {}", model.label),
                     );
@@ -2585,7 +2566,7 @@ pub(crate) fn handle_model_popup_key(
                     })?;
                 }
                 app.set_status(
-                    app::LogLevel::Info,
+                    LogLevel::Info,
                     "model",
                     "delegate model uses profile default",
                 );
@@ -2693,7 +2674,7 @@ pub(crate) fn apply_sessions_key(
                             }
                             if app.is_remote_session_id(&session_id) {
                                 app.set_status(
-                                    app::LogLevel::Warn,
+                                    LogLevel::Warn,
                                     "session",
                                     "remote session is missing node id; refresh sessions and try again",
                                 );
@@ -3522,6 +3503,6 @@ mod model_popup_tests {
         assert_eq!(app.agent_mode, "review");
         assert_eq!(app.mode_before_review.as_deref(), Some("plan"));
         assert!(rx.try_recv().is_err());
-        assert_eq!(app.status, "already in review mode");
+        assert_eq!(app.diagnostics.status, "already in review mode");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod acp_state;
 mod app;
 mod command;
 mod config;
+mod diagnostics;
 mod domain;
 mod handlers;
 mod highlight;

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -1,7 +1,8 @@
 use std::time::{Duration, Instant};
 
-use crate::app::{App, LogLevel, Popup};
+use crate::app::{App, Popup};
 use crate::command::Command;
+use crate::diagnostics::LogLevel;
 use crate::domain::mesh::{
     MeshInviteCreatedInfo, MeshNodesInfo, MeshStatusInfo, RemoteSessionAttachInfo,
     RemoteSessionInfo, RemoteSessionListInfo,

--- a/src/runtime/editor.rs
+++ b/src/runtime/editor.rs
@@ -5,7 +5,8 @@ use std::{
     process::Command,
 };
 
-use crate::app::{App, LogLevel};
+use crate::app::App;
+use crate::diagnostics::LogLevel;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct EditorCommand {
@@ -161,8 +162,8 @@ mod tests {
 
         assert_eq!(app.input, "revised prompt");
         assert_eq!(app.input_cursor, "revised prompt".len());
-        assert_eq!(app.status, "loaded prompt from external editor");
-        assert!(matches!(app.logs.last(), Some(entry) if entry.target == "editor"));
+        assert_eq!(app.diagnostics.status, "loaded prompt from external editor");
+        assert!(matches!(app.diagnostics.logs.last(), Some(entry) if entry.target == "editor"));
     }
 
     #[test]
@@ -173,6 +174,6 @@ mod tests {
         apply_external_editor_outcome(&mut app, Ok(None));
 
         assert_eq!(app.input, "draft");
-        assert_eq!(app.status, "external editor cancelled");
+        assert_eq!(app.diagnostics.status, "external editor cancelled");
     }
 }

--- a/src/runtime/event_loop.rs
+++ b/src/runtime/event_loop.rs
@@ -7,6 +7,7 @@ use tokio::sync::mpsc;
 use crate::{
     app::{self, App},
     command::Command,
+    diagnostics::LogLevel,
     handlers::{AppAction, handle_key, handle_mouse},
     server_manager::{self, ServerEvent, ServerState},
     ui,
@@ -41,7 +42,7 @@ fn reconnect_session_commands(app: &mut App) -> Vec<Command> {
     }
     if app.is_remote_session_id(&session_id) {
         app.set_status(
-            app::LogLevel::Warn,
+            LogLevel::Warn,
             "session",
             "remote session is missing node id; reconnect attach skipped",
         );
@@ -63,7 +64,7 @@ pub(super) async fn run_loop(
     let mut term_events = EventStream::new();
 
     loop {
-        app.tick = tick_from_elapsed(app.started_at.elapsed());
+        app.tick = tick_from_elapsed(app.diagnostics.started_at.elapsed());
         app.clear_expired_cancel_confirm();
         terminal.draw(|frame| ui::draw(frame, app))?;
 
@@ -83,7 +84,7 @@ pub(super) async fn run_loop(
                             }
                         } else if was_connected && app.conn == app::ConnState::Disconnected {
                             app.set_status(
-                                app::LogLevel::Warn,
+                                LogLevel::Warn,
                                 "connection",
                                 "connection lost - reconnecting...",
                             );
@@ -101,20 +102,20 @@ pub(super) async fn run_loop(
                     ServerEvent::Starting => {
                         app.server_state = ServerState::Starting;
                         if app.conn != app::ConnState::Connected {
-                            app.set_status(app::LogLevel::Info, "acp", "starting qmtcode ACP agent...");
+                            app.set_status(LogLevel::Info, "acp", "starting qmtcode ACP agent...");
                         }
                     }
                     ServerEvent::Started => {
                         app.server_state = ServerState::Running;
                         if app.conn != app::ConnState::Connected {
-                            app.set_status(app::LogLevel::Info, "acp", "qmtcode ACP agent started");
+                            app.set_status(LogLevel::Info, "acp", "qmtcode ACP agent started");
                         }
                     }
                     ServerEvent::BinaryNotFound => {
                         app.server_state = ServerState::BinaryNotFound;
                         if app.conn != app::ConnState::Connected {
                             app.set_status(
-                                app::LogLevel::Warn,
+                                LogLevel::Warn,
                                 "acp",
                                 "qmtcode not found; install it or set acp.binary_path in ~/.qmt/qmtui.toml",
                             );
@@ -123,7 +124,7 @@ pub(super) async fn run_loop(
                     ServerEvent::StartFailed { error } => {
                         app.server_state = ServerState::StartFailed { error: error.clone() };
                         app.set_status(
-                            app::LogLevel::Error,
+                            LogLevel::Error,
                             "acp",
                             format!("ACP start failed: {error}"),
                         );
@@ -131,7 +132,7 @@ pub(super) async fn run_loop(
                     ServerEvent::Stopped { reason } => {
                         app.server_state = ServerState::Restarting { reason: reason.clone() };
                         app.set_status(
-                            app::LogLevel::Warn,
+                            LogLevel::Warn,
                             "acp",
                             format!("ACP agent stopped ({reason})"),
                         );
@@ -243,7 +244,7 @@ mod tests {
         }];
 
         assert!(reconnect_session_commands(&mut app).is_empty());
-        assert!(app.status.contains("missing node id"));
+        assert!(app.diagnostics.status.contains("missing node id"));
     }
 
     #[test]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -12,6 +12,7 @@ use crate::{
     app::{self, App, Screen},
     command::Command,
     config,
+    diagnostics::LogLevel,
     domain::model::DelegateModelPreference,
     server_manager, theme,
 };
@@ -583,8 +584,8 @@ mod external_editor_tests {
         let action = handle_key(&mut app, plain_key('e'), &tx).unwrap();
 
         assert_eq!(action, AppAction::None);
-        assert!(app.status.contains("only available in chat"));
-        assert!(matches!(app.logs.last(), Some(entry) if entry.target == "editor"));
+        assert!(app.diagnostics.status.contains("only available in chat"));
+        assert!(matches!(app.diagnostics.logs.last(), Some(entry) if entry.target == "editor"));
     }
 
     #[test]
@@ -601,8 +602,8 @@ mod external_editor_tests {
 
         assert_eq!(action, AppAction::None);
         assert_ne!(app.popup, app::Popup::ModelSelect);
-        assert!(app.status.contains("only available in chat"));
-        assert!(matches!(app.logs.last(), Some(entry) if entry.target == "model"));
+        assert!(app.diagnostics.status.contains("only available in chat"));
+        assert!(matches!(app.diagnostics.logs.last(), Some(entry) if entry.target == "model"));
     }
 
     #[test]
@@ -627,12 +628,22 @@ mod external_editor_tests {
             },
         );
 
-        assert!(app.logs.iter().any(|entry| entry.target == "acp"
-            && entry.level == app::LogLevel::Info
-            && entry.message == "acp.binary_path not set; checking qmtcode on PATH"));
-        assert!(app.logs.iter().any(|entry| entry.target == "acp"
-            && entry.level == app::LogLevel::Info
-            && entry.message == "qmtcode not found on PATH"));
+        assert!(
+            app.diagnostics
+                .logs
+                .iter()
+                .any(|entry| entry.target == "acp"
+                    && entry.level == LogLevel::Info
+                    && entry.message == "acp.binary_path not set; checking qmtcode on PATH")
+        );
+        assert!(
+            app.diagnostics
+                .logs
+                .iter()
+                .any(|entry| entry.target == "acp"
+                    && entry.level == LogLevel::Info
+                    && entry.message == "qmtcode not found on PATH")
+        );
     }
 
     #[test]
@@ -935,7 +946,7 @@ mod external_editor_tests {
         .unwrap();
 
         assert_eq!(app.agent_mode, "build");
-        assert!(app.status.contains("already in build"));
+        assert!(app.diagnostics.status.contains("already in build"));
     }
 
     #[test]
@@ -955,7 +966,7 @@ mod external_editor_tests {
         )
         .unwrap();
 
-        assert!(app.status.contains("unknown mode"));
+        assert!(app.diagnostics.status.contains("unknown mode"));
     }
 
     #[test]
@@ -1053,7 +1064,7 @@ mod external_editor_tests {
         )
         .unwrap();
 
-        assert!(app.status.contains("thinking: high"));
+        assert!(app.diagnostics.status.contains("thinking: high"));
     }
 
     #[test]
@@ -1071,7 +1082,7 @@ mod external_editor_tests {
         )
         .unwrap();
 
-        assert!(app.status.contains("unknown level"));
+        assert!(app.diagnostics.status.contains("unknown level"));
     }
 
     #[test]
@@ -1092,7 +1103,7 @@ mod external_editor_tests {
 
         // state must not change when disconnected
         assert_eq!(app.reasoning_effort, Some("high".into()));
-        assert!(app.status.contains("not connected"));
+        assert!(app.diagnostics.status.contains("not connected"));
     }
 
     fn app_with_forkable_messages() -> App {
@@ -1164,8 +1175,8 @@ mod external_editor_tests {
 
         assert_ne!(app.popup, app::Popup::ForkTurnSelect);
         assert!(rx.try_recv().is_err());
-        assert!(app.status.contains("only available in chat"));
-        assert!(matches!(app.logs.last(), Some(entry) if entry.target == "fork"));
+        assert!(app.diagnostics.status.contains("only available in chat"));
+        assert!(matches!(app.diagnostics.logs.last(), Some(entry) if entry.target == "fork"));
     }
 
     #[test]
@@ -1185,8 +1196,8 @@ mod external_editor_tests {
 
         assert!(rx.try_recv().is_err());
         assert!(app.pending_fork_message_id.is_none());
-        assert!(app.status.contains("only available in chat"));
-        assert!(matches!(app.logs.last(), Some(entry) if entry.target == "fork"));
+        assert!(app.diagnostics.status.contains("only available in chat"));
+        assert!(matches!(app.diagnostics.logs.last(), Some(entry) if entry.target == "fork"));
     }
 
     #[test]
@@ -1246,7 +1257,7 @@ mod external_editor_tests {
         .unwrap();
 
         assert!(rx.try_recv().is_err());
-        assert!(app.status.contains("no forkable turns"));
+        assert!(app.diagnostics.status.contains("no forkable turns"));
     }
 
     #[test]
@@ -1319,9 +1330,9 @@ mod external_editor_tests {
             rx.try_recv().expect("cancel sent"),
             Command::CancelSession
         ));
-        assert_eq!(app.status, "stopping...");
+        assert_eq!(app.diagnostics.status, "stopping...");
         assert!(matches!(
-            app.logs.last(),
+            app.diagnostics.logs.last(),
             Some(entry) if entry.target == "activity" && entry.message == "stopping..."
         ));
     }
@@ -1405,7 +1416,7 @@ mod external_editor_tests {
             &tx,
         )
         .unwrap();
-        assert_eq!(app.status, "press Esc again to stop");
+        assert_eq!(app.diagnostics.status, "press Esc again to stop");
         assert!(rx.try_recv().is_err());
 
         handle_chat_key(
@@ -1414,7 +1425,7 @@ mod external_editor_tests {
             &tx,
         )
         .unwrap();
-        assert_eq!(app.status, "stopping...");
+        assert_eq!(app.diagnostics.status, "stopping...");
         assert!(matches!(
             rx.try_recv().expect("cancel sent"),
             Command::CancelSession
@@ -1435,19 +1446,19 @@ fn log_server_binary_discovery(
     }
     if let Some(path) = discovery.configured_path.as_deref() {
         app.push_log(
-            app::LogLevel::Info,
+            LogLevel::Info,
             "acp",
             format!("configured qmtcode path not found: {path}; checking PATH"),
         );
     } else if cfg.acp.binary_path.is_none() {
         app.push_log(
-            app::LogLevel::Info,
+            LogLevel::Info,
             "acp",
             "acp.binary_path not set; checking qmtcode on PATH",
         );
     }
     if discovery.binary.is_none() {
-        app.push_log(app::LogLevel::Info, "acp", "qmtcode not found on PATH");
+        app.push_log(LogLevel::Info, "acp", "qmtcode not found on PATH");
     }
 }
 
@@ -1515,7 +1526,7 @@ pub async fn run() -> anyhow::Result<()> {
     } = &selection
     {
         app.push_log(
-            app::LogLevel::Info,
+            LogLevel::Info,
             "acp",
             format!("found ACP WebSocket server at {url}"),
         );
@@ -1544,7 +1555,7 @@ pub async fn run() -> anyhow::Result<()> {
     } = &selection
     {
         app.push_log(
-            app::LogLevel::Warn,
+            LogLevel::Warn,
             "acp",
             format!("qmtcode unavailable; waiting for ACP WebSocket at {url}"),
         );
@@ -2608,16 +2619,16 @@ mod session_popup_key_tests {
         .unwrap();
 
         assert_eq!(app.popup, Popup::Log);
-        assert_eq!(app.log_cursor, 0);
-        assert!(app.log_filter.is_empty());
+        assert_eq!(app.diagnostics.log_cursor, 0);
+        assert!(app.diagnostics.log_filter.is_empty());
     }
 
     #[test]
     fn log_popup_filters_cycles_level_and_closes() {
         let mut app = App::new();
         app.popup = Popup::Log;
-        app.log_cursor = 2;
-        app.log_level_filter = crate::app::LogLevel::Info;
+        app.diagnostics.log_cursor = 2;
+        app.diagnostics.log_level_filter = LogLevel::Info;
 
         let (tx, _rx) = mpsc::unbounded_channel();
         handle_key(
@@ -2626,8 +2637,8 @@ mod session_popup_key_tests {
             &tx,
         )
         .unwrap();
-        assert_eq!(app.log_filter, "x");
-        assert_eq!(app.log_cursor, 0);
+        assert_eq!(app.diagnostics.log_filter, "x");
+        assert_eq!(app.diagnostics.log_cursor, 0);
 
         handle_key(
             &mut app,
@@ -2635,7 +2646,7 @@ mod session_popup_key_tests {
             &tx,
         )
         .unwrap();
-        assert!(app.log_filter.is_empty());
+        assert!(app.diagnostics.log_filter.is_empty());
 
         handle_key(
             &mut app,
@@ -2643,7 +2654,7 @@ mod session_popup_key_tests {
             &tx,
         )
         .unwrap();
-        assert_eq!(app.log_level_filter, crate::app::LogLevel::Warn);
+        assert_eq!(app.diagnostics.log_level_filter, LogLevel::Warn);
 
         handle_key(
             &mut app,
@@ -3087,9 +3098,9 @@ mod chord_reasoning_effort_tests {
         handle_key(&mut app, ctrl_t(), &tx).unwrap();
         // status should reflect the new level
         assert!(
-            app.status.contains("low"),
+            app.diagnostics.status.contains("low"),
             "expected status to mention 'low', got: {}",
-            app.status
+            app.diagnostics.status
         );
     }
 
@@ -3103,7 +3114,7 @@ mod chord_reasoning_effort_tests {
 
         // state must not change when disconnected
         assert_eq!(app.reasoning_effort, Some("high".into()));
-        assert!(app.status.contains("not connected"));
+        assert!(app.diagnostics.status.contains("not connected"));
     }
 }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -471,6 +471,7 @@ mod tests {
     use super::*;
     use crate::acp_state::{AcpAppEvent, AcpSessionUpdate};
     use crate::app::{App, Screen};
+    use crate::diagnostics::LogLevel;
     use crate::domain::activity::{
         DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus, SessionActivity,
     };
@@ -2420,15 +2421,11 @@ mod tests {
     fn draw_log_popup_shows_filter_level_and_entries() {
         let mut app = App::new();
         app.popup = Popup::Log;
-        app.log_filter = "server".into();
-        app.log_level_filter = crate::app::LogLevel::Info;
-        app.push_log(
-            crate::app::LogLevel::Info,
-            "server",
-            "starting local server",
-        );
-        app.push_log(crate::app::LogLevel::Error, "server", "start failed");
-        app.log_cursor = app.filtered_logs().len().saturating_sub(1);
+        app.diagnostics.log_filter = "server".into();
+        app.diagnostics.log_level_filter = LogLevel::Info;
+        app.push_log(LogLevel::Info, "server", "starting local server");
+        app.push_log(LogLevel::Error, "server", "start failed");
+        app.diagnostics.log_cursor = app.filtered_logs().len().saturating_sub(1);
 
         let backend = ratatui::backend::TestBackend::new(100, 20);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();

--- a/src/ui/popups.rs
+++ b/src/ui/popups.rs
@@ -7,7 +7,8 @@ use ratatui::{
 };
 use unicode_width::UnicodeWidthStr;
 
-use crate::app::{App, AuthPanel, LogLevel, session_group_count_text};
+use crate::app::{App, AuthPanel, session_group_count_text};
+use crate::diagnostics::LogLevel;
 use crate::domain::activity::DelegateStats;
 use crate::domain::auth::{OAuthFlowKind, OAuthStatus};
 use crate::domain::model::ModelEntry;
@@ -2201,8 +2202,11 @@ pub(super) fn draw_log_popup(f: &mut Frame, app: &App) {
     );
 
     let avail = chunks[1].width.saturating_sub(2) as usize;
-    let (log_filter_display, log_filter_cur) =
-        scroll_input(&app.log_filter, app.log_filter.len(), avail);
+    let (log_filter_display, log_filter_cur) = scroll_input(
+        &app.diagnostics.log_filter,
+        app.diagnostics.log_filter.len(),
+        avail,
+    );
     let filter_line = Line::from(vec![
         Span::styled("> ", Theme::popup_title()),
         Span::styled(log_filter_display, Theme::popup_bg()),
@@ -2216,8 +2220,8 @@ pub(super) fn draw_log_popup(f: &mut Frame, app: &App) {
     let level_line = Line::from(vec![
         Span::styled("level: ", Theme::status()),
         Span::styled(
-            format!("{}+", app.log_level_filter.label()),
-            popup_log_level_style(app.log_level_filter),
+            format!("{}+", app.diagnostics.log_level_filter.label()),
+            popup_log_level_style(app.diagnostics.log_level_filter),
         ),
     ]);
     f.render_widget(
@@ -2268,8 +2272,11 @@ pub(super) fn draw_log_popup(f: &mut Frame, app: &App) {
     };
 
     let list = List::new(items).block(Block::default().style(Theme::popup_bg()));
-    let selected =
-        (!filtered.is_empty()).then_some(app.log_cursor.min(filtered.len().saturating_sub(1)));
+    let selected = (!filtered.is_empty()).then_some(
+        app.diagnostics
+            .log_cursor
+            .min(filtered.len().saturating_sub(1)),
+    );
     let mut state = ListState::default().with_selected(selected);
     f.render_stateful_widget(list, chunks[3], &mut state);
 


### PR DESCRIPTION
## behavior

- extract `DiagnosticsState`, `LogLevel`, and `AppLogEntry` into private `src/diagnostics.rs`
- replace six flat `App` fields with one crate-visible diagnostics state while preserving defaults, status strings, log order/deduplication, filtering, cursor behavior, and session-reset behavior
- keep runtime ticks and log elapsed timestamps on the same `DiagnosticsState::started_at`

## compatibility

- retain exactly four logic-free `App` forwards: `push_log`, `set_status`, `filtered_logs`, and `cycle_log_level_filter`
- tag all four as `phase 11 compatibility forward` for later deletion
- add no getter, alias, `Deref`, re-export, or additional state group

## tests

- move and expand focused diagnostics tests for constructor defaults, duplicate suppression and changed entries, status logging, case-insensitive message/target/level filtering, minimum-level filtering, level cycling, and shared elapsed timing
- preserve cross-boundary connection/status, ACP warning, editor, keyboard filter, runtime, and popup rendering coverage
- pass `cargo fmt --all -- --check`, all-target/all-feature check, Clippy with warnings denied, build, 760 tests, and `git diff --check`

## non-goals

- no connection, session, auth, profile, mesh, navigation, model, command/effect, popup-routing, ACP transport, or UI layout redesign
- no second Phase 4 state group
