### PR TITLE
refactor: extract mesh state

### DIFF
--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -2641,18 +2641,53 @@ mod tests {
     #[test]
     fn native_mesh_nodes_store_state_and_requests_first_node_sessions() {
         let mut app = App::new();
-
-        let replies = app.handle_acp_event(AcpAppEvent::MeshNodes(MeshNodesInfo {
-            nodes: vec![RemoteNodeInfo {
+        app.mesh.mesh_nodes = vec![
+            RemoteNodeInfo {
+                id: "node-0".into(),
+                label: "local".into(),
+                ..Default::default()
+            },
+            RemoteNodeInfo {
                 id: "node-1".into(),
                 label: "framework".into(),
-                active_sessions: 2,
+                ..Default::default()
+            },
+        ];
+        app.mesh.mesh_node_cursor = 1;
+        app.mesh.remote_session_cursor = 4;
+        app.mesh.remote_sessions_by_node.insert(
+            "stale-node".into(),
+            vec![RemoteSessionInfo {
+                id: "stale-session".into(),
+                node_id: "stale-node".into(),
                 ..Default::default()
             }],
+        );
+
+        let replies = app.handle_acp_event(AcpAppEvent::MeshNodes(MeshNodesInfo {
+            nodes: vec![
+                RemoteNodeInfo {
+                    id: "node-0".into(),
+                    label: "local".into(),
+                    ..Default::default()
+                },
+                RemoteNodeInfo {
+                    id: "node-1".into(),
+                    label: "framework".into(),
+                    active_sessions: 2,
+                    ..Default::default()
+                },
+            ],
         }));
 
-        assert_eq!(app.mesh_node_count, Some(1));
-        assert_eq!(app.selected_mesh_node_id(), Some("node-1"));
+        assert_eq!(app.mesh.mesh_node_count, Some(2));
+        assert_eq!(app.mesh.selected_mesh_node_id(), Some("node-1"));
+        assert_eq!(app.mesh.mesh_node_cursor, 1);
+        assert_eq!(app.mesh.remote_session_cursor, 4);
+        assert_eq!(
+            app.mesh.remote_sessions_by_node["stale-node"][0].id,
+            "stale-session"
+        );
         assert!(matches!(
             replies.as_slice(),
             [Command::ListRemoteSessions { node_id, offset: 0, limit: 50 }]
@@ -2661,14 +2696,36 @@ mod tests {
     }
 
     #[test]
+    fn mesh_status_stores_before_appending_diagnostic_log() {
+        let mut app = App::new();
+        let before = app.diagnostics.logs.len();
+
+        app.handle_acp_event(AcpAppEvent::MeshStatus(MeshStatusInfo {
+            enabled: true,
+            known_peer_count: 2,
+            ..Default::default()
+        }));
+
+        assert!(
+            app.mesh
+                .mesh_status
+                .as_ref()
+                .is_some_and(|status| { status.enabled && status.known_peer_count == 2 })
+        );
+        let log = &app.diagnostics.logs[before];
+        assert_eq!(log.target, "mesh");
+        assert_eq!(log.message, "mesh status: enabled=true, peers=2");
+    }
+
+    #[test]
     fn native_remote_sessions_store_values_and_clamp_cursor() {
         let mut app = App::new();
-        app.mesh_nodes = vec![RemoteNodeInfo {
+        app.mesh.mesh_nodes = vec![RemoteNodeInfo {
             id: "node-1".into(),
             label: "Framework".into(),
             ..Default::default()
         }];
-        app.remote_session_cursor = 4;
+        app.mesh.remote_session_cursor = 4;
 
         let replies = app.handle_acp_event(AcpAppEvent::RemoteSessions(RemoteSessionListInfo {
             node_id: "node-1".into(),
@@ -2684,10 +2741,10 @@ mod tests {
         }));
 
         assert!(replies.is_empty());
-        assert_eq!(app.remote_session_cursor, 0);
-        assert_eq!(app.selected_remote_sessions()[0].id, "session-1");
+        assert_eq!(app.mesh.remote_session_cursor, 0);
+        assert_eq!(app.mesh.selected_remote_sessions()[0].id, "session-1");
         assert_eq!(
-            app.selected_remote_sessions()[0].title.as_deref(),
+            app.mesh.selected_remote_sessions()[0].title.as_deref(),
             Some("Boundary")
         );
         assert_eq!(app.session_remote_node_id("session-1"), Some("node-1"));
@@ -2711,7 +2768,7 @@ mod tests {
         }));
 
         assert!(matches!(app.popup, Popup::MeshInviteQr));
-        assert_eq!(app.mesh_invite_url(), Some("qmt://mesh/join/token"));
+        assert_eq!(app.mesh.invite_url(), Some("qmt://mesh/join/token"));
     }
 
     #[test]
@@ -2984,6 +3041,13 @@ mod tests {
         app.elicitation = Some(ElicitationState::new_for_test(Vec::new()));
         app.elicitation_ui = Some(crate::ui::ElicitationUiState::default());
         app.session_stats.total_tool_calls = 1;
+        app.mesh.mesh_nodes = vec![RemoteNodeInfo {
+            id: "node-1".into(),
+            label: "framework".into(),
+            ..Default::default()
+        }];
+        app.mesh.mesh_node_count = Some(1);
+        app.mesh.mesh_invite_name = "preserved".into();
 
         let replies = app.handle_acp_event(AcpAppEvent::SessionCreated {
             agent_id: "agent-1".into(),
@@ -3000,6 +3064,9 @@ mod tests {
         assert!(app.undo_state.is_none());
         assert!(app.elicitation.is_none());
         assert_eq!(app.session_stats.total_tool_calls, 0);
+        assert_eq!(app.mesh.mesh_node_count, Some(1));
+        assert_eq!(app.mesh.selected_mesh_node_id(), Some("node-1"));
+        assert_eq!(app.mesh.mesh_invite_name, "preserved");
         assert!(matches!(
             replies.as_slice(),
             [
@@ -3112,6 +3179,8 @@ mod tests {
                 target_agent_id: None,
                 objective: "clear".into(),
             });
+        app.mesh.mesh_node_count = Some(2);
+        app.mesh.mesh_invite_ttl = "48h".into();
 
         app.handle_acp_event(AcpAppEvent::SessionLoaded {
             agent_id: "agent-1".into(),
@@ -3124,6 +3193,8 @@ mod tests {
         assert!(app.delegate_entries.is_empty());
         assert!(app.pending_delegate_child_states.is_empty());
         assert!(app.pending_delegate_tool_calls.is_empty());
+        assert_eq!(app.mesh.mesh_node_count, Some(2));
+        assert_eq!(app.mesh.mesh_invite_ttl, "48h");
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,9 +13,7 @@ use crate::domain::activity::{
 };
 use crate::domain::chat::{ChatEntry, format_outcome_labels};
 use crate::domain::elicitation::ElicitationState;
-use crate::domain::mesh::{
-    MeshInviteCreatedInfo, MeshStatusInfo, RemoteNodeInfo, RemoteSessionInfo, RemoteSessionLocation,
-};
+use crate::domain::mesh::RemoteSessionLocation;
 use crate::domain::model::{DelegateModelPreference, ModelEntry};
 use crate::domain::profile::AgentInfo;
 use crate::domain::session::{
@@ -24,7 +22,7 @@ use crate::domain::session::{
 };
 use crate::highlight::Highlighter;
 use crate::markdown::CardBlock;
-use crate::mesh::{MeshFocus, MeshInviteFormField};
+use crate::mesh_state::MeshState;
 use crate::profiles_state::ProfilesState;
 use crate::protocol::audit::EventKind;
 use crate::ui::{CardCache, ElicitationUiState};
@@ -642,22 +640,7 @@ pub struct App {
     pub pending_cancel_confirm_until: Option<Instant>,
 
     // mesh / remote (from ACP extensions)
-    /// Count of mesh nodes from the last `querymt/mesh/nodes` fetch.
-    pub mesh_node_count: Option<u32>,
-    pub mesh_status: Option<MeshStatusInfo>,
-    pub mesh_nodes: Vec<RemoteNodeInfo>,
-    pub remote_sessions_by_node: HashMap<String, Vec<RemoteSessionInfo>>,
-    pub mesh_node_cursor: usize,
-    pub remote_session_cursor: usize,
-    pub mesh_focus: MeshFocus,
-    pub mesh_error: Option<String>,
-    pub mesh_error_until: Option<Instant>,
-    pub mesh_invite: Option<MeshInviteCreatedInfo>,
-    pub mesh_invite_name: String,
-    pub mesh_invite_ttl: String,
-    pub mesh_invite_max_uses: String,
-    pub mesh_invite_form_field: MeshInviteFormField,
-    pub mesh_clipboard_fallback: Option<String>,
+    pub(crate) mesh: MeshState,
 
     // connection
     pub conn: ConnState,
@@ -854,21 +837,7 @@ impl App {
             context_limit: 0,
             session_stats: SessionStatsLite::default(),
             pending_cancel_confirm_until: None,
-            mesh_node_count: None,
-            mesh_status: None,
-            mesh_nodes: Vec::new(),
-            remote_sessions_by_node: HashMap::new(),
-            mesh_node_cursor: 0,
-            remote_session_cursor: 0,
-            mesh_focus: MeshFocus::Nodes,
-            mesh_error: None,
-            mesh_error_until: None,
-            mesh_invite: None,
-            mesh_invite_name: String::new(),
-            mesh_invite_ttl: "24h".into(),
-            mesh_invite_max_uses: "1".into(),
-            mesh_invite_form_field: MeshInviteFormField::MeshName,
-            mesh_clipboard_fallback: None,
+            mesh: MeshState::new(),
             conn: ConnState::Connecting,
             reconnect_attempt: 0,
             reconnect_delay_ms: None,

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -357,33 +357,36 @@ pub(crate) fn handle_mesh_popup_key(
 ) -> anyhow::Result<()> {
     match key.code {
         KeyCode::Esc => app.popup = Popup::None,
-        KeyCode::Tab | KeyCode::Right | KeyCode::Left => {
-            app.mesh_focus = match app.mesh_focus {
-                crate::mesh::MeshFocus::Nodes => crate::mesh::MeshFocus::Sessions,
-                crate::mesh::MeshFocus::Sessions => crate::mesh::MeshFocus::Nodes,
-            };
-        }
-        KeyCode::Up => match app.mesh_focus {
-            crate::mesh::MeshFocus::Nodes => {
-                if let Some(msg) = app.move_mesh_node_cursor(-1) {
-                    cmd_tx.send(msg)?;
+        KeyCode::Tab | KeyCode::Right | KeyCode::Left => app.mesh.toggle_focus(),
+        KeyCode::Up => match app.mesh.mesh_focus {
+            crate::mesh_state::MeshFocus::Nodes => {
+                if let Some(node_id) = app.mesh.move_mesh_node_cursor(-1) {
+                    cmd_tx.send(Command::ListRemoteSessions {
+                        node_id,
+                        offset: 0,
+                        limit: 50,
+                    })?;
                 }
             }
-            crate::mesh::MeshFocus::Sessions => app.move_remote_session_cursor(-1),
+            crate::mesh_state::MeshFocus::Sessions => app.mesh.move_remote_session_cursor(-1),
         },
-        KeyCode::Down => match app.mesh_focus {
-            crate::mesh::MeshFocus::Nodes => {
-                if let Some(msg) = app.move_mesh_node_cursor(1) {
-                    cmd_tx.send(msg)?;
+        KeyCode::Down => match app.mesh.mesh_focus {
+            crate::mesh_state::MeshFocus::Nodes => {
+                if let Some(node_id) = app.mesh.move_mesh_node_cursor(1) {
+                    cmd_tx.send(Command::ListRemoteSessions {
+                        node_id,
+                        offset: 0,
+                        limit: 50,
+                    })?;
                 }
             }
-            crate::mesh::MeshFocus::Sessions => app.move_remote_session_cursor(1),
+            crate::mesh_state::MeshFocus::Sessions => app.mesh.move_remote_session_cursor(1),
         },
         KeyCode::Char('r') => cmd_tx.send(Command::ListRemoteNodes)?,
-        KeyCode::Enter => match app.mesh_focus {
-            crate::mesh::MeshFocus::Nodes => {
-                app.mesh_focus = crate::mesh::MeshFocus::Sessions;
-                if let Some(node_id) = app.selected_mesh_node_id() {
+        KeyCode::Enter => match app.mesh.mesh_focus {
+            crate::mesh_state::MeshFocus::Nodes => {
+                app.mesh.focus_sessions();
+                if let Some(node_id) = app.mesh.selected_mesh_node_id() {
                     cmd_tx.send(Command::ListRemoteSessions {
                         node_id: node_id.to_string(),
                         offset: 0,
@@ -391,8 +394,8 @@ pub(crate) fn handle_mesh_popup_key(
                     })?;
                 }
             }
-            crate::mesh::MeshFocus::Sessions => {
-                if let Some(session) = app.selected_remote_session() {
+            crate::mesh_state::MeshFocus::Sessions => {
+                if let Some(session) = app.mesh.selected_remote_session() {
                     cmd_tx.send(Command::AttachRemoteSession {
                         node_id: session.node_id.clone(),
                         session_id: session.id.clone(),
@@ -401,7 +404,7 @@ pub(crate) fn handle_mesh_popup_key(
             }
         },
         KeyCode::Char('n') => {
-            if let Some(node_id) = app.selected_mesh_node_id() {
+            if let Some(node_id) = app.mesh.selected_mesh_node_id() {
                 cmd_tx.send(Command::CreateRemoteSession {
                     node_id: node_id.to_string(),
                     cwd: None,
@@ -418,42 +421,15 @@ pub(crate) fn handle_mesh_invite_popup_key(
     key: KeyEvent,
     cmd_tx: &mpsc::UnboundedSender<Command>,
 ) -> anyhow::Result<()> {
-    if app.mesh_clipboard_fallback.is_some() {
-        app.mesh_clipboard_fallback = None;
+    if app.mesh.consume_clipboard_fallback() {
         return Ok(());
     }
 
     match key.code {
         KeyCode::Esc => app.popup = Popup::None,
-        KeyCode::Up => {
-            app.mesh_invite_form_field = match app.mesh_invite_form_field {
-                crate::mesh::MeshInviteFormField::MeshName => {
-                    crate::mesh::MeshInviteFormField::MaxUses
-                }
-                crate::mesh::MeshInviteFormField::Ttl => crate::mesh::MeshInviteFormField::MeshName,
-                crate::mesh::MeshInviteFormField::MaxUses => crate::mesh::MeshInviteFormField::Ttl,
-            };
-        }
-        KeyCode::Down | KeyCode::Tab => {
-            app.mesh_invite_form_field = match app.mesh_invite_form_field {
-                crate::mesh::MeshInviteFormField::MeshName => crate::mesh::MeshInviteFormField::Ttl,
-                crate::mesh::MeshInviteFormField::Ttl => crate::mesh::MeshInviteFormField::MaxUses,
-                crate::mesh::MeshInviteFormField::MaxUses => {
-                    crate::mesh::MeshInviteFormField::MeshName
-                }
-            };
-        }
-        KeyCode::Backspace => match app.mesh_invite_form_field {
-            crate::mesh::MeshInviteFormField::MeshName => {
-                app.mesh_invite_name.pop();
-            }
-            crate::mesh::MeshInviteFormField::Ttl => {
-                app.mesh_invite_ttl.pop();
-            }
-            crate::mesh::MeshInviteFormField::MaxUses => {
-                app.mesh_invite_max_uses.pop();
-            }
-        },
+        KeyCode::Up => app.mesh.move_invite_form_field(-1),
+        KeyCode::Down | KeyCode::Tab => app.mesh.move_invite_form_field(1),
+        KeyCode::Backspace => app.mesh.invite_form_backspace(),
         KeyCode::Enter => {
             if let Some(msg) = app.mesh_invite_form_command() {
                 cmd_tx.send(msg)?;
@@ -461,14 +437,7 @@ pub(crate) fn handle_mesh_invite_popup_key(
             }
         }
         KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
-            match app.mesh_invite_form_field {
-                crate::mesh::MeshInviteFormField::MeshName => app.mesh_invite_name.push(c),
-                crate::mesh::MeshInviteFormField::Ttl => app.mesh_invite_ttl.push(c),
-                crate::mesh::MeshInviteFormField::MaxUses if c.is_ascii_digit() => {
-                    app.mesh_invite_max_uses.push(c)
-                }
-                crate::mesh::MeshInviteFormField::MaxUses => {}
-            }
+            app.mesh.invite_form_insert(c);
         }
         _ => {}
     }
@@ -476,24 +445,21 @@ pub(crate) fn handle_mesh_invite_popup_key(
 }
 
 pub(crate) fn handle_mesh_invite_qr_popup_key(app: &mut App, key: KeyEvent) -> anyhow::Result<()> {
-    if app.mesh_clipboard_fallback.is_some() {
-        app.mesh_clipboard_fallback = None;
+    if app.mesh.consume_clipboard_fallback() {
         return Ok(());
     }
 
     match key.code {
         KeyCode::Esc => app.popup = Popup::MeshInvite,
         KeyCode::Char('u') => {
-            if let Some(url) = app.mesh_invite_url().map(str::to_string) {
-                app.mesh_clipboard_fallback = Some(url);
-            }
+            app.mesh.show_invite_url_fallback();
         }
         KeyCode::Char('y') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-            if let Some(url) = app.mesh_invite_url().map(str::to_string) {
+            if let Some(url) = app.mesh.invite_url().map(str::to_string) {
                 if copy_text_to_clipboard(&url) {
                     app.set_status(LogLevel::Info, "mesh", "invite URL copied");
                 } else {
-                    app.mesh_clipboard_fallback = Some(url);
+                    app.mesh.set_clipboard_fallback(url);
                 }
             }
         }
@@ -2898,13 +2864,13 @@ mod model_popup_tests {
     fn mesh_popup_enter_on_session_attaches_remote_session() {
         let mut app = App::new();
         app.popup = Popup::Mesh;
-        app.mesh_focus = crate::mesh::MeshFocus::Sessions;
-        app.mesh_nodes = vec![crate::domain::mesh::RemoteNodeInfo {
+        app.mesh.mesh_focus = crate::mesh_state::MeshFocus::Sessions;
+        app.mesh.mesh_nodes = vec![crate::domain::mesh::RemoteNodeInfo {
             id: "node-1".into(),
             label: "framework".into(),
             ..Default::default()
         }];
-        app.remote_sessions_by_node.insert(
+        app.mesh.remote_sessions_by_node.insert(
             "node-1".into(),
             vec![crate::domain::mesh::RemoteSessionInfo {
                 id: "remote-1".into(),
@@ -2929,7 +2895,7 @@ mod model_popup_tests {
         let mut app = App::new();
         app.popup = Popup::Mesh;
         app.launch_cwd = Some("/local/launch".into());
-        app.mesh_nodes = vec![crate::domain::mesh::RemoteNodeInfo {
+        app.mesh.mesh_nodes = vec![crate::domain::mesh::RemoteNodeInfo {
             id: "node-1".into(),
             label: "framework".into(),
             ..Default::default()
@@ -2958,8 +2924,8 @@ mod model_popup_tests {
         handle_command_palette_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
 
         assert!(matches!(app.popup, Popup::MeshInvite));
-        assert_eq!(app.mesh_invite_ttl, "24h");
-        assert_eq!(app.mesh_invite_max_uses, "1");
+        assert_eq!(app.mesh.mesh_invite_ttl, "24h");
+        assert_eq!(app.mesh.mesh_invite_max_uses, "1");
     }
 
     #[test]
@@ -2989,33 +2955,38 @@ mod model_popup_tests {
         handle_mesh_invite_qr_popup_key(&mut app, key(KeyCode::Char('u'))).unwrap();
 
         assert_eq!(
-            app.mesh_clipboard_fallback.as_deref(),
+            app.mesh.mesh_clipboard_fallback.as_deref(),
             Some("qmt://mesh/join/token")
         );
+
+        handle_mesh_invite_qr_popup_key(&mut app, key(KeyCode::Esc)).unwrap();
+
+        assert!(matches!(app.popup, Popup::MeshInviteQr));
+        assert!(app.mesh.mesh_clipboard_fallback.is_none());
     }
 
     #[test]
     fn mesh_invite_form_rejects_invalid_ttl_and_max_uses() {
         let mut app = App::new();
         app.open_mesh_invite_form();
-        app.mesh_invite_ttl = "lol".into();
+        app.mesh.mesh_invite_ttl = "lol".into();
 
         let (tx, mut rx) = mpsc::unbounded_channel();
         handle_mesh_invite_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
 
         assert!(rx.try_recv().is_err());
         assert_eq!(
-            app.mesh_error.as_deref(),
+            app.mesh.mesh_error.as_deref(),
             Some("ttl must be like 30m, 1d3h, or 1d3h5m")
         );
 
-        app.mesh_invite_ttl = "24h".into();
-        app.mesh_invite_max_uses = "0".into();
+        app.mesh.mesh_invite_ttl = "24h".into();
+        app.mesh.mesh_invite_max_uses = "0".into();
         handle_mesh_invite_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
 
         assert!(rx.try_recv().is_err());
         assert_eq!(
-            app.mesh_error.as_deref(),
+            app.mesh.mesh_error.as_deref(),
             Some("max uses must be at least 1")
         );
     }
@@ -3025,8 +2996,8 @@ mod model_popup_tests {
         let mut app = App::new();
         app.popup = Popup::Mesh;
         app.open_mesh_invite_form();
-        app.mesh_invite_name = "Team Mesh".into();
-        app.mesh_invite_ttl = "1d3h5m".into();
+        app.mesh.mesh_invite_name = "Team Mesh".into();
+        app.mesh.mesh_invite_ttl = "1d3h5m".into();
 
         let (tx, mut rx) = mpsc::unbounded_channel();
         handle_mesh_invite_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod highlight;
 mod input;
 mod markdown;
 mod mesh;
+mod mesh_state;
 mod profiles_state;
 mod protocol;
 pub mod runtime;

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -1,152 +1,41 @@
-use std::time::{Duration, Instant};
-
 use crate::app::{App, Popup};
 use crate::command::Command;
 use crate::diagnostics::LogLevel;
 use crate::domain::mesh::{
     MeshInviteCreatedInfo, MeshNodesInfo, MeshStatusInfo, RemoteSessionAttachInfo,
-    RemoteSessionInfo, RemoteSessionListInfo,
+    RemoteSessionListInfo,
 };
 
-const INVITE_ERROR_TTL: Duration = Duration::from_secs(5);
-
-fn validate_invite_ttl(value: &str) -> Result<Option<String>, String> {
-    if value.is_empty() {
-        return Ok(None);
-    }
-
-    let mut chars = value.char_indices().peekable();
-    let mut segments = 0usize;
-    while chars.peek().is_some() {
-        let amount_start = chars.peek().map(|(idx, _)| *idx).unwrap_or(0);
-        while matches!(chars.peek(), Some((_, c)) if c.is_ascii_digit()) {
-            chars.next();
-        }
-        let amount_end = chars.peek().map(|(idx, _)| *idx).unwrap_or(value.len());
-        if amount_start == amount_end {
-            return Err("ttl must be like 30m, 1d3h, or 1d3h5m".into());
-        }
-        let amount = value[amount_start..amount_end]
-            .parse::<u64>()
-            .map_err(|_| "ttl amount is too large".to_string())?;
-        if amount == 0 {
-            return Err("ttl amounts must be greater than 0".into());
-        }
-        let Some((_, unit)) = chars.next() else {
-            return Err("ttl must end with s, m, h, d, or w".into());
-        };
-        if !matches!(unit, 's' | 'm' | 'h' | 'd' | 'w') {
-            return Err("ttl units must be s, m, h, d, or w".into());
-        }
-        segments += 1;
-    }
-
-    if segments == 0 {
-        Err("ttl must be like 30m, 1d3h, or 1d3h5m".into())
-    } else {
-        Ok(Some(value.to_string()))
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum MeshFocus {
-    #[default]
-    Nodes,
-    Sessions,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum MeshInviteFormField {
-    #[default]
-    MeshName,
-    Ttl,
-    MaxUses,
-}
-
 impl App {
-    pub fn set_mesh_error(&mut self, message: impl Into<String>) {
-        self.mesh_error = Some(message.into());
-        self.mesh_error_until = Some(Instant::now() + INVITE_ERROR_TTL);
-    }
-
-    pub fn clear_mesh_error(&mut self) {
-        self.mesh_error = None;
-        self.mesh_error_until = None;
-    }
-
-    pub fn current_mesh_error(&self) -> Option<&str> {
-        match (self.mesh_error.as_deref(), self.mesh_error_until) {
-            (Some(message), Some(until)) if Instant::now() < until => Some(message),
-            _ => None,
-        }
-    }
-
     pub fn open_mesh_popup(&mut self) {
         self.popup = Popup::Mesh;
-        self.mesh_focus = MeshFocus::Nodes;
-        self.clear_mesh_error();
+        self.mesh.reset_for_popup();
         self.set_status(LogLevel::Debug, "mesh", "refreshing mesh");
     }
 
     pub fn open_mesh_invite_form(&mut self) {
         self.popup = Popup::MeshInvite;
-        if self.mesh_invite_ttl.trim().is_empty() {
-            self.mesh_invite_ttl = "24h".into();
-        }
-        if self.mesh_invite_max_uses.trim().is_empty() {
-            self.mesh_invite_max_uses = "1".into();
-        }
-        self.mesh_invite_form_field = MeshInviteFormField::MeshName;
-        self.clear_mesh_error();
+        self.mesh.reset_invite_form();
     }
 
     pub fn apply_mesh_invite_created(&mut self, invite: MeshInviteCreatedInfo) {
-        let url = invite.url.clone();
-        self.mesh_invite = Some(invite);
+        let url = self.mesh.store_invite(invite);
         self.popup = Popup::MeshInviteQr;
-        self.mesh_clipboard_fallback = None;
-        self.clear_mesh_error();
         self.set_status(LogLevel::Info, "mesh", "mesh invite created");
         self.push_log(LogLevel::Info, "mesh", format!("mesh invite: {url}"));
     }
 
     pub fn mesh_invite_form_command(&mut self) -> Option<Command> {
-        let max_uses = match self.mesh_invite_max_uses.trim().parse::<u32>() {
-            Ok(max_uses) if max_uses > 0 => max_uses,
-            Ok(_) => {
-                self.set_mesh_error("max uses must be at least 1");
-                return None;
-            }
-            Err(_) => {
-                self.set_mesh_error("max uses must be a number");
-                return None;
-            }
-        };
-        let ttl = match validate_invite_ttl(self.mesh_invite_ttl.trim()) {
-            Ok(ttl) => ttl,
-            Err(message) => {
-                self.set_mesh_error(message);
-                return None;
-            }
-        };
-        let mesh_name = (!self.mesh_invite_name.trim().is_empty())
-            .then(|| self.mesh_invite_name.trim().to_string());
-        self.clear_mesh_error();
+        let (mesh_name, ttl, max_uses) = self.mesh.validate_invite_form()?;
         Some(Command::CreateMeshInvite {
             mesh_name,
             ttl,
-            max_uses: Some(max_uses),
+            max_uses,
         })
     }
 
-    pub fn mesh_invite_url(&self) -> Option<&str> {
-        self.mesh_invite.as_ref().map(|invite| invite.url.as_str())
-    }
-
     pub fn apply_mesh_status(&mut self, status: MeshStatusInfo) {
-        let enabled = status.enabled;
-        let peer_count = status.known_peer_count;
-        self.mesh_status = Some(status);
+        let (enabled, peer_count) = self.mesh.replace_status(status);
         self.push_log(
             LogLevel::Debug,
             "mesh",
@@ -155,19 +44,11 @@ impl App {
     }
 
     pub fn apply_mesh_nodes(&mut self, nodes: MeshNodesInfo) -> Vec<Command> {
-        self.mesh_node_count = Some(nodes.nodes.len() as u32);
-        self.mesh_nodes = nodes.nodes;
-        if self.mesh_node_cursor >= self.mesh_nodes.len() {
-            self.mesh_node_cursor = self.mesh_nodes.len().saturating_sub(1);
-        }
-        self.push_log(
-            LogLevel::Info,
-            "mesh",
-            format!("mesh nodes: {}", self.mesh_nodes.len()),
-        );
-        self.selected_mesh_node_id()
+        let (count, selected_node_id) = self.mesh.replace_nodes(nodes.nodes);
+        self.push_log(LogLevel::Info, "mesh", format!("mesh nodes: {count}"));
+        selected_node_id
             .map(|node_id| Command::ListRemoteSessions {
-                node_id: node_id.to_string(),
+                node_id,
                 offset: 0,
                 limit: 50,
             })
@@ -176,7 +57,6 @@ impl App {
     }
 
     pub fn apply_remote_sessions(&mut self, list: RemoteSessionListInfo) {
-        let count = list.sessions.len();
         for session in &list.sessions {
             self.remember_remote_session_location(
                 &session.id,
@@ -184,11 +64,9 @@ impl App {
                 session.cwd.clone(),
             );
         }
-        self.remote_sessions_by_node
-            .insert(list.node_id.clone(), list.sessions);
-        if self.remote_session_cursor >= count {
-            self.remote_session_cursor = count.saturating_sub(1);
-        }
+        let count = self
+            .mesh
+            .replace_remote_sessions(&list.node_id, list.sessions);
         self.push_log(
             LogLevel::Info,
             "mesh",
@@ -220,56 +98,5 @@ impl App {
                 limit: 50,
             }]
         }
-    }
-
-    pub fn selected_mesh_node_id(&self) -> Option<&str> {
-        self.mesh_nodes
-            .get(self.mesh_node_cursor)
-            .map(|node| node.id.as_str())
-    }
-
-    pub fn selected_mesh_node_label(&self) -> Option<&str> {
-        self.mesh_nodes
-            .get(self.mesh_node_cursor)
-            .map(|node| node.label.as_str())
-    }
-
-    pub fn selected_remote_sessions(&self) -> &[RemoteSessionInfo] {
-        self.selected_mesh_node_id()
-            .and_then(|node_id| self.remote_sessions_by_node.get(node_id))
-            .map(Vec::as_slice)
-            .unwrap_or(&[])
-    }
-
-    pub fn selected_remote_session(&self) -> Option<&RemoteSessionInfo> {
-        self.selected_remote_sessions()
-            .get(self.remote_session_cursor)
-    }
-
-    pub fn move_mesh_node_cursor(&mut self, delta: isize) -> Option<Command> {
-        let len = self.mesh_nodes.len();
-        if len == 0 {
-            self.mesh_node_cursor = 0;
-            return None;
-        }
-        self.mesh_node_cursor =
-            (self.mesh_node_cursor as isize + delta).rem_euclid(len as isize) as usize;
-        self.remote_session_cursor = 0;
-        self.selected_mesh_node_id()
-            .map(|node_id| Command::ListRemoteSessions {
-                node_id: node_id.to_string(),
-                offset: 0,
-                limit: 50,
-            })
-    }
-
-    pub fn move_remote_session_cursor(&mut self, delta: isize) {
-        let len = self.selected_remote_sessions().len();
-        if len == 0 {
-            self.remote_session_cursor = 0;
-            return;
-        }
-        self.remote_session_cursor =
-            (self.remote_session_cursor as isize + delta).rem_euclid(len as isize) as usize;
     }
 }

--- a/src/mesh_state.rs
+++ b/src/mesh_state.rs
@@ -1,0 +1,682 @@
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use crate::domain::mesh::{
+    MeshInviteCreatedInfo, MeshStatusInfo, RemoteNodeInfo, RemoteSessionInfo,
+};
+
+const INVITE_ERROR_TTL: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum MeshFocus {
+    #[default]
+    Nodes,
+    Sessions,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum MeshInviteFormField {
+    #[default]
+    MeshName,
+    Ttl,
+    MaxUses,
+}
+
+pub(crate) struct MeshState {
+    pub(crate) mesh_node_count: Option<u32>,
+    pub(crate) mesh_status: Option<MeshStatusInfo>,
+    pub(crate) mesh_nodes: Vec<RemoteNodeInfo>,
+    pub(crate) remote_sessions_by_node: HashMap<String, Vec<RemoteSessionInfo>>,
+    pub(crate) mesh_node_cursor: usize,
+    pub(crate) remote_session_cursor: usize,
+    pub(crate) mesh_focus: MeshFocus,
+    pub(crate) mesh_error: Option<String>,
+    pub(crate) mesh_error_until: Option<Instant>,
+    pub(crate) mesh_invite: Option<MeshInviteCreatedInfo>,
+    pub(crate) mesh_invite_name: String,
+    pub(crate) mesh_invite_ttl: String,
+    pub(crate) mesh_invite_max_uses: String,
+    pub(crate) mesh_invite_form_field: MeshInviteFormField,
+    pub(crate) mesh_clipboard_fallback: Option<String>,
+}
+
+impl MeshState {
+    pub(crate) fn new() -> Self {
+        Self {
+            mesh_node_count: None,
+            mesh_status: None,
+            mesh_nodes: Vec::new(),
+            remote_sessions_by_node: HashMap::new(),
+            mesh_node_cursor: 0,
+            remote_session_cursor: 0,
+            mesh_focus: MeshFocus::Nodes,
+            mesh_error: None,
+            mesh_error_until: None,
+            mesh_invite: None,
+            mesh_invite_name: String::new(),
+            mesh_invite_ttl: "24h".into(),
+            mesh_invite_max_uses: "1".into(),
+            mesh_invite_form_field: MeshInviteFormField::MeshName,
+            mesh_clipboard_fallback: None,
+        }
+    }
+
+    pub(crate) fn set_error(&mut self, message: impl Into<String>) {
+        self.mesh_error = Some(message.into());
+        self.mesh_error_until = Some(Instant::now() + INVITE_ERROR_TTL);
+    }
+
+    pub(crate) fn clear_error(&mut self) {
+        self.mesh_error = None;
+        self.mesh_error_until = None;
+    }
+
+    pub(crate) fn current_error(&self) -> Option<&str> {
+        match (self.mesh_error.as_deref(), self.mesh_error_until) {
+            (Some(message), Some(until)) if Instant::now() < until => Some(message),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn reset_for_popup(&mut self) {
+        self.mesh_focus = MeshFocus::Nodes;
+        self.clear_error();
+    }
+
+    pub(crate) fn reset_invite_form(&mut self) {
+        if self.mesh_invite_ttl.trim().is_empty() {
+            self.mesh_invite_ttl = "24h".into();
+        }
+        if self.mesh_invite_max_uses.trim().is_empty() {
+            self.mesh_invite_max_uses = "1".into();
+        }
+        self.mesh_invite_form_field = MeshInviteFormField::MeshName;
+        self.clear_error();
+    }
+
+    pub(crate) fn validate_invite_form(
+        &mut self,
+    ) -> Option<(Option<String>, Option<String>, Option<u32>)> {
+        let max_uses = match self.mesh_invite_max_uses.trim().parse::<u32>() {
+            Ok(max_uses) if max_uses > 0 => max_uses,
+            Ok(_) => {
+                self.set_error("max uses must be at least 1");
+                return None;
+            }
+            Err(_) => {
+                self.set_error("max uses must be a number");
+                return None;
+            }
+        };
+        let ttl = match validate_invite_ttl(self.mesh_invite_ttl.trim()) {
+            Ok(ttl) => ttl,
+            Err(message) => {
+                self.set_error(message);
+                return None;
+            }
+        };
+        let mesh_name = (!self.mesh_invite_name.trim().is_empty())
+            .then(|| self.mesh_invite_name.trim().to_string());
+        self.clear_error();
+        Some((mesh_name, ttl, Some(max_uses)))
+    }
+
+    pub(crate) fn store_invite(&mut self, invite: MeshInviteCreatedInfo) -> String {
+        let url = invite.url.clone();
+        self.mesh_invite = Some(invite);
+        self.mesh_clipboard_fallback = None;
+        self.clear_error();
+        url
+    }
+
+    pub(crate) fn invite_url(&self) -> Option<&str> {
+        self.mesh_invite.as_ref().map(|invite| invite.url.as_str())
+    }
+
+    pub(crate) fn show_invite_url_fallback(&mut self) -> bool {
+        let Some(url) = self.invite_url().map(str::to_string) else {
+            return false;
+        };
+        self.mesh_clipboard_fallback = Some(url);
+        true
+    }
+
+    pub(crate) fn set_clipboard_fallback(&mut self, url: String) {
+        self.mesh_clipboard_fallback = Some(url);
+    }
+
+    pub(crate) fn consume_clipboard_fallback(&mut self) -> bool {
+        self.mesh_clipboard_fallback.take().is_some()
+    }
+
+    pub(crate) fn replace_status(&mut self, status: MeshStatusInfo) -> (bool, u32) {
+        let summary = (status.enabled, status.known_peer_count);
+        self.mesh_status = Some(status);
+        summary
+    }
+
+    pub(crate) fn replace_nodes(&mut self, nodes: Vec<RemoteNodeInfo>) -> (usize, Option<String>) {
+        let count = nodes.len();
+        self.mesh_node_count = Some(count as u32);
+        self.mesh_nodes = nodes;
+        if self.mesh_node_cursor >= self.mesh_nodes.len() {
+            self.mesh_node_cursor = self.mesh_nodes.len().saturating_sub(1);
+        }
+        (count, self.selected_mesh_node_id().map(str::to_string))
+    }
+
+    pub(crate) fn replace_remote_sessions(
+        &mut self,
+        node_id: &str,
+        sessions: Vec<RemoteSessionInfo>,
+    ) -> usize {
+        let count = sessions.len();
+        self.remote_sessions_by_node
+            .insert(node_id.to_string(), sessions);
+        if self.remote_session_cursor >= count {
+            self.remote_session_cursor = count.saturating_sub(1);
+        }
+        count
+    }
+
+    pub(crate) fn selected_mesh_node_id(&self) -> Option<&str> {
+        self.mesh_nodes
+            .get(self.mesh_node_cursor)
+            .map(|node| node.id.as_str())
+    }
+
+    pub(crate) fn selected_mesh_node_label(&self) -> Option<&str> {
+        self.mesh_nodes
+            .get(self.mesh_node_cursor)
+            .map(|node| node.label.as_str())
+    }
+
+    pub(crate) fn selected_remote_sessions(&self) -> &[RemoteSessionInfo] {
+        self.selected_mesh_node_id()
+            .and_then(|node_id| self.remote_sessions_by_node.get(node_id))
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+
+    pub(crate) fn selected_remote_session(&self) -> Option<&RemoteSessionInfo> {
+        self.selected_remote_sessions()
+            .get(self.remote_session_cursor)
+    }
+
+    pub(crate) fn toggle_focus(&mut self) {
+        self.mesh_focus = match self.mesh_focus {
+            MeshFocus::Nodes => MeshFocus::Sessions,
+            MeshFocus::Sessions => MeshFocus::Nodes,
+        };
+    }
+
+    pub(crate) fn focus_sessions(&mut self) {
+        self.mesh_focus = MeshFocus::Sessions;
+    }
+
+    pub(crate) fn move_mesh_node_cursor(&mut self, delta: isize) -> Option<String> {
+        let len = self.mesh_nodes.len();
+        if len == 0 {
+            self.mesh_node_cursor = 0;
+            return None;
+        }
+        self.mesh_node_cursor =
+            (self.mesh_node_cursor as isize + delta).rem_euclid(len as isize) as usize;
+        self.remote_session_cursor = 0;
+        self.selected_mesh_node_id().map(str::to_string)
+    }
+
+    pub(crate) fn move_remote_session_cursor(&mut self, delta: isize) {
+        let len = self.selected_remote_sessions().len();
+        if len == 0 {
+            self.remote_session_cursor = 0;
+            return;
+        }
+        self.remote_session_cursor =
+            (self.remote_session_cursor as isize + delta).rem_euclid(len as isize) as usize;
+    }
+
+    pub(crate) fn move_invite_form_field(&mut self, delta: isize) {
+        let current = match self.mesh_invite_form_field {
+            MeshInviteFormField::MeshName => 0,
+            MeshInviteFormField::Ttl => 1,
+            MeshInviteFormField::MaxUses => 2,
+        };
+        self.mesh_invite_form_field = match (current + delta).rem_euclid(3) {
+            0 => MeshInviteFormField::MeshName,
+            1 => MeshInviteFormField::Ttl,
+            _ => MeshInviteFormField::MaxUses,
+        };
+    }
+
+    pub(crate) fn invite_form_backspace(&mut self) {
+        match self.mesh_invite_form_field {
+            MeshInviteFormField::MeshName => {
+                self.mesh_invite_name.pop();
+            }
+            MeshInviteFormField::Ttl => {
+                self.mesh_invite_ttl.pop();
+            }
+            MeshInviteFormField::MaxUses => {
+                self.mesh_invite_max_uses.pop();
+            }
+        }
+    }
+
+    pub(crate) fn invite_form_insert(&mut self, character: char) {
+        match self.mesh_invite_form_field {
+            MeshInviteFormField::MeshName => self.mesh_invite_name.push(character),
+            MeshInviteFormField::Ttl => self.mesh_invite_ttl.push(character),
+            MeshInviteFormField::MaxUses if character.is_ascii_digit() => {
+                self.mesh_invite_max_uses.push(character);
+            }
+            MeshInviteFormField::MaxUses => {}
+        }
+    }
+}
+
+fn validate_invite_ttl(value: &str) -> Result<Option<String>, String> {
+    if value.is_empty() {
+        return Ok(None);
+    }
+
+    let mut chars = value.char_indices().peekable();
+    let mut segments = 0usize;
+    while chars.peek().is_some() {
+        let amount_start = chars.peek().map(|(idx, _)| *idx).unwrap_or(0);
+        while matches!(chars.peek(), Some((_, c)) if c.is_ascii_digit()) {
+            chars.next();
+        }
+        let amount_end = chars.peek().map(|(idx, _)| *idx).unwrap_or(value.len());
+        if amount_start == amount_end {
+            return Err("ttl must be like 30m, 1d3h, or 1d3h5m".into());
+        }
+        let amount = value[amount_start..amount_end]
+            .parse::<u64>()
+            .map_err(|_| "ttl amount is too large".to_string())?;
+        if amount == 0 {
+            return Err("ttl amounts must be greater than 0".into());
+        }
+        let Some((_, unit)) = chars.next() else {
+            return Err("ttl must end with s, m, h, d, or w".into());
+        };
+        if !matches!(unit, 's' | 'm' | 'h' | 'd' | 'w') {
+            return Err("ttl units must be s, m, h, d, or w".into());
+        }
+        segments += 1;
+    }
+
+    if segments == 0 {
+        Err("ttl must be like 30m, 1d3h, or 1d3h5m".into())
+    } else {
+        Ok(Some(value.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(id: &str) -> RemoteNodeInfo {
+        RemoteNodeInfo {
+            id: id.into(),
+            label: format!("node {id}"),
+            ..Default::default()
+        }
+    }
+
+    fn session(id: &str, node_id: &str) -> RemoteSessionInfo {
+        RemoteSessionInfo {
+            id: id.into(),
+            node_id: node_id.into(),
+            ..Default::default()
+        }
+    }
+
+    fn invite(url: &str) -> MeshInviteCreatedInfo {
+        MeshInviteCreatedInfo {
+            invite_id: "invite-1".into(),
+            url: url.into(),
+            qr_code: Some("QR".into()),
+            expires_at: 1,
+            max_uses: 1,
+            mesh_name: None,
+        }
+    }
+
+    #[test]
+    fn constructor_uses_exact_defaults() {
+        let state = MeshState::new();
+
+        assert_eq!(state.mesh_node_count, None);
+        assert!(state.mesh_status.is_none());
+        assert!(state.mesh_nodes.is_empty());
+        assert!(state.remote_sessions_by_node.is_empty());
+        assert_eq!(state.mesh_node_cursor, 0);
+        assert_eq!(state.remote_session_cursor, 0);
+        assert_eq!(state.mesh_focus, MeshFocus::Nodes);
+        assert!(state.mesh_error.is_none());
+        assert!(state.mesh_error_until.is_none());
+        assert!(state.mesh_invite.is_none());
+        assert!(state.mesh_invite_name.is_empty());
+        assert_eq!(state.mesh_invite_ttl, "24h");
+        assert_eq!(state.mesh_invite_max_uses, "1");
+        assert_eq!(state.mesh_invite_form_field, MeshInviteFormField::MeshName);
+        assert!(state.mesh_clipboard_fallback.is_none());
+    }
+
+    #[test]
+    fn popup_reset_changes_only_focus_and_error() {
+        let mut state = MeshState::new();
+        state.mesh_focus = MeshFocus::Sessions;
+        state.set_error("stale");
+        state.mesh_node_cursor = 2;
+        state.remote_session_cursor = 3;
+        state.mesh_invite_name = "preserved".into();
+
+        state.reset_for_popup();
+
+        assert_eq!(state.mesh_focus, MeshFocus::Nodes);
+        assert!(state.mesh_error.is_none());
+        assert!(state.mesh_error_until.is_none());
+        assert_eq!(state.mesh_node_cursor, 2);
+        assert_eq!(state.remote_session_cursor, 3);
+        assert_eq!(state.mesh_invite_name, "preserved");
+    }
+
+    #[test]
+    fn invite_reset_restores_only_blank_defaults_and_clears_error() {
+        let mut state = MeshState::new();
+        state.mesh_invite_ttl = "  ".into();
+        state.mesh_invite_max_uses.clear();
+        state.mesh_invite_form_field = MeshInviteFormField::MaxUses;
+        state.set_error("stale");
+
+        state.reset_invite_form();
+
+        assert_eq!(state.mesh_invite_ttl, "24h");
+        assert_eq!(state.mesh_invite_max_uses, "1");
+        assert_eq!(state.mesh_invite_form_field, MeshInviteFormField::MeshName);
+        assert!(state.mesh_error.is_none());
+
+        state.mesh_invite_ttl = "2h".into();
+        state.mesh_invite_max_uses = "4".into();
+        state.reset_invite_form();
+        assert_eq!(state.mesh_invite_ttl, "2h");
+        assert_eq!(state.mesh_invite_max_uses, "4");
+    }
+
+    #[test]
+    fn error_visibility_expires_lazily_after_five_seconds() {
+        let mut state = MeshState::new();
+        state.set_error("invalid invite");
+
+        assert_eq!(state.current_error(), Some("invalid invite"));
+        let until = state.mesh_error_until.expect("error deadline");
+        assert!(until > Instant::now());
+        assert!(until <= Instant::now() + Duration::from_secs(5));
+
+        state.mesh_error_until = Some(Instant::now() - Duration::from_millis(1));
+        assert_eq!(state.current_error(), None);
+        assert_eq!(state.mesh_error.as_deref(), Some("invalid invite"));
+
+        state.clear_error();
+        assert!(state.mesh_error.is_none());
+        assert!(state.mesh_error_until.is_none());
+    }
+
+    #[test]
+    fn invite_validation_trims_and_normalizes_valid_values() {
+        let mut state = MeshState::new();
+        state.mesh_invite_name = "  Team Mesh  ".into();
+        state.mesh_invite_ttl = "  1d3h5m  ".into();
+        state.mesh_invite_max_uses = " 7 ".into();
+        state.set_error("stale");
+
+        assert_eq!(
+            state.validate_invite_form(),
+            Some((Some("Team Mesh".into()), Some("1d3h5m".into()), Some(7)))
+        );
+        assert!(state.mesh_error.is_none());
+        assert!(state.mesh_error_until.is_none());
+
+        state.mesh_invite_name = "  ".into();
+        state.mesh_invite_ttl = "  ".into();
+        state.mesh_invite_max_uses = "1".into();
+        assert_eq!(state.validate_invite_form(), Some((None, None, Some(1))));
+    }
+
+    #[test]
+    fn invite_validation_preserves_exact_max_use_errors_and_precedence() {
+        let mut state = MeshState::new();
+        state.mesh_invite_ttl = "invalid".into();
+        state.mesh_invite_max_uses = "0".into();
+
+        assert_eq!(state.validate_invite_form(), None);
+        assert_eq!(
+            state.mesh_error.as_deref(),
+            Some("max uses must be at least 1")
+        );
+
+        state.mesh_invite_max_uses = "many".into();
+        assert_eq!(state.validate_invite_form(), None);
+        assert_eq!(
+            state.mesh_error.as_deref(),
+            Some("max uses must be a number")
+        );
+    }
+
+    #[test]
+    fn invite_validation_preserves_exact_ttl_errors() {
+        let cases = [
+            ("lol", "ttl must be like 30m, 1d3h, or 1d3h5m"),
+            ("1", "ttl must end with s, m, h, d, or w"),
+            ("1y", "ttl units must be s, m, h, d, or w"),
+            ("0m", "ttl amounts must be greater than 0"),
+            ("184467440737095516160m", "ttl amount is too large"),
+        ];
+
+        for (value, expected) in cases {
+            let mut state = MeshState::new();
+            state.mesh_invite_ttl = value.into();
+            assert_eq!(state.validate_invite_form(), None, "value: {value}");
+            assert_eq!(
+                state.mesh_error.as_deref(),
+                Some(expected),
+                "value: {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn invite_storage_url_and_fallback_transitions_are_exact() {
+        let mut state = MeshState::new();
+        state.set_error("stale");
+        state.set_clipboard_fallback("old".into());
+
+        let url = state.store_invite(invite("qmt://mesh/join/token"));
+
+        assert_eq!(url, "qmt://mesh/join/token");
+        assert_eq!(state.invite_url(), Some("qmt://mesh/join/token"));
+        assert!(state.mesh_error.is_none());
+        assert!(state.mesh_clipboard_fallback.is_none());
+        assert!(state.show_invite_url_fallback());
+        assert_eq!(
+            state.mesh_clipboard_fallback.as_deref(),
+            Some("qmt://mesh/join/token")
+        );
+        assert!(state.consume_clipboard_fallback());
+        assert!(!state.consume_clipboard_fallback());
+
+        let mut empty = MeshState::new();
+        assert!(!empty.show_invite_url_fallback());
+        assert!(empty.mesh_clipboard_fallback.is_none());
+    }
+
+    #[test]
+    fn status_replacement_returns_log_values_and_stores_full_status() {
+        let mut state = MeshState::new();
+        let status = MeshStatusInfo {
+            enabled: true,
+            peer_id: Some("peer-1".into()),
+            known_peer_count: 3,
+            has_invite_store: true,
+            ..Default::default()
+        };
+
+        assert_eq!(state.replace_status(status), (true, 3));
+        let stored = state.mesh_status.as_ref().expect("stored status");
+        assert_eq!(stored.peer_id.as_deref(), Some("peer-1"));
+        assert!(stored.has_invite_store);
+    }
+
+    #[test]
+    fn node_replacement_preserves_valid_cursor_session_cursor_and_stale_lists() {
+        let mut state = MeshState::new();
+        state.mesh_node_cursor = 1;
+        state.remote_session_cursor = 4;
+        state
+            .remote_sessions_by_node
+            .insert("stale".into(), vec![session("old", "stale")]);
+
+        let (count, selected) = state.replace_nodes(vec![node("first"), node("second")]);
+
+        assert_eq!(count, 2);
+        assert_eq!(selected.as_deref(), Some("second"));
+        assert_eq!(state.mesh_node_count, Some(2));
+        assert_eq!(state.mesh_node_cursor, 1);
+        assert_eq!(state.remote_session_cursor, 4);
+        assert_eq!(state.remote_sessions_by_node["stale"][0].id, "old");
+    }
+
+    #[test]
+    fn node_replacement_clamps_only_invalid_cursor_values() {
+        let mut state = MeshState::new();
+        state.mesh_node_cursor = 8;
+        let (_, selected) = state.replace_nodes(vec![node("first"), node("second")]);
+        assert_eq!(state.mesh_node_cursor, 1);
+        assert_eq!(selected.as_deref(), Some("second"));
+
+        let (_, selected) = state.replace_nodes(Vec::new());
+        assert_eq!(state.mesh_node_count, Some(0));
+        assert_eq!(state.mesh_node_cursor, 0);
+        assert_eq!(selected, None);
+    }
+
+    #[test]
+    fn remote_session_replacement_is_per_node_and_clamps_global_cursor() {
+        let mut state = MeshState::new();
+        state.replace_nodes(vec![node("first"), node("second")]);
+        state
+            .remote_sessions_by_node
+            .insert("second".into(), vec![session("preserved", "second")]);
+        state.remote_session_cursor = 3;
+
+        assert_eq!(
+            state.replace_remote_sessions("first", vec![session("fresh", "first")]),
+            1
+        );
+        assert_eq!(state.remote_session_cursor, 0);
+        assert_eq!(state.remote_sessions_by_node["first"][0].id, "fresh");
+        assert_eq!(state.remote_sessions_by_node["second"][0].id, "preserved");
+
+        state.remote_session_cursor = 2;
+        state.replace_remote_sessions(
+            "first",
+            vec![
+                session("one", "first"),
+                session("two", "first"),
+                session("three", "first"),
+            ],
+        );
+        assert_eq!(state.remote_session_cursor, 2);
+    }
+
+    #[test]
+    fn selections_and_node_cursor_movement_wrap_and_reset_session_cursor() {
+        let mut state = MeshState::new();
+        state.replace_nodes(vec![node("first"), node("second")]);
+        state.replace_remote_sessions("first", vec![session("a", "first")]);
+        state.replace_remote_sessions("second", vec![session("b", "second")]);
+        state.remote_session_cursor = 7;
+
+        assert_eq!(state.selected_mesh_node_id(), Some("first"));
+        assert_eq!(state.selected_mesh_node_label(), Some("node first"));
+        assert_eq!(state.move_mesh_node_cursor(-1).as_deref(), Some("second"));
+        assert_eq!(state.mesh_node_cursor, 1);
+        assert_eq!(state.remote_session_cursor, 0);
+        assert_eq!(
+            state.selected_remote_session().map(|item| item.id.as_str()),
+            Some("b")
+        );
+        assert_eq!(state.move_mesh_node_cursor(1).as_deref(), Some("first"));
+
+        state.replace_nodes(Vec::new());
+        state.mesh_node_cursor = 5;
+        assert_eq!(state.move_mesh_node_cursor(1), None);
+        assert_eq!(state.mesh_node_cursor, 0);
+    }
+
+    #[test]
+    fn remote_session_cursor_wraps_and_empty_selection_resets_it() {
+        let mut state = MeshState::new();
+        state.replace_nodes(vec![node("node")]);
+        state.replace_remote_sessions("node", vec![session("one", "node"), session("two", "node")]);
+
+        state.move_remote_session_cursor(-1);
+        assert_eq!(state.remote_session_cursor, 1);
+        state.move_remote_session_cursor(1);
+        assert_eq!(state.remote_session_cursor, 0);
+
+        state.replace_remote_sessions("node", Vec::new());
+        state.remote_session_cursor = 9;
+        state.move_remote_session_cursor(1);
+        assert_eq!(state.remote_session_cursor, 0);
+        assert!(state.selected_remote_sessions().is_empty());
+        assert!(state.selected_remote_session().is_none());
+    }
+
+    #[test]
+    fn focus_and_invite_field_movement_wrap() {
+        let mut state = MeshState::new();
+        state.toggle_focus();
+        assert_eq!(state.mesh_focus, MeshFocus::Sessions);
+        state.toggle_focus();
+        assert_eq!(state.mesh_focus, MeshFocus::Nodes);
+        state.focus_sessions();
+        assert_eq!(state.mesh_focus, MeshFocus::Sessions);
+
+        state.move_invite_form_field(-1);
+        assert_eq!(state.mesh_invite_form_field, MeshInviteFormField::MaxUses);
+        state.move_invite_form_field(1);
+        assert_eq!(state.mesh_invite_form_field, MeshInviteFormField::MeshName);
+        state.move_invite_form_field(1);
+        assert_eq!(state.mesh_invite_form_field, MeshInviteFormField::Ttl);
+    }
+
+    #[test]
+    fn invite_input_targets_selected_field_and_filters_max_uses() {
+        let mut state = MeshState::new();
+        state.invite_form_insert('M');
+        state.invite_form_insert('é');
+        assert_eq!(state.mesh_invite_name, "Mé");
+        state.invite_form_backspace();
+        assert_eq!(state.mesh_invite_name, "M");
+
+        state.mesh_invite_form_field = MeshInviteFormField::Ttl;
+        state.mesh_invite_ttl.clear();
+        state.invite_form_insert('2');
+        state.invite_form_insert('h');
+        assert_eq!(state.mesh_invite_ttl, "2h");
+        state.invite_form_backspace();
+        assert_eq!(state.mesh_invite_ttl, "2");
+
+        state.mesh_invite_form_field = MeshInviteFormField::MaxUses;
+        state.mesh_invite_max_uses.clear();
+        state.invite_form_insert('x');
+        state.invite_form_insert('7');
+        assert_eq!(state.mesh_invite_max_uses, "7");
+        state.invite_form_backspace();
+        assert!(state.mesh_invite_max_uses.is_empty());
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -428,7 +428,7 @@ fn conn_indicator(app: &App) -> Span<'static> {
 }
 
 pub(crate) fn mesh_header_span(app: &App) -> Option<Span<'static>> {
-    let n = app.mesh_node_count.filter(|&n| n > 0)?;
+    let n = app.mesh.mesh_node_count.filter(|&n| n > 0)?;
     Some(Span::styled(
         format!(" {} {n} ", chat::ICON_MESH),
         Theme::status(),
@@ -2223,13 +2223,13 @@ mod tests {
     fn draw_mesh_popup_shows_nodes_sessions_and_hints() {
         let mut app = App::new();
         app.popup = Popup::Mesh;
-        app.mesh_nodes = vec![crate::domain::mesh::RemoteNodeInfo {
+        app.mesh.mesh_nodes = vec![crate::domain::mesh::RemoteNodeInfo {
             id: "node-1".into(),
             label: "framework".into(),
             active_sessions: 1,
             ..Default::default()
         }];
-        app.remote_sessions_by_node.insert(
+        app.mesh.remote_sessions_by_node.insert(
             "node-1".into(),
             vec![crate::domain::mesh::RemoteSessionInfo {
                 id: "remote-1".into(),

--- a/src/ui/popups.rs
+++ b/src/ui/popups.rs
@@ -1487,6 +1487,7 @@ pub(super) fn draw_mesh_popup(f: &mut Frame, app: &App) {
         ])
         .split(inner);
     let title = app
+        .mesh
         .mesh_status
         .as_ref()
         .map(|status| {
@@ -1502,6 +1503,7 @@ pub(super) fn draw_mesh_popup(f: &mut Frame, app: &App) {
         })
         .unwrap_or_else(|| "mesh".to_string());
     let subtitle = app
+        .mesh
         .selected_mesh_node_label()
         .map(|label| format!("selected node: {label}"))
         .unwrap_or_else(|| "no mesh nodes loaded".to_string());
@@ -1519,17 +1521,18 @@ pub(super) fn draw_mesh_popup(f: &mut Frame, app: &App) {
         .constraints([Constraint::Percentage(42), Constraint::Percentage(58)])
         .split(chunks[1]);
 
-    let node_items: Vec<ListItem> = if app.mesh_nodes.is_empty() {
+    let node_items: Vec<ListItem> = if app.mesh.mesh_nodes.is_empty() {
         vec![ListItem::new(Line::from(Span::styled(
             "  no nodes",
             Theme::status(),
         )))]
     } else {
-        app.mesh_nodes
+        app.mesh
+            .mesh_nodes
             .iter()
             .enumerate()
             .map(|(i, node)| {
-                let selected = i == app.mesh_node_cursor;
+                let selected = i == app.mesh.mesh_node_cursor;
                 let style = if selected {
                     Theme::selected()
                 } else {
@@ -1548,14 +1551,17 @@ pub(super) fn draw_mesh_popup(f: &mut Frame, app: &App) {
     };
     let node_block = Block::bordered()
         .title(" nodes ")
-        .border_style(if matches!(app.mesh_focus, crate::mesh::MeshFocus::Nodes) {
-            Theme::status_accent()
-        } else {
-            Theme::status()
-        })
+        .border_style(
+            if matches!(app.mesh.mesh_focus, crate::mesh_state::MeshFocus::Nodes) {
+                Theme::status_accent()
+            } else {
+                Theme::status()
+            },
+        )
         .style(Theme::popup_bg());
     let mut node_state = ListState::default().with_selected(
-        (!app.mesh_nodes.is_empty()).then(|| app.mesh_node_cursor.min(app.mesh_nodes.len() - 1)),
+        (!app.mesh.mesh_nodes.is_empty())
+            .then(|| app.mesh.mesh_node_cursor.min(app.mesh.mesh_nodes.len() - 1)),
     );
     f.render_stateful_widget(
         List::new(node_items).block(node_block),
@@ -1563,7 +1569,7 @@ pub(super) fn draw_mesh_popup(f: &mut Frame, app: &App) {
         &mut node_state,
     );
 
-    let sessions = app.selected_remote_sessions();
+    let sessions = app.mesh.selected_remote_sessions();
     let session_items: Vec<ListItem> = if sessions.is_empty() {
         vec![ListItem::new(Line::from(Span::styled(
             "  no remote sessions",
@@ -1574,7 +1580,7 @@ pub(super) fn draw_mesh_popup(f: &mut Frame, app: &App) {
             .iter()
             .enumerate()
             .map(|(i, session)| {
-                let selected = i == app.remote_session_cursor;
+                let selected = i == app.mesh.remote_session_cursor;
                 let style = if selected {
                     Theme::selected()
                 } else {
@@ -1595,7 +1601,7 @@ pub(super) fn draw_mesh_popup(f: &mut Frame, app: &App) {
     let session_block = Block::bordered()
         .title(" remote sessions ")
         .border_style(
-            if matches!(app.mesh_focus, crate::mesh::MeshFocus::Sessions) {
+            if matches!(app.mesh.mesh_focus, crate::mesh_state::MeshFocus::Sessions) {
                 Theme::status_accent()
             } else {
                 Theme::status()
@@ -1603,7 +1609,7 @@ pub(super) fn draw_mesh_popup(f: &mut Frame, app: &App) {
         )
         .style(Theme::popup_bg());
     let mut session_state = ListState::default().with_selected(
-        (!sessions.is_empty()).then(|| app.remote_session_cursor.min(sessions.len() - 1)),
+        (!sessions.is_empty()).then(|| app.mesh.remote_session_cursor.min(sessions.len() - 1)),
     );
     f.render_stateful_widget(
         List::new(session_items).block(session_block),
@@ -1671,6 +1677,7 @@ pub(super) fn draw_mesh_invite_popup(f: &mut Frame, app: &App) {
 pub(super) fn draw_mesh_invite_qr_popup(f: &mut Frame, app: &App) {
     let area = f.area();
     let (qr_width, qr_height) = app
+        .mesh
         .mesh_invite
         .as_ref()
         .and_then(|invite| invite.qr_code.as_deref())
@@ -1717,7 +1724,7 @@ pub(super) fn draw_mesh_invite_qr_popup(f: &mut Frame, app: &App) {
     );
     draw_mesh_invite_details(f, app, chunks[2]);
 
-    if let Some(ref url) = app.mesh_clipboard_fallback {
+    if let Some(ref url) = app.mesh.mesh_clipboard_fallback {
         draw_mesh_clipboard_fallback(f, inner, url);
     }
 
@@ -1763,7 +1770,7 @@ fn draw_mesh_invite_form(f: &mut Frame, app: &App, area: Rect) {
         ])
         .split(area);
 
-    let field = app.mesh_invite_form_field;
+    let field = app.mesh.mesh_invite_form_field;
     let line = |label: &'static str, value: &str, selected: bool| {
         let label_style = Theme::status();
         let value_style = if selected {
@@ -1781,12 +1788,12 @@ fn draw_mesh_invite_form(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(
         Paragraph::new(line(
             "mesh name",
-            if app.mesh_invite_name.is_empty() {
+            if app.mesh.mesh_invite_name.is_empty() {
                 "(none)"
             } else {
-                &app.mesh_invite_name
+                &app.mesh.mesh_invite_name
             },
-            matches!(field, crate::mesh::MeshInviteFormField::MeshName),
+            matches!(field, crate::mesh_state::MeshInviteFormField::MeshName),
         ))
         .style(Theme::popup_bg()),
         rows[0],
@@ -1794,8 +1801,8 @@ fn draw_mesh_invite_form(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(
         Paragraph::new(line(
             "ttl",
-            &app.mesh_invite_ttl,
-            matches!(field, crate::mesh::MeshInviteFormField::Ttl),
+            &app.mesh.mesh_invite_ttl,
+            matches!(field, crate::mesh_state::MeshInviteFormField::Ttl),
         ))
         .style(Theme::popup_bg()),
         rows[1],
@@ -1803,13 +1810,13 @@ fn draw_mesh_invite_form(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(
         Paragraph::new(line(
             "max uses",
-            &app.mesh_invite_max_uses,
-            matches!(field, crate::mesh::MeshInviteFormField::MaxUses),
+            &app.mesh.mesh_invite_max_uses,
+            matches!(field, crate::mesh_state::MeshInviteFormField::MaxUses),
         ))
         .style(Theme::popup_bg()),
         rows[2],
     );
-    if let Some(message) = app.current_mesh_error() {
+    if let Some(message) = app.mesh.current_error() {
         f.render_widget(
             Paragraph::new(Line::from(Span::styled(
                 format!(" ! {message}"),
@@ -1832,7 +1839,7 @@ fn draw_mesh_invite_form(f: &mut Frame, app: &App, area: Rect) {
 
 fn draw_mesh_invite_details(f: &mut Frame, app: &App, area: Rect) {
     let mut lines: Vec<Line<'static>> = Vec::new();
-    if let Some(invite) = app.mesh_invite.as_ref() {
+    if let Some(invite) = app.mesh.mesh_invite.as_ref() {
         if let Some(qr) = invite.qr_code.as_deref() {
             for row in qr.lines() {
                 lines.push(Line::from(Span::styled(


### PR DESCRIPTION
## what changed
- extract the complete 15-field mesh UI/application slice into private `MeshState`
- move mesh focus/invite form types and pure transitions into `src/mesh_state.rs`
- retain exactly eight cross-state `App` coordinators for popup, diagnostics, commands, remote identity/cwd, and attach behavior
- migrate ACP, handler, and UI callers without compatibility forwards
- add focused owner and cross-boundary characterization coverage

## behavior preserved
- valid node cursor and stale per-node session lists survive node replacement
- remote session cursor, offset/limit, invite validation/errors, and fallback consumption remain unchanged
- remote create keeps `cwd: None`; attach keeps load-then-subscribe and detached refresh ordering
- remote location/cwd, opaque attach snapshot/config, and reconnect attach-first behavior remain session/runtime-owned and unchanged

## validation
- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --all-targets --all-features`
- `cargo test --all-targets --all-features -- --quiet` (816 passed; 3.09s harness, 3.294s wall)
- `git diff --check`
