### PR TITLE
refactor: extract auth state

### DIFF
--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -215,7 +215,7 @@ impl crate::app::App {
                 if let Some(effort) = reasoning_effort {
                     self.reasoning_effort = effort;
                 }
-                self.auth_ui_notice = None;
+                self.auth.ui_notice = None;
                 self.set_status(LogLevel::Info, "connection", "connected");
                 vec![]
             }
@@ -512,11 +512,11 @@ impl crate::app::App {
                 vec![]
             }
             AcpAppEvent::AuthProviders(providers) => {
-                self.auth_providers = providers;
+                self.auth.providers = providers;
                 self.push_log(
                     LogLevel::Debug,
                     "auth",
-                    format!("{} auth provider(s)", self.auth_providers.len()),
+                    format!("{} auth provider(s)", self.auth.providers.len()),
                 );
                 vec![]
             }
@@ -526,12 +526,7 @@ impl crate::app::App {
                     "auth",
                     format!("OAuth flow started for {}", flow.provider),
                 );
-                self.auth_oauth_flow = Some(flow);
-                self.auth_panel = crate::app::AuthPanel::OAuthFlow;
-                self.auth_oauth_response.clear();
-                self.auth_oauth_response_cursor = 0;
-                self.auth_last_result = None;
-                self.auth_ui_notice = None;
+                self.auth.begin_oauth_flow(flow);
                 vec![]
             }
             AcpAppEvent::OAuthResult(result) => {
@@ -542,12 +537,8 @@ impl crate::app::App {
                     LogLevel::Warn
                 };
                 self.push_log(level, "auth", &result.message);
-                self.auth_ui_notice = None;
-                self.auth_last_result = Some(result);
-                if is_success {
-                    self.auth_oauth_flow = None;
-                    self.auth_panel = crate::app::AuthPanel::List;
-                }
+                let applied_success = self.auth.apply_oauth_result(result);
+                debug_assert_eq!(applied_success, is_success);
                 vec![Command::ListAuthProviders]
             }
             AcpAppEvent::InfoLog { target, message } => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,13 +4,13 @@ use std::time::{Duration, Instant};
 use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
 
+use crate::auth_state::AuthState;
 use crate::command::Command;
 use crate::diagnostics::{AppLogEntry, DiagnosticsState, LogLevel};
 use crate::domain::activity::{
     ActivityState, DelegateChildState, DelegateEntry, DelegateStats, PendingDelegateToolCall,
     SessionActivity, SessionOp, SessionStatsLite,
 };
