### PR TITLE
refactor: extract profiles state

### DIFF
--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -575,24 +575,11 @@ impl crate::app::App {
         profiles: Vec<ProfileInfo>,
         backend_active_profile_id: Option<String>,
     ) -> Vec<Command> {
-        let previous_profile_id = self.active_profile_id.clone();
-        let is_available =
-            |profile_id: &str| profiles.iter().any(|profile| profile.id == profile_id);
-        let selected = self
-            .active_profile_id
-            .take()
-            .filter(|profile_id| is_available(profile_id));
-        let backend_default =
-            backend_active_profile_id.filter(|profile_id| is_available(profile_id));
-        self.active_profile_id = selected
-            .or(backend_default)
-            .or_else(|| profiles.first().map(|profile| profile.id.clone()));
-        self.profiles = profiles;
-        if self.profile_cursor >= self.profiles.len() {
-            self.profile_cursor = self.profiles.len().saturating_sub(1);
-        }
+        let active_profile_changed = self
+            .profiles
+            .apply_catalog(profiles, backend_active_profile_id);
         let desired_profile_id = self.desired_agents_profile_id().map(str::to_string);
-        if self.active_profile_id != previous_profile_id
+        if active_profile_changed
             || self.agents_profile_id.as_deref() != desired_profile_id.as_deref()
             || self.agents.len() <= 1
         {
@@ -2227,56 +2214,113 @@ mod tests {
     }
 
     #[test]
+    fn initialized_placeholder_empty_catalog_preserves_profiles_and_discards_catalog_commands() {
+        let mut app = App::new();
+        app.profiles.profiles = vec![profile("fast")];
+        app.profiles.active_profile_id = Some("fast".into());
+        app.agents.clear();
+
+        let commands = app.handle_acp_event(AcpAppEvent::Initialized {
+            agent_id: "agent-1".into(),
+            agent_name: "Agent".into(),
+            profiles: Vec::new(),
+            active_profile_id: None,
+            agent_mode: None,
+            reasoning_effort: None,
+        });
+
+        assert!(commands.is_empty());
+        assert_eq!(app.profiles.profiles.len(), 1);
+        assert_eq!(app.profiles.active_profile_id.as_deref(), Some("fast"));
+        assert_eq!(app.agents.len(), 1);
+        assert_eq!(app.agents_profile_id, None);
+    }
+
+    #[test]
+    fn initialized_non_empty_catalog_keeps_discarded_catalog_command_behavior() {
+        let mut app = App::new();
+
+        let commands = app.handle_acp_event(AcpAppEvent::Initialized {
+            agent_id: "agent-1".into(),
+            agent_name: "Agent".into(),
+            profiles: vec![profile("fast")],
+            active_profile_id: Some("fast".into()),
+            agent_mode: None,
+            reasoning_effort: None,
+        });
+
+        assert!(commands.is_empty());
+        assert_eq!(app.profiles.active_profile_id.as_deref(), Some("fast"));
+        assert_eq!(app.agents.len(), 1);
+        assert_eq!(app.agents_profile_id, None);
+    }
+
+    #[test]
     fn profile_catalog_preserves_valid_local_selection() {
         let mut app = App::new();
-        app.active_profile_id = Some("deep".into());
+        app.profiles.active_profile_id = Some("deep".into());
 
         app.handle_acp_event(AcpAppEvent::Profiles {
             profiles: vec![profile("fast"), profile("deep")],
             active_profile_id: Some("fast".into()),
         });
 
-        assert_eq!(app.active_profile_id.as_deref(), Some("deep"));
+        assert_eq!(app.profiles.active_profile_id.as_deref(), Some("deep"));
     }
 
     #[test]
     fn profile_catalog_falls_back_to_backend_default_then_first_profile() {
         let mut app = App::new();
-        app.active_profile_id = Some("removed".into());
+        app.profiles.active_profile_id = Some("removed".into());
 
         app.handle_acp_event(AcpAppEvent::Profiles {
             profiles: vec![profile("fast"), profile("deep")],
             active_profile_id: Some("deep".into()),
         });
-        assert_eq!(app.active_profile_id.as_deref(), Some("deep"));
+        assert_eq!(app.profiles.active_profile_id.as_deref(), Some("deep"));
 
-        app.active_profile_id = Some("removed-again".into());
+        app.profiles.active_profile_id = Some("removed-again".into());
         app.handle_acp_event(AcpAppEvent::Profiles {
             profiles: vec![profile("fast"), profile("deep")],
             active_profile_id: Some("missing".into()),
         });
-        assert_eq!(app.active_profile_id.as_deref(), Some("fast"));
+        assert_eq!(app.profiles.active_profile_id.as_deref(), Some("fast"));
     }
 
     #[test]
     fn empty_profile_catalog_clears_stale_selection() {
         let mut app = App::new();
-        app.profiles = vec![profile("fast")];
-        app.active_profile_id = Some("fast".into());
+        app.profiles.profiles = vec![profile("fast")];
+        app.profiles.active_profile_id = Some("fast".into());
 
         app.handle_acp_event(AcpAppEvent::Profiles {
             profiles: Vec::new(),
             active_profile_id: None,
         });
 
-        assert!(app.profiles.is_empty());
-        assert!(app.active_profile_id.is_none());
+        assert!(app.profiles.profiles.is_empty());
+        assert!(app.profiles.active_profile_id.is_none());
+    }
+
+    #[test]
+    fn profile_catalog_command_order_remains_list_agents_only() {
+        let mut app = App::new();
+
+        let commands = app.handle_acp_event(AcpAppEvent::Profiles {
+            profiles: vec![profile("fast")],
+            active_profile_id: Some("fast".into()),
+        });
+
+        assert!(matches!(
+            commands.as_slice(),
+            [Command::ListProfileAgents { profile_id }] if profile_id == "fast"
+        ));
     }
 
     #[test]
     fn loading_session_profile_does_not_replace_new_session_selection() {
         let mut app = App::new();
-        app.active_profile_id = Some("deep".into());
+        app.profiles.active_profile_id = Some("deep".into());
 
         app.handle_acp_event(AcpAppEvent::SessionLoaded {
             agent_id: "agent-1".into(),
@@ -2284,8 +2328,50 @@ mod tests {
             profile_id: Some("fast".into()),
         });
 
-        assert_eq!(app.active_profile_id.as_deref(), Some("deep"));
+        assert_eq!(app.profiles.active_profile_id.as_deref(), Some("deep"));
         assert_eq!(app.current_session_profile_id(), Some("fast"));
+    }
+
+    #[test]
+    fn loading_missing_local_profile_preserves_binding_and_command_order() {
+        let mut app = App::new();
+        app.profiles
+            .bind_session_profile("session-1".into(), "fast".into());
+
+        let commands = app.handle_acp_event(AcpAppEvent::SessionLoaded {
+            agent_id: "agent-1".into(),
+            session_id: "session-1".into(),
+            profile_id: None,
+        });
+
+        assert_eq!(app.current_session_profile_id(), Some("fast"));
+        assert!(matches!(
+            commands.as_slice(),
+            [
+                Command::SetAgentMode { mode },
+                Command::ListProfileAgents { profile_id },
+            ] if mode == "build" && profile_id == "fast"
+        ));
+    }
+
+    #[test]
+    fn loading_missing_remote_profile_removes_stale_binding() {
+        let mut app = App::new();
+        app.remember_remote_session_node("remote-1", "node-1");
+        app.profiles
+            .bind_session_profile("remote-1".into(), "fast".into());
+
+        let commands = app.handle_acp_event(AcpAppEvent::SessionLoaded {
+            agent_id: "agent-1".into(),
+            session_id: "remote-1".into(),
+            profile_id: None,
+        });
+
+        assert!(app.current_session_profile_id().is_none());
+        assert!(matches!(
+            commands.as_slice(),
+            [Command::SetAgentMode { mode }] if mode == "build"
+        ));
     }
 
     #[test]
@@ -2464,7 +2550,7 @@ mod tests {
     #[test]
     fn profile_agents_populate_delegate_tabs_and_ignore_stale_responses() {
         let mut app = App::new();
-        app.active_profile_id = Some("quorum".into());
+        app.profiles.active_profile_id = Some("quorum".into());
 
         app.handle_acp_event(AcpAppEvent::ProfileAgents {
             profile_id: "old".into(),
@@ -2503,8 +2589,8 @@ mod tests {
     fn profile_agents_reapply_profile_scoped_preferences_to_parent_session() {
         let mut app = App::new();
         app.session_id = Some("parent".into());
-        app.session_profiles
-            .insert("parent".into(), "quorum".into());
+        app.profiles
+            .bind_session_profile("parent".into(), "quorum".into());
         app.delegate_model_preferences.insert(
             "quorum".into(),
             [(

--- a/src/app.rs
+++ b/src/app.rs
@@ -17,7 +17,7 @@ use crate::domain::mesh::{
     MeshInviteCreatedInfo, MeshStatusInfo, RemoteNodeInfo, RemoteSessionInfo, RemoteSessionLocation,
 };
 use crate::domain::model::{DelegateModelPreference, ModelEntry};
-use crate::domain::profile::{AgentInfo, ProfileInfo};
+use crate::domain::profile::AgentInfo;
 use crate::domain::session::{
     ForkBoundaryKind, ForkTurnItem, SessionGroup, UndoFrame, UndoFrameStatus, UndoStackSnapshot,
     UndoState, UndoableTurn,
@@ -25,6 +25,7 @@ use crate::domain::session::{
 use crate::highlight::Highlighter;
 use crate::markdown::CardBlock;
 use crate::mesh::{MeshFocus, MeshInviteFormField};
+use crate::profiles_state::ProfilesState;
 use crate::protocol::audit::EventKind;
 use crate::ui::{CardCache, ElicitationUiState};
 
@@ -596,11 +597,7 @@ pub struct App {
     /// Matches `reasoningEffort: string | null` in the web UI.
     pub reasoning_effort: Option<String>,
     // profile info
-    pub profiles: Vec<ProfileInfo>,
-    pub active_profile_id: Option<String>,
-    pub session_profiles: HashMap<String, String>,
-    pub profile_cursor: usize,
-    pub profile_filter: String,
+    pub(crate) profiles: ProfilesState,
 
     // model info
     pub current_model: Option<String>,
@@ -835,11 +832,7 @@ impl App {
             elicitation_ui: None,
             show_thinking: true,
             reasoning_effort: None,
-            profiles: Vec::new(),
-            active_profile_id: None,
-            session_profiles: HashMap::new(),
-            profile_cursor: 0,
-            profile_filter: String::new(),
+            profiles: ProfilesState::new(),
             current_model: None,
             current_provider: None,
             current_model_node_id: None,
@@ -1023,118 +1016,27 @@ impl App {
         self.auth.reset_for_open();
     }
 
-    pub fn profile_by_id(&self, profile_id: &str) -> Option<&ProfileInfo> {
-        self.profiles
-            .iter()
-            .find(|profile| profile.id == profile_id)
-    }
-
-    pub fn active_profile(&self) -> Option<&ProfileInfo> {
-        self.active_profile_id
-            .as_deref()
-            .and_then(|profile_id| self.profile_by_id(profile_id))
-    }
-
     pub fn current_session_profile_id(&self) -> Option<&str> {
         self.session_id
             .as_deref()
-            .and_then(|session_id| self.session_profiles.get(session_id).map(String::as_str))
-    }
-
-    pub fn current_session_profile(&self) -> Option<&ProfileInfo> {
-        self.current_session_profile_id()
-            .and_then(|profile_id| self.profile_by_id(profile_id))
-    }
-
-    pub fn profile_display_name(&self, profile_id: &str) -> String {
-        self.profile_by_id(profile_id)
-            .map(|profile| profile.name.clone())
-            .unwrap_or_else(|| profile_id.to_string())
-    }
-
-    fn profile_label_or(
-        &self,
-        profile_id: Option<&str>,
-        fallback: impl FnOnce() -> String,
-    ) -> String {
-        profile_id
-            .map(|profile_id| self.profile_display_name(profile_id))
-            .unwrap_or_else(fallback)
-    }
-
-    pub fn active_profile_label(&self) -> String {
-        self.profile_label_or(self.active_profile_id.as_deref(), || "default".to_string())
+            .and_then(|session_id| self.profiles.session_profile_id(session_id))
     }
 
     pub fn current_profile_label(&self) -> String {
-        self.profile_label_or(self.current_session_profile_id(), || {
-            if self.current_session_is_remote() {
-                "remote".to_string()
-            } else {
-                self.active_profile_label()
-            }
-        })
-    }
-
-    pub fn filtered_profiles(&self) -> Vec<&ProfileInfo> {
-        if self.profile_filter.is_empty() {
-            self.profiles.iter().collect()
-        } else {
-            let matcher = SkimMatcherV2::default();
-            let mut scored: Vec<(i64, &ProfileInfo)> = self
-                .profiles
-                .iter()
-                .filter_map(|profile| {
-                    let score = [
-                        matcher.fuzzy_match(&profile.name, &self.profile_filter),
-                        matcher.fuzzy_match(&profile.id, &self.profile_filter),
-                        profile.description.as_deref().and_then(|description| {
-                            matcher.fuzzy_match(description, &self.profile_filter)
-                        }),
-                    ]
-                    .into_iter()
-                    .flatten()
-                    .max();
-                    score.map(|s| (s, profile))
-                })
-                .collect();
-            scored.sort_by_key(|item| std::cmp::Reverse(item.0));
-            scored.into_iter().map(|(_, profile)| profile).collect()
-        }
-    }
-
-    pub fn move_profile_cursor(&mut self, delta: isize) {
-        self.profile_cursor =
-            move_wrapping_cursor(self.profile_cursor, self.filtered_profiles().len(), delta);
-    }
-
-    pub fn selected_profile(&self) -> Option<&ProfileInfo> {
-        self.filtered_profiles().get(self.profile_cursor).copied()
+        self.current_session_profile_id()
+            .map(|profile_id| self.profiles.profile_display_name(profile_id))
+            .unwrap_or_else(|| {
+                if self.current_session_is_remote() {
+                    "remote".to_string()
+                } else {
+                    self.profiles.active_profile_label()
+                }
+            })
     }
 
     pub fn open_profile_popup(&mut self) {
         self.popup = Popup::ProfileSelect;
-        self.profile_filter.clear();
-        self.profile_cursor = self
-            .active_profile_id
-            .as_deref()
-            .and_then(|active_id| {
-                self.profiles
-                    .iter()
-                    .position(|profile| profile.id == active_id)
-            })
-            .unwrap_or(0);
-    }
-
-    pub fn find_profile_id(&self, query: &str) -> Option<String> {
-        let needle = query.trim();
-        if needle.is_empty() {
-            return None;
-        }
-        self.profiles
-            .iter()
-            .find(|profile| profile.id == needle || profile.name.eq_ignore_ascii_case(needle))
-            .map(|profile| profile.id.clone())
+        self.profiles.reset_for_open();
     }
 
     pub fn filtered_models(&self) -> Vec<&ModelEntry> {
@@ -1848,7 +1750,7 @@ impl App {
 
     pub fn delegate_preference_profile_id(&self) -> Option<&str> {
         self.current_session_profile_id()
-            .or(self.active_profile_id.as_deref())
+            .or(self.profiles.active_profile_id.as_deref())
     }
 
     pub fn desired_agents_profile_id(&self) -> Option<&str> {
@@ -4506,7 +4408,7 @@ mod delegate_model_preference_tests {
             make_model("openai", "gpt-4o"),
             make_model("anthropic", "claude-sonnet"),
         ];
-        app.active_profile_id = Some("profile".into());
+        app.profiles.active_profile_id = Some("profile".into());
         app.set_delegate_model_preference("profile", "coder", &app.models[1].clone());
         let cursor = app.delegate_model_cursor("coder");
         // Should point to the second item (index 1 in models, but popup items

--- a/src/config.rs
+++ b/src/config.rs
@@ -157,8 +157,8 @@ impl TuiConfig {
         merged.theme = Some(crate::theme::Theme::current_id().to_string());
         merged.show_thinking = Some(app.show_thinking);
         merged.profile_delegate_models = app.delegate_model_preferences.clone();
-        merged.profile.id = app.active_profile_id.clone();
-        if let Some(profile_id) = app.active_profile_id.as_deref()
+        merged.profile.id = app.profiles.active_profile_id.clone();
+        if let Some(profile_id) = app.profiles.active_profile_id.as_deref()
             && let Some(preferences) = app.delegate_model_preferences.get(profile_id)
         {
             merged
@@ -394,7 +394,7 @@ mod tests {
             family: None,
             quant: None,
         };
-        app.active_profile_id = Some("quorum".into());
+        app.profiles.active_profile_id = Some("quorum".into());
         app.set_delegate_model_preference("quorum", "coder", &coder);
         app.set_delegate_model_preference("quorum", "planner", &planner);
 
@@ -411,6 +411,34 @@ mod tests {
             loaded.profile_delegate_models["quorum"]["planner"].model_id,
             "openai/gpt-4o"
         );
+    }
+
+    #[test]
+    fn with_app_settings_persists_only_active_profile_state() {
+        let mut app = App::new();
+        app.profiles.active_profile_id = Some("fast".into());
+        app.profiles
+            .profiles
+            .push(crate::domain::profile::ProfileInfo {
+                id: "fast".into(),
+                name: "Fast".into(),
+                ..Default::default()
+            });
+        app.profiles
+            .bind_session_profile("session".into(), "fast".into());
+        app.profiles.profile_cursor = 7;
+        app.profiles.profile_filter = "query".into();
+
+        let merged = TuiConfig::default().with_app_settings(&app);
+        let text = toml::to_string_pretty(&merged).unwrap();
+
+        assert_eq!(merged.profile.id.as_deref(), Some("fast"));
+        assert!(text.contains("[profile]"));
+        assert!(text.contains("id = \"fast\""));
+        assert!(!text.contains("session"));
+        assert!(!text.contains("query"));
+        assert!(!text.contains("profile_cursor"));
+        assert!(!text.contains("profile_filter"));
     }
 
     #[test]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1481,22 +1481,26 @@ pub(crate) fn handle_profile_popup_key(
         KeyCode::Esc => {
             app.popup = Popup::None;
         }
-        KeyCode::Up => app.move_profile_cursor(-1),
-        KeyCode::Down => app.move_profile_cursor(1),
+        KeyCode::Up => app.profiles.move_profile_cursor(-1),
+        KeyCode::Down => app.profiles.move_profile_cursor(1),
         KeyCode::Backspace => {
-            app.profile_filter.pop();
-            app.profile_cursor = 0;
+            app.profiles.profile_filter.pop();
+            app.profiles.profile_cursor = 0;
         }
         KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
-            app.profile_filter.push(c);
-            app.profile_cursor = 0;
+            app.profiles.profile_filter.push(c);
+            app.profiles.profile_cursor = 0;
         }
         KeyCode::Enter => {
             if !can_send_server_commands(app) {
                 return Ok(());
             }
-            if let Some(profile_id) = app.selected_profile().map(|profile| profile.id.clone()) {
-                app.active_profile_id = Some(profile_id.clone());
+            if let Some(profile_id) = app
+                .profiles
+                .selected_profile()
+                .map(|profile| profile.id.clone())
+            {
+                app.profiles.active_profile_id = Some(profile_id.clone());
                 if app.current_session_profile_id().is_none() {
                     app.agents.clear();
                     app.agents_profile_id = None;
@@ -1576,7 +1580,7 @@ pub(crate) fn handle_new_session_popup_key(
             app.popup = Popup::None;
             cmd_tx.send(Command::NewSession {
                 cwd,
-                profile_id: app.active_profile_id.clone(),
+                profile_id: app.profiles.active_profile_id.clone(),
             })?;
         }
         _ => {}
@@ -1992,8 +1996,8 @@ fn try_execute_slash_command(
             if arg.is_empty() {
                 app.open_profile_popup();
                 cmd_tx.send(Command::ListProfiles)?;
-            } else if let Some(profile_id) = app.find_profile_id(&arg) {
-                app.active_profile_id = Some(profile_id.clone());
+            } else if let Some(profile_id) = app.profiles.find_profile_id(&arg) {
+                app.profiles.active_profile_id = Some(profile_id.clone());
                 if app.current_session_profile_id().is_none() {
                     app.agents.clear();
                     app.agents_profile_id = None;
@@ -3059,11 +3063,17 @@ mod model_popup_tests {
         app.conn = app::ConnState::Connected;
         app.popup = Popup::CommandPalette;
         app.command_palette_filter = "profile".into();
+        app.profiles.profiles = vec![make_profile("fast", "Fast"), make_profile("deep", "Deep")];
+        app.profiles.active_profile_id = Some("deep".into());
+        app.profiles.profile_filter = "stale".into();
+        app.profiles.profile_cursor = 0;
 
         let (tx, mut rx) = mpsc::unbounded_channel();
         handle_command_palette_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
 
         assert!(matches!(app.popup, Popup::ProfileSelect));
+        assert!(app.profiles.profile_filter.is_empty());
+        assert_eq!(app.profiles.profile_cursor, 1);
         assert!(matches!(rx.try_recv(), Ok(Command::ListProfiles)));
     }
 
@@ -3089,8 +3099,8 @@ mod model_popup_tests {
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
         app.screen = Screen::Chat;
-        app.profiles = vec![make_profile("fast", "Fast")];
-        app.active_profile_id = Some("old".into());
+        app.profiles.profiles = vec![make_profile("fast", "Fast")];
+        app.profiles.active_profile_id = Some("old".into());
         app.input = "/profile Fast".into();
         app.input_cursor = app.input.len();
 
@@ -3101,7 +3111,11 @@ mod model_popup_tests {
             rx.try_recv(),
             Ok(Command::ListProfileAgents { profile_id }) if profile_id == "fast"
         ));
-        assert_eq!(app.active_profile_id.as_deref(), Some("fast"));
+        assert!(rx.try_recv().is_err());
+        assert_eq!(app.profiles.active_profile_id.as_deref(), Some("fast"));
+        assert_eq!(app.current_session_profile_id(), None);
+        let saved = crate::config::TuiConfig::load();
+        assert_eq!(saved.profile.id.as_deref(), Some("fast"));
     }
 
     #[test]
@@ -3110,8 +3124,8 @@ mod model_popup_tests {
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
         app.popup = Popup::ProfileSelect;
-        app.profiles = vec![make_profile("fast", "Fast"), make_profile("deep", "Deep")];
-        app.profile_cursor = 1;
+        app.profiles.profiles = vec![make_profile("fast", "Fast"), make_profile("deep", "Deep")];
+        app.profiles.profile_cursor = 1;
 
         let (tx, mut rx) = mpsc::unbounded_channel();
         handle_profile_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
@@ -3121,7 +3135,29 @@ mod model_popup_tests {
             rx.try_recv(),
             Ok(Command::ListProfileAgents { profile_id }) if profile_id == "deep"
         ));
-        assert_eq!(app.active_profile_id.as_deref(), Some("deep"));
+        assert!(rx.try_recv().is_err());
+        assert_eq!(app.profiles.active_profile_id.as_deref(), Some("deep"));
+        let saved = crate::config::TuiConfig::load();
+        assert_eq!(saved.profile.id.as_deref(), Some("deep"));
+    }
+
+    #[test]
+    fn profile_selection_with_bound_session_skips_agent_refresh() {
+        let _guard = TestPersistenceGuard::new("profile-bound-session");
+        let mut app = App::new();
+        app.conn = app::ConnState::Connected;
+        app.popup = Popup::ProfileSelect;
+        app.session_id = Some("session".into());
+        app.profiles
+            .bind_session_profile("session".into(), "current".into());
+        app.profiles.profiles = vec![make_profile("fast", "Fast")];
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        handle_profile_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+
+        assert!(rx.try_recv().is_err());
+        assert_eq!(app.profiles.active_profile_id.as_deref(), Some("fast"));
+        assert_eq!(app.current_session_profile_id(), Some("current"));
     }
 
     #[test]
@@ -3131,7 +3167,7 @@ mod model_popup_tests {
         app.popup = Popup::NewSession;
         app.new_session_path = "/repo".into();
         app.new_session_cursor = app.new_session_path.len();
-        app.active_profile_id = Some("coder-delegate".into());
+        app.profiles.active_profile_id = Some("coder-delegate".into());
 
         let (tx, mut rx) = mpsc::unbounded_channel();
         handle_new_session_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
@@ -3149,8 +3185,9 @@ mod model_popup_tests {
         let mut app = App::new();
         app.popup = Popup::ModelSelect;
         app.session_id = Some("s1".into());
-        app.active_profile_id = Some("profile".into());
-        app.session_profiles.insert("s1".into(), "profile".into());
+        app.profiles.active_profile_id = Some("profile".into());
+        app.profiles
+            .bind_session_profile("s1".into(), "profile".into());
         app.agent_mode = "plan".into();
         app.current_provider = Some("openai".into());
         app.current_model = Some("gpt-4o".into());
@@ -3200,8 +3237,9 @@ mod model_popup_tests {
         let mut app = App::new();
         app.popup = Popup::ModelSelect;
         app.session_id = Some("s1".into());
-        app.active_profile_id = Some("profile".into());
-        app.session_profiles.insert("s1".into(), "profile".into());
+        app.profiles.active_profile_id = Some("profile".into());
+        app.profiles
+            .bind_session_profile("s1".into(), "profile".into());
         app.agents = vec![
             make_agent("primary", "Session"),
             make_agent("coder", "Coder"),
@@ -3235,9 +3273,9 @@ mod model_popup_tests {
         app.popup = Popup::ModelSelect;
         app.session_id = Some("child".into());
         app.parent_session_id = Some("parent".into());
-        app.active_profile_id = Some("profile".into());
-        app.session_profiles
-            .insert("child".into(), "profile".into());
+        app.profiles.active_profile_id = Some("profile".into());
+        app.profiles
+            .bind_session_profile("child".into(), "profile".into());
         app.agents = vec![
             make_agent("primary", "Session"),
             make_agent("coder", "Coder"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod highlight;
 mod input;
 mod markdown;
 mod mesh;
+mod profiles_state;
 mod protocol;
 pub mod runtime;
 mod server_manager;

--- a/src/profiles_state.rs
+++ b/src/profiles_state.rs
@@ -1,0 +1,420 @@
+use std::collections::HashMap;
+
+use fuzzy_matcher::FuzzyMatcher;
+use fuzzy_matcher::skim::SkimMatcherV2;
+
+use crate::domain::profile::ProfileInfo;
+
+pub(crate) struct ProfilesState {
+    pub(crate) profiles: Vec<ProfileInfo>,
+    pub(crate) active_profile_id: Option<String>,
+    pub(crate) session_profiles: HashMap<String, String>,
+    pub(crate) profile_cursor: usize,
+    pub(crate) profile_filter: String,
+}
+
+impl ProfilesState {
+    pub(crate) fn new() -> Self {
+        Self {
+            profiles: Vec::new(),
+            active_profile_id: None,
+            session_profiles: HashMap::new(),
+            profile_cursor: 0,
+            profile_filter: String::new(),
+        }
+    }
+
+    pub(crate) fn profile_by_id(&self, profile_id: &str) -> Option<&ProfileInfo> {
+        self.profiles
+            .iter()
+            .find(|profile| profile.id == profile_id)
+    }
+
+    pub(crate) fn active_profile(&self) -> Option<&ProfileInfo> {
+        self.active_profile_id
+            .as_deref()
+            .and_then(|profile_id| self.profile_by_id(profile_id))
+    }
+
+    pub(crate) fn profile_display_name(&self, profile_id: &str) -> String {
+        self.profile_by_id(profile_id)
+            .map(|profile| profile.name.clone())
+            .unwrap_or_else(|| profile_id.to_string())
+    }
+
+    fn profile_label_or(
+        &self,
+        profile_id: Option<&str>,
+        fallback: impl FnOnce() -> String,
+    ) -> String {
+        profile_id
+            .map(|profile_id| self.profile_display_name(profile_id))
+            .unwrap_or_else(fallback)
+    }
+
+    pub(crate) fn active_profile_label(&self) -> String {
+        self.profile_label_or(self.active_profile_id.as_deref(), || "default".to_string())
+    }
+
+    pub(crate) fn filtered_profiles(&self) -> Vec<&ProfileInfo> {
+        if self.profile_filter.is_empty() {
+            self.profiles.iter().collect()
+        } else {
+            let matcher = SkimMatcherV2::default();
+            let mut scored: Vec<(i64, &ProfileInfo)> = self
+                .profiles
+                .iter()
+                .filter_map(|profile| {
+                    let score = [
+                        matcher.fuzzy_match(&profile.name, &self.profile_filter),
+                        matcher.fuzzy_match(&profile.id, &self.profile_filter),
+                        profile.description.as_deref().and_then(|description| {
+                            matcher.fuzzy_match(description, &self.profile_filter)
+                        }),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .max();
+                    score.map(|score| (score, profile))
+                })
+                .collect();
+            scored.sort_by_key(|item| std::cmp::Reverse(item.0));
+            scored.into_iter().map(|(_, profile)| profile).collect()
+        }
+    }
+
+    pub(crate) fn move_profile_cursor(&mut self, delta: isize) {
+        let len = self.filtered_profiles().len();
+        self.profile_cursor = if len == 0 {
+            0
+        } else {
+            (self.profile_cursor as isize + delta).rem_euclid(len as isize) as usize
+        };
+    }
+
+    pub(crate) fn selected_profile(&self) -> Option<&ProfileInfo> {
+        self.filtered_profiles().get(self.profile_cursor).copied()
+    }
+
+    pub(crate) fn reset_for_open(&mut self) {
+        self.profile_filter.clear();
+        self.profile_cursor = self
+            .active_profile_id
+            .as_deref()
+            .and_then(|active_id| {
+                self.profiles
+                    .iter()
+                    .position(|profile| profile.id == active_id)
+            })
+            .unwrap_or(0);
+    }
+
+    pub(crate) fn find_profile_id(&self, query: &str) -> Option<String> {
+        let needle = query.trim();
+        if needle.is_empty() {
+            return None;
+        }
+        self.profiles
+            .iter()
+            .find(|profile| profile.id == needle || profile.name.eq_ignore_ascii_case(needle))
+            .map(|profile| profile.id.clone())
+    }
+
+    pub(crate) fn session_profile_id(&self, session_id: &str) -> Option<&str> {
+        self.session_profiles.get(session_id).map(String::as_str)
+    }
+
+    pub(crate) fn session_profile(&self, session_id: &str) -> Option<&ProfileInfo> {
+        self.session_profile_id(session_id)
+            .and_then(|profile_id| self.profile_by_id(profile_id))
+    }
+
+    pub(crate) fn bind_session_profile(
+        &mut self,
+        session_id: String,
+        profile_id: String,
+    ) -> Option<String> {
+        self.session_profiles.insert(session_id, profile_id)
+    }
+
+    pub(crate) fn remove_session_profile(&mut self, session_id: &str) -> Option<String> {
+        self.session_profiles.remove(session_id)
+    }
+
+    pub(crate) fn apply_catalog(
+        &mut self,
+        profiles: Vec<ProfileInfo>,
+        backend_active_profile_id: Option<String>,
+    ) -> bool {
+        let previous_profile_id = self.active_profile_id.clone();
+        let is_available =
+            |profile_id: &str| profiles.iter().any(|profile| profile.id == profile_id);
+        let selected = self
+            .active_profile_id
+            .take()
+            .filter(|profile_id| is_available(profile_id));
+        let backend_default =
+            backend_active_profile_id.filter(|profile_id| is_available(profile_id));
+        self.active_profile_id = selected
+            .or(backend_default)
+            .or_else(|| profiles.first().map(|profile| profile.id.clone()));
+        self.profiles = profiles;
+        if self.profile_cursor >= self.profiles.len() {
+            self.profile_cursor = self.profiles.len().saturating_sub(1);
+        }
+        self.active_profile_id != previous_profile_id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn profile(id: &str, name: &str, description: Option<&str>) -> ProfileInfo {
+        ProfileInfo {
+            id: id.into(),
+            name: name.into(),
+            description: description.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    fn ids(profiles: Vec<&ProfileInfo>) -> Vec<&str> {
+        profiles
+            .into_iter()
+            .map(|profile| profile.id.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn constructor_uses_exact_defaults() {
+        let state = ProfilesState::new();
+
+        assert!(state.profiles.is_empty());
+        assert!(state.active_profile_id.is_none());
+        assert!(state.session_profiles.is_empty());
+        assert_eq!(state.profile_cursor, 0);
+        assert!(state.profile_filter.is_empty());
+    }
+
+    #[test]
+    fn lookup_active_profile_and_labels_preserve_unknown_ids() {
+        let mut state = ProfilesState::new();
+        state.profiles = vec![profile("fast", "Fast", None)];
+        state.active_profile_id = Some("fast".into());
+
+        assert_eq!(
+            state.profile_by_id("fast").map(|p| p.name.as_str()),
+            Some("Fast")
+        );
+        assert!(state.profile_by_id("FAST").is_none());
+        assert_eq!(state.active_profile().map(|p| p.id.as_str()), Some("fast"));
+        assert_eq!(state.profile_display_name("fast"), "Fast");
+        assert_eq!(state.profile_display_name("missing"), "missing");
+        assert_eq!(state.active_profile_label(), "Fast");
+
+        state.active_profile_id = Some("missing".into());
+        assert!(state.active_profile().is_none());
+        assert_eq!(state.active_profile_label(), "missing");
+        state.active_profile_id = None;
+        assert_eq!(state.active_profile_label(), "default");
+    }
+
+    #[test]
+    fn filtering_matches_name_id_and_description() {
+        let mut state = ProfilesState::new();
+        state.profiles = vec![
+            profile("fast-id", "Quick", Some("low latency")),
+            profile("deep-id", "Reasoner", Some("thorough analysis")),
+        ];
+
+        state.profile_filter = "Quick".into();
+        assert_eq!(ids(state.filtered_profiles()), vec!["fast-id"]);
+        state.profile_filter = "deep-id".into();
+        assert_eq!(ids(state.filtered_profiles()), vec!["deep-id"]);
+        state.profile_filter = "latency".into();
+        assert_eq!(ids(state.filtered_profiles()), vec!["fast-id"]);
+    }
+
+    #[test]
+    fn filtering_uses_max_score_descending_with_stable_ties() {
+        let mut state = ProfilesState::new();
+        state.profiles = vec![
+            profile("first", "Common", Some("shared")),
+            profile("second", "Common", Some("shared")),
+            profile("common", "Other", None),
+        ];
+        state.profile_filter = "common".into();
+
+        assert_eq!(
+            ids(state.filtered_profiles()),
+            vec!["common", "first", "second"]
+        );
+    }
+
+    #[test]
+    fn filtering_excludes_profile_metadata_and_preserves_catalog_order_when_empty() {
+        let mut state = ProfilesState::new();
+        let mut first = profile("first", "One", None);
+        first.tags = vec!["metadata-query".into()];
+        first.source = Some("metadata-query".into());
+        first.config_kind = Some("metadata-query".into());
+        first.fingerprint = Some("metadata-query".into());
+        state.profiles = vec![first, profile("second", "Two", None)];
+
+        assert_eq!(ids(state.filtered_profiles()), vec!["first", "second"]);
+        state.profile_filter = "metadata-query".into();
+        assert!(state.filtered_profiles().is_empty());
+    }
+
+    #[test]
+    fn cursor_wraps_selects_filtered_rows_and_resets_when_empty() {
+        let mut state = ProfilesState::new();
+        state.profiles = vec![
+            profile("one", "One", None),
+            profile("two", "Two", None),
+            profile("three", "Three", None),
+        ];
+
+        state.move_profile_cursor(-1);
+        assert_eq!(state.profile_cursor, 2);
+        assert_eq!(
+            state.selected_profile().map(|p| p.id.as_str()),
+            Some("three")
+        );
+        state.move_profile_cursor(1);
+        assert_eq!(state.profile_cursor, 0);
+
+        state.profile_filter = "Two".into();
+        assert_eq!(state.selected_profile().map(|p| p.id.as_str()), Some("two"));
+        state.profile_filter = "missing".into();
+        state.profile_cursor = 9;
+        state.move_profile_cursor(1);
+        assert_eq!(state.profile_cursor, 0);
+        assert!(state.selected_profile().is_none());
+    }
+
+    #[test]
+    fn reset_for_open_clears_filter_and_uses_raw_active_position() {
+        let mut state = ProfilesState::new();
+        state.profiles = vec![
+            profile("one", "One", None),
+            profile("two", "Two", None),
+            profile("three", "Three", None),
+        ];
+        state.active_profile_id = Some("three".into());
+        state.profile_filter = "One".into();
+        state.profile_cursor = 7;
+
+        state.reset_for_open();
+
+        assert!(state.profile_filter.is_empty());
+        assert_eq!(state.profile_cursor, 2);
+
+        state.active_profile_id = Some("missing".into());
+        state.profile_filter = "again".into();
+        state.reset_for_open();
+        assert!(state.profile_filter.is_empty());
+        assert_eq!(state.profile_cursor, 0);
+    }
+
+    #[test]
+    fn catalog_selection_precedence_and_change_result_are_exact() {
+        let mut state = ProfilesState::new();
+        state.active_profile_id = Some("deep".into());
+
+        assert!(!state.apply_catalog(
+            vec![profile("fast", "Fast", None), profile("deep", "Deep", None)],
+            Some("fast".into()),
+        ));
+        assert_eq!(state.active_profile_id.as_deref(), Some("deep"));
+
+        state.active_profile_id = Some("removed".into());
+        assert!(state.apply_catalog(
+            vec![profile("fast", "Fast", None), profile("deep", "Deep", None)],
+            Some("deep".into()),
+        ));
+        assert_eq!(state.active_profile_id.as_deref(), Some("deep"));
+
+        state.active_profile_id = Some("removed-again".into());
+        assert!(state.apply_catalog(
+            vec![profile("fast", "Fast", None), profile("deep", "Deep", None)],
+            Some("missing".into()),
+        ));
+        assert_eq!(state.active_profile_id.as_deref(), Some("fast"));
+    }
+
+    #[test]
+    fn catalog_empty_clamps_cursor_and_preserves_filter_and_session_map() {
+        let mut state = ProfilesState::new();
+        state.profiles = vec![profile("old", "Old", None)];
+        state.active_profile_id = Some("old".into());
+        state.profile_cursor = 4;
+        state.profile_filter = "keep".into();
+        state.bind_session_profile("session".into(), "old".into());
+
+        assert!(state.apply_catalog(Vec::new(), None));
+
+        assert!(state.profiles.is_empty());
+        assert!(state.active_profile_id.is_none());
+        assert_eq!(state.profile_cursor, 0);
+        assert_eq!(state.profile_filter, "keep");
+        assert_eq!(state.session_profile_id("session"), Some("old"));
+    }
+
+    #[test]
+    fn catalog_clamps_cursor_to_last_entry_without_other_normalization() {
+        let mut state = ProfilesState::new();
+        state.profile_cursor = 8;
+
+        state.apply_catalog(
+            vec![profile("one", "One", None), profile("two", "Two", None)],
+            None,
+        );
+
+        assert_eq!(state.profile_cursor, 1);
+        assert_eq!(state.active_profile_id.as_deref(), Some("one"));
+    }
+
+    #[test]
+    fn find_profile_id_trims_and_uses_exact_id_or_ascii_insensitive_name() {
+        let mut state = ProfilesState::new();
+        state.profiles = vec![
+            profile("UPPER", "Duplicate", None),
+            profile("lower", "duplicate", None),
+            profile("exact", "Other", None),
+        ];
+
+        assert_eq!(state.find_profile_id("  exact  ").as_deref(), Some("exact"));
+        assert_eq!(state.find_profile_id("duplicate").as_deref(), Some("UPPER"));
+        assert!(state.find_profile_id("upper").is_none());
+        assert!(state.find_profile_id("   ").is_none());
+    }
+
+    #[test]
+    fn session_map_insert_overwrite_lookup_profile_and_remove() {
+        let mut state = ProfilesState::new();
+        state.profiles = vec![profile("fast", "Fast", None), profile("deep", "Deep", None)];
+
+        assert!(
+            state
+                .bind_session_profile("session".into(), "fast".into())
+                .is_none()
+        );
+        assert_eq!(state.session_profile_id("session"), Some("fast"));
+        assert_eq!(
+            state
+                .session_profile("session")
+                .map(|profile| profile.name.as_str()),
+            Some("Fast")
+        );
+        assert_eq!(
+            state.bind_session_profile("session".into(), "deep".into()),
+            Some("fast".into())
+        );
+        assert_eq!(state.session_profile_id("session"), Some("deep"));
+        assert_eq!(state.remove_session_profile("session"), Some("deep".into()));
+        assert!(state.session_profile_id("session").is_none());
+        assert!(state.remove_session_profile("missing").is_none());
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1479,7 +1479,7 @@ pub async fn run() -> anyhow::Result<()> {
 
     let mut app = App::new();
     app.launch_cwd = detect_launch_cwd();
-    app.active_profile_id = cfg.profile.id.clone();
+    app.profiles.active_profile_id = cfg.profile.id.clone();
     app.show_thinking = cfg.show_thinking.unwrap_or(true);
     app.delegate_model_preferences = cfg.profile_delegate_models.clone();
     if let Some(profile_id) = cfg.profile.id.as_deref() {

--- a/src/session.rs
+++ b/src/session.rs
@@ -158,10 +158,10 @@ impl App {
 
     pub fn apply_session_profile_binding(&mut self, session_id: &str, profile_id: Option<String>) {
         if let Some(profile_id) = profile_id {
-            self.session_profiles
-                .insert(session_id.to_string(), profile_id);
+            self.profiles
+                .bind_session_profile(session_id.to_string(), profile_id);
         } else if self.is_remote_session_id(session_id) {
-            self.session_profiles.remove(session_id);
+            self.profiles.remove_session_profile(session_id);
         }
     }
 
@@ -759,6 +759,62 @@ mod tests {
             app.session_remote_cwd("remote-1"),
             Some("/remote/repo".into())
         );
+    }
+
+    #[test]
+    fn current_profile_label_uses_binding_active_fallback_and_remote_fallback() {
+        let mut app = App::new();
+        app.profiles.profiles = vec![crate::domain::profile::ProfileInfo {
+            id: "fast".into(),
+            name: "Fast".into(),
+            ..Default::default()
+        }];
+        app.profiles.active_profile_id = Some("fast".into());
+        app.session_id = Some("local".into());
+
+        assert_eq!(app.current_profile_label(), "Fast");
+
+        app.profiles
+            .bind_session_profile("local".into(), "unknown".into());
+        assert_eq!(app.current_profile_label(), "unknown");
+
+        app.session_id = Some("remote".into());
+        app.remember_remote_session_node("remote", "node-1");
+        assert_eq!(app.current_profile_label(), "remote");
+    }
+
+    #[test]
+    fn profile_binding_some_inserts_and_overwrites() {
+        let mut app = App::new();
+
+        app.apply_session_profile_binding("session", Some("fast".into()));
+        assert_eq!(app.profiles.session_profile_id("session"), Some("fast"));
+
+        app.apply_session_profile_binding("session", Some("deep".into()));
+        assert_eq!(app.profiles.session_profile_id("session"), Some("deep"));
+    }
+
+    #[test]
+    fn missing_local_profile_preserves_existing_binding() {
+        let mut app = App::new();
+        app.profiles
+            .bind_session_profile("local".into(), "fast".into());
+
+        app.apply_session_profile_binding("local", None);
+
+        assert_eq!(app.profiles.session_profile_id("local"), Some("fast"));
+    }
+
+    #[test]
+    fn missing_remote_profile_removes_existing_binding() {
+        let mut app = App::new();
+        app.remember_remote_session_node("remote", "node-1");
+        app.profiles
+            .bind_session_profile("remote".into(), "fast".into());
+
+        app.apply_session_profile_binding("remote", None);
+
+        assert!(app.profiles.session_profile_id("remote").is_none());
     }
 
     #[test]

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -816,7 +816,7 @@ fn build_chat_header_spans(app: &App) -> (Vec<Span<'static>>, Vec<Span<'static>>
         left_spans.push(Span::styled(" \u{2b11} child ", Theme::status_accent()));
     }
     let profile_label = app.current_profile_label();
-    let active_profile_id = app.active_profile_id.as_deref();
+    let active_profile_id = app.profiles.active_profile_id.as_deref();
     let current_profile_id = app.current_session_profile_id();
     let profile_text = if current_profile_id.is_some()
         && active_profile_id.is_some()
@@ -825,7 +825,7 @@ fn build_chat_header_spans(app: &App) -> (Vec<Span<'static>>, Vec<Span<'static>>
         format!(
             " profile:{} (new:{}) ",
             profile_label,
-            app.active_profile_label()
+            app.profiles.active_profile_label()
         )
     } else {
         format!(" profile:{} ", profile_label)
@@ -2014,5 +2014,42 @@ fn draw_messages(f: &mut Frame, app: &mut App, area: Rect) {
         }
 
         y += card_h as i32;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn buffer_text(buffer: &ratatui::buffer::Buffer) -> String {
+        buffer.content().iter().map(|cell| cell.symbol()).collect()
+    }
+
+    #[test]
+    fn chat_header_shows_current_and_distinct_new_profile_labels() {
+        let mut app = App::new();
+        app.session_id = Some("session-1".into());
+        app.agent_id = Some("agent-1".into());
+        app.profiles.profiles = vec![
+            crate::domain::profile::ProfileInfo {
+                id: "current".into(),
+                name: "Current".into(),
+                ..Default::default()
+            },
+            crate::domain::profile::ProfileInfo {
+                id: "next".into(),
+                name: "Next".into(),
+                ..Default::default()
+            },
+        ];
+        app.profiles.active_profile_id = Some("next".into());
+        app.profiles
+            .bind_session_profile("session-1".into(), "current".into());
+        let backend = ratatui::backend::TestBackend::new(100, 12);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+
+        terminal.draw(|frame| draw_chat(frame, &mut app)).unwrap();
+
+        assert!(buffer_text(terminal.backend().buffer()).contains("profile:Current (new:Next)"));
     }
 }

--- a/src/ui/popups.rs
+++ b/src/ui/popups.rs
@@ -963,7 +963,7 @@ pub(crate) fn profile_source_symbol(profile: &ProfileInfo) -> &'static str {
 }
 
 pub(crate) fn profile_empty_text(app: &App) -> &'static str {
-    if app.profiles.is_empty() {
+    if app.profiles.profiles.is_empty() {
         "No profiles available"
     } else {
         "No profiles match filter"
@@ -1113,8 +1113,11 @@ pub(super) fn draw_profile_popup(f: &mut Frame, app: &App) {
         chunks[0],
     );
     let avail = chunks[1].width.saturating_sub(2) as usize;
-    let (filter_display, filter_cur) =
-        scroll_input(&app.profile_filter, app.profile_filter.len(), avail);
+    let (filter_display, filter_cur) = scroll_input(
+        &app.profiles.profile_filter,
+        app.profiles.profile_filter.len(),
+        avail,
+    );
     let input_line = Line::from(vec![
         Span::styled("> ", Theme::popup_title()),
         Span::styled(filter_display, Theme::popup_bg()),
@@ -1125,9 +1128,9 @@ pub(super) fn draw_profile_popup(f: &mut Frame, app: &App) {
     );
     f.set_cursor_position((chunks[1].x + 2 + filter_cur as u16, chunks[1].y));
 
-    let active_id = app.active_profile_id.as_deref();
+    let active_id = app.profiles.active_profile_id.as_deref();
     let current_session_id = app.current_session_profile_id();
-    let profiles = app.filtered_profiles();
+    let profiles = app.profiles.filtered_profiles();
     let has_matches = !profiles.is_empty();
     let row_data: Vec<(String, String, String, String)> = profiles
         .into_iter()
@@ -1209,7 +1212,7 @@ pub(super) fn draw_profile_popup(f: &mut Frame, app: &App) {
     .block(Block::default().style(Theme::popup_bg()))
     .style(Theme::popup_bg())
     .row_highlight_style(Theme::selected());
-    let selected = has_matches.then_some(app.profile_cursor);
+    let selected = has_matches.then_some(app.profiles.profile_cursor);
     let mut state = TableState::default().with_selected(selected);
     f.render_stateful_widget(table, chunks[2], &mut state);
 
@@ -3011,6 +3014,77 @@ mod tests {
         }
     }
 
+    fn buffer_line(buffer: &ratatui::buffer::Buffer, y: u16) -> String {
+        (0..buffer.area.width)
+            .map(|x| buffer[(x, y)].symbol())
+            .collect()
+    }
+
+    fn find_buffer_text(buffer: &ratatui::buffer::Buffer, needle: &str) -> Option<(u16, u16)> {
+        for y in 0..buffer.area.height {
+            let line = buffer_line(buffer, y);
+            if let Some(byte_idx) = line.find(needle) {
+                return Some((line[..byte_idx].chars().count() as u16, y));
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn profile_popup_marks_active_before_current_and_highlights_filtered_row() {
+        let mut app = App::new();
+        app.profiles.profiles = vec![
+            ProfileInfo {
+                id: "active".into(),
+                name: "Active".into(),
+                description: Some("selected".into()),
+                ..Default::default()
+            },
+            profile("other", "Other"),
+        ];
+        app.profiles.active_profile_id = Some("active".into());
+        app.session_id = Some("session".into());
+        app.profiles
+            .bind_session_profile("session".into(), "active".into());
+        app.profiles.profile_filter = "selected".into();
+
+        let backend = ratatui::backend::TestBackend::new(80, 20);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| draw_profile_popup(frame, &app))
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+
+        let active = find_buffer_text(buffer, "Active").expect("active row");
+        let active_line = buffer_line(buffer, active.1);
+        assert!(active_line.contains('*'));
+        assert!(!active_line.contains('@'));
+        assert_eq!(buffer[active].bg, Theme::selected().bg.unwrap());
+        assert!(find_buffer_text(buffer, "Other").is_none());
+    }
+
+    #[test]
+    fn profile_popup_marks_distinct_current_session_with_at_symbol() {
+        let mut app = App::new();
+        app.profiles.profiles = vec![profile("active", "Active"), profile("current", "Current")];
+        app.profiles.active_profile_id = Some("active".into());
+        app.session_id = Some("session".into());
+        app.profiles
+            .bind_session_profile("session".into(), "current".into());
+
+        let backend = ratatui::backend::TestBackend::new(80, 20);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| draw_profile_popup(frame, &app))
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+
+        let active_y = find_buffer_text(buffer, "Active").unwrap().1;
+        let current_y = find_buffer_text(buffer, "Current").unwrap().1;
+        assert!(buffer_line(buffer, active_y).contains('*'));
+        assert!(buffer_line(buffer, current_y).contains('@'));
+    }
+
     #[test]
     fn profile_source_symbol_maps_known_sources() {
         let mut profile = profile("fast", "Fast");
@@ -3037,9 +3111,11 @@ mod tests {
         let mut app = App::new();
         assert_eq!(profile_empty_text(&app), "No profiles available");
 
-        app.profiles = vec![profile("fast", "Fast")];
-        app.profile_filter = "missing".into();
-        assert!(app.filtered_profiles().is_empty());
+        app.profiles.profiles = vec![profile("fast", "Fast")];
+        app.profiles.profile_filter = "missing".into();
+
+        assert!(app.profiles.filtered_profiles().is_empty());
+
         assert_eq!(profile_empty_text(&app), "No profiles match filter");
     }
 

--- a/src/ui/start.rs
+++ b/src/ui/start.rs
@@ -193,7 +193,7 @@ pub(super) fn draw_start(f: &mut Frame, app: &mut App) {
         app,
         outer[0],
         vec![Span::styled(
-            format!(" profile:{} ", app.active_profile_label()),
+            format!(" profile:{} ", app.profiles.active_profile_label()),
             Theme::status(),
         )],
         right,
@@ -498,4 +498,33 @@ pub(super) fn draw_start(f: &mut Frame, app: &mut App) {
         Paragraph::new(Line::from(text_spans)).alignment(Alignment::Center),
         button_rect,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn start_page_header_uses_active_profile_label() {
+        let mut app = App::new();
+        app.profiles.profiles = vec![crate::domain::profile::ProfileInfo {
+            id: "fast".into(),
+            name: "Fast".into(),
+            ..Default::default()
+        }];
+        app.profiles.active_profile_id = Some("fast".into());
+        let backend = ratatui::backend::TestBackend::new(100, 20);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+
+        terminal.draw(|frame| draw_start(frame, &mut app)).unwrap();
+
+        let text = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(text.contains("profile:Fast"));
+    }
 }


### PR DESCRIPTION
## what changed
- add private `ProfilesState` ownership for the profile catalog, active profile, session bindings, popup cursor, and filter
- move pure lookup, labeling, fuzzy filtering, cursor, session-map, and catalog transitions out of `App`
- retain popup/session/remote/agent/model/command/persistence coordination at existing application boundaries
- migrate startup, persistence, handlers, and profile UI to nested state without compatibility forwards

## behavior preserved
- profile catalog selection precedence, authoritative explicit empty catalogs, placeholder initialization behavior, cursor clamping, and agent command ordering
- local versus remote missing-profile binding asymmetry and active future-session independence
- fuzzy matching/ranking, raw active popup position, marker precedence, chat/start labels, slash/popup selection, and `NewSession` profile payload
- existing `[profile] id` persistence schema; catalog, bindings, cursor, and filter remain transient

## validation
- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --all-targets --all-features`
- `cargo test --all-targets --all-features -- --quiet` (799 passed)
- `git diff --check`
- boundary/allowlist searches: one `ProfilesState` field, zero flat profile accesses, zero old pure `App` methods, zero forbidden owner imports, four existing compatibility tags, exactly 11 source files

## scope
Source-complete Phase 4 slice only. `ProfilesState`, broad Phase 4 acceptance, review/integration, and manual smoke remain pending. No next state group is included.