-use crate::domain::auth::{AuthProviderEntry, OAuthFlow, OAuthResult};
 use crate::domain::chat::{ChatEntry, format_outcome_labels};
 use crate::domain::elicitation::ElicitationState;
 use crate::domain::mesh::{
@@ -501,25 +501,6 @@ pub enum ModelPopupItem {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AuthUiNotice {
-    pub provider: Option<String>,
-    pub success: bool,
-    pub message: String,
-}
-
-/// Which sub-panel is active in the provider auth popup.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub enum AuthPanel {
-    /// Browsing the provider list.
-    #[default]
-    List,
-    /// Editing an API key for the selected provider.
-    ApiKeyInput,
-    /// Active OAuth flow — showing URL and callback/device-poll input.
-    OAuthFlow,
-}
-
 pub struct App {
     pub screen: Screen,
     pub popup: Popup,
@@ -696,21 +677,7 @@ pub struct App {
     pub(crate) card_cache: CardCache,
 
     // auth popup state
-    pub auth_providers: Vec<AuthProviderEntry>,
-    pub auth_cursor: usize,
-    pub auth_filter: String,
-    pub auth_selected: Option<usize>,
-    pub auth_panel: AuthPanel,
-    pub auth_api_key_input: String,
-    pub auth_api_key_cursor: usize,
-    pub auth_api_key_masked: bool,
-    pub auth_oauth_flow: Option<OAuthFlow>,
-    pub auth_oauth_response: String,
-    pub auth_oauth_response_cursor: usize,
-    pub auth_last_result: Option<OAuthResult>,
-    pub auth_ui_notice: Option<AuthUiNotice>,
-    /// When clipboard copy fails, store the URL here for a fallback display popup.
-    pub auth_clipboard_fallback: Option<String>,
+    pub(crate) auth: AuthState,
 
     // delegate session listing (built from event stream)
     pub delegate_entries: Vec<DelegateEntry>,
@@ -915,20 +882,7 @@ impl App {
             server_state: crate::server_manager::ServerState::default(),
             hl: Highlighter::new(),
             card_cache: CardCache::new(),
-            auth_providers: Vec::new(),
-            auth_cursor: 0,
-            auth_filter: String::new(),
-            auth_selected: None,
-            auth_panel: AuthPanel::default(),
-            auth_api_key_input: String::new(),
-            auth_api_key_cursor: 0,
-            auth_api_key_masked: true,
-            auth_oauth_flow: None,
-            auth_oauth_response: String::new(),
-            auth_oauth_response_cursor: 0,
-            auth_last_result: None,
-            auth_ui_notice: None,
-            auth_clipboard_fallback: None,
+            auth: AuthState::new(),
             delegate_entries: Vec::new(),
             delegate_cursor: 0,
             delegate_filter: String::new(),
@@ -1063,69 +1017,10 @@ impl App {
         }
     }
 
-    /// Filtered auth providers matching the current `auth_filter`.
-    pub fn filtered_auth_providers(&self) -> Vec<(usize, &AuthProviderEntry)> {
-        if self.auth_filter.is_empty() {
-            self.auth_providers.iter().enumerate().collect()
-        } else {
-            let q = self.auth_filter.to_lowercase();
-            self.auth_providers
-                .iter()
-                .enumerate()
-                .filter(|(_, p)| {
-                    p.display_name.to_lowercase().contains(&q)
-                        || p.provider.to_lowercase().contains(&q)
-                })
-                .collect()
-        }
-    }
-
-    /// Reset auth popup state for a fresh open.
+    /// Route to a freshly reset auth popup while preserving provider data.
     pub fn open_auth_popup(&mut self) {
         self.popup = Popup::ProviderAuth;
-        self.auth_cursor = 0;
-        self.auth_filter.clear();
-        self.auth_selected = None;
-        self.auth_panel = AuthPanel::List;
-        self.auth_api_key_input.clear();
-        self.auth_api_key_cursor = 0;
-        self.auth_api_key_masked = true;
-        self.auth_oauth_flow = None;
-        self.auth_oauth_response.clear();
-        self.auth_oauth_response_cursor = 0;
-        self.auth_last_result = None;
-        self.auth_ui_notice = None;
-        self.auth_clipboard_fallback = None;
-    }
-
-    /// Reset auth detail panel state (when switching providers or going back).
-    pub fn auth_close_detail(&mut self) {
-        self.auth_selected = None;
-        self.auth_panel = AuthPanel::List;
-        self.auth_api_key_input.clear();
-        self.auth_api_key_cursor = 0;
-        self.auth_oauth_flow = None;
-        self.auth_oauth_response.clear();
-        self.auth_oauth_response_cursor = 0;
-        self.auth_last_result = None;
-        self.auth_ui_notice = None;
-        self.auth_clipboard_fallback = None;
-    }
-
-    pub fn auth_feedback_for_provider(&self, provider: &str) -> Option<(bool, &str)> {
-        if let Some(notice) = self.auth_ui_notice.as_ref().filter(|notice| {
-            notice
-                .provider
-                .as_deref()
-                .is_none_or(|notice_provider| notice_provider == provider)
-        }) {
-            return Some((notice.success, notice.message.as_str()));
-        }
-
-        self.auth_last_result
-            .as_ref()
-            .filter(|result| result.provider == provider)
-            .map(|result| (result.is_success(), result.message.as_str()))
+        self.auth.reset_for_open();
     }
 
     pub fn profile_by_id(&self, profile_id: &str) -> Option<&ProfileInfo> {

--- a/src/auth_state.rs
+++ b/src/auth_state.rs
@@ -1,0 +1,437 @@
+use crate::domain::auth::{AuthProviderEntry, OAuthFlow, OAuthResult};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AuthUiNotice {
+    pub(crate) provider: Option<String>,
+    pub(crate) success: bool,
+    pub(crate) message: String,
+}
+
+/// Which sub-panel is active in the provider auth popup.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) enum AuthPanel {
+    /// Browsing the provider list.
+    #[default]
+    List,
+    /// Editing an API key for the selected provider.
+    ApiKeyInput,
+    /// Active OAuth flow showing URL and callback/device-poll input.
+    OAuthFlow,
+}
+
+pub(crate) struct AuthState {
+    pub(crate) providers: Vec<AuthProviderEntry>,
+    pub(crate) cursor: usize,
+    pub(crate) filter: String,
+    pub(crate) selected: Option<usize>,
+    pub(crate) panel: AuthPanel,
+    pub(crate) api_key_input: String,
+    pub(crate) api_key_cursor: usize,
+    pub(crate) api_key_masked: bool,
+    pub(crate) oauth_flow: Option<OAuthFlow>,
+    pub(crate) oauth_response: String,
+    pub(crate) oauth_response_cursor: usize,
+    pub(crate) last_result: Option<OAuthResult>,
+    pub(crate) ui_notice: Option<AuthUiNotice>,
+    pub(crate) clipboard_fallback: Option<String>,
+}
+
+impl AuthState {
+    pub(crate) fn new() -> Self {
+        Self {
+            providers: Vec::new(),
+            cursor: 0,
+            filter: String::new(),
+            selected: None,
+            panel: AuthPanel::List,
+            api_key_input: String::new(),
+            api_key_cursor: 0,
+            api_key_masked: true,
+            oauth_flow: None,
+            oauth_response: String::new(),
+            oauth_response_cursor: 0,
+            last_result: None,
+            ui_notice: None,
+            clipboard_fallback: None,
+        }
+    }
+
+    pub(crate) fn filtered_providers(&self) -> Vec<(usize, &AuthProviderEntry)> {
+        if self.filter.is_empty() {
+            self.providers.iter().enumerate().collect()
+        } else {
+            let query = self.filter.to_lowercase();
+            self.providers
+                .iter()
+                .enumerate()
+                .filter(|(_, provider)| {
+                    provider.display_name.to_lowercase().contains(&query)
+                        || provider.provider.to_lowercase().contains(&query)
+                })
+                .collect()
+        }
+    }
+
+    pub(crate) fn reset_for_open(&mut self) {
+        self.cursor = 0;
+        self.filter.clear();
+        self.selected = None;
+        self.panel = AuthPanel::List;
+        self.api_key_input.clear();
+        self.api_key_cursor = 0;
+        self.api_key_masked = true;
+        self.oauth_flow = None;
+        self.oauth_response.clear();
+        self.oauth_response_cursor = 0;
+        self.last_result = None;
+        self.ui_notice = None;
+        self.clipboard_fallback = None;
+    }
+
+    pub(crate) fn close_detail(&mut self) {
+        self.selected = None;
+        self.panel = AuthPanel::List;
+        self.api_key_input.clear();
+        self.api_key_cursor = 0;
+        self.oauth_flow = None;
+        self.oauth_response.clear();
+        self.oauth_response_cursor = 0;
+        self.last_result = None;
+        self.ui_notice = None;
+        self.clipboard_fallback = None;
+    }
+
+    pub(crate) fn feedback_for_provider(&self, provider: &str) -> Option<(bool, &str)> {
+        if let Some(notice) = self.ui_notice.as_ref().filter(|notice| {
+            notice
+                .provider
+                .as_deref()
+                .is_none_or(|notice_provider| notice_provider == provider)
+        }) {
+            return Some((notice.success, notice.message.as_str()));
+        }
+
+        self.last_result
+            .as_ref()
+            .filter(|result| result.provider == provider)
+            .map(|result| (result.is_success(), result.message.as_str()))
+    }
+
+    pub(crate) fn begin_oauth_flow(&mut self, flow: OAuthFlow) {
+        self.oauth_flow = Some(flow);
+        self.panel = AuthPanel::OAuthFlow;
+        self.oauth_response.clear();
+        self.oauth_response_cursor = 0;
+        self.last_result = None;
+        self.ui_notice = None;
+    }
+
+    pub(crate) fn apply_oauth_result(&mut self, result: OAuthResult) -> bool {
+        let is_success = result.is_success();
+        self.ui_notice = None;
+        self.last_result = Some(result);
+        if is_success {
+            self.oauth_flow = None;
+            self.panel = AuthPanel::List;
+        }
+        is_success
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::auth::{OAuthFlowKind, OAuthResultStatus, OAuthStatus};
+
+    fn provider(id: &str, display_name: &str) -> AuthProviderEntry {
+        AuthProviderEntry {
+            provider: id.into(),
+            display_name: display_name.into(),
+            oauth_status: Some(OAuthStatus::NotAuthenticated),
+            has_stored_api_key: false,
+            has_env_api_key: false,
+            env_var_name: Some(format!("{}_API_KEY", id.to_uppercase())),
+            supports_oauth: true,
+            preferred_method: None,
+        }
+    }
+
+    fn oauth_flow(provider: &str) -> OAuthFlow {
+        OAuthFlow {
+            flow_id: "flow-1".into(),
+            provider: provider.into(),
+            authorization_url: "https://example.com/authorize".into(),
+            flow_kind: OAuthFlowKind::RedirectCode,
+        }
+    }
+
+    fn oauth_result(provider: &str, status: OAuthResultStatus, message: &str) -> OAuthResult {
+        OAuthResult {
+            provider: provider.into(),
+            status,
+            message: message.into(),
+        }
+    }
+
+    #[test]
+    fn constructor_uses_expected_defaults() {
+        let auth = AuthState::new();
+
+        assert!(auth.providers.is_empty());
+        assert_eq!(auth.cursor, 0);
+        assert!(auth.filter.is_empty());
+        assert!(auth.selected.is_none());
+        assert_eq!(auth.panel, AuthPanel::List);
+        assert!(auth.api_key_input.is_empty());
+        assert_eq!(auth.api_key_cursor, 0);
+        assert!(auth.api_key_masked);
+        assert!(auth.oauth_flow.is_none());
+        assert!(auth.oauth_response.is_empty());
+        assert_eq!(auth.oauth_response_cursor, 0);
+        assert!(auth.last_result.is_none());
+        assert!(auth.ui_notice.is_none());
+        assert!(auth.clipboard_fallback.is_none());
+    }
+
+    #[test]
+    fn reset_for_open_clears_transient_state_and_preserves_providers() {
+        let mut auth = AuthState::new();
+        auth.providers = vec![provider("openai", "OpenAI")];
+        auth.cursor = 5;
+        auth.filter = "test".into();
+        auth.selected = Some(2);
+        auth.panel = AuthPanel::OAuthFlow;
+        auth.api_key_input = "secret".into();
+        auth.api_key_cursor = 6;
+        auth.api_key_masked = false;
+        auth.oauth_flow = Some(oauth_flow("openai"));
+        auth.oauth_response = "response".into();
+        auth.oauth_response_cursor = 8;
+        auth.last_result = Some(oauth_result(
+            "openai",
+            OAuthResultStatus::Failure,
+            "old result",
+        ));
+        auth.ui_notice = Some(AuthUiNotice {
+            provider: Some("openai".into()),
+            success: true,
+            message: "old notice".into(),
+        });
+        auth.clipboard_fallback = Some("https://example.com".into());
+
+        auth.reset_for_open();
+
+        assert_eq!(auth.providers.len(), 1);
+        assert_eq!(auth.providers[0].provider, "openai");
+        assert_eq!(auth.cursor, 0);
+        assert!(auth.filter.is_empty());
+        assert!(auth.selected.is_none());
+        assert_eq!(auth.panel, AuthPanel::List);
+        assert!(auth.api_key_input.is_empty());
+        assert_eq!(auth.api_key_cursor, 0);
+        assert!(auth.api_key_masked);
+        assert!(auth.oauth_flow.is_none());
+        assert!(auth.oauth_response.is_empty());
+        assert_eq!(auth.oauth_response_cursor, 0);
+        assert!(auth.last_result.is_none());
+        assert!(auth.ui_notice.is_none());
+        assert!(auth.clipboard_fallback.is_none());
+    }
+
+    #[test]
+    fn filtered_providers_with_empty_filter_returns_all_rows() {
+        let mut auth = AuthState::new();
+        auth.providers = vec![provider("openai", "OpenAI"), provider("groq", "Groq")];
+
+        let filtered = auth.filtered_providers();
+
+        assert_eq!(filtered.len(), 2);
+        assert_eq!(filtered[0].0, 0);
+        assert_eq!(filtered[1].0, 1);
+    }
+
+    #[test]
+    fn filtered_providers_matches_id_and_name_case_insensitively() {
+        let mut auth = AuthState::new();
+        auth.providers = vec![
+            provider("openai", "OpenAI"),
+            provider("anthropic", "Claude Provider"),
+        ];
+
+        auth.filter = "CLAUDE".into();
+        let by_name = auth.filtered_providers();
+        assert_eq!(by_name.len(), 1);
+        assert_eq!(by_name[0].0, 1);
+
+        auth.filter = "OPENAI".into();
+        let by_id = auth.filtered_providers();
+        assert_eq!(by_id.len(), 1);
+        assert_eq!(by_id[0].0, 0);
+    }
+
+    #[test]
+    fn close_detail_resets_panel_state_and_preserves_list_state_and_mask() {
+        let mut auth = AuthState::new();
+        auth.providers = vec![provider("openai", "OpenAI")];
+        auth.cursor = 3;
+        auth.filter = "open".into();
+        auth.selected = Some(0);
+        auth.panel = AuthPanel::ApiKeyInput;
+        auth.api_key_input = "secret".into();
+        auth.api_key_cursor = 6;
+        auth.api_key_masked = false;
+        auth.oauth_flow = Some(oauth_flow("openai"));
+        auth.oauth_response = "response".into();
+        auth.oauth_response_cursor = 8;
+        auth.last_result = Some(oauth_result(
+            "openai",
+            OAuthResultStatus::Success,
+            "connected",
+        ));
+        auth.ui_notice = Some(AuthUiNotice {
+            provider: None,
+            success: true,
+            message: "saved".into(),
+        });
+        auth.clipboard_fallback = Some("https://example.com".into());
+
+        auth.close_detail();
+
+        assert_eq!(auth.providers.len(), 1);
+        assert_eq!(auth.cursor, 3);
+        assert_eq!(auth.filter, "open");
+        assert!(!auth.api_key_masked);
+        assert!(auth.selected.is_none());
+        assert_eq!(auth.panel, AuthPanel::List);
+        assert!(auth.api_key_input.is_empty());
+        assert_eq!(auth.api_key_cursor, 0);
+        assert!(auth.oauth_flow.is_none());
+        assert!(auth.oauth_response.is_empty());
+        assert_eq!(auth.oauth_response_cursor, 0);
+        assert!(auth.last_result.is_none());
+        assert!(auth.ui_notice.is_none());
+        assert!(auth.clipboard_fallback.is_none());
+    }
+
+    #[test]
+    fn feedback_scopes_oauth_result_to_its_provider() {
+        let mut auth = AuthState::new();
+        auth.last_result = Some(oauth_result(
+            "openai",
+            OAuthResultStatus::Failure,
+            "authorization denied",
+        ));
+
+        assert_eq!(auth.feedback_for_provider("anthropic"), None);
+        assert_eq!(
+            auth.feedback_for_provider("openai"),
+            Some((false, "authorization denied"))
+        );
+    }
+
+    #[test]
+    fn feedback_scopes_ui_notice_and_takes_precedence() {
+        let mut auth = AuthState::new();
+        auth.last_result = Some(oauth_result(
+            "openai",
+            OAuthResultStatus::Failure,
+            "authorization denied",
+        ));
+        auth.ui_notice = Some(AuthUiNotice {
+            provider: Some("openai".into()),
+            success: true,
+            message: "Copied to clipboard".into(),
+        });
+
+        assert_eq!(auth.feedback_for_provider("anthropic"), None);
+        assert_eq!(
+            auth.feedback_for_provider("openai"),
+            Some((true, "Copied to clipboard"))
+        );
+    }
+
+    #[test]
+    fn feedback_supports_generic_ui_notice() {
+        let mut auth = AuthState::new();
+        auth.ui_notice = Some(AuthUiNotice {
+            provider: None,
+            success: false,
+            message: "Clipboard unavailable".into(),
+        });
+
+        assert_eq!(
+            auth.feedback_for_provider("openai"),
+            Some((false, "Clipboard unavailable"))
+        );
+        assert_eq!(
+            auth.feedback_for_provider("anthropic"),
+            Some((false, "Clipboard unavailable"))
+        );
+    }
+
+    #[test]
+    fn begin_oauth_flow_replaces_flow_and_clears_response_and_feedback() {
+        let mut auth = AuthState::new();
+        auth.oauth_response = "stale response".into();
+        auth.oauth_response_cursor = auth.oauth_response.len();
+        auth.last_result = Some(oauth_result(
+            "openai",
+            OAuthResultStatus::Failure,
+            "old result",
+        ));
+        auth.ui_notice = Some(AuthUiNotice {
+            provider: Some("openai".into()),
+            success: true,
+            message: "old notice".into(),
+        });
+        let flow = oauth_flow("openai");
+
+        auth.begin_oauth_flow(flow.clone());
+
+        assert_eq!(auth.oauth_flow, Some(flow));
+        assert_eq!(auth.panel, AuthPanel::OAuthFlow);
+        assert!(auth.oauth_response.is_empty());
+        assert_eq!(auth.oauth_response_cursor, 0);
+        assert!(auth.last_result.is_none());
+        assert!(auth.ui_notice.is_none());
+    }
+
+    #[test]
+    fn successful_oauth_result_clears_flow_and_returns_true() {
+        let mut auth = AuthState::new();
+        auth.oauth_flow = Some(oauth_flow("openai"));
+        auth.panel = AuthPanel::OAuthFlow;
+        auth.ui_notice = Some(AuthUiNotice {
+            provider: Some("openai".into()),
+            success: true,
+            message: "old notice".into(),
+        });
+        let result = oauth_result("openai", OAuthResultStatus::Success, "connected");
+
+        assert!(auth.apply_oauth_result(result.clone()));
+        assert!(auth.oauth_flow.is_none());
+        assert_eq!(auth.panel, AuthPanel::List);
+        assert_eq!(auth.last_result, Some(result));
+        assert!(auth.ui_notice.is_none());
+    }
+
+    #[test]
+    fn failed_oauth_result_preserves_flow_and_returns_false() {
+        let mut auth = AuthState::new();
+        let flow = oauth_flow("openai");
+        auth.oauth_flow = Some(flow.clone());
+        auth.panel = AuthPanel::OAuthFlow;
+        auth.ui_notice = Some(AuthUiNotice {
+            provider: Some("openai".into()),
+            success: true,
+            message: "old notice".into(),
+        });
+        let result = oauth_result("openai", OAuthResultStatus::Failure, "denied");
+
+        assert!(!auth.apply_oauth_result(result.clone()));
+        assert_eq!(auth.oauth_flow, Some(flow));
+        assert_eq!(auth.panel, AuthPanel::OAuthFlow);
+        assert_eq!(auth.last_result, Some(result));
+        assert!(auth.ui_notice.is_none());
+    }
+}

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,7 +1,8 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use tokio::sync::mpsc;
 
-use crate::app::{self, App, AuthUiNotice, CommandPaletteAction, Popup, Screen};
+use crate::app::{self, App, CommandPaletteAction, Popup, Screen};
+use crate::auth_state::{AuthPanel, AuthUiNotice};
 use crate::diagnostics::LogLevel;
 use crate::domain::activity::{ActivityState, SessionOp};
 use crate::domain::auth::{OAuthFlowKind, OAuthStatus};
@@ -2173,63 +2174,61 @@ pub(crate) fn handle_auth_popup_key(
     key: KeyEvent,
     cmd_tx: &mpsc::UnboundedSender<Command>,
 ) -> anyhow::Result<()> {
-    use crate::app::AuthPanel;
-
     // Clipboard fallback popup: any key dismisses it
-    if app.auth_clipboard_fallback.is_some() {
-        app.auth_clipboard_fallback = None;
+    if app.auth.clipboard_fallback.is_some() {
+        app.auth.clipboard_fallback = None;
         return Ok(());
     }
 
-    match app.auth_panel {
+    match app.auth.panel {
         AuthPanel::List => match key.code {
             KeyCode::Esc => {
-                if app.auth_selected.is_some() {
-                    app.auth_close_detail();
+                if app.auth.selected.is_some() {
+                    app.auth.close_detail();
                 } else {
                     app.popup = Popup::None;
                 }
             }
             KeyCode::Up => {
-                let max = app.filtered_auth_providers().len().saturating_sub(1);
-                app.auth_cursor = app.auth_cursor.saturating_sub(1).min(max);
+                let max = app.auth.filtered_providers().len().saturating_sub(1);
+                app.auth.cursor = app.auth.cursor.saturating_sub(1).min(max);
             }
             KeyCode::Down => {
-                let max = app.filtered_auth_providers().len().saturating_sub(1);
-                app.auth_cursor = (app.auth_cursor + 1).min(max);
+                let max = app.auth.filtered_providers().len().saturating_sub(1);
+                app.auth.cursor = (app.auth.cursor + 1).min(max);
             }
             KeyCode::Enter => {
-                let filtered = app.filtered_auth_providers();
-                if let Some(&(real_idx, _)) = filtered.get(app.auth_cursor) {
-                    let provider = &app.auth_providers[real_idx];
-                    app.auth_last_result = None;
-                    app.auth_ui_notice = None;
+                let filtered = app.auth.filtered_providers();
+                if let Some(&(real_idx, _)) = filtered.get(app.auth.cursor) {
+                    let provider = &app.auth.providers[real_idx];
+                    app.auth.last_result = None;
+                    app.auth.ui_notice = None;
                     if provider.is_unconfigurable() {
-                        app.auth_selected = Some(real_idx);
+                        app.auth.selected = Some(real_idx);
                         // Stay in list — the draw fn shows the info message
                     } else if provider.is_api_key_only() {
-                        app.auth_selected = Some(real_idx);
-                        app.auth_panel = AuthPanel::ApiKeyInput;
-                        app.auth_api_key_input.clear();
-                        app.auth_api_key_cursor = 0;
+                        app.auth.selected = Some(real_idx);
+                        app.auth.panel = AuthPanel::ApiKeyInput;
+                        app.auth.api_key_input.clear();
+                        app.auth.api_key_cursor = 0;
                     } else if provider.is_oauth_only()
                         && provider.oauth_status != Some(OAuthStatus::Connected)
                     {
-                        app.auth_selected = Some(real_idx);
+                        app.auth.selected = Some(real_idx);
                         let provider_id = provider.provider.clone();
                         cmd_tx.send(Command::StartOAuthLogin {
                             provider: provider_id,
                         })?;
                     } else {
                         // Multi-method or connected OAuth-only: select for detail
-                        app.auth_selected = Some(real_idx);
+                        app.auth.selected = Some(real_idx);
                     }
                 }
             }
             KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 // Ctrl+D: disconnect/clear credential for selected provider
-                if let Some(idx) = app.auth_selected {
-                    let provider = &app.auth_providers[idx];
+                if let Some(idx) = app.auth.selected {
+                    let provider = &app.auth.providers[idx];
                     if provider.oauth_status == Some(OAuthStatus::Connected) {
                         let provider_id = provider.provider.clone();
                         cmd_tx.send(Command::DisconnectOAuth {
@@ -2245,26 +2244,26 @@ pub(crate) fn handle_auth_popup_key(
             }
             KeyCode::Char('k') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 // Ctrl+K: open API key panel for selected provider
-                let filtered = app.filtered_auth_providers();
-                if let Some(&(real_idx, _)) = filtered.get(app.auth_cursor) {
-                    let provider = &app.auth_providers[real_idx];
+                let filtered = app.auth.filtered_providers();
+                if let Some(&(real_idx, _)) = filtered.get(app.auth.cursor) {
+                    let provider = &app.auth.providers[real_idx];
                     if provider.env_var_name.is_some() || provider.has_stored_api_key {
-                        app.auth_ui_notice = None;
-                        app.auth_selected = Some(real_idx);
-                        app.auth_panel = AuthPanel::ApiKeyInput;
-                        app.auth_api_key_input.clear();
-                        app.auth_api_key_cursor = 0;
+                        app.auth.ui_notice = None;
+                        app.auth.selected = Some(real_idx);
+                        app.auth.panel = AuthPanel::ApiKeyInput;
+                        app.auth.api_key_input.clear();
+                        app.auth.api_key_cursor = 0;
                     }
                 }
             }
             KeyCode::Char('o') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 // Ctrl+O: start OAuth for selected provider
-                let filtered = app.filtered_auth_providers();
-                if let Some(&(real_idx, _)) = filtered.get(app.auth_cursor) {
-                    let provider = &app.auth_providers[real_idx];
+                let filtered = app.auth.filtered_providers();
+                if let Some(&(real_idx, _)) = filtered.get(app.auth.cursor) {
+                    let provider = &app.auth.providers[real_idx];
                     if provider.supports_oauth {
-                        app.auth_ui_notice = None;
-                        app.auth_selected = Some(real_idx);
+                        app.auth.ui_notice = None;
+                        app.auth.selected = Some(real_idx);
                         let provider_id = provider.provider.clone();
                         cmd_tx.send(Command::StartOAuthLogin {
                             provider: provider_id,
@@ -2273,26 +2272,26 @@ pub(crate) fn handle_auth_popup_key(
                 }
             }
             KeyCode::Backspace => {
-                app.auth_filter.pop();
-                app.auth_cursor = 0;
+                app.auth.filter.pop();
+                app.auth.cursor = 0;
             }
             KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
-                app.auth_filter.push(c);
-                app.auth_cursor = 0;
+                app.auth.filter.push(c);
+                app.auth.cursor = 0;
             }
             _ => {}
         },
         AuthPanel::ApiKeyInput => match key.code {
             KeyCode::Esc => {
-                app.auth_panel = AuthPanel::List;
-                app.auth_api_key_input.clear();
-                app.auth_api_key_cursor = 0;
+                app.auth.panel = AuthPanel::List;
+                app.auth.api_key_input.clear();
+                app.auth.api_key_cursor = 0;
             }
             KeyCode::Enter => {
-                if let Some(idx) = app.auth_selected {
-                    let trimmed = app.auth_api_key_input.trim().to_string();
+                if let Some(idx) = app.auth.selected {
+                    let trimmed = app.auth.api_key_input.trim().to_string();
                     if !trimmed.is_empty() {
-                        let provider = app.auth_providers[idx].provider.clone();
+                        let provider = app.auth.providers[idx].provider.clone();
                         cmd_tx.send(Command::SetApiToken {
                             provider,
                             api_key: trimmed,
@@ -2301,67 +2300,67 @@ pub(crate) fn handle_auth_popup_key(
                 }
             }
             KeyCode::Tab => {
-                app.auth_api_key_masked = !app.auth_api_key_masked;
+                app.auth.api_key_masked = !app.auth.api_key_masked;
             }
             KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 // Clear stored key
-                if let Some(idx) = app.auth_selected {
-                    let provider = app.auth_providers[idx].provider.clone();
+                if let Some(idx) = app.auth.selected {
+                    let provider = app.auth.providers[idx].provider.clone();
                     cmd_tx.send(Command::ClearApiToken { provider })?;
                 }
             }
             KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
-                app.auth_api_key_input.insert(app.auth_api_key_cursor, c);
-                app.auth_api_key_cursor += c.len_utf8();
+                app.auth.api_key_input.insert(app.auth.api_key_cursor, c);
+                app.auth.api_key_cursor += c.len_utf8();
             }
-            KeyCode::Backspace if app.auth_api_key_cursor > 0 => {
-                let cursor = app.auth_api_key_cursor;
-                let ch = app.auth_api_key_input[..cursor]
+            KeyCode::Backspace if app.auth.api_key_cursor > 0 => {
+                let cursor = app.auth.api_key_cursor;
+                let ch = app.auth.api_key_input[..cursor]
                     .chars()
                     .next_back()
                     .unwrap();
-                app.auth_api_key_input.remove(cursor - ch.len_utf8());
-                app.auth_api_key_cursor -= ch.len_utf8();
+                app.auth.api_key_input.remove(cursor - ch.len_utf8());
+                app.auth.api_key_cursor -= ch.len_utf8();
             }
-            KeyCode::Left if app.auth_api_key_cursor > 0 => {
-                let ch = app.auth_api_key_input[..app.auth_api_key_cursor]
+            KeyCode::Left if app.auth.api_key_cursor > 0 => {
+                let ch = app.auth.api_key_input[..app.auth.api_key_cursor]
                     .chars()
                     .next_back()
                     .unwrap();
-                app.auth_api_key_cursor -= ch.len_utf8();
+                app.auth.api_key_cursor -= ch.len_utf8();
             }
-            KeyCode::Right if app.auth_api_key_cursor < app.auth_api_key_input.len() => {
-                let ch = app.auth_api_key_input[app.auth_api_key_cursor..]
+            KeyCode::Right if app.auth.api_key_cursor < app.auth.api_key_input.len() => {
+                let ch = app.auth.api_key_input[app.auth.api_key_cursor..]
                     .chars()
                     .next()
                     .unwrap();
-                app.auth_api_key_cursor += ch.len_utf8();
+                app.auth.api_key_cursor += ch.len_utf8();
             }
             _ => {}
         },
         AuthPanel::OAuthFlow => match key.code {
             KeyCode::Esc => {
-                app.auth_oauth_flow = None;
-                app.auth_panel = AuthPanel::List;
-                app.auth_oauth_response.clear();
-                app.auth_oauth_response_cursor = 0;
+                app.auth.oauth_flow = None;
+                app.auth.panel = AuthPanel::List;
+                app.auth.oauth_response.clear();
+                app.auth.oauth_response_cursor = 0;
             }
             KeyCode::Char('y') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 // Copy authorization URL to clipboard (C-y to avoid global C-c quit)
-                if let Some(ref flow) = app.auth_oauth_flow {
+                if let Some(ref flow) = app.auth.oauth_flow {
                     let provider = flow.provider.clone();
                     let url = flow.authorization_url.clone();
                     try_copy_to_clipboard(app, &provider, &url);
                 }
             }
             KeyCode::Enter => {
-                if let Some(ref flow) = app.auth_oauth_flow {
+                if let Some(ref flow) = app.auth.oauth_flow {
                     let flow_id = flow.flow_id.clone();
                     let is_device_poll = flow.flow_kind == OAuthFlowKind::DevicePoll;
                     let response = if is_device_poll {
                         String::new()
                     } else {
-                        app.auth_oauth_response.trim().to_string()
+                        app.auth.oauth_response.trim().to_string()
                     };
                     if is_device_poll || !response.is_empty() {
                         cmd_tx.send(Command::CompleteOAuthLogin { flow_id, response })?;
@@ -2369,32 +2368,33 @@ pub(crate) fn handle_auth_popup_key(
                 }
             }
             KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
-                app.auth_oauth_response
-                    .insert(app.auth_oauth_response_cursor, c);
-                app.auth_oauth_response_cursor += c.len_utf8();
+                app.auth
+                    .oauth_response
+                    .insert(app.auth.oauth_response_cursor, c);
+                app.auth.oauth_response_cursor += c.len_utf8();
             }
-            KeyCode::Backspace if app.auth_oauth_response_cursor > 0 => {
-                let cursor = app.auth_oauth_response_cursor;
-                let ch = app.auth_oauth_response[..cursor]
+            KeyCode::Backspace if app.auth.oauth_response_cursor > 0 => {
+                let cursor = app.auth.oauth_response_cursor;
+                let ch = app.auth.oauth_response[..cursor]
                     .chars()
                     .next_back()
                     .unwrap();
-                app.auth_oauth_response.remove(cursor - ch.len_utf8());
-                app.auth_oauth_response_cursor -= ch.len_utf8();
+                app.auth.oauth_response.remove(cursor - ch.len_utf8());
+                app.auth.oauth_response_cursor -= ch.len_utf8();
             }
-            KeyCode::Left if app.auth_oauth_response_cursor > 0 => {
-                let ch = app.auth_oauth_response[..app.auth_oauth_response_cursor]
+            KeyCode::Left if app.auth.oauth_response_cursor > 0 => {
+                let ch = app.auth.oauth_response[..app.auth.oauth_response_cursor]
                     .chars()
                     .next_back()
                     .unwrap();
-                app.auth_oauth_response_cursor -= ch.len_utf8();
+                app.auth.oauth_response_cursor -= ch.len_utf8();
             }
-            KeyCode::Right if app.auth_oauth_response_cursor < app.auth_oauth_response.len() => {
-                let ch = app.auth_oauth_response[app.auth_oauth_response_cursor..]
+            KeyCode::Right if app.auth.oauth_response_cursor < app.auth.oauth_response.len() => {
+                let ch = app.auth.oauth_response[app.auth.oauth_response_cursor..]
                     .chars()
                     .next()
                     .unwrap();
-                app.auth_oauth_response_cursor += ch.len_utf8();
+                app.auth.oauth_response_cursor += ch.len_utf8();
             }
             _ => {}
         },
@@ -2435,17 +2435,17 @@ fn copy_text_to_clipboard(text: &str) -> bool {
 }
 
 fn try_copy_to_clipboard(app: &mut App, provider: &str, text: &str) {
-    app.auth_ui_notice = None;
-    app.auth_clipboard_fallback = None;
+    app.auth.ui_notice = None;
+    app.auth.clipboard_fallback = None;
     if copy_text_to_clipboard(text) {
-        app.auth_ui_notice = Some(AuthUiNotice {
+        app.auth.ui_notice = Some(AuthUiNotice {
             provider: Some(provider.to_string()),
             success: true,
             message: "Copied to clipboard".into(),
         });
     } else {
-        app.auth_ui_notice = None;
-        app.auth_clipboard_fallback = Some(text.to_string());
+        app.auth.ui_notice = None;
+        app.auth.clipboard_fallback = Some(text.to_string());
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 mod acp_client;
 mod acp_state;
 mod app;
+mod auth_state;
 mod command;
 mod config;
 mod diagnostics;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3373,7 +3373,7 @@ mod runtime_tests {
 #[cfg(test)]
 mod auth_tests {
     use super::*;
-    use crate::app::AuthUiNotice;
+    use crate::auth_state::{AuthPanel, AuthUiNotice};
     use crate::command::Command;
     use crate::domain::auth::{
         AuthProviderEntry, OAuthFlow, OAuthFlowKind, OAuthResult, OAuthResultStatus, OAuthStatus,
@@ -3431,7 +3431,7 @@ mod auth_tests {
     fn make_app_with_providers(providers: Vec<AuthProviderEntry>) -> App {
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
-        app.auth_providers = providers;
+        app.auth.providers = providers;
         app.popup = app::Popup::ProviderAuth;
         app
     }
@@ -3441,126 +3441,30 @@ mod auth_tests {
     #[test]
     fn open_auth_popup_resets_state() {
         let mut app = App::new();
-        app.auth_cursor = 5;
-        app.auth_filter = "test".into();
-        app.auth_selected = Some(2);
-        app.auth_api_key_input = "secret".into();
-        app.auth_last_result = Some(OAuthResult {
+        app.auth.cursor = 5;
+        app.auth.filter = "test".into();
+        app.auth.selected = Some(2);
+        app.auth.api_key_input = "secret".into();
+        app.auth.last_result = Some(OAuthResult {
             provider: "openai".into(),
             status: OAuthResultStatus::Failure,
             message: "old result".into(),
         });
-        app.auth_ui_notice = Some(AuthUiNotice {
+        app.auth.ui_notice = Some(AuthUiNotice {
             provider: Some("openai".into()),
             success: true,
             message: "old notice".into(),
         });
         app.open_auth_popup();
         assert_eq!(app.popup, app::Popup::ProviderAuth);
-        assert_eq!(app.auth_cursor, 0);
-        assert!(app.auth_filter.is_empty());
-        assert!(app.auth_selected.is_none());
-        assert!(app.auth_api_key_input.is_empty());
-        assert!(app.auth_last_result.is_none());
-        assert!(app.auth_ui_notice.is_none());
-        assert!(app.auth_api_key_masked);
-        assert_eq!(app.auth_panel, app::AuthPanel::List);
-    }
-
-    #[test]
-    fn filtered_auth_providers_with_empty_filter() {
-        let app = make_app_with_providers(vec![make_provider("OpenAI"), make_provider("Groq")]);
-        let filtered = app.filtered_auth_providers();
-        assert_eq!(filtered.len(), 2);
-    }
-
-    #[test]
-    fn filtered_auth_providers_filters_by_name() {
-        let mut app = make_app_with_providers(vec![make_provider("OpenAI"), make_provider("Groq")]);
-        app.auth_filter = "groq".into();
-        let filtered = app.filtered_auth_providers();
-        assert_eq!(filtered.len(), 1);
-        assert_eq!(filtered[0].1.provider, "groq");
-    }
-
-    #[test]
-    fn auth_close_detail_resets_panel_state() {
-        let mut app = App::new();
-        app.auth_selected = Some(1);
-        app.auth_panel = app::AuthPanel::ApiKeyInput;
-        app.auth_api_key_input = "secret".into();
-        app.auth_last_result = Some(OAuthResult {
-            provider: "openai".into(),
-            status: OAuthResultStatus::Success,
-            message: "connected".into(),
-        });
-        app.auth_ui_notice = Some(AuthUiNotice {
-            provider: None,
-            success: true,
-            message: "saved".into(),
-        });
-        app.auth_close_detail();
-        assert!(app.auth_selected.is_none());
-        assert_eq!(app.auth_panel, app::AuthPanel::List);
-        assert!(app.auth_api_key_input.is_empty());
-        assert!(app.auth_last_result.is_none());
-        assert!(app.auth_ui_notice.is_none());
-    }
-
-    #[test]
-    fn auth_feedback_scopes_oauth_result_to_its_provider() {
-        let mut app = App::new();
-        app.auth_last_result = Some(OAuthResult {
-            provider: "openai".into(),
-            status: OAuthResultStatus::Failure,
-            message: "authorization denied".into(),
-        });
-
-        assert_eq!(app.auth_feedback_for_provider("anthropic"), None);
-        assert_eq!(
-            app.auth_feedback_for_provider("openai"),
-            Some((false, "authorization denied"))
-        );
-    }
-
-    #[test]
-    fn auth_feedback_scopes_ui_notice_and_takes_precedence() {
-        let mut app = App::new();
-        app.auth_last_result = Some(OAuthResult {
-            provider: "openai".into(),
-            status: OAuthResultStatus::Failure,
-            message: "authorization denied".into(),
-        });
-        app.auth_ui_notice = Some(AuthUiNotice {
-            provider: Some("openai".into()),
-            success: true,
-            message: "Copied to clipboard".into(),
-        });
-
-        assert_eq!(app.auth_feedback_for_provider("anthropic"), None);
-        assert_eq!(
-            app.auth_feedback_for_provider("openai"),
-            Some((true, "Copied to clipboard"))
-        );
-    }
-
-    #[test]
-    fn auth_feedback_supports_generic_ui_notice() {
-        let mut app = App::new();
-        app.auth_ui_notice = Some(AuthUiNotice {
-            provider: None,
-            success: false,
-            message: "Clipboard unavailable".into(),
-        });
-
-        assert_eq!(
-            app.auth_feedback_for_provider("openai"),
-            Some((false, "Clipboard unavailable"))
-        );
-        assert_eq!(
-            app.auth_feedback_for_provider("anthropic"),
-            Some((false, "Clipboard unavailable"))
-        );
+        assert_eq!(app.auth.cursor, 0);
+        assert!(app.auth.filter.is_empty());
+        assert!(app.auth.selected.is_none());
+        assert!(app.auth.api_key_input.is_empty());
+        assert!(app.auth.last_result.is_none());
+        assert!(app.auth.ui_notice.is_none());
+        assert!(app.auth.api_key_masked);
+        assert_eq!(app.auth.panel, AuthPanel::List);
     }
 
     // ── Key handler tests: List panel ─────────────────────────────────────────
@@ -3576,13 +3480,13 @@ mod auth_tests {
     #[test]
     fn auth_list_esc_clears_selection_when_selected() {
         let mut app = make_app_with_providers(vec![make_provider("OpenAI")]);
-        app.auth_selected = Some(0);
-        app.auth_last_result = Some(OAuthResult {
+        app.auth.selected = Some(0);
+        app.auth.last_result = Some(OAuthResult {
             provider: "openai".into(),
             status: OAuthResultStatus::Failure,
             message: "old result".into(),
         });
-        app.auth_ui_notice = Some(AuthUiNotice {
+        app.auth.ui_notice = Some(AuthUiNotice {
             provider: Some("openai".into()),
             success: true,
             message: "old notice".into(),
@@ -3590,9 +3494,9 @@ mod auth_tests {
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         handle_auth_popup_key(&mut app, key(KeyCode::Esc), &tx).unwrap();
         assert_eq!(app.popup, app::Popup::ProviderAuth);
-        assert!(app.auth_selected.is_none());
-        assert!(app.auth_last_result.is_none());
-        assert!(app.auth_ui_notice.is_none());
+        assert!(app.auth.selected.is_none());
+        assert!(app.auth.last_result.is_none());
+        assert!(app.auth.ui_notice.is_none());
     }
 
     #[test]
@@ -3603,67 +3507,67 @@ mod auth_tests {
             make_provider("DeepSeek"),
         ]);
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-        assert_eq!(app.auth_cursor, 0);
+        assert_eq!(app.auth.cursor, 0);
         handle_auth_popup_key(&mut app, key(KeyCode::Down), &tx).unwrap();
-        assert_eq!(app.auth_cursor, 1);
+        assert_eq!(app.auth.cursor, 1);
         handle_auth_popup_key(&mut app, key(KeyCode::Down), &tx).unwrap();
-        assert_eq!(app.auth_cursor, 2);
+        assert_eq!(app.auth.cursor, 2);
         handle_auth_popup_key(&mut app, key(KeyCode::Down), &tx).unwrap();
-        assert_eq!(app.auth_cursor, 2); // clamped
+        assert_eq!(app.auth.cursor, 2); // clamped
         handle_auth_popup_key(&mut app, key(KeyCode::Up), &tx).unwrap();
-        assert_eq!(app.auth_cursor, 1);
+        assert_eq!(app.auth.cursor, 1);
     }
 
     #[test]
     fn auth_list_enter_on_api_key_only_opens_api_key_panel() {
         let mut app = make_app_with_providers(vec![make_api_key_only("Groq")]);
-        app.auth_last_result = Some(OAuthResult {
+        app.auth.last_result = Some(OAuthResult {
             provider: "openai".into(),
             status: OAuthResultStatus::Failure,
             message: "old result".into(),
         });
-        app.auth_ui_notice = Some(AuthUiNotice {
+        app.auth.ui_notice = Some(AuthUiNotice {
             provider: Some("openai".into()),
             success: true,
             message: "old notice".into(),
         });
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         handle_auth_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
-        assert_eq!(app.auth_panel, app::AuthPanel::ApiKeyInput);
-        assert_eq!(app.auth_selected, Some(0));
-        assert!(app.auth_last_result.is_none());
-        assert!(app.auth_ui_notice.is_none());
+        assert_eq!(app.auth.panel, AuthPanel::ApiKeyInput);
+        assert_eq!(app.auth.selected, Some(0));
+        assert!(app.auth.last_result.is_none());
+        assert!(app.auth.ui_notice.is_none());
     }
 
     #[test]
     fn auth_list_enter_on_oauth_only_starts_flow() {
         let mut app = make_app_with_providers(vec![make_oauth_only("Codex")]);
-        app.auth_ui_notice = Some(AuthUiNotice {
+        app.auth.ui_notice = Some(AuthUiNotice {
             provider: Some("codex".into()),
             success: true,
             message: "old notice".into(),
         });
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         handle_auth_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
-        assert_eq!(app.auth_selected, Some(0));
+        assert_eq!(app.auth.selected, Some(0));
         let msg = rx.try_recv().expect("message sent");
         assert!(matches!(msg, Command::StartOAuthLogin { provider } if provider == "codex"));
-        assert!(app.auth_ui_notice.is_none());
+        assert!(app.auth.ui_notice.is_none());
     }
 
     #[test]
     fn auth_list_enter_on_multi_method_selects_provider() {
         let mut app = make_app_with_providers(vec![make_provider("OpenAI")]);
-        app.auth_ui_notice = Some(AuthUiNotice {
+        app.auth.ui_notice = Some(AuthUiNotice {
             provider: Some("openai".into()),
             success: true,
             message: "old notice".into(),
         });
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         handle_auth_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
-        assert_eq!(app.auth_selected, Some(0));
-        assert_eq!(app.auth_panel, app::AuthPanel::List);
-        assert!(app.auth_ui_notice.is_none());
+        assert_eq!(app.auth.selected, Some(0));
+        assert_eq!(app.auth.panel, AuthPanel::List);
+        assert!(app.auth.ui_notice.is_none());
     }
 
     #[test]
@@ -3671,38 +3575,38 @@ mod auth_tests {
         let mut app = make_app_with_providers(vec![make_provider("OpenAI"), make_provider("Groq")]);
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         handle_auth_popup_key(&mut app, key(KeyCode::Char('g')), &tx).unwrap();
-        assert_eq!(app.auth_filter, "g");
-        assert_eq!(app.auth_cursor, 0);
+        assert_eq!(app.auth.filter, "g");
+        assert_eq!(app.auth.cursor, 0);
     }
 
     #[test]
     fn auth_list_backspace_removes_filter() {
         let mut app = make_app_with_providers(vec![make_provider("OpenAI")]);
-        app.auth_filter = "op".into();
+        app.auth.filter = "op".into();
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         handle_auth_popup_key(&mut app, key(KeyCode::Backspace), &tx).unwrap();
-        assert_eq!(app.auth_filter, "o");
+        assert_eq!(app.auth.filter, "o");
     }
 
     #[test]
     fn auth_list_ctrl_k_opens_api_key_panel() {
         let mut app = make_app_with_providers(vec![make_provider("OpenAI")]);
-        app.auth_ui_notice = Some(AuthUiNotice {
+        app.auth.ui_notice = Some(AuthUiNotice {
             provider: Some("openai".into()),
             success: true,
             message: "old notice".into(),
         });
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         handle_auth_popup_key(&mut app, ctrl('k'), &tx).unwrap();
-        assert_eq!(app.auth_panel, app::AuthPanel::ApiKeyInput);
-        assert_eq!(app.auth_selected, Some(0));
-        assert!(app.auth_ui_notice.is_none());
+        assert_eq!(app.auth.panel, AuthPanel::ApiKeyInput);
+        assert_eq!(app.auth.selected, Some(0));
+        assert!(app.auth.ui_notice.is_none());
     }
 
     #[test]
     fn auth_list_ctrl_o_starts_oauth() {
         let mut app = make_app_with_providers(vec![make_provider("OpenAI")]);
-        app.auth_ui_notice = Some(AuthUiNotice {
+        app.auth.ui_notice = Some(AuthUiNotice {
             provider: Some("openai".into()),
             success: true,
             message: "old notice".into(),
@@ -3711,22 +3615,45 @@ mod auth_tests {
         handle_auth_popup_key(&mut app, ctrl('o'), &tx).unwrap();
         let msg = rx.try_recv().expect("message sent");
         assert!(matches!(msg, Command::StartOAuthLogin { provider } if provider == "openai"));
-        assert!(app.auth_ui_notice.is_none());
+        assert!(app.auth.ui_notice.is_none());
     }
 
     // ── Key handler tests: API Key panel ──────────────────────────────────────
 
     #[test]
+    fn auth_api_key_cursor_uses_utf8_byte_offsets() {
+        let mut app = make_app_with_providers(vec![make_api_key_only("Groq")]);
+        app.auth.selected = Some(0);
+        app.auth.panel = AuthPanel::ApiKeyInput;
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+
+        handle_auth_popup_key(&mut app, key(KeyCode::Char('é')), &tx).unwrap();
+        handle_auth_popup_key(&mut app, key(KeyCode::Char('ß')), &tx).unwrap();
+        assert_eq!(app.auth.api_key_input, "éß");
+        assert_eq!(app.auth.api_key_cursor, 4);
+
+        handle_auth_popup_key(&mut app, key(KeyCode::Left), &tx).unwrap();
+        handle_auth_popup_key(&mut app, key(KeyCode::Char('x')), &tx).unwrap();
+        assert_eq!(app.auth.api_key_input, "éxß");
+        assert_eq!(app.auth.api_key_cursor, 3);
+
+        handle_auth_popup_key(&mut app, key(KeyCode::Backspace), &tx).unwrap();
+        handle_auth_popup_key(&mut app, key(KeyCode::Right), &tx).unwrap();
+        assert_eq!(app.auth.api_key_input, "éß");
+        assert_eq!(app.auth.api_key_cursor, 4);
+    }
+
+    #[test]
     fn auth_api_key_typing_and_submit() {
         let mut app = make_app_with_providers(vec![make_api_key_only("Groq")]);
-        app.auth_selected = Some(0);
-        app.auth_panel = app::AuthPanel::ApiKeyInput;
+        app.auth.selected = Some(0);
+        app.auth.panel = AuthPanel::ApiKeyInput;
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 
         handle_auth_popup_key(&mut app, key(KeyCode::Char('s')), &tx).unwrap();
         handle_auth_popup_key(&mut app, key(KeyCode::Char('k')), &tx).unwrap();
-        assert_eq!(app.auth_api_key_input, "sk");
-        assert_eq!(app.auth_api_key_cursor, 2);
+        assert_eq!(app.auth.api_key_input, "sk");
+        assert_eq!(app.auth.api_key_cursor, 2);
 
         handle_auth_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
         let msg = rx.try_recv().expect("message sent");
@@ -3740,49 +3667,49 @@ mod auth_tests {
     #[test]
     fn auth_api_key_backspace() {
         let mut app = make_app_with_providers(vec![make_api_key_only("Groq")]);
-        app.auth_selected = Some(0);
-        app.auth_panel = app::AuthPanel::ApiKeyInput;
-        app.auth_api_key_input = "abc".into();
-        app.auth_api_key_cursor = 3;
+        app.auth.selected = Some(0);
+        app.auth.panel = AuthPanel::ApiKeyInput;
+        app.auth.api_key_input = "abc".into();
+        app.auth.api_key_cursor = 3;
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
 
         handle_auth_popup_key(&mut app, key(KeyCode::Backspace), &tx).unwrap();
-        assert_eq!(app.auth_api_key_input, "ab");
-        assert_eq!(app.auth_api_key_cursor, 2);
+        assert_eq!(app.auth.api_key_input, "ab");
+        assert_eq!(app.auth.api_key_cursor, 2);
     }
 
     #[test]
     fn auth_api_key_esc_returns_to_list() {
         let mut app = make_app_with_providers(vec![make_api_key_only("Groq")]);
-        app.auth_selected = Some(0);
-        app.auth_panel = app::AuthPanel::ApiKeyInput;
-        app.auth_api_key_input = "draft".into();
+        app.auth.selected = Some(0);
+        app.auth.panel = AuthPanel::ApiKeyInput;
+        app.auth.api_key_input = "draft".into();
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
 
         handle_auth_popup_key(&mut app, key(KeyCode::Esc), &tx).unwrap();
-        assert_eq!(app.auth_panel, app::AuthPanel::List);
-        assert!(app.auth_api_key_input.is_empty());
+        assert_eq!(app.auth.panel, AuthPanel::List);
+        assert!(app.auth.api_key_input.is_empty());
     }
 
     #[test]
     fn auth_api_key_tab_toggles_mask() {
         let mut app = make_app_with_providers(vec![make_api_key_only("Groq")]);
-        app.auth_selected = Some(0);
-        app.auth_panel = app::AuthPanel::ApiKeyInput;
-        assert!(app.auth_api_key_masked);
+        app.auth.selected = Some(0);
+        app.auth.panel = AuthPanel::ApiKeyInput;
+        assert!(app.auth.api_key_masked);
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
 
         handle_auth_popup_key(&mut app, key(KeyCode::Tab), &tx).unwrap();
-        assert!(!app.auth_api_key_masked);
+        assert!(!app.auth.api_key_masked);
         handle_auth_popup_key(&mut app, key(KeyCode::Tab), &tx).unwrap();
-        assert!(app.auth_api_key_masked);
+        assert!(app.auth.api_key_masked);
     }
 
     #[test]
     fn auth_api_key_ctrl_d_sends_clear() {
         let mut app = make_app_with_providers(vec![make_api_key_only("Groq")]);
-        app.auth_selected = Some(0);
-        app.auth_panel = app::AuthPanel::ApiKeyInput;
+        app.auth.selected = Some(0);
+        app.auth.panel = AuthPanel::ApiKeyInput;
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 
         handle_auth_popup_key(&mut app, ctrl('d'), &tx).unwrap();
@@ -3793,8 +3720,8 @@ mod auth_tests {
     #[test]
     fn auth_api_key_empty_submit_does_nothing() {
         let mut app = make_app_with_providers(vec![make_api_key_only("Groq")]);
-        app.auth_selected = Some(0);
-        app.auth_panel = app::AuthPanel::ApiKeyInput;
+        app.auth.selected = Some(0);
+        app.auth.panel = AuthPanel::ApiKeyInput;
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 
         handle_auth_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
@@ -3806,9 +3733,9 @@ mod auth_tests {
     #[test]
     fn auth_oauth_esc_returns_to_list() {
         let mut app = make_app_with_providers(vec![make_oauth_only("Codex")]);
-        app.auth_selected = Some(0);
-        app.auth_panel = app::AuthPanel::OAuthFlow;
-        app.auth_oauth_flow = Some(OAuthFlow {
+        app.auth.selected = Some(0);
+        app.auth.panel = AuthPanel::OAuthFlow;
+        app.auth.oauth_flow = Some(OAuthFlow {
             flow_id: "f1".into(),
             provider: "codex".into(),
             authorization_url: "https://example.com".into(),
@@ -3817,16 +3744,16 @@ mod auth_tests {
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
 
         handle_auth_popup_key(&mut app, key(KeyCode::Esc), &tx).unwrap();
-        assert_eq!(app.auth_panel, app::AuthPanel::List);
-        assert!(app.auth_oauth_flow.is_none());
+        assert_eq!(app.auth.panel, AuthPanel::List);
+        assert!(app.auth.oauth_flow.is_none());
     }
 
     #[test]
     fn auth_oauth_redirect_code_typing_and_submit() {
         let mut app = make_app_with_providers(vec![make_oauth_only("Codex")]);
-        app.auth_selected = Some(0);
-        app.auth_panel = app::AuthPanel::OAuthFlow;
-        app.auth_oauth_flow = Some(OAuthFlow {
+        app.auth.selected = Some(0);
+        app.auth.panel = AuthPanel::OAuthFlow;
+        app.auth.oauth_flow = Some(OAuthFlow {
             flow_id: "f1".into(),
             provider: "codex".into(),
             authorization_url: "https://example.com".into(),
@@ -3838,7 +3765,7 @@ mod auth_tests {
         handle_auth_popup_key(&mut app, key(KeyCode::Char('o')), &tx).unwrap();
         handle_auth_popup_key(&mut app, key(KeyCode::Char('d')), &tx).unwrap();
         handle_auth_popup_key(&mut app, key(KeyCode::Char('e')), &tx).unwrap();
-        assert_eq!(app.auth_oauth_response, "code");
+        assert_eq!(app.auth.oauth_response, "code");
 
         handle_auth_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
         let msg = rx.try_recv().expect("message sent");
@@ -3852,9 +3779,9 @@ mod auth_tests {
     #[test]
     fn auth_oauth_device_poll_enter_sends_empty_response() {
         let mut app = make_app_with_providers(vec![make_oauth_only("Codex")]);
-        app.auth_selected = Some(0);
-        app.auth_panel = app::AuthPanel::OAuthFlow;
-        app.auth_oauth_flow = Some(OAuthFlow {
+        app.auth.selected = Some(0);
+        app.auth.panel = AuthPanel::OAuthFlow;
+        app.auth.oauth_flow = Some(OAuthFlow {
             flow_id: "f1".into(),
             provider: "codex".into(),
             authorization_url: "https://example.com/device".into(),
@@ -3871,12 +3798,47 @@ mod auth_tests {
         ));
     }
 
+    #[test]
+    fn auth_oauth_cursor_uses_utf8_byte_offsets() {
+        let mut app = make_app_with_providers(vec![make_oauth_only("Codex")]);
+        app.auth.selected = Some(0);
+        app.auth.panel = AuthPanel::OAuthFlow;
+        app.auth.oauth_flow = Some(OAuthFlow {
+            flow_id: "f1".into(),
+            provider: "codex".into(),
+            authorization_url: "https://example.com".into(),
+            flow_kind: OAuthFlowKind::RedirectCode,
+        });
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+
+        handle_auth_popup_key(&mut app, key(KeyCode::Char('é')), &tx).unwrap();
+        handle_auth_popup_key(&mut app, key(KeyCode::Char('ß')), &tx).unwrap();
+        assert_eq!(app.auth.oauth_response, "éß");
+        assert_eq!(app.auth.oauth_response_cursor, 4);
+
+        handle_auth_popup_key(&mut app, key(KeyCode::Left), &tx).unwrap();
+        handle_auth_popup_key(&mut app, key(KeyCode::Char('x')), &tx).unwrap();
+        handle_auth_popup_key(&mut app, key(KeyCode::Backspace), &tx).unwrap();
+        handle_auth_popup_key(&mut app, key(KeyCode::Right), &tx).unwrap();
+        assert_eq!(app.auth.oauth_response, "éß");
+        assert_eq!(app.auth.oauth_response_cursor, 4);
+    }
+
     // ── Native ACP event handling tests ───────────────────────────────────────
 
     #[test]
     fn native_initialized_event_clears_auth_ui_notice() {
         let mut app = App::new();
-        app.auth_ui_notice = Some(AuthUiNotice {
+        app.auth.filter = "keep".into();
+        app.auth.selected = Some(3);
+        app.auth.panel = AuthPanel::ApiKeyInput;
+        app.auth.last_result = Some(OAuthResult {
+            provider: "openai".into(),
+            status: OAuthResultStatus::Failure,
+            message: "old result".into(),
+        });
+        app.auth.clipboard_fallback = Some("https://example.com".into());
+        app.auth.ui_notice = Some(AuthUiNotice {
             provider: Some("openai".into()),
             success: true,
             message: "old notice".into(),
@@ -3892,12 +3854,22 @@ mod auth_tests {
         });
 
         assert!(cmds.is_empty());
-        assert!(app.auth_ui_notice.is_none());
+        assert!(app.auth.ui_notice.is_none());
+        assert_eq!(app.auth.filter, "keep");
+        assert_eq!(app.auth.selected, Some(3));
+        assert_eq!(app.auth.panel, AuthPanel::ApiKeyInput);
+        assert!(app.auth.last_result.is_some());
+        assert_eq!(
+            app.auth.clipboard_fallback.as_deref(),
+            Some("https://example.com")
+        );
     }
 
     #[test]
     fn native_auth_providers_event_populates_list() {
         let mut app = App::new();
+        app.auth.cursor = 7;
+        app.auth.selected = Some(9);
         let mut openai = make_provider("OpenAI");
         openai.has_env_api_key = true;
         let mut groq = make_api_key_only("Groq");
@@ -3906,11 +3878,37 @@ mod auth_tests {
         let cmds = app.handle_acp_event(AcpAppEvent::AuthProviders(vec![openai, groq]));
 
         assert!(cmds.is_empty());
-        assert_eq!(app.auth_providers.len(), 2);
-        assert_eq!(app.auth_providers[0].provider, "openai");
-        assert!(app.auth_providers[0].has_env_api_key);
-        assert_eq!(app.auth_providers[1].provider, "groq");
-        assert!(app.auth_providers[1].has_stored_api_key);
+        assert_eq!(app.auth.providers.len(), 2);
+        assert_eq!(app.auth.providers[0].provider, "openai");
+        assert!(app.auth.providers[0].has_env_api_key);
+        assert_eq!(app.auth.providers[1].provider, "groq");
+        assert!(app.auth.providers[1].has_stored_api_key);
+        assert_eq!(app.auth.cursor, 7);
+        assert_eq!(app.auth.selected, Some(9));
+    }
+
+    #[test]
+    fn auth_state_survives_session_load() {
+        let mut app = App::new();
+        app.auth.providers = vec![make_provider("OpenAI")];
+        app.auth.cursor = 4;
+        app.auth.filter = "keep".into();
+        app.auth.selected = Some(0);
+        app.auth.panel = AuthPanel::ApiKeyInput;
+        app.auth.api_key_input = "secret".into();
+
+        app.handle_acp_event(AcpAppEvent::SessionLoaded {
+            agent_id: "agent-1".into(),
+            session_id: "session-1".into(),
+            profile_id: None,
+        });
+
+        assert_eq!(app.auth.providers.len(), 1);
+        assert_eq!(app.auth.cursor, 4);
+        assert_eq!(app.auth.filter, "keep");
+        assert_eq!(app.auth.selected, Some(0));
+        assert_eq!(app.auth.panel, AuthPanel::ApiKeyInput);
+        assert_eq!(app.auth.api_key_input, "secret");
     }
 
     #[test]
@@ -3918,12 +3916,12 @@ mod auth_tests {
         let mut app = App::new();
         app.popup = app::Popup::ProviderAuth;
 
-        app.auth_last_result = Some(OAuthResult {
+        app.auth.last_result = Some(OAuthResult {
             provider: "openai".into(),
             status: OAuthResultStatus::Failure,
             message: "old result".into(),
         });
-        app.auth_ui_notice = Some(AuthUiNotice {
+        app.auth.ui_notice = Some(AuthUiNotice {
             provider: Some("openai".into()),
             success: true,
             message: "old notice".into(),
@@ -3937,26 +3935,26 @@ mod auth_tests {
         }));
 
         assert!(cmds.is_empty());
-        assert!(app.auth_oauth_flow.is_some());
-        let flow = app.auth_oauth_flow.unwrap();
+        assert!(app.auth.oauth_flow.is_some());
+        let flow = app.auth.oauth_flow.unwrap();
         assert_eq!(flow.flow_id, "flow-123");
         assert_eq!(flow.provider, "openai");
         assert_eq!(flow.flow_kind, OAuthFlowKind::RedirectCode);
-        assert_eq!(app.auth_panel, app::AuthPanel::OAuthFlow);
-        assert!(app.auth_last_result.is_none());
-        assert!(app.auth_ui_notice.is_none());
+        assert_eq!(app.auth.panel, AuthPanel::OAuthFlow);
+        assert!(app.auth.last_result.is_none());
+        assert!(app.auth.ui_notice.is_none());
     }
 
     #[test]
     fn native_oauth_result_success_clears_flow() {
         let mut app = App::new();
-        app.auth_oauth_flow = Some(OAuthFlow {
+        app.auth.oauth_flow = Some(OAuthFlow {
             flow_id: "f1".into(),
             provider: "openai".into(),
             authorization_url: "https://example.com".into(),
             flow_kind: OAuthFlowKind::RedirectCode,
         });
-        app.auth_panel = app::AuthPanel::OAuthFlow;
+        app.auth.panel = AuthPanel::OAuthFlow;
 
         let cmds = app.handle_acp_event(AcpAppEvent::OAuthResult(OAuthResult {
             provider: "openai".into(),
@@ -3966,10 +3964,10 @@ mod auth_tests {
 
         assert_eq!(cmds.len(), 1);
         assert!(matches!(cmds[0], Command::ListAuthProviders));
-        assert!(app.auth_oauth_flow.is_none());
-        assert_eq!(app.auth_panel, app::AuthPanel::List);
+        assert!(app.auth.oauth_flow.is_none());
+        assert_eq!(app.auth.panel, AuthPanel::List);
         assert_eq!(
-            app.auth_last_result,
+            app.auth.last_result,
             Some(OAuthResult {
                 provider: "openai".into(),
                 status: OAuthResultStatus::Success,
@@ -3987,8 +3985,8 @@ mod auth_tests {
             authorization_url: "https://example.com".into(),
             flow_kind: OAuthFlowKind::RedirectCode,
         };
-        app.auth_oauth_flow = Some(flow.clone());
-        app.auth_panel = app::AuthPanel::OAuthFlow;
+        app.auth.oauth_flow = Some(flow.clone());
+        app.auth.panel = AuthPanel::OAuthFlow;
 
         let result = OAuthResult {
             provider: "anthropic".into(),
@@ -3999,15 +3997,15 @@ mod auth_tests {
 
         assert_eq!(cmds.len(), 1);
         assert!(matches!(cmds[0], Command::ListAuthProviders));
-        assert_eq!(app.auth_oauth_flow, Some(flow));
-        assert_eq!(app.auth_panel, app::AuthPanel::OAuthFlow);
-        assert_eq!(app.auth_last_result, Some(result));
+        assert_eq!(app.auth.oauth_flow, Some(flow));
+        assert_eq!(app.auth.panel, AuthPanel::OAuthFlow);
+        assert_eq!(app.auth.last_result, Some(result));
     }
 
     #[test]
     fn native_oauth_result_clears_auth_ui_notice() {
         let mut app = App::new();
-        app.auth_ui_notice = Some(AuthUiNotice {
+        app.auth.ui_notice = Some(AuthUiNotice {
             provider: Some("openai".into()),
             success: true,
             message: "Copied to clipboard".into(),
@@ -4019,7 +4017,7 @@ mod auth_tests {
             message: "Authorization denied".into(),
         }));
 
-        assert!(app.auth_ui_notice.is_none());
+        assert!(app.auth.ui_notice.is_none());
     }
 
     // ── Disconnect / clear credential tests (C-d in List panel) ─────────────
@@ -4029,7 +4027,7 @@ mod auth_tests {
         let mut provider = make_provider("OpenAI");
         provider.oauth_status = Some(OAuthStatus::Connected);
         let mut app = make_app_with_providers(vec![provider]);
-        app.auth_selected = Some(0);
+        app.auth.selected = Some(0);
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 
         handle_auth_popup_key(&mut app, ctrl('d'), &tx).unwrap();
@@ -4045,7 +4043,7 @@ mod auth_tests {
         let mut provider = make_api_key_only("Groq");
         provider.has_stored_api_key = true;
         let mut app = make_app_with_providers(vec![provider]);
-        app.auth_selected = Some(0);
+        app.auth.selected = Some(0);
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 
         handle_auth_popup_key(&mut app, ctrl('d'), &tx).unwrap();
@@ -4060,7 +4058,7 @@ mod auth_tests {
     fn auth_list_ctrl_d_noop_when_no_credential() {
         let app_provider = make_provider("OpenAI"); // not connected, no stored key
         let mut app = make_app_with_providers(vec![app_provider]);
-        app.auth_selected = Some(0);
+        app.auth.selected = Some(0);
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 
         handle_auth_popup_key(&mut app, ctrl('d'), &tx).unwrap();
@@ -4086,7 +4084,7 @@ mod auth_tests {
         provider.oauth_status = Some(OAuthStatus::Connected);
         provider.has_stored_api_key = true;
         let mut app = make_app_with_providers(vec![provider]);
-        app.auth_selected = Some(0);
+        app.auth.selected = Some(0);
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 
         handle_auth_popup_key(&mut app, ctrl('d'), &tx).unwrap();
@@ -4100,9 +4098,9 @@ mod auth_tests {
     #[test]
     fn auth_oauth_ctrl_y_triggers_clipboard_copy() {
         let mut app = make_app_with_providers(vec![make_oauth_only("Codex")]);
-        app.auth_selected = Some(0);
-        app.auth_panel = app::AuthPanel::OAuthFlow;
-        app.auth_oauth_flow = Some(OAuthFlow {
+        app.auth.selected = Some(0);
+        app.auth.panel = AuthPanel::OAuthFlow;
+        app.auth.oauth_flow = Some(OAuthFlow {
             flow_id: "f1".into(),
             provider: "codex".into(),
             authorization_url: "https://auth.example.com/authorize".into(),
@@ -4120,25 +4118,25 @@ mod auth_tests {
         let expected_url = "https://auth.example.com/authorize";
         assert!(
             matches!(
-                (&app.auth_ui_notice, &app.auth_clipboard_fallback),
+                (&app.auth.ui_notice, &app.auth.clipboard_fallback),
                 (Some(notice), None) if notice == &expected_notice
             ) || matches!(
-                (&app.auth_ui_notice, &app.auth_clipboard_fallback),
+                (&app.auth.ui_notice, &app.auth.clipboard_fallback),
                 (None, Some(url)) if url == expected_url
             ),
             "C-y should show the provider notice or exact fallback URL"
         );
-        assert!(app.auth_last_result.is_none());
+        assert!(app.auth.last_result.is_none());
     }
 
     #[test]
     fn auth_clipboard_fallback_dismisses_on_any_key() {
         let mut app = make_app_with_providers(vec![make_oauth_only("Codex")]);
-        app.auth_clipboard_fallback = Some("https://example.com".into());
+        app.auth.clipboard_fallback = Some("https://example.com".into());
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
 
         handle_auth_popup_key(&mut app, key(KeyCode::Char('x')), &tx).unwrap();
-        assert!(app.auth_clipboard_fallback.is_none());
+        assert!(app.auth.clipboard_fallback.is_none());
     }
 
     // ── Chord binding test ────────────────────────────────────────────────────

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -471,9 +471,13 @@ mod tests {
     use super::*;
     use crate::acp_state::{AcpAppEvent, AcpSessionUpdate};
     use crate::app::{App, Screen};
+    use crate::auth_state::{AuthPanel, AuthUiNotice};
     use crate::diagnostics::LogLevel;
     use crate::domain::activity::{
         DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus, SessionActivity,
+    };
+    use crate::domain::auth::{
+        AuthProviderEntry, OAuthFlow, OAuthFlowKind, OAuthResult, OAuthResultStatus, OAuthStatus,
     };
     use crate::domain::chat::ChatEntry;
     use crate::domain::elicitation::{
@@ -535,6 +539,31 @@ mod tests {
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
         terminal.draw(|f| draw_delegate_view(f, app)).unwrap();
         terminal.backend().buffer().clone()
+    }
+
+    fn auth_provider(id: &str, display_name: &str, supports_oauth: bool) -> AuthProviderEntry {
+        AuthProviderEntry {
+            provider: id.into(),
+            display_name: display_name.into(),
+            oauth_status: supports_oauth.then_some(OAuthStatus::NotAuthenticated),
+            has_stored_api_key: false,
+            has_env_api_key: false,
+            env_var_name: Some(format!("{}_API_KEY", id.to_uppercase())),
+            supports_oauth,
+            preferred_method: None,
+        }
+    }
+
+    fn render_auth_popup(
+        app: &App,
+        width: u16,
+        height: u16,
+    ) -> (ratatui::buffer::Buffer, Position) {
+        let backend = ratatui::backend::TestBackend::new(width, height);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal.draw(|f| draw_auth_popup(f, app)).unwrap();
+        let cursor = terminal.backend_mut().get_cursor_position().unwrap();
+        (terminal.backend().buffer().clone(), cursor)
     }
 
     fn load_session(app: &mut App, session_id: &str, agent_id: &str) {
@@ -1900,6 +1929,116 @@ mod tests {
 
         assert!(rendered.contains('…'));
         assert!(!rendered.contains("..."));
+    }
+
+    #[test]
+    fn draw_auth_popup_filters_provider_rows_and_keeps_filtered_cursor() {
+        let mut app = App::new();
+        app.popup = Popup::ProviderAuth;
+        app.auth.providers = vec![
+            auth_provider("openai", "OpenAI", true),
+            auth_provider("groq", "Groq", false),
+            auth_provider("anthropic", "Anthropic", true),
+        ];
+        app.auth.filter = "a".into();
+        app.auth.cursor = 1;
+
+        let (buffer, _) = render_auth_popup(&app, 80, 24);
+        let rendered = buffer_text(&buffer);
+
+        assert!(rendered.contains("OpenAI"));
+        assert!(!rendered.contains("Groq"));
+        assert!(rendered.contains("Anthropic"));
+        let (anthropic_x, anthropic_y) =
+            find_buffer_text(&buffer, "Anthropic").expect("filtered row missing");
+        assert_eq!(
+            buffer[(anthropic_x, anthropic_y)].style().bg,
+            Theme::selected().bg
+        );
+    }
+
+    #[test]
+    fn draw_auth_popup_masks_api_key_and_uses_utf8_byte_cursor() {
+        let mut app = App::new();
+        app.popup = Popup::ProviderAuth;
+        app.auth.providers = vec![auth_provider("groq", "Groq", false)];
+        app.auth.selected = Some(0);
+        app.auth.panel = AuthPanel::ApiKeyInput;
+        app.auth.api_key_input = "éß".into();
+        app.auth.api_key_cursor = "é".len();
+        app.auth.api_key_masked = true;
+
+        let (masked_buffer, masked_cursor) = render_auth_popup(&app, 80, 24);
+        let masked = buffer_text(&masked_buffer);
+        let (bullets_x, bullets_y) =
+            find_buffer_text(&masked_buffer, "••").expect("masked input missing");
+        assert!(!masked.contains("éß"));
+        assert_eq!(masked_cursor, Position::new(bullets_x + 1, bullets_y));
+
+        app.auth.api_key_masked = false;
+        let (plain_buffer, plain_cursor) = render_auth_popup(&app, 80, 24);
+        let (input_x, input_y) = find_buffer_text(&plain_buffer, "éß").expect("input missing");
+        assert_eq!(plain_cursor, Position::new(input_x + 1, input_y));
+    }
+
+    #[test]
+    fn draw_auth_popup_renders_redirect_and_device_oauth_panels() {
+        let mut app = App::new();
+        app.popup = Popup::ProviderAuth;
+        app.auth.providers = vec![auth_provider("codex", "Codex", true)];
+        app.auth.selected = Some(0);
+        app.auth.panel = AuthPanel::OAuthFlow;
+        app.auth.oauth_flow = Some(OAuthFlow {
+            flow_id: "flow-1".into(),
+            provider: "codex".into(),
+            authorization_url: "https://example.com/authorize".into(),
+            flow_kind: OAuthFlowKind::RedirectCode,
+        });
+        app.auth.oauth_response = "écode".into();
+        app.auth.oauth_response_cursor = "é".len();
+
+        let (redirect_buffer, redirect_cursor) = render_auth_popup(&app, 80, 24);
+        let redirect = buffer_text(&redirect_buffer);
+        let (response_x, response_y) =
+            find_buffer_text(&redirect_buffer, "écode").expect("OAuth response missing");
+        assert!(redirect.contains("paste callback below"));
+        assert_eq!(redirect_cursor, Position::new(response_x + 1, response_y));
+
+        app.auth.oauth_flow.as_mut().unwrap().flow_kind = OAuthFlowKind::DevicePoll;
+        let (device_buffer, _) = render_auth_popup(&app, 80, 24);
+        let device = buffer_text(&device_buffer);
+        assert!(device.contains("press Enter to check"));
+        assert!(!device.contains("paste callback below"));
+    }
+
+    #[test]
+    fn draw_auth_popup_prefers_notice_and_renders_clipboard_fallback_overlay() {
+        let mut app = App::new();
+        app.popup = Popup::ProviderAuth;
+        app.auth.providers = vec![auth_provider("openai", "OpenAI", true)];
+        app.auth.selected = Some(0);
+        app.auth.last_result = Some(OAuthResult {
+            provider: "openai".into(),
+            status: OAuthResultStatus::Failure,
+            message: "authorization denied".into(),
+        });
+        app.auth.ui_notice = Some(AuthUiNotice {
+            provider: Some("openai".into()),
+            success: true,
+            message: "Copied to clipboard".into(),
+        });
+
+        let (notice_buffer, _) = render_auth_popup(&app, 80, 24);
+        let notice = buffer_text(&notice_buffer);
+        assert!(notice.contains("Copied to clipboard"));
+        assert!(!notice.contains("authorization denied"));
+
+        app.auth.clipboard_fallback = Some("https://example.com/manual".into());
+        let (fallback_buffer, _) = render_auth_popup(&app, 80, 24);
+        let fallback = buffer_text(&fallback_buffer);
+        assert!(fallback.contains("Clipboard not available"));
+        assert!(fallback.contains("https://example.com/manual"));
+        assert!(!fallback.contains("Copied to clipboard"));
     }
 
     #[test]

--- a/src/ui/popups.rs
+++ b/src/ui/popups.rs
@@ -7,7 +7,8 @@ use ratatui::{
 };
 use unicode_width::UnicodeWidthStr;
 
-use crate::app::{App, AuthPanel, session_group_count_text};
+use crate::app::{App, session_group_count_text};
+use crate::auth_state::AuthPanel;
 use crate::diagnostics::LogLevel;
 use crate::domain::activity::DelegateStats;
 use crate::domain::auth::{OAuthFlowKind, OAuthStatus};
@@ -2507,15 +2508,15 @@ pub(super) fn draw_auth_popup(f: &mut Frame, app: &App) {
     };
 
     // If clipboard fallback is active, draw a simple URL display popup over everything.
-    if let Some(ref url) = app.auth_clipboard_fallback {
+    if let Some(ref url) = app.auth.clipboard_fallback {
         draw_auth_clipboard_fallback(f, inner, url);
         return;
     }
 
     // Determine detail area height based on panel state.
-    let detail_height: u16 = match app.auth_panel {
+    let detail_height: u16 = match app.auth.panel {
         AuthPanel::List => {
-            if app.auth_selected.is_some() {
+            if app.auth.selected.is_some() {
                 3 // status line + info
             } else {
                 0
@@ -2547,7 +2548,7 @@ pub(super) fn draw_auth_popup(f: &mut Frame, app: &App) {
     // filter
     let avail = chunks[1].width.saturating_sub(2) as usize;
     let (auth_filter_display, auth_filter_cur) =
-        scroll_input(&app.auth_filter, app.auth_filter.len(), avail);
+        scroll_input(&app.auth.filter, app.auth.filter.len(), avail);
     let filter_line = Line::from(vec![
         Span::styled("> ", Theme::popup_title()),
         Span::styled(auth_filter_display, Theme::popup_bg()),
@@ -2556,19 +2557,19 @@ pub(super) fn draw_auth_popup(f: &mut Frame, app: &App) {
         Paragraph::new(filter_line).style(Theme::popup_bg()),
         chunks[1],
     );
-    if app.auth_panel == AuthPanel::List {
+    if app.auth.panel == AuthPanel::List {
         f.set_cursor_position((chunks[1].x + 2 + auth_filter_cur as u16, chunks[1].y));
     }
 
     // provider list
-    let filtered = app.filtered_auth_providers();
+    let filtered = app.auth.filtered_providers();
     let list_w = chunks[3].width as usize;
 
     let items: Vec<ListItem> = filtered
         .iter()
         .enumerate()
         .map(|(i, (_, provider))| {
-            let selected = i == app.auth_cursor;
+            let selected = i == app.auth.cursor;
             let badge = provider.auth_badge_label();
             let badge_active = provider.is_auth_active();
             let is_expired = provider.oauth_status == Some(OAuthStatus::Expired);
@@ -2615,7 +2616,7 @@ pub(super) fn draw_auth_popup(f: &mut Frame, app: &App) {
         .collect();
 
     if items.is_empty() {
-        let msg = if app.auth_filter.is_empty() {
+        let msg = if app.auth.filter.is_empty() {
             "loading providers..."
         } else {
             "no providers match filter"
@@ -2629,11 +2630,12 @@ pub(super) fn draw_auth_popup(f: &mut Frame, app: &App) {
         let list = List::new(items).block(Block::default().style(Theme::popup_bg()));
         let visible_rows = chunks[3].height as usize;
         let offset = app
-            .auth_cursor
+            .auth
+            .cursor
             .saturating_sub(visible_rows.saturating_sub(1));
         let mut state = ListState::default()
             .with_offset(offset)
-            .with_selected(Some(app.auth_cursor));
+            .with_selected(Some(app.auth.cursor));
         f.render_stateful_widget(list, chunks[3], &mut state);
     }
 
@@ -2643,7 +2645,7 @@ pub(super) fn draw_auth_popup(f: &mut Frame, app: &App) {
     }
 
     // hint
-    let hint = match app.auth_panel {
+    let hint = match app.auth.panel {
         AuthPanel::List => {
             let mut spans = vec![
                 Span::styled(" esc ", Theme::status_accent()),
@@ -2652,8 +2654,8 @@ pub(super) fn draw_auth_popup(f: &mut Frame, app: &App) {
                 Span::styled("select  ", Theme::status()),
             ];
             // Show C-d contextually when a provider with clearable credentials is selected
-            if let Some(idx) = app.auth_selected
-                && let Some(provider) = app.auth_providers.get(idx)
+            if let Some(idx) = app.auth.selected
+                && let Some(provider) = app.auth.providers.get(idx)
             {
                 if provider.oauth_status == Some(OAuthStatus::Connected) {
                     spans.push(Span::styled("C-d ", Theme::status_accent()));
@@ -2692,14 +2694,14 @@ pub(super) fn draw_auth_popup(f: &mut Frame, app: &App) {
 }
 
 fn draw_auth_detail_panel(f: &mut Frame, app: &App, area: Rect) {
-    let Some(idx) = app.auth_selected else {
+    let Some(idx) = app.auth.selected else {
         return;
     };
-    let Some(provider) = app.auth_providers.get(idx) else {
+    let Some(provider) = app.auth.providers.get(idx) else {
         return;
     };
 
-    match app.auth_panel {
+    match app.auth.panel {
         AuthPanel::List => {
             // Show selected provider status summary
             let mut lines: Vec<Line<'static>> = Vec::new();
@@ -2731,7 +2733,7 @@ fn draw_auth_detail_panel(f: &mut Frame, app: &App, area: Rect) {
                 )));
             }
 
-            if let Some((success, message)) = app.auth_feedback_for_provider(&provider.provider) {
+            if let Some((success, message)) = app.auth.feedback_for_provider(&provider.provider) {
                 let style = if success {
                     ratatui::style::Style::default()
                         .fg(Theme::ok())
@@ -2783,13 +2785,13 @@ fn draw_auth_detail_panel(f: &mut Frame, app: &App, area: Rect) {
             }
 
             // Input line
-            let cursor_chars = app.auth_api_key_input[..app.auth_api_key_cursor]
+            let cursor_chars = app.auth.api_key_input[..app.auth.api_key_cursor]
                 .chars()
                 .count();
-            let display_input = if app.auth_api_key_masked && !app.auth_api_key_input.is_empty() {
-                "\u{2022}".repeat(app.auth_api_key_input.chars().count())
+            let display_input = if app.auth.api_key_masked && !app.auth.api_key_input.is_empty() {
+                "\u{2022}".repeat(app.auth.api_key_input.chars().count())
             } else {
-                app.auth_api_key_input.clone()
+                app.auth.api_key_input.clone()
             };
             let placeholder = if provider.has_stored_api_key {
                 "new key to update..."
@@ -2798,13 +2800,13 @@ fn draw_auth_detail_panel(f: &mut Frame, app: &App, area: Rect) {
             };
             // " > " prefix = 3 cols
             let avail = area.width.saturating_sub(3) as usize;
-            let (input_text, api_key_cur) = if app.auth_api_key_input.is_empty() {
+            let (input_text, api_key_cur) = if app.auth.api_key_input.is_empty() {
                 (placeholder.to_string(), 0usize)
             } else {
                 let (vis, col) = scroll_input_chars(&display_input, cursor_chars, avail);
                 (vis, col)
             };
-            let input_style = if app.auth_api_key_input.is_empty() {
+            let input_style = if app.auth.api_key_input.is_empty() {
                 Theme::status()
             } else {
                 Theme::popup_bg()
@@ -2814,7 +2816,7 @@ fn draw_auth_detail_panel(f: &mut Frame, app: &App, area: Rect) {
                 Span::styled(input_text, input_style),
             ]));
 
-            if let Some((success, message)) = app.auth_feedback_for_provider(&provider.provider) {
+            if let Some((success, message)) = app.auth.feedback_for_provider(&provider.provider) {
                 let style = if success {
                     ratatui::style::Style::default()
                         .fg(Theme::ok())
@@ -2853,7 +2855,7 @@ fn draw_auth_detail_panel(f: &mut Frame, app: &App, area: Rect) {
         AuthPanel::OAuthFlow => {
             let mut lines: Vec<Line<'static>> = Vec::new();
 
-            if let Some(ref flow) = app.auth_oauth_flow {
+            if let Some(ref flow) = app.auth.oauth_flow {
                 let is_device_poll = flow.flow_kind == OAuthFlowKind::DevicePoll;
 
                 lines.push(Line::from(Span::styled(
@@ -2884,8 +2886,8 @@ fn draw_auth_detail_panel(f: &mut Frame, app: &App, area: Rect) {
                     // " > " prefix = 3 cols
                     let avail = area.width.saturating_sub(3) as usize;
                     let (response_display, _) = scroll_input(
-                        &app.auth_oauth_response,
-                        app.auth_oauth_response_cursor,
+                        &app.auth.oauth_response,
+                        app.auth.oauth_response_cursor,
                         avail,
                     );
                     lines.push(Line::from(Span::styled(
@@ -2904,7 +2906,7 @@ fn draw_auth_detail_panel(f: &mut Frame, app: &App, area: Rect) {
                 )));
             }
 
-            if let Some((success, message)) = app.auth_feedback_for_provider(&provider.provider) {
+            if let Some((success, message)) = app.auth.feedback_for_provider(&provider.provider) {
                 let style = if success {
                     ratatui::style::Style::default()
                         .fg(Theme::ok())
@@ -2931,16 +2933,17 @@ fn draw_auth_detail_panel(f: &mut Frame, app: &App, area: Rect) {
             }
 
             // Position cursor on callback input (non-device-poll only, row 3)
-            if app.auth_oauth_flow.is_some()
+            if app.auth.oauth_flow.is_some()
                 && app
-                    .auth_oauth_flow
+                    .auth
+                    .oauth_flow
                     .as_ref()
                     .is_some_and(|f| f.flow_kind != OAuthFlowKind::DevicePoll)
             {
                 let avail = area.width.saturating_sub(3) as usize;
                 let (_, oauth_cur) = scroll_input(
-                    &app.auth_oauth_response,
-                    app.auth_oauth_response_cursor,
+                    &app.auth.oauth_response,
+                    app.auth.oauth_response_cursor,
                     avail,
                 );
                 if 3 < area.height {


### PR DESCRIPTION
## what changed

- add private `src/auth_state.rs` as the application/UI owner for `AuthPanel`, `AuthUiNotice`, and the 14 auth fields
- replace the flat `App` auth fields with one crate-visible `auth: AuthState` composition field
- move filtering, open/reset, detail-close, feedback, OAuth-start, and OAuth-result transitions to `AuthState`
- migrate reducer, handler, rendering, and test call sites directly to nested auth state with no compatibility forwards
- preserve popup routing, provider index/cursor semantics, reset survival, UTF-8 byte cursors, clipboard/notice precedence, OAuth logging and command ordering, and unsupported token transport behavior

## validation

- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --all-targets --all-features`
- `cargo test --all-targets --all-features -- --quiet` (772 passed)
- `git diff --check`
- boundary searches: zero flat auth accesses/declarations, zero old app auth imports, zero forbidden owner dependencies, exactly one `auth: AuthState`, and four unchanged diagnostics compatibility tags

## scope

This is the second bounded Phase 4 slice from verified base `1a3e4db353387fba4404529d07ea212c31109188`. It does not start profiles, mesh, navigation, models, connection, or another state group. The ignored local `REFACTOR.md` records source-complete/review-pending status and remains uncommitted.
