### PR TITLE
refactor: extract navigation state

### DIFF
--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use serde_json::Value;
 
 use crate::acp_client::DelegateModelOverrideInfo;
-use crate::app::{POPUP_SESSION_PAGE_TARGET, Popup, Screen};
+use crate::app::POPUP_SESSION_PAGE_TARGET;
 use crate::command::{Command, SessionListRequest};
 use crate::diagnostics::LogLevel;
 use crate::domain::activity::{
@@ -24,6 +24,7 @@ use crate::domain::session::{
     UndoStackSnapshot, UndoableTurn,
 };
 use crate::domain::tool::ToolDetail;
+use crate::navigation_state::{Popup, Screen};
 use crate::tool_detail;
 
 #[derive(Debug, Clone, Default)]
@@ -449,7 +450,7 @@ impl crate::app::App {
                         forked_session_id: Some(forked_session_id),
                         message: _,
                     } => {
-                        self.popup = Popup::None;
+                        self.navigation.popup = Popup::None;
                         self.set_status(LogLevel::Info, "fork", "forked - loading session");
                         return Command::load_session_commands(
                             forked_session_id,
@@ -770,7 +771,7 @@ impl crate::app::App {
         self.apply_session_profile_binding(&session_id, profile_id);
         self.agent_id = Some(agent_id);
         self.reset_active_session_view();
-        self.screen = Screen::Chat;
+        self.navigation.screen = Screen::Chat;
         self.set_status(LogLevel::Info, "session", "session created");
         let mut commands = vec![Command::SubscribeSession {
             session_id: session_id.clone(),
@@ -801,7 +802,7 @@ impl crate::app::App {
         self.session_id = Some(session_id.clone());
         self.agent_id = Some(agent_id);
         self.reset_active_session_view();
-        self.screen = if self.parent_session_id.is_some() {
+        self.navigation.screen = if self.parent_session_id.is_some() {
             Screen::Delegate
         } else {
             Screen::Chat
@@ -2095,7 +2096,7 @@ fn acp_content_to_string(value: &Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::{App, Screen};
+    use crate::app::App;
     use crate::domain::activity::{PendingDelegateToolCall, SessionOp};
     use crate::domain::mesh::{RemoteNodeInfo, RemoteSessionInfo};
     use crate::domain::model::DelegateModelPreference;
@@ -2767,7 +2768,7 @@ mod tests {
             mesh_name: Some("Team Mesh".into()),
         }));
 
-        assert!(matches!(app.popup, Popup::MeshInviteQr));
+        assert!(matches!(app.navigation.popup, Popup::MeshInviteQr));
         assert_eq!(app.mesh.invite_url(), Some("qmt://mesh/join/token"));
     }
 
@@ -3057,7 +3058,7 @@ mod tests {
 
         assert_eq!(app.session_id.as_deref(), Some("session-1"));
         assert_eq!(app.agent_id.as_deref(), Some("agent-1"));
-        assert_eq!(app.screen, Screen::Chat);
+        assert_eq!(app.navigation.screen, Screen::Chat);
         assert!(app.messages.is_empty());
         assert!(app.streaming_content.is_empty());
         assert_eq!(app.scroll_offset, 0);
@@ -3136,7 +3137,7 @@ mod tests {
         });
 
         assert_eq!(app.parent_session_id.as_deref(), Some("parent"));
-        assert_eq!(app.screen, Screen::Delegate);
+        assert_eq!(app.navigation.screen, Screen::Delegate);
         assert!(app.messages.is_empty());
         assert!(app.streaming_content.is_empty());
         assert_eq!(app.streaming_content_message_id, None);
@@ -3189,7 +3190,7 @@ mod tests {
         });
 
         assert_eq!(app.parent_session_id, None);
-        assert_eq!(app.screen, Screen::Chat);
+        assert_eq!(app.navigation.screen, Screen::Chat);
         assert!(app.delegate_entries.is_empty());
         assert!(app.pending_delegate_child_states.is_empty());
         assert!(app.pending_delegate_tool_calls.is_empty());
@@ -4081,7 +4082,7 @@ mod tests {
     fn native_fork_result_success_loads_forked_session() {
         let mut app = App::new();
         app.agent_id = Some("agent-1".into());
-        app.popup = Popup::ForkTurnSelect;
+        app.navigation.popup = Popup::ForkTurnSelect;
         app.pending_fork_message_id = Some("msg-1".into());
 
         let replies = app.handle_acp_event(AcpAppEvent::ForkResult(ForkResult::Succeeded {
@@ -4091,7 +4092,7 @@ mod tests {
         }));
 
         assert_eq!(app.pending_fork_message_id, None);
-        assert_eq!(app.popup, Popup::None);
+        assert_eq!(app.navigation.popup, Popup::None);
         assert_eq!(app.diagnostics.status, "forked - loading session");
         assert_eq!(replies.len(), 2);
         assert!(matches!(
@@ -4106,7 +4107,7 @@ mod tests {
     #[test]
     fn native_fork_result_success_without_id_warns_and_keeps_popup() {
         let mut app = App::new();
-        app.popup = Popup::ForkTurnSelect;
+        app.navigation.popup = Popup::ForkTurnSelect;
         app.pending_fork_message_id = Some("msg-1".into());
 
         let replies = app.handle_acp_event(AcpAppEvent::ForkResult(ForkResult::Succeeded {
@@ -4117,14 +4118,14 @@ mod tests {
 
         assert!(replies.is_empty());
         assert_eq!(app.pending_fork_message_id, None);
-        assert_eq!(app.popup, Popup::ForkTurnSelect);
+        assert_eq!(app.navigation.popup, Popup::ForkTurnSelect);
         assert_eq!(app.diagnostics.status, "fork succeeded without session id");
     }
 
     #[test]
     fn native_fork_result_failure_clears_pending_and_keeps_popup() {
         let mut app = App::new();
-        app.popup = Popup::ForkTurnSelect;
+        app.navigation.popup = Popup::ForkTurnSelect;
         app.pending_fork_message_id = Some("msg-1".into());
 
         let replies = app.handle_acp_event(AcpAppEvent::ForkResult(ForkResult::Failed {
@@ -4134,7 +4135,7 @@ mod tests {
 
         assert!(replies.is_empty());
         assert_eq!(app.pending_fork_message_id, None);
-        assert_eq!(app.popup, Popup::ForkTurnSelect);
+        assert_eq!(app.navigation.popup, Popup::ForkTurnSelect);
         assert_eq!(app.diagnostics.status, "fork failed");
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -23,6 +23,7 @@ use crate::domain::session::{
 use crate::highlight::Highlighter;
 use crate::markdown::CardBlock;
 use crate::mesh_state::MeshState;
+use crate::navigation_state::{NavigationState, Popup};
 use crate::profiles_state::ProfilesState;
 use crate::protocol::audit::EventKind;
 use crate::ui::{CardCache, ElicitationUiState};
@@ -65,160 +66,6 @@ impl StreamingCache {
         self.blocks.clear();
     }
 }
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Screen {
-    Sessions,
-    Chat,
-    /// Read-only view for delegate child sessions (no input box).
-    Delegate,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Popup {
-    None,
-    CommandPalette,
-    Mesh,
-    MeshInvite,
-    MeshInviteQr,
-    ModelSelect,
-    SessionSelect,
-    NewSession,
-    ThemeSelect,
-    Help,
-    Log,
-    ProviderAuth,
-    ForkTurnSelect,
-    ProfileSelect,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CommandPaletteAction {
-    OpenMesh,
-    AttachRemoteSession,
-    CreateRemoteSession,
-    CreateMeshInvite,
-    ModelSelect,
-    SessionSelect,
-    DelegateSessions,
-    NewSession,
-    ThemeSelect,
-    Help,
-    Log,
-    ProviderAuth,
-    ForkTurnSelect,
-    ProfileSelect,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct CommandPaletteCommand {
-    pub title: &'static str,
-    pub description: &'static str,
-    pub shortcut: &'static str,
-    pub action: CommandPaletteAction,
-    pub chat_only: bool,
-}
-
-pub const COMMAND_PALETTE_COMMANDS: &[CommandPaletteCommand] = &[
-    CommandPaletteCommand {
-        title: "Open Mesh",
-        description: "View mesh nodes and remote sessions",
-        shortcut: "",
-        action: CommandPaletteAction::OpenMesh,
-        chat_only: false,
-    },
-    CommandPaletteCommand {
-        title: "Attach remote session",
-        description: "Attach an existing session from a mesh node",
-        shortcut: "",
-        action: CommandPaletteAction::AttachRemoteSession,
-        chat_only: false,
-    },
-    CommandPaletteCommand {
-        title: "Create remote session",
-        description: "Start a new session on a mesh node",
-        shortcut: "",
-        action: CommandPaletteAction::CreateRemoteSession,
-        chat_only: false,
-    },
-    CommandPaletteCommand {
-        title: "Create mesh invite",
-        description: "Generate a mesh invite link and QR code",
-        shortcut: "",
-        action: CommandPaletteAction::CreateMeshInvite,
-        chat_only: false,
-    },
-    CommandPaletteCommand {
-        title: "Model selector",
-        description: "Choose the model for this session or delegates",
-        shortcut: "C-x m",
-        action: CommandPaletteAction::ModelSelect,
-        chat_only: true,
-    },
-    CommandPaletteCommand {
-        title: "Session switcher",
-        description: "Browse and load sessions",
-        shortcut: "C-x l",
-        action: CommandPaletteAction::SessionSelect,
-        chat_only: false,
-    },
-    CommandPaletteCommand {
-        title: "Delegate sessions",
-        description: "Browse delegate child sessions",
-        shortcut: "",
-        action: CommandPaletteAction::DelegateSessions,
-        chat_only: true,
-    },
-    CommandPaletteCommand {
-        title: "New session",
-        description: "Start a new session in a directory",
-        shortcut: "C-x n",
-        action: CommandPaletteAction::NewSession,
-        chat_only: false,
-    },
-    CommandPaletteCommand {
-        title: "Theme picker",
-        description: "Change the UI theme",
-        shortcut: "C-x t",
-        action: CommandPaletteAction::ThemeSelect,
-        chat_only: false,
-    },
-    CommandPaletteCommand {
-        title: "Help",
-        description: "Show keyboard shortcuts and commands",
-        shortcut: "C-x ?",
-        action: CommandPaletteAction::Help,
-        chat_only: false,
-    },
-    CommandPaletteCommand {
-        title: "Logs",
-        description: "Show in-memory logs",
-        shortcut: "Ctrl+l",
-        action: CommandPaletteAction::Log,
-        chat_only: false,
-    },
-    CommandPaletteCommand {
-        title: "Provider auth",
-        description: "Manage provider authentication",
-        shortcut: "C-x a",
-        action: CommandPaletteAction::ProviderAuth,
-        chat_only: false,
-    },
-    CommandPaletteCommand {
-        title: "Fork selector",
-        description: "Choose a turn to fork from",
-        shortcut: "C-x f",
-        action: CommandPaletteAction::ForkTurnSelect,
-        chat_only: true,
-    },
-    CommandPaletteCommand {
-        title: "Profile selector",
-        description: "Choose the active profile for new sessions",
-        shortcut: "C-x p",
-        action: CommandPaletteAction::ProfileSelect,
-        chat_only: false,
-    },
-];
 
 // ── Delegation tracking ───────────────────────────────────────────────────────
 
@@ -501,11 +348,7 @@ pub enum ModelPopupItem {
 }
 
 pub struct App {
-    pub screen: Screen,
-    pub popup: Popup,
-    pub chord: bool, // true after ctrl+x pressed, waiting for second key
-    pub command_palette_cursor: usize,
-    pub command_palette_filter: String,
+    pub(crate) navigation: NavigationState,
 
     // sessions
     /// Session groups as received from the server (preserve group structure for start page).
@@ -614,13 +457,6 @@ pub struct App {
     pub model_popup_agent_tab: usize,
     /// Explicit model preferences scoped by profile ID and delegate agent ID.
     pub delegate_model_preferences: HashMap<String, HashMap<String, DelegateModelPreference>>,
-
-    // theme selector
-    pub theme_cursor: usize,
-    pub theme_filter: String,
-
-    // help popup
-    pub help_scroll: usize,
 
     // in-memory logs popup and status line
     pub(crate) diagnostics: DiagnosticsState,
@@ -755,11 +591,7 @@ impl App {
 
     pub fn new() -> Self {
         Self {
-            screen: Screen::Sessions,
-            popup: Popup::None,
-            chord: false,
-            command_palette_cursor: 0,
-            command_palette_filter: String::new(),
+            navigation: NavigationState::new(),
             session_groups: Vec::new(),
             session_cursor: 0,
             session_filter: String::new(),
@@ -826,9 +658,6 @@ impl App {
             agents_profile_id: None,
             model_popup_agent_tab: 0,
             delegate_model_preferences: HashMap::new(),
-            theme_cursor: 0,
-            theme_filter: String::new(),
-            help_scroll: 0,
             diagnostics: DiagnosticsState::new(),
             undo_state: None,
             undoable_turns: Vec::new(),
@@ -862,50 +691,6 @@ impl App {
             tick: 0,
             should_quit: false,
         }
-    }
-
-    pub fn open_command_palette(&mut self) {
-        self.popup = Popup::CommandPalette;
-        self.command_palette_filter.clear();
-        self.command_palette_cursor = 0;
-    }
-
-    pub fn filtered_command_palette_commands(&self) -> Vec<&'static CommandPaletteCommand> {
-        let q = self.command_palette_filter.trim().to_lowercase();
-        COMMAND_PALETTE_COMMANDS
-            .iter()
-            .filter(|command| !command.chat_only || matches!(self.screen, Screen::Chat))
-            .filter(|command| {
-                q.is_empty()
-                    || command.title.to_lowercase().contains(&q)
-                    || command.description.to_lowercase().contains(&q)
-                    || command.shortcut.to_lowercase().contains(&q)
-            })
-            .collect()
-    }
-
-    pub fn move_command_palette_cursor(&mut self, delta: isize) {
-        self.command_palette_cursor = move_wrapping_cursor(
-            self.command_palette_cursor,
-            self.filtered_command_palette_commands().len(),
-            delta,
-        );
-    }
-
-    pub fn selected_command_palette_action(&self) -> Option<CommandPaletteAction> {
-        self.filtered_command_palette_commands()
-            .get(self.command_palette_cursor)
-            .map(|command| command.action)
-    }
-
-    pub fn command_palette_filter_insert(&mut self, c: char) {
-        self.command_palette_filter.push(c);
-        self.command_palette_cursor = 0;
-    }
-
-    pub fn command_palette_filter_backspace(&mut self) {
-        self.command_palette_filter.pop();
-        self.command_palette_cursor = 0;
     }
 
     /// Invalidate both streaming caches and clear the thinking buffer.
@@ -981,7 +766,7 @@ impl App {
 
     /// Route to a freshly reset auth popup while preserving provider data.
     pub fn open_auth_popup(&mut self) {
-        self.popup = Popup::ProviderAuth;
+        self.navigation.popup = Popup::ProviderAuth;
         self.auth.reset_for_open();
     }
 
@@ -1004,7 +789,7 @@ impl App {
     }
 
     pub fn open_profile_popup(&mut self) {
-        self.popup = Popup::ProfileSelect;
+        self.navigation.popup = Popup::ProfileSelect;
         self.profiles.reset_for_open();
     }
 
@@ -1318,7 +1103,7 @@ impl App {
     }
 
     pub fn open_fork_turn_popup(&mut self) {
-        self.popup = Popup::ForkTurnSelect;
+        self.navigation.popup = Popup::ForkTurnSelect;
         self.fork_filter.clear();
         self.fork_cursor = 0;
     }
@@ -2118,7 +1903,7 @@ mod reasoning_effort_tests {
 
         app.open_new_session_popup();
 
-        assert_eq!(app.popup, Popup::NewSession);
+        assert_eq!(app.navigation.popup, Popup::NewSession);
         assert_eq!(app.new_session_path, "/launch");
         assert_eq!(app.new_session_cursor, "/launch".len());
     }
@@ -4069,51 +3854,6 @@ mod popup_item_tests {
         assert!(app.popup_collapsed_groups.contains("/a"));
         // start page collapsed_groups should be untouched
         assert!(!app.collapsed_groups.contains("/a"));
-    }
-
-    // ── command palette ───────────────────────────────────────────────────────
-
-    #[test]
-    fn command_palette_filters_commands_and_hides_chat_only_outside_chat() {
-        let mut app = App::new();
-        app.screen = Screen::Sessions;
-        app.command_palette_filter = "selector".into();
-
-        let titles: Vec<&str> = app
-            .filtered_command_palette_commands()
-            .iter()
-            .map(|command| command.title)
-            .collect();
-
-        assert_eq!(titles, vec!["Profile selector"]);
-    }
-
-    #[test]
-    fn command_palette_includes_chat_only_commands_in_chat() {
-        let mut app = App::new();
-        app.screen = Screen::Chat;
-        app.command_palette_filter = "model".into();
-
-        let actions: Vec<CommandPaletteAction> = app
-            .filtered_command_palette_commands()
-            .iter()
-            .map(|command| command.action)
-            .collect();
-
-        assert!(actions.contains(&CommandPaletteAction::ModelSelect));
-    }
-
-    #[test]
-    fn command_palette_cursor_wraps() {
-        let mut app = App::new();
-        app.screen = Screen::Chat;
-
-        app.move_command_palette_cursor(-1);
-
-        assert_eq!(
-            app.command_palette_cursor,
-            app.filtered_command_palette_commands().len() - 1
-        );
     }
 
     // ── slash completion state ─────────────────────────────────────────────────

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,13 +1,14 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use tokio::sync::mpsc;
 
-use crate::app::{self, App, CommandPaletteAction, Popup, Screen};
+use crate::app::{self, App};
 use crate::auth_state::{AuthPanel, AuthUiNotice};
 use crate::diagnostics::LogLevel;
 use crate::domain::activity::{ActivityState, SessionOp};
 use crate::domain::auth::{OAuthFlowKind, OAuthStatus};
 use crate::domain::chat::{ChatEntry, format_outcome_labels};
 use crate::domain::model::ModelEntry;
+use crate::navigation_state::{CommandPaletteAction, Popup, Screen};
 
 fn popup_page_step(visible_rows: usize) -> usize {
     visible_rows.saturating_sub(1).max(1)
@@ -237,7 +238,7 @@ pub(crate) fn handle_elicitation_key(
 }
 
 fn open_model_popup(app: &mut App, cmd_tx: &mpsc::UnboundedSender<Command>) -> anyhow::Result<()> {
-    if app.screen != Screen::Chat {
+    if app.navigation.screen != Screen::Chat {
         app.set_status(
             LogLevel::Warn,
             "model",
@@ -248,7 +249,7 @@ fn open_model_popup(app: &mut App, cmd_tx: &mpsc::UnboundedSender<Command>) -> a
     if !can_send_server_commands(app) {
         return Ok(());
     }
-    app.popup = Popup::ModelSelect;
+    app.navigation.popup = Popup::ModelSelect;
     app.model_filter.clear();
     app.model_popup_agent_tab = 0;
     app.model_cursor = app.model_popup_open_cursor();
@@ -263,7 +264,7 @@ fn open_session_popup(
     if !can_send_server_commands(app) {
         return Ok(());
     }
-    app.popup = Popup::SessionSelect;
+    app.navigation.popup = Popup::SessionSelect;
     app.session_popup_tab = 0;
     app.session_cursor = 0;
     app.session_filter.clear();
@@ -274,7 +275,7 @@ fn open_session_popup(
 }
 
 fn open_log_popup(app: &mut App) {
-    app.popup = Popup::Log;
+    app.navigation.popup = Popup::Log;
     app.diagnostics.log_cursor = app.filtered_logs().len().saturating_sub(1);
     app.diagnostics.log_filter.clear();
 }
@@ -320,14 +321,10 @@ fn execute_command_palette_action(
             app.open_new_session_popup();
         }
         CommandPaletteAction::ThemeSelect => {
-            app.popup = Popup::ThemeSelect;
-            app.theme_filter.clear();
-            app.theme_cursor = theme::Theme::current_index();
+            app.navigation
+                .open_theme_selector(theme::Theme::current_index());
         }
-        CommandPaletteAction::Help => {
-            app.popup = Popup::Help;
-            app.help_scroll = 0;
-        }
+        CommandPaletteAction::Help => app.navigation.open_help(),
         CommandPaletteAction::Log => open_log_popup(app),
         CommandPaletteAction::ProviderAuth => {
             if !can_send_server_commands(app) {
@@ -356,7 +353,7 @@ pub(crate) fn handle_mesh_popup_key(
     cmd_tx: &mpsc::UnboundedSender<Command>,
 ) -> anyhow::Result<()> {
     match key.code {
-        KeyCode::Esc => app.popup = Popup::None,
+        KeyCode::Esc => app.navigation.popup = Popup::None,
         KeyCode::Tab | KeyCode::Right | KeyCode::Left => app.mesh.toggle_focus(),
         KeyCode::Up => match app.mesh.mesh_focus {
             crate::mesh_state::MeshFocus::Nodes => {
@@ -426,7 +423,7 @@ pub(crate) fn handle_mesh_invite_popup_key(
     }
 
     match key.code {
-        KeyCode::Esc => app.popup = Popup::None,
+        KeyCode::Esc => app.navigation.popup = Popup::None,
         KeyCode::Up => app.mesh.move_invite_form_field(-1),
         KeyCode::Down | KeyCode::Tab => app.mesh.move_invite_form_field(1),
         KeyCode::Backspace => app.mesh.invite_form_backspace(),
@@ -450,7 +447,7 @@ pub(crate) fn handle_mesh_invite_qr_popup_key(app: &mut App, key: KeyEvent) -> a
     }
 
     match key.code {
-        KeyCode::Esc => app.popup = Popup::MeshInvite,
+        KeyCode::Esc => app.navigation.popup = Popup::MeshInvite,
         KeyCode::Char('u') => {
             app.mesh.show_invite_url_fallback();
         }
@@ -474,17 +471,17 @@ pub(crate) fn handle_command_palette_key(
     cmd_tx: &mpsc::UnboundedSender<Command>,
 ) -> anyhow::Result<()> {
     match key.code {
-        KeyCode::Esc => app.popup = Popup::None,
-        KeyCode::Up => app.move_command_palette_cursor(-1),
-        KeyCode::Down => app.move_command_palette_cursor(1),
-        KeyCode::Backspace => app.command_palette_filter_backspace(),
+        KeyCode::Esc => app.navigation.popup = Popup::None,
+        KeyCode::Up => app.navigation.move_command_palette_cursor(-1),
+        KeyCode::Down => app.navigation.move_command_palette_cursor(1),
+        KeyCode::Backspace => app.navigation.command_palette_filter_backspace(),
         KeyCode::Enter => {
-            if let Some(action) = app.selected_command_palette_action() {
+            if let Some(action) = app.navigation.selected_command_palette_action() {
                 execute_command_palette_action(app, action, cmd_tx)?;
             }
         }
         KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
-            app.command_palette_filter_insert(c);
+            app.navigation.command_palette_filter_insert(c);
         }
         _ => {}
     }
@@ -517,17 +514,17 @@ pub(crate) fn handle_key(
     if key.modifiers.contains(KeyModifiers::CONTROL)
         && matches!(key.code, KeyCode::Char('p') | KeyCode::Char('P'))
     {
-        app.chord = false;
-        app.open_command_palette();
+        app.navigation.chord = false;
+        app.navigation.open_command_palette();
         return Ok(AppAction::None);
     }
 
     // chord second key: ctrl+x was pressed, now handle the follow-up
-    if app.chord {
-        app.chord = false;
+    if app.navigation.chord {
+        app.navigation.chord = false;
         app.set_status(LogLevel::Debug, "input", "ready");
         if key.code == KeyCode::Char('e') {
-            if app.screen != Screen::Chat {
+            if app.navigation.screen != Screen::Chat {
                 app.set_status(
                     LogLevel::Warn,
                     "editor",
@@ -585,13 +582,13 @@ pub(crate) fn handle_key(
 
     // chord start: ctrl+x
     if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('x') {
-        app.chord = true;
+        app.navigation.chord = true;
         app.set_status(LogLevel::Debug, "input", "C-x ...");
         return Ok(AppAction::None);
     }
 
     // popup handling
-    match app.popup {
+    match app.navigation.popup {
         Popup::CommandPalette => {
             handle_command_palette_key(app, key, cmd_tx)?;
             return Ok(AppAction::None);
@@ -627,14 +624,10 @@ pub(crate) fn handle_key(
         Popup::Help => {
             match key.code {
                 KeyCode::Esc => {
-                    app.popup = Popup::None;
+                    app.navigation.popup = Popup::None;
                 }
-                KeyCode::Up => {
-                    app.help_scroll = app.help_scroll.saturating_sub(1);
-                }
-                KeyCode::Down => {
-                    app.help_scroll = app.help_scroll.saturating_add(1);
-                }
+                KeyCode::Up => app.navigation.scroll_help_up(),
+                KeyCode::Down => app.navigation.scroll_help_down(),
                 _ => {}
             }
             return Ok(AppAction::None);
@@ -668,7 +661,7 @@ pub(crate) fn handle_key(
         return Ok(AppAction::None);
     }
 
-    match app.screen {
+    match app.navigation.screen {
         Screen::Sessions => handle_sessions_key(app, key, cmd_tx)?,
         Screen::Chat => return handle_chat_key(app, key, cmd_tx),
         Screen::Delegate => return handle_delegate_view_key(app, key, cmd_tx),
@@ -677,7 +670,7 @@ pub(crate) fn handle_key(
 }
 
 pub(crate) fn handle_mouse(app: &mut App, mouse: MouseEvent) {
-    match (mouse.kind, &app.screen, &app.popup) {
+    match (mouse.kind, &app.navigation.screen, &app.navigation.popup) {
         (MouseEventKind::ScrollUp, Screen::Chat | Screen::Delegate, Popup::None) => {
             app.scroll_offset = app.scroll_offset.saturating_add(3);
         }
@@ -718,11 +711,9 @@ pub(crate) fn handle_chord(
             app.set_status(LogLevel::Warn, "editor", "external editor unavailable here");
         }
 
-        KeyCode::Char('t') => {
-            app.popup = Popup::ThemeSelect;
-            app.theme_filter.clear();
-            app.theme_cursor = theme::Theme::current_index();
-        }
+        KeyCode::Char('t') => app
+            .navigation
+            .open_theme_selector(theme::Theme::current_index()),
         KeyCode::Char('l') => {
             open_session_popup(app, cmd_tx)?;
         }
@@ -742,7 +733,7 @@ pub(crate) fn handle_chord(
             cmd_tx.send(Command::ListProfiles)?;
         }
         KeyCode::Char('j') => {
-            if !matches!(app.screen, Screen::Chat | Screen::Delegate) {
+            if !matches!(app.navigation.screen, Screen::Chat | Screen::Delegate) {
                 app.set_status(
                     LogLevel::Warn,
                     "session",
@@ -764,12 +755,9 @@ pub(crate) fn handle_chord(
                 app.set_status(LogLevel::Info, "session", "no parent session");
             }
         }
-        KeyCode::Char('?') => {
-            app.popup = Popup::Help;
-            app.help_scroll = 0;
-        }
+        KeyCode::Char('?') => app.navigation.open_help(),
         KeyCode::Char('f') => {
-            if app.screen != Screen::Chat {
+            if app.navigation.screen != Screen::Chat {
                 app.set_status(
                     LogLevel::Warn,
                     "fork",
@@ -1027,7 +1015,7 @@ pub(crate) fn apply_popup_session_key(
 
     match key {
         KeyCode::Esc => {
-            app.popup = Popup::None;
+            app.navigation.popup = Popup::None;
         }
         KeyCode::Up => {
             app.session_cursor = app.session_cursor.saturating_sub(1);
@@ -1062,7 +1050,7 @@ pub(crate) fn apply_popup_session_key(
                     } => {
                         let session = app.session_by_path(group_idx, &path).cloned();
                         if let Some(session) = session {
-                            app.popup = Popup::None;
+                            app.navigation.popup = Popup::None;
                             let session_id = session.session_id;
                             if let Some(node_id) =
                                 app.session_remote_node_id(&session_id).map(str::to_string)
@@ -1280,7 +1268,7 @@ pub(crate) fn apply_delegate_popup_key(
 ) -> SessionKeyAction {
     match key {
         KeyCode::Esc => {
-            app.popup = Popup::None;
+            app.navigation.popup = Popup::None;
         }
         KeyCode::Up => {
             app.delegate_cursor = app.delegate_cursor.saturating_sub(1);
@@ -1315,7 +1303,7 @@ pub(crate) fn apply_delegate_popup_key(
                         .parent_session_id
                         .clone()
                         .or_else(|| app.session_id.clone());
-                    app.popup = Popup::None;
+                    app.navigation.popup = Popup::None;
                     return SessionKeyAction::LoadSession {
                         session_id: sid,
                         agent_id: target_agent_id,
@@ -1377,7 +1365,7 @@ pub(crate) fn handle_fork_turn_popup_key(
     cmd_tx: &mpsc::UnboundedSender<Command>,
 ) -> anyhow::Result<()> {
     match key.code {
-        KeyCode::Esc => app.popup = Popup::None,
+        KeyCode::Esc => app.navigation.popup = Popup::None,
         KeyCode::Up => app.move_fork_cursor(-1),
         KeyCode::Down => app.move_fork_cursor(1),
         KeyCode::Backspace => app.fork_filter_backspace(),
@@ -1399,7 +1387,7 @@ pub(crate) fn handle_fork_turn_popup_key(
 pub(crate) fn handle_log_popup_key(app: &mut App, key: KeyEvent) -> anyhow::Result<()> {
     match key.code {
         KeyCode::Esc => {
-            app.popup = Popup::None;
+            app.navigation.popup = Popup::None;
         }
         KeyCode::Up => {
             app.diagnostics.log_cursor = app.diagnostics.log_cursor.saturating_sub(1);
@@ -1445,7 +1433,7 @@ pub(crate) fn handle_profile_popup_key(
 ) -> anyhow::Result<()> {
     match key.code {
         KeyCode::Esc => {
-            app.popup = Popup::None;
+            app.navigation.popup = Popup::None;
         }
         KeyCode::Up => app.profiles.move_profile_cursor(-1),
         KeyCode::Down => app.profiles.move_profile_cursor(1),
@@ -1475,7 +1463,7 @@ pub(crate) fn handle_profile_popup_key(
                         profile_id: profile_id.clone(),
                     })?;
                 }
-                app.popup = Popup::None;
+                app.navigation.popup = Popup::None;
                 app.set_status(
                     LogLevel::Info,
                     "profile",
@@ -1498,7 +1486,7 @@ pub(crate) fn handle_new_session_popup_key(
 ) -> anyhow::Result<()> {
     match key.code {
         KeyCode::Esc => {
-            app.popup = Popup::None;
+            app.navigation.popup = Popup::None;
         }
         KeyCode::Up => {
             app.move_new_session_completion_selection(-1);
@@ -1543,7 +1531,7 @@ pub(crate) fn handle_new_session_popup_key(
                 return Ok(());
             }
             let cwd = app.normalize_new_session_path(&app.new_session_path);
-            app.popup = Popup::None;
+            app.navigation.popup = Popup::None;
             cmd_tx.send(Command::NewSession {
                 cwd,
                 profile_id: app.profiles.active_profile_id.clone(),
@@ -1563,59 +1551,33 @@ pub(crate) fn invalidate_theme_caches(app: &mut App) {
 }
 
 pub(crate) fn handle_theme_popup_key(app: &mut App, key: KeyEvent) -> anyhow::Result<()> {
-    let filtered_len = || -> usize {
-        let q = app.theme_filter.to_lowercase();
-        if q.is_empty() {
-            theme::Theme::available_themes().len()
-        } else {
-            theme::Theme::available_themes()
-                .iter()
-                .filter(|t| t.label.to_lowercase().contains(&q) || t.id.to_lowercase().contains(&q))
-                .count()
-        }
-    };
-
-    let filtered_index = |cursor: usize| -> Option<usize> {
-        let q = app.theme_filter.to_lowercase();
-        let iter = theme::Theme::available_themes().iter().enumerate();
-        if q.is_empty() {
-            Some(cursor)
-        } else {
-            iter.filter(|(_, t)| {
-                t.label.to_lowercase().contains(&q) || t.id.to_lowercase().contains(&q)
-            })
-            .nth(cursor)
-            .map(|(i, _)| i)
-        }
-    };
-
     match key.code {
         KeyCode::Esc => {
-            app.popup = Popup::None;
+            app.navigation.popup = Popup::None;
         }
-        KeyCode::Up => {
-            app.theme_cursor = app.theme_cursor.saturating_sub(1);
-        }
+        KeyCode::Up => app.navigation.move_theme_cursor_up(),
         KeyCode::Down => {
-            let max = filtered_len().saturating_sub(1);
-            app.theme_cursor = (app.theme_cursor + 1).min(max);
+            let filtered_len = app
+                .navigation
+                .filtered_themes(theme::Theme::available_themes())
+                .len();
+            app.navigation.move_theme_cursor_down(filtered_len);
         }
         KeyCode::Enter => {
-            if let Some(idx) = filtered_index(app.theme_cursor) {
+            if let Some(idx) = app
+                .navigation
+                .selected_theme_index(theme::Theme::available_themes())
+            {
                 theme::Theme::set_by_index(idx);
                 theme::Theme::begin_frame();
                 invalidate_theme_caches(app);
-                app.popup = Popup::None;
+                app.navigation.popup = Popup::None;
                 save_config(app);
             }
         }
-        KeyCode::Backspace => {
-            app.theme_filter.pop();
-            app.theme_cursor = 0;
-        }
+        KeyCode::Backspace => app.navigation.theme_filter_backspace(),
         KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
-            app.theme_filter.push(c);
-            app.theme_cursor = 0;
+            app.navigation.theme_filter_insert(c);
         }
         _ => {}
     }
@@ -1852,7 +1814,7 @@ fn try_execute_slash_command(
     match cmd.as_str() {
         "model" => {
             app.take_input();
-            if app.screen != crate::app::Screen::Chat {
+            if app.navigation.screen != Screen::Chat {
                 app.set_status(
                     LogLevel::Warn,
                     "model",
@@ -1863,7 +1825,7 @@ fn try_execute_slash_command(
             if !can_send_server_commands(app) {
                 return Ok(SlashResult::Handled);
             }
-            app.popup = crate::app::Popup::ModelSelect;
+            app.navigation.popup = Popup::ModelSelect;
             app.model_popup_agent_tab = 0;
             if arg.is_empty() {
                 app.model_filter.clear();
@@ -1950,9 +1912,8 @@ fn try_execute_slash_command(
         }
         "theme" => {
             app.take_input();
-            app.popup = crate::app::Popup::ThemeSelect;
-            app.theme_filter.clear();
-            app.theme_cursor = crate::theme::Theme::current_index();
+            app.navigation
+                .open_theme_selector(crate::theme::Theme::current_index());
         }
         "profile" => {
             app.take_input();
@@ -1991,7 +1952,7 @@ fn try_execute_slash_command(
             if !can_send_server_commands(app) {
                 return Ok(SlashResult::Handled);
             }
-            app.popup = crate::app::Popup::SessionSelect;
+            app.navigation.popup = Popup::SessionSelect;
             app.session_popup_tab = 0;
             app.session_cursor = 0;
             app.session_filter.clear();
@@ -2001,7 +1962,7 @@ fn try_execute_slash_command(
         }
         "delegates" => {
             app.take_input();
-            if app.screen != crate::app::Screen::Chat {
+            if app.navigation.screen != Screen::Chat {
                 app.set_status(
                     LogLevel::Warn,
                     "delegates",
@@ -2023,12 +1984,11 @@ fn try_execute_slash_command(
         }
         "help" => {
             app.take_input();
-            app.popup = crate::app::Popup::Help;
-            app.help_scroll = 0;
+            app.navigation.open_help();
         }
         "logs" => {
             app.take_input();
-            app.popup = crate::app::Popup::Log;
+            app.navigation.popup = Popup::Log;
             app.diagnostics.log_cursor = app.filtered_logs().len().saturating_sub(1);
             app.diagnostics.log_filter.clear();
         }
@@ -2042,7 +2002,7 @@ fn try_execute_slash_command(
         }
         "fork" => {
             app.take_input();
-            if app.screen != crate::app::Screen::Chat {
+            if app.navigation.screen != Screen::Chat {
                 app.set_status(LogLevel::Warn, "fork", "forking is only available in chat");
                 return Ok(SlashResult::Handled);
             }
@@ -2156,7 +2116,7 @@ pub(crate) fn handle_auth_popup_key(
                 if app.auth.selected.is_some() {
                     app.auth.close_detail();
                 } else {
-                    app.popup = Popup::None;
+                    app.navigation.popup = Popup::None;
                 }
             }
             KeyCode::Up => {
@@ -2426,7 +2386,7 @@ pub(crate) fn handle_model_popup_key(
 ) -> anyhow::Result<()> {
     match key.code {
         KeyCode::Esc => {
-            app.popup = Popup::None;
+            app.navigation.popup = Popup::None;
         }
         KeyCode::Tab | KeyCode::BackTab => {
             if !app.model_popup_has_tabs() {
@@ -2660,7 +2620,7 @@ pub(crate) fn apply_sessions_key(
                         }
                     }
                     StartPageItem::ShowMore { .. } => {
-                        app.popup = Popup::SessionSelect;
+                        app.navigation.popup = Popup::SessionSelect;
                         app.session_popup_tab = 0;
                         app.session_cursor = 0;
                         app.session_filter.clear();
@@ -2722,7 +2682,7 @@ pub(crate) fn apply_sessions_key(
 #[cfg(test)]
 mod model_popup_tests {
     use super::*;
-    use crate::app::{App, Popup};
+    use crate::app::App;
     use crate::config::TestPersistenceGuard;
     use crate::domain::model::ModelEntry;
     use crate::domain::profile::{AgentInfo, ProfileInfo};
@@ -2792,7 +2752,7 @@ mod model_popup_tests {
     #[test]
     fn popup_enter_on_remote_session_attaches_instead_of_loading() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![SessionGroup {
             sessions: vec![SessionSummary {
                 session_id: "remote-1".into(),
@@ -2813,13 +2773,18 @@ mod model_popup_tests {
                 session_id: "remote-1".into(),
             }
         );
-        assert!(matches!(app.popup, Popup::None));
+        assert!(matches!(app.navigation.popup, Popup::None));
     }
 
     #[test]
     fn ctrl_p_opens_command_palette_over_existing_popup() {
         let mut app = App::new();
-        app.popup = Popup::ThemeSelect;
+        app.navigation.popup = Popup::ThemeSelect;
+        app.navigation.chord = true;
+        app.navigation.command_palette_cursor = 4;
+        app.navigation.command_palette_filter = "old".into();
+        app.navigation.theme_filter = "keep".into();
+        app.navigation.help_scroll = 9;
 
         let (tx, _rx) = mpsc::unbounded_channel();
         handle_key(
@@ -2829,41 +2794,90 @@ mod model_popup_tests {
         )
         .unwrap();
 
-        assert!(matches!(app.popup, Popup::CommandPalette));
-        assert_eq!(app.command_palette_cursor, 0);
-        assert!(app.command_palette_filter.is_empty());
+        assert!(matches!(app.navigation.popup, Popup::CommandPalette));
+        assert!(!app.navigation.chord);
+        assert_eq!(app.navigation.command_palette_cursor, 0);
+        assert!(app.navigation.command_palette_filter.is_empty());
+        assert_eq!(app.navigation.theme_filter, "keep");
+        assert_eq!(app.navigation.help_scroll, 9);
+    }
+
+    #[test]
+    fn help_popup_routes_scroll_and_escape_before_screen_keys() {
+        let mut app = App::new();
+        app.navigation.open_help();
+        app.session_filter = "keep".into();
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        handle_key(&mut app, key(KeyCode::Char('x')), &tx).unwrap();
+        assert_eq!(app.session_filter, "keep");
+        assert_eq!(app.navigation.popup, Popup::Help);
+
+        handle_key(&mut app, key(KeyCode::Down), &tx).unwrap();
+        assert_eq!(app.navigation.help_scroll, 1);
+        handle_key(&mut app, key(KeyCode::Up), &tx).unwrap();
+        handle_key(&mut app, key(KeyCode::Up), &tx).unwrap();
+        assert_eq!(app.navigation.help_scroll, 0);
+
+        handle_key(&mut app, key(KeyCode::Esc), &tx).unwrap();
+        assert_eq!(app.navigation.popup, Popup::None);
+    }
+
+    #[test]
+    fn theme_popup_clamps_cursor_and_keeps_no_match_open() {
+        let mut app = App::new();
+        app.navigation.popup = Popup::ThemeSelect;
+        app.navigation.theme_filter = "no theme matches this".into();
+        app.navigation.theme_cursor = 8;
+
+        handle_theme_popup_key(&mut app, key(KeyCode::Down)).unwrap();
+        assert_eq!(app.navigation.theme_cursor, 0);
+        handle_theme_popup_key(&mut app, key(KeyCode::Enter)).unwrap();
+        assert_eq!(app.navigation.popup, Popup::ThemeSelect);
+    }
+
+    #[test]
+    fn empty_theme_filter_out_of_range_enter_still_closes() {
+        let _guard = TestPersistenceGuard::new("theme-out-of-range");
+        let mut app = App::new();
+        app.navigation.popup = Popup::ThemeSelect;
+        app.navigation.theme_cursor = theme::Theme::available_themes().len() + 10;
+
+        handle_theme_popup_key(&mut app, key(KeyCode::Enter)).unwrap();
+
+        assert_eq!(app.navigation.popup, Popup::None);
     }
 
     #[test]
     fn command_palette_enter_opens_theme_picker() {
         let mut app = App::new();
-        app.popup = Popup::CommandPalette;
-        app.command_palette_filter = "theme".into();
+        app.navigation.popup = Popup::CommandPalette;
+        app.navigation.command_palette_filter = "theme".into();
 
         let (tx, _rx) = mpsc::unbounded_channel();
         handle_command_palette_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
 
-        assert!(matches!(app.popup, Popup::ThemeSelect));
+        assert!(matches!(app.navigation.popup, Popup::ThemeSelect));
     }
 
     #[test]
     fn command_palette_open_mesh_refreshes_remote_nodes() {
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
-        app.popup = Popup::CommandPalette;
-        app.command_palette_filter = "open mesh".into();
+        app.navigation.popup = Popup::CommandPalette;
+        app.navigation.command_palette_filter = "open mesh".into();
 
         let (tx, mut rx) = mpsc::unbounded_channel();
         handle_command_palette_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
 
-        assert!(matches!(app.popup, Popup::Mesh));
+        assert!(matches!(app.navigation.popup, Popup::Mesh));
         assert!(matches!(rx.try_recv(), Ok(Command::ListRemoteNodes)));
     }
 
     #[test]
     fn mesh_popup_enter_on_session_attaches_remote_session() {
         let mut app = App::new();
-        app.popup = Popup::Mesh;
+        app.navigation.popup = Popup::Mesh;
         app.mesh.mesh_focus = crate::mesh_state::MeshFocus::Sessions;
         app.mesh.mesh_nodes = vec![crate::domain::mesh::RemoteNodeInfo {
             id: "node-1".into(),
@@ -2893,7 +2907,7 @@ mod model_popup_tests {
     #[test]
     fn mesh_popup_create_remote_session_does_not_forward_local_cwd() {
         let mut app = App::new();
-        app.popup = Popup::Mesh;
+        app.navigation.popup = Popup::Mesh;
         app.launch_cwd = Some("/local/launch".into());
         app.mesh.mesh_nodes = vec![crate::domain::mesh::RemoteNodeInfo {
             id: "node-1".into(),
@@ -2917,13 +2931,13 @@ mod model_popup_tests {
     fn command_palette_create_mesh_invite_opens_prefilled_invite_popup() {
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
-        app.popup = Popup::CommandPalette;
-        app.command_palette_filter = "mesh invite".into();
+        app.navigation.popup = Popup::CommandPalette;
+        app.navigation.command_palette_filter = "mesh invite".into();
 
         let (tx, _rx) = mpsc::unbounded_channel();
         handle_command_palette_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
 
-        assert!(matches!(app.popup, Popup::MeshInvite));
+        assert!(matches!(app.navigation.popup, Popup::MeshInvite));
         assert_eq!(app.mesh.mesh_invite_ttl, "24h");
         assert_eq!(app.mesh.mesh_invite_max_uses, "1");
     }
@@ -2931,12 +2945,12 @@ mod model_popup_tests {
     #[test]
     fn mesh_popup_i_no_longer_opens_invite_popup() {
         let mut app = App::new();
-        app.popup = Popup::Mesh;
+        app.navigation.popup = Popup::Mesh;
 
         let (tx, _rx) = mpsc::unbounded_channel();
         handle_mesh_popup_key(&mut app, key(KeyCode::Char('i')), &tx).unwrap();
 
-        assert!(matches!(app.popup, Popup::Mesh));
+        assert!(matches!(app.navigation.popup, Popup::Mesh));
     }
 
     #[test]
@@ -2961,7 +2975,7 @@ mod model_popup_tests {
 
         handle_mesh_invite_qr_popup_key(&mut app, key(KeyCode::Esc)).unwrap();
 
-        assert!(matches!(app.popup, Popup::MeshInviteQr));
+        assert!(matches!(app.navigation.popup, Popup::MeshInviteQr));
         assert!(app.mesh.mesh_clipboard_fallback.is_none());
     }
 
@@ -2994,7 +3008,7 @@ mod model_popup_tests {
     #[test]
     fn mesh_invite_form_enter_sends_create_invite() {
         let mut app = App::new();
-        app.popup = Popup::Mesh;
+        app.navigation.popup = Popup::Mesh;
         app.open_mesh_invite_form();
         app.mesh.mesh_invite_name = "Team Mesh".into();
         app.mesh.mesh_invite_ttl = "1d3h5m".into();
@@ -3025,15 +3039,15 @@ mod model_popup_tests {
 
         handle_mesh_invite_qr_popup_key(&mut app, key(KeyCode::Esc)).unwrap();
 
-        assert!(matches!(app.popup, Popup::MeshInvite));
+        assert!(matches!(app.navigation.popup, Popup::MeshInvite));
     }
 
     #[test]
     fn command_palette_profile_lists_profiles() {
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
-        app.popup = Popup::CommandPalette;
-        app.command_palette_filter = "profile".into();
+        app.navigation.popup = Popup::CommandPalette;
+        app.navigation.command_palette_filter = "profile".into();
         app.profiles.profiles = vec![make_profile("fast", "Fast"), make_profile("deep", "Deep")];
         app.profiles.active_profile_id = Some("deep".into());
         app.profiles.profile_filter = "stale".into();
@@ -3042,7 +3056,7 @@ mod model_popup_tests {
         let (tx, mut rx) = mpsc::unbounded_channel();
         handle_command_palette_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
 
-        assert!(matches!(app.popup, Popup::ProfileSelect));
+        assert!(matches!(app.navigation.popup, Popup::ProfileSelect));
         assert!(app.profiles.profile_filter.is_empty());
         assert_eq!(app.profiles.profile_cursor, 1);
         assert!(matches!(rx.try_recv(), Ok(Command::ListProfiles)));
@@ -3052,7 +3066,7 @@ mod model_popup_tests {
     fn slash_profile_without_arg_opens_selector_and_lists_profiles() {
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.input = "/profile".into();
         app.input_cursor = app.input.len();
 
@@ -3060,7 +3074,7 @@ mod model_popup_tests {
         let action = handle_chat_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
 
         assert!(matches!(action, AppAction::None));
-        assert!(matches!(app.popup, Popup::ProfileSelect));
+        assert!(matches!(app.navigation.popup, Popup::ProfileSelect));
         assert!(matches!(rx.try_recv(), Ok(Command::ListProfiles)));
     }
 
@@ -3069,7 +3083,7 @@ mod model_popup_tests {
         let _guard = TestPersistenceGuard::new("slash-profile");
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.profiles.profiles = vec![make_profile("fast", "Fast")];
         app.profiles.active_profile_id = Some("old".into());
         app.input = "/profile Fast".into();
@@ -3094,14 +3108,14 @@ mod model_popup_tests {
         let _guard = TestPersistenceGuard::new("profile-popup-enter");
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
-        app.popup = Popup::ProfileSelect;
+        app.navigation.popup = Popup::ProfileSelect;
         app.profiles.profiles = vec![make_profile("fast", "Fast"), make_profile("deep", "Deep")];
         app.profiles.profile_cursor = 1;
 
         let (tx, mut rx) = mpsc::unbounded_channel();
         handle_profile_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
 
-        assert!(matches!(app.popup, Popup::None));
+        assert!(matches!(app.navigation.popup, Popup::None));
         assert!(matches!(
             rx.try_recv(),
             Ok(Command::ListProfileAgents { profile_id }) if profile_id == "deep"
@@ -3117,7 +3131,7 @@ mod model_popup_tests {
         let _guard = TestPersistenceGuard::new("profile-bound-session");
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
-        app.popup = Popup::ProfileSelect;
+        app.navigation.popup = Popup::ProfileSelect;
         app.session_id = Some("session".into());
         app.profiles
             .bind_session_profile("session".into(), "current".into());
@@ -3135,7 +3149,7 @@ mod model_popup_tests {
     fn new_session_uses_locally_selected_profile() {
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
-        app.popup = Popup::NewSession;
+        app.navigation.popup = Popup::NewSession;
         app.new_session_path = "/repo".into();
         app.new_session_cursor = app.new_session_path.len();
         app.profiles.active_profile_id = Some("coder-delegate".into());
@@ -3154,7 +3168,7 @@ mod model_popup_tests {
     fn select_model_on_delegate_tab_saves_pref_not_session_model() {
         let _guard = TestPersistenceGuard::new("delegate-tab");
         let mut app = App::new();
-        app.popup = Popup::ModelSelect;
+        app.navigation.popup = Popup::ModelSelect;
         app.session_id = Some("s1".into());
         app.profiles.active_profile_id = Some("profile".into());
         app.profiles
@@ -3206,7 +3220,7 @@ mod model_popup_tests {
     fn delete_on_delegate_tab_resets_parent_override() {
         let _guard = TestPersistenceGuard::new("delegate-reset");
         let mut app = App::new();
-        app.popup = Popup::ModelSelect;
+        app.navigation.popup = Popup::ModelSelect;
         app.session_id = Some("s1".into());
         app.profiles.active_profile_id = Some("profile".into());
         app.profiles
@@ -3241,7 +3255,7 @@ mod model_popup_tests {
     fn delegate_child_model_selection_is_saved_without_mutating_child_session() {
         let _guard = TestPersistenceGuard::new("delegate-child-model");
         let mut app = App::new();
-        app.popup = Popup::ModelSelect;
+        app.navigation.popup = Popup::ModelSelect;
         app.session_id = Some("child".into());
         app.parent_session_id = Some("parent".into());
         app.profiles.active_profile_id = Some("profile".into());
@@ -3269,7 +3283,7 @@ mod model_popup_tests {
     fn select_model_on_session_tab_applies_set_session_model() {
         let _guard = TestPersistenceGuard::new("active-mode");
         let mut app = App::new();
-        app.popup = Popup::ModelSelect;
+        app.navigation.popup = Popup::ModelSelect;
         app.session_id = Some("s1".into());
         app.agent_mode = "build".into();
         app.current_provider = Some("openai".into());
@@ -3312,7 +3326,7 @@ mod model_popup_tests {
     fn select_remote_model_on_local_session_sends_node_id() {
         let _guard = TestPersistenceGuard::new("remote-mesh-model");
         let mut app = App::new();
-        app.popup = Popup::ModelSelect;
+        app.navigation.popup = Popup::ModelSelect;
         app.session_id = Some("s1".into());
         app.agent_mode = "build".into();
         app.current_provider = Some("openai".into());
@@ -3364,7 +3378,7 @@ mod model_popup_tests {
     fn select_model_on_attached_remote_session_does_not_apply() {
         let _guard = TestPersistenceGuard::new("active-remote-mode");
         let mut app = App::new();
-        app.popup = Popup::ModelSelect;
+        app.navigation.popup = Popup::ModelSelect;
         app.session_id = Some("remote-1".into());
         app.agent_mode = "build".into();
         app.session_groups = vec![SessionGroup {
@@ -3392,7 +3406,7 @@ mod model_popup_tests {
     fn opening_model_popup_starts_on_session_tab() {
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.agent_mode = "review".into();
         app.current_provider = Some("openai".into());
         app.current_model = Some("gpt-4o".into());
@@ -3401,7 +3415,7 @@ mod model_popup_tests {
         let (tx, _rx) = mpsc::unbounded_channel();
         handle_chord(&mut app, key(KeyCode::Char('m')), &tx).unwrap();
 
-        assert!(matches!(app.popup, Popup::ModelSelect));
+        assert!(matches!(app.navigation.popup, Popup::ModelSelect));
         assert_eq!(app.model_popup_agent_tab, 0);
         assert_eq!(app.model_cursor, app.model_popup_open_cursor());
     }
@@ -3410,7 +3424,7 @@ mod model_popup_tests {
     fn slash_model_starts_on_session_tab() {
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.agent_mode = "review".into();
         app.current_provider = Some("openai".into());
         app.current_model = Some("gpt-4o".into());
@@ -3422,7 +3436,7 @@ mod model_popup_tests {
         let action = handle_chat_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
 
         assert!(matches!(action, AppAction::None));
-        assert!(matches!(app.popup, Popup::ModelSelect));
+        assert!(matches!(app.navigation.popup, Popup::ModelSelect));
         assert_eq!(app.model_popup_agent_tab, 0);
         assert_eq!(app.model_cursor, app.model_popup_open_cursor());
     }
@@ -3432,7 +3446,7 @@ mod model_popup_tests {
         let _guard = TestPersistenceGuard::new("review-cycle");
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.agent_mode = "plan".into();
         app.input = "/review".into();
         app.input_cursor = app.input.len();
@@ -3460,14 +3474,13 @@ mod model_popup_tests {
 
     #[test]
     fn delegate_popup_subscribes_with_child_target_agent() {
-        use crate::app::Popup;
         use crate::domain::activity::{
             DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus,
         };
 
         let mut app = App::new();
         app.agent_id = Some("planner".into());
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.delegate_entries.push(DelegateEntry {
             delegation_id: "del-1".into(),
             child_session_id: Some("child-1".into()),
@@ -3500,7 +3513,7 @@ mod model_popup_tests {
     fn review_slash_command_is_noop_when_already_in_review() {
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.agent_mode = "review".into();
         app.mode_before_review = Some("plan".into());
         app.input = "/review".into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod input;
 mod markdown;
 mod mesh;
 mod mesh_state;
+mod navigation_state;
 mod profiles_state;
 mod protocol;
 pub mod runtime;

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -1,26 +1,27 @@
-use crate::app::{App, Popup};
+use crate::app::App;
 use crate::command::Command;
 use crate::diagnostics::LogLevel;
 use crate::domain::mesh::{
     MeshInviteCreatedInfo, MeshNodesInfo, MeshStatusInfo, RemoteSessionAttachInfo,
     RemoteSessionListInfo,
 };
+use crate::navigation_state::Popup;
 
 impl App {
     pub fn open_mesh_popup(&mut self) {
-        self.popup = Popup::Mesh;
+        self.navigation.popup = Popup::Mesh;
         self.mesh.reset_for_popup();
         self.set_status(LogLevel::Debug, "mesh", "refreshing mesh");
     }
 
     pub fn open_mesh_invite_form(&mut self) {
-        self.popup = Popup::MeshInvite;
+        self.navigation.popup = Popup::MeshInvite;
         self.mesh.reset_invite_form();
     }
 
     pub fn apply_mesh_invite_created(&mut self, invite: MeshInviteCreatedInfo) {
         let url = self.mesh.store_invite(invite);
-        self.popup = Popup::MeshInviteQr;
+        self.navigation.popup = Popup::MeshInviteQr;
         self.set_status(LogLevel::Info, "mesh", "mesh invite created");
         self.push_log(LogLevel::Info, "mesh", format!("mesh invite: {url}"));
     }
@@ -82,7 +83,7 @@ impl App {
         // extension snapshot/config directly would duplicate replay or configuration.
         self.remember_remote_session_node(&attached.session_id, &attached.node_id);
         if attached.attached {
-            self.popup = Popup::None;
+            self.navigation.popup = Popup::None;
             self.set_status(LogLevel::Info, "mesh", "remote session attached");
             Command::load_session_commands(
                 attached.session_id.clone(),

--- a/src/navigation_state.rs
+++ b/src/navigation_state.rs
@@ -1,0 +1,530 @@
+use crate::themes_gen::Base16Palette;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Screen {
+    Sessions,
+    Chat,
+    /// Read-only view for delegate child sessions (no input box).
+    Delegate,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Popup {
+    None,
+    CommandPalette,
+    Mesh,
+    MeshInvite,
+    MeshInviteQr,
+    ModelSelect,
+    SessionSelect,
+    NewSession,
+    ThemeSelect,
+    Help,
+    Log,
+    ProviderAuth,
+    ForkTurnSelect,
+    ProfileSelect,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CommandPaletteAction {
+    OpenMesh,
+    AttachRemoteSession,
+    CreateRemoteSession,
+    CreateMeshInvite,
+    ModelSelect,
+    SessionSelect,
+    DelegateSessions,
+    NewSession,
+    ThemeSelect,
+    Help,
+    Log,
+    ProviderAuth,
+    ForkTurnSelect,
+    ProfileSelect,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CommandPaletteCommand {
+    pub(crate) title: &'static str,
+    pub(crate) description: &'static str,
+    pub(crate) shortcut: &'static str,
+    pub(crate) action: CommandPaletteAction,
+    pub(crate) chat_only: bool,
+}
+
+pub(crate) const COMMAND_PALETTE_COMMANDS: &[CommandPaletteCommand] = &[
+    CommandPaletteCommand {
+        title: "Open Mesh",
+        description: "View mesh nodes and remote sessions",
+        shortcut: "",
+        action: CommandPaletteAction::OpenMesh,
+        chat_only: false,
+    },
+    CommandPaletteCommand {
+        title: "Attach remote session",
+        description: "Attach an existing session from a mesh node",
+        shortcut: "",
+        action: CommandPaletteAction::AttachRemoteSession,
+        chat_only: false,
+    },
+    CommandPaletteCommand {
+        title: "Create remote session",
+        description: "Start a new session on a mesh node",
+        shortcut: "",
+        action: CommandPaletteAction::CreateRemoteSession,
+        chat_only: false,
+    },
+    CommandPaletteCommand {
+        title: "Create mesh invite",
+        description: "Generate a mesh invite link and QR code",
+        shortcut: "",
+        action: CommandPaletteAction::CreateMeshInvite,
+        chat_only: false,
+    },
+    CommandPaletteCommand {
+        title: "Model selector",
+        description: "Choose the model for this session or delegates",
+        shortcut: "C-x m",
+        action: CommandPaletteAction::ModelSelect,
+        chat_only: true,
+    },
+    CommandPaletteCommand {
+        title: "Session switcher",
+        description: "Browse and load sessions",
+        shortcut: "C-x l",
+        action: CommandPaletteAction::SessionSelect,
+        chat_only: false,
+    },
+    CommandPaletteCommand {
+        title: "Delegate sessions",
+        description: "Browse delegate child sessions",
+        shortcut: "",
+        action: CommandPaletteAction::DelegateSessions,
+        chat_only: true,
+    },
+    CommandPaletteCommand {
+        title: "New session",
+        description: "Start a new session in a directory",
+        shortcut: "C-x n",
+        action: CommandPaletteAction::NewSession,
+        chat_only: false,
+    },
+    CommandPaletteCommand {
+        title: "Theme picker",
+        description: "Change the UI theme",
+        shortcut: "C-x t",
+        action: CommandPaletteAction::ThemeSelect,
+        chat_only: false,
+    },
+    CommandPaletteCommand {
+        title: "Help",
+        description: "Show keyboard shortcuts and commands",
+        shortcut: "C-x ?",
+        action: CommandPaletteAction::Help,
+        chat_only: false,
+    },
+    CommandPaletteCommand {
+        title: "Logs",
+        description: "Show in-memory logs",
+        shortcut: "Ctrl+l",
+        action: CommandPaletteAction::Log,
+        chat_only: false,
+    },
+    CommandPaletteCommand {
+        title: "Provider auth",
+        description: "Manage provider authentication",
+        shortcut: "C-x a",
+        action: CommandPaletteAction::ProviderAuth,
+        chat_only: false,
+    },
+    CommandPaletteCommand {
+        title: "Fork selector",
+        description: "Choose a turn to fork from",
+        shortcut: "C-x f",
+        action: CommandPaletteAction::ForkTurnSelect,
+        chat_only: true,
+    },
+    CommandPaletteCommand {
+        title: "Profile selector",
+        description: "Choose the active profile for new sessions",
+        shortcut: "C-x p",
+        action: CommandPaletteAction::ProfileSelect,
+        chat_only: false,
+    },
+];
+
+pub(crate) struct NavigationState {
+    pub(crate) screen: Screen,
+    pub(crate) popup: Popup,
+    pub(crate) chord: bool, // true after ctrl+x pressed, waiting for second key
+    pub(crate) command_palette_cursor: usize,
+    pub(crate) command_palette_filter: String,
+    pub(crate) theme_cursor: usize,
+    pub(crate) theme_filter: String,
+    pub(crate) help_scroll: usize,
+}
+
+impl NavigationState {
+    pub(crate) fn new() -> Self {
+        Self {
+            screen: Screen::Sessions,
+            popup: Popup::None,
+            chord: false,
+            command_palette_cursor: 0,
+            command_palette_filter: String::new(),
+            theme_cursor: 0,
+            theme_filter: String::new(),
+            help_scroll: 0,
+        }
+    }
+
+    pub(crate) fn open_command_palette(&mut self) {
+        self.popup = Popup::CommandPalette;
+        self.command_palette_filter.clear();
+        self.command_palette_cursor = 0;
+    }
+
+    pub(crate) fn filtered_command_palette_commands(&self) -> Vec<&'static CommandPaletteCommand> {
+        let q = self.command_palette_filter.trim().to_lowercase();
+        COMMAND_PALETTE_COMMANDS
+            .iter()
+            .filter(|command| !command.chat_only || matches!(self.screen, Screen::Chat))
+            .filter(|command| {
+                q.is_empty()
+                    || command.title.to_lowercase().contains(&q)
+                    || command.description.to_lowercase().contains(&q)
+                    || command.shortcut.to_lowercase().contains(&q)
+            })
+            .collect()
+    }
+
+    pub(crate) fn move_command_palette_cursor(&mut self, delta: isize) {
+        self.command_palette_cursor = move_wrapping_cursor(
+            self.command_palette_cursor,
+            self.filtered_command_palette_commands().len(),
+            delta,
+        );
+    }
+
+    pub(crate) fn selected_command_palette_action(&self) -> Option<CommandPaletteAction> {
+        self.filtered_command_palette_commands()
+            .get(self.command_palette_cursor)
+            .map(|command| command.action)
+    }
+
+    pub(crate) fn command_palette_filter_insert(&mut self, c: char) {
+        self.command_palette_filter.push(c);
+        self.command_palette_cursor = 0;
+    }
+
+    pub(crate) fn command_palette_filter_backspace(&mut self) {
+        self.command_palette_filter.pop();
+        self.command_palette_cursor = 0;
+    }
+
+    pub(crate) fn open_theme_selector(&mut self, current_index: usize) {
+        self.popup = Popup::ThemeSelect;
+        self.theme_filter.clear();
+        self.theme_cursor = current_index;
+    }
+
+    pub(crate) fn theme_matches(&self, id: &str, label: &str) -> bool {
+        let q = self.theme_filter.to_lowercase();
+        q.is_empty() || label.to_lowercase().contains(&q) || id.to_lowercase().contains(&q)
+    }
+
+    pub(crate) fn filtered_themes<'a>(
+        &self,
+        themes: &'a [Base16Palette],
+    ) -> Vec<(usize, &'a Base16Palette)> {
+        themes
+            .iter()
+            .enumerate()
+            .filter(|(_, theme)| self.theme_matches(theme.id, theme.label))
+            .collect()
+    }
+
+    pub(crate) fn selected_theme_index(&self, themes: &[Base16Palette]) -> Option<usize> {
+        if self.theme_filter.is_empty() {
+            Some(self.theme_cursor)
+        } else {
+            self.filtered_themes(themes)
+                .get(self.theme_cursor)
+                .map(|(index, _)| *index)
+        }
+    }
+
+    pub(crate) fn move_theme_cursor_up(&mut self) {
+        self.theme_cursor = self.theme_cursor.saturating_sub(1);
+    }
+
+    pub(crate) fn move_theme_cursor_down(&mut self, filtered_len: usize) {
+        let max = filtered_len.saturating_sub(1);
+        self.theme_cursor = (self.theme_cursor + 1).min(max);
+    }
+
+    pub(crate) fn theme_filter_insert(&mut self, c: char) {
+        self.theme_filter.push(c);
+        self.theme_cursor = 0;
+    }
+
+    pub(crate) fn theme_filter_backspace(&mut self) {
+        self.theme_filter.pop();
+        self.theme_cursor = 0;
+    }
+
+    pub(crate) fn open_help(&mut self) {
+        self.popup = Popup::Help;
+        self.help_scroll = 0;
+    }
+
+    pub(crate) fn scroll_help_up(&mut self) {
+        self.help_scroll = self.help_scroll.saturating_sub(1);
+    }
+
+    pub(crate) fn scroll_help_down(&mut self) {
+        self.help_scroll = self.help_scroll.saturating_add(1);
+    }
+}
+
+fn move_wrapping_cursor(cursor: usize, len: usize, delta: isize) -> usize {
+    if len == 0 {
+        0
+    } else {
+        (cursor as isize + delta).rem_euclid(len as isize) as usize
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn command_titles(state: &NavigationState) -> Vec<&'static str> {
+        state
+            .filtered_command_palette_commands()
+            .into_iter()
+            .map(|command| command.title)
+            .collect()
+    }
+
+    #[test]
+    fn constructor_uses_exact_defaults() {
+        let state = NavigationState::new();
+
+        assert_eq!(state.screen, Screen::Sessions);
+        assert_eq!(state.popup, Popup::None);
+        assert!(!state.chord);
+        assert_eq!(state.command_palette_cursor, 0);
+        assert!(state.command_palette_filter.is_empty());
+        assert_eq!(state.theme_cursor, 0);
+        assert!(state.theme_filter.is_empty());
+        assert_eq!(state.help_scroll, 0);
+    }
+
+    #[test]
+    fn palette_filter_trims_lowercases_and_matches_title() {
+        let mut state = NavigationState::new();
+        state.command_palette_filter = "  tHeMe PICK  ".into();
+
+        assert_eq!(command_titles(&state), ["Theme picker"]);
+    }
+
+    #[test]
+    fn palette_filter_matches_description() {
+        let mut state = NavigationState::new();
+        state.command_palette_filter = "keyboard shortcuts".into();
+
+        assert_eq!(command_titles(&state), ["Help"]);
+    }
+
+    #[test]
+    fn palette_filter_matches_shortcut() {
+        let mut state = NavigationState::new();
+        state.screen = Screen::Chat;
+        state.command_palette_filter = "C-X F".into();
+
+        assert_eq!(command_titles(&state), ["Fork selector"]);
+    }
+
+    #[test]
+    fn palette_chat_only_commands_require_chat_screen() {
+        let mut state = NavigationState::new();
+
+        state.screen = Screen::Sessions;
+        assert!(!command_titles(&state).contains(&"Model selector"));
+        state.screen = Screen::Delegate;
+        assert!(!command_titles(&state).contains(&"Model selector"));
+        state.screen = Screen::Chat;
+        assert!(command_titles(&state).contains(&"Model selector"));
+        assert!(command_titles(&state).contains(&"Delegate sessions"));
+        assert!(command_titles(&state).contains(&"Fork selector"));
+    }
+
+    #[test]
+    fn opening_palette_replaces_popup_and_resets_only_palette_input() {
+        let mut state = NavigationState::new();
+        state.popup = Popup::Help;
+        state.chord = true;
+        state.command_palette_filter = "theme".into();
+        state.command_palette_cursor = 4;
+        state.theme_filter = "keep".into();
+        state.help_scroll = 8;
+
+        state.open_command_palette();
+
+        assert_eq!(state.popup, Popup::CommandPalette);
+        assert!(state.chord);
+        assert!(state.command_palette_filter.is_empty());
+        assert_eq!(state.command_palette_cursor, 0);
+        assert_eq!(state.theme_filter, "keep");
+        assert_eq!(state.help_scroll, 8);
+    }
+
+    #[test]
+    fn palette_cursor_wraps_and_selects_filtered_action() {
+        let mut state = NavigationState::new();
+        state.screen = Screen::Chat;
+
+        state.move_command_palette_cursor(-1);
+        assert_eq!(
+            state.command_palette_cursor,
+            state.filtered_command_palette_commands().len() - 1
+        );
+
+        state.command_palette_filter = "theme".into();
+        state.command_palette_cursor = 0;
+        assert_eq!(
+            state.selected_command_palette_action(),
+            Some(CommandPaletteAction::ThemeSelect)
+        );
+        state.move_command_palette_cursor(1);
+        assert_eq!(state.command_palette_cursor, 0);
+    }
+
+    #[test]
+    fn palette_empty_result_resets_cursor_and_has_no_selection() {
+        let mut state = NavigationState::new();
+        state.command_palette_filter = "no command matches this".into();
+        state.command_palette_cursor = 9;
+
+        state.move_command_palette_cursor(1);
+
+        assert_eq!(state.command_palette_cursor, 0);
+        assert_eq!(state.selected_command_palette_action(), None);
+    }
+
+    #[test]
+    fn palette_filter_edits_reset_cursor() {
+        let mut state = NavigationState::new();
+        state.command_palette_cursor = 5;
+
+        state.command_palette_filter_insert('x');
+        assert_eq!(state.command_palette_filter, "x");
+        assert_eq!(state.command_palette_cursor, 0);
+        state.command_palette_cursor = 3;
+        state.command_palette_filter_backspace();
+        assert!(state.command_palette_filter.is_empty());
+        assert_eq!(state.command_palette_cursor, 0);
+    }
+
+    #[test]
+    fn opening_theme_selector_uses_supplied_index_and_resets_filter() {
+        let mut state = NavigationState::new();
+        state.popup = Popup::Help;
+        state.theme_filter = "old".into();
+        state.theme_cursor = 2;
+
+        state.open_theme_selector(17);
+
+        assert_eq!(state.popup, Popup::ThemeSelect);
+        assert!(state.theme_filter.is_empty());
+        assert_eq!(state.theme_cursor, 17);
+    }
+
+    #[test]
+    fn theme_matching_is_case_insensitive_for_id_and_label() {
+        let mut state = NavigationState::new();
+        state.theme_filter = "PENUMBRA".into();
+        assert!(state.theme_matches("other", "Penumbra Dark"));
+
+        state.theme_filter = "BASE16-3024".into();
+        assert!(state.theme_matches("base16-3024", "other"));
+    }
+
+    #[test]
+    fn theme_matching_does_not_trim_query() {
+        let mut state = NavigationState::new();
+        state.theme_filter = " penumbra ".into();
+
+        assert!(!state.theme_matches("base16-penumbra", "Penumbra"));
+    }
+
+    #[test]
+    fn theme_cursor_clamps_without_wrapping() {
+        let mut state = NavigationState::new();
+
+        state.move_theme_cursor_up();
+        assert_eq!(state.theme_cursor, 0);
+        state.move_theme_cursor_down(3);
+        state.move_theme_cursor_down(3);
+        state.move_theme_cursor_down(3);
+        assert_eq!(state.theme_cursor, 2);
+        state.move_theme_cursor_down(0);
+        assert_eq!(state.theme_cursor, 0);
+    }
+
+    #[test]
+    fn theme_filter_edits_reset_cursor() {
+        let mut state = NavigationState::new();
+        state.theme_cursor = 12;
+
+        state.theme_filter_insert('x');
+        assert_eq!(state.theme_filter, "x");
+        assert_eq!(state.theme_cursor, 0);
+        state.theme_cursor = 4;
+        state.theme_filter_backspace();
+        assert!(state.theme_filter.is_empty());
+        assert_eq!(state.theme_cursor, 0);
+    }
+
+    #[test]
+    fn empty_theme_filter_preserves_out_of_range_selection_index() {
+        let mut state = NavigationState::new();
+        state.theme_cursor = 99;
+
+        assert_eq!(state.selected_theme_index(&[]), Some(99));
+    }
+
+    #[test]
+    fn nonempty_theme_filter_returns_no_selection_without_match() {
+        let mut state = NavigationState::new();
+        state.theme_filter = "missing".into();
+        state.theme_cursor = 0;
+
+        assert_eq!(state.selected_theme_index(&[]), None);
+    }
+
+    #[test]
+    fn opening_help_resets_scroll() {
+        let mut state = NavigationState::new();
+        state.popup = Popup::ThemeSelect;
+        state.help_scroll = 14;
+
+        state.open_help();
+
+        assert_eq!(state.popup, Popup::Help);
+        assert_eq!(state.help_scroll, 0);
+    }
+
+    #[test]
+    fn help_scroll_saturates_in_both_directions() {
+        let mut state = NavigationState::new();
+
+        state.scroll_help_up();
+        assert_eq!(state.help_scroll, 0);
+        state.help_scroll = usize::MAX;
+        state.scroll_help_down();
+        assert_eq!(state.help_scroll, usize::MAX);
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -9,11 +9,12 @@ use std::time::Duration;
 use crate::{
     acp_client,
     acp_state::AcpAppEvent,
-    app::{self, App, Screen},
+    app::{self, App},
     command::Command,
     config,
     diagnostics::LogLevel,
     domain::model::DelegateModelPreference,
+    navigation_state::Screen,
     server_manager, theme,
 };
 use clap::Parser;
@@ -24,6 +25,9 @@ use endpoint::{
 use event_loop::run_loop;
 
 use tokio::sync::mpsc;
+
+#[cfg(test)]
+use crate::navigation_state::Popup;
 
 #[derive(Debug)]
 pub(crate) enum ConnectionManagerEvent {
@@ -504,7 +508,7 @@ mod external_editor_tests {
     fn chat_up_down_navigate_wrapped_input_without_scrolling_history() {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.input = "abcdef".into();
         app.input_cursor = 4;
         app.input_line_width = 4;
@@ -533,7 +537,7 @@ mod external_editor_tests {
     fn chat_pageup_pagedown_still_scroll_history() {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.scroll_offset = 3;
 
         handle_chat_key(
@@ -557,7 +561,7 @@ mod external_editor_tests {
     fn ctrl_x_e_returns_open_editor_action_in_chat() {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.input = "draft".into();
         assert_eq!(
             handle_key(&mut app, ctrl_x(), &tx).unwrap(),
@@ -567,7 +571,7 @@ mod external_editor_tests {
         let action = handle_key(&mut app, plain_key('e'), &tx).unwrap();
 
         assert_eq!(action, AppAction::OpenExternalEditor);
-        assert!(!app.chord);
+        assert!(!app.navigation.chord);
         assert_eq!(app.input, "draft");
     }
 
@@ -575,7 +579,7 @@ mod external_editor_tests {
     fn ctrl_x_e_outside_chat_stays_in_tui() {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Sessions;
+        app.navigation.screen = Screen::Sessions;
         assert_eq!(
             handle_key(&mut app, ctrl_x(), &tx).unwrap(),
             AppAction::None
@@ -592,7 +596,7 @@ mod external_editor_tests {
     fn ctrl_x_m_outside_chat_does_not_open_model_popup() {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Sessions;
+        app.navigation.screen = Screen::Sessions;
         assert_eq!(
             handle_key(&mut app, ctrl_x(), &tx).unwrap(),
             AppAction::None
@@ -601,7 +605,7 @@ mod external_editor_tests {
         let action = handle_key(&mut app, plain_key('m'), &tx).unwrap();
 
         assert_eq!(action, AppAction::None);
-        assert_ne!(app.popup, app::Popup::ModelSelect);
+        assert_ne!(app.navigation.popup, Popup::ModelSelect);
         assert!(app.diagnostics.status.contains("only available in chat"));
         assert!(matches!(app.diagnostics.logs.last(), Some(entry) if entry.target == "model"));
     }
@@ -650,7 +654,7 @@ mod external_editor_tests {
     fn chat_input_accepts_typing_and_submit_while_turn_active() {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
         app.activity = ActivityState::RunningTool {
             name: "read_tool".into(),
@@ -687,7 +691,7 @@ mod external_editor_tests {
     fn chat_submit_normalizes_prompt_before_sending_and_rendering() {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
         app.input = "  first line\nsecond line\n  ".into();
         app.input_cursor = app.input.len();
@@ -715,7 +719,7 @@ mod external_editor_tests {
     fn whitespace_only_chat_submit_does_not_send_or_render_prompt() {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
         app.input = " \n  ".into();
         app.input_cursor = app.input.len();
@@ -738,7 +742,7 @@ mod external_editor_tests {
     fn left_arrow_with_slash_input_does_not_crash() {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.input = "/model".into();
         app.input_cursor = "/model".len();
         app.refresh_slash_state();
@@ -761,7 +765,7 @@ mod external_editor_tests {
     fn slash_esc_clears_slash_state() {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.input = "/mo".into();
         app.input_cursor = 3;
         app.refresh_slash_state();
@@ -781,7 +785,7 @@ mod external_editor_tests {
     fn slash_enter_opens_help_popup() {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.input = "/help".into();
         app.input_cursor = "/help".len();
         app.refresh_slash_state();
@@ -793,7 +797,7 @@ mod external_editor_tests {
         )
         .unwrap();
 
-        assert_eq!(app.popup, app::Popup::Help);
+        assert_eq!(app.navigation.popup, Popup::Help);
         assert!(app.input.is_empty());
     }
 
@@ -801,7 +805,7 @@ mod external_editor_tests {
     fn slash_enter_with_partial_completion_executes_command() {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.input = "/hel".into();
         app.input_cursor = "/hel".len();
         app.refresh_slash_state();
@@ -814,7 +818,7 @@ mod external_editor_tests {
         )
         .unwrap();
 
-        assert_eq!(app.popup, app::Popup::Help);
+        assert_eq!(app.navigation.popup, Popup::Help);
         assert!(app.input.is_empty());
         assert!(app.slash_state.is_none());
     }
@@ -823,7 +827,7 @@ mod external_editor_tests {
     fn slash_tab_completes_command_name_without_executing() {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.input = "/hel".into();
         app.input_cursor = "/hel".len();
         app.refresh_slash_state();
@@ -837,7 +841,7 @@ mod external_editor_tests {
 
         // Completed but not executed — no popup opened
         assert_eq!(app.input, "/help ");
-        assert_eq!(app.popup, app::Popup::None);
+        assert_eq!(app.navigation.popup, Popup::None);
         assert!(app.slash_state.is_none());
     }
 
@@ -845,7 +849,7 @@ mod external_editor_tests {
     fn slash_down_up_navigates_selection() {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.input = "/".into();
         app.input_cursor = 1;
         app.refresh_slash_state();
@@ -877,7 +881,7 @@ mod external_editor_tests {
         let _guard = TestPersistenceGuard::new("slash-mode-cycle");
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
         app.session_id = Some("s1".into());
         app.agent_mode = "build".into();
@@ -906,7 +910,7 @@ mod external_editor_tests {
         let _guard = TestPersistenceGuard::new("slash-mode-plan");
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
         app.session_id = Some("s1".into());
         app.agent_mode = "build".into();
@@ -931,7 +935,7 @@ mod external_editor_tests {
     fn slash_mode_same_is_idempotent() {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
         app.session_id = Some("s1".into());
         app.agent_mode = "build".into();
@@ -953,7 +957,7 @@ mod external_editor_tests {
     fn slash_mode_unknown_shows_error() {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
         app.session_id = Some("s1".into());
         app.input = "/mode xyz".into();
@@ -975,7 +979,7 @@ mod external_editor_tests {
         let _guard = TestPersistenceGuard::new("slash-thinking-high");
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
         app.session_id = Some("s1".into());
         app.input = "/thinking high".into();
@@ -1001,7 +1005,7 @@ mod external_editor_tests {
         let _guard = TestPersistenceGuard::new("slash-thinking-auto");
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
         app.session_id = Some("s1".into());
         app.reasoning_effort = Some("max".into());
@@ -1028,7 +1032,7 @@ mod external_editor_tests {
         let _guard = TestPersistenceGuard::new("slash-thinking-med");
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
         app.session_id = Some("s1".into());
         app.input = "/thinking med".into();
@@ -1052,7 +1056,7 @@ mod external_editor_tests {
     fn slash_thinking_no_arg_shows_current() {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.reasoning_effort = Some("high".into());
         app.input = "/thinking".into();
         app.input_cursor = "/thinking".len();
@@ -1071,7 +1075,7 @@ mod external_editor_tests {
     fn slash_thinking_unknown_shows_error() {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.input = "/thinking xyz".into();
         app.input_cursor = "/thinking xyz".len();
 
@@ -1089,7 +1093,7 @@ mod external_editor_tests {
     fn slash_thinking_when_disconnected_does_not_change_state() {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.reasoning_effort = Some("high".into());
         app.input = "/thinking max".into();
         app.input_cursor = "/thinking max".len();
@@ -1108,7 +1112,7 @@ mod external_editor_tests {
 
     fn app_with_forkable_messages() -> App {
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
         app.messages = vec![
             ChatEntry::User {
@@ -1158,7 +1162,7 @@ mod external_editor_tests {
         handle_key(&mut app, plain_key('f'), &tx).unwrap();
         handle_key(&mut app, plain_key('b'), &tx).unwrap();
 
-        assert_eq!(app.popup, app::Popup::ForkTurnSelect);
+        assert_eq!(app.navigation.popup, Popup::ForkTurnSelect);
         assert_eq!(app.fork_filter, "b");
         assert!(app.input.is_empty());
         assert_eq!(app.filtered_fork_turns().len(), 1);
@@ -1168,12 +1172,12 @@ mod external_editor_tests {
     fn ctrl_x_f_in_delegate_view_does_not_open_fork_popup() {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = app_with_forkable_messages();
-        app.screen = Screen::Delegate;
+        app.navigation.screen = Screen::Delegate;
 
         handle_key(&mut app, ctrl_x(), &tx).unwrap();
         handle_key(&mut app, plain_key('f'), &tx).unwrap();
 
-        assert_ne!(app.popup, app::Popup::ForkTurnSelect);
+        assert_ne!(app.navigation.popup, Popup::ForkTurnSelect);
         assert!(rx.try_recv().is_err());
         assert!(app.diagnostics.status.contains("only available in chat"));
         assert!(matches!(app.diagnostics.logs.last(), Some(entry) if entry.target == "fork"));
@@ -1183,7 +1187,7 @@ mod external_editor_tests {
     fn slash_fork_in_delegate_view_sends_nothing() {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = app_with_forkable_messages();
-        app.screen = Screen::Delegate;
+        app.navigation.screen = Screen::Delegate;
         app.input = "/fork".into();
         app.input_cursor = "/fork".len();
 
@@ -1245,7 +1249,7 @@ mod external_editor_tests {
     fn fork_popup_enter_with_no_eligible_turns_sends_nothing() {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
         app.open_fork_turn_popup();
 
@@ -1264,7 +1268,7 @@ mod external_editor_tests {
     fn slash_model_with_arg_prefilters_popup() {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
         app.session_id = Some("s1".into());
         app.input = "/model sonnet".into();
@@ -1277,7 +1281,7 @@ mod external_editor_tests {
         )
         .unwrap();
 
-        assert_eq!(app.popup, app::Popup::ModelSelect);
+        assert_eq!(app.navigation.popup, Popup::ModelSelect);
         assert_eq!(app.model_filter, "sonnet");
         assert_eq!(app.model_cursor, 0);
     }
@@ -1286,7 +1290,7 @@ mod external_editor_tests {
     fn slash_model_no_arg_opens_popup_unfiltered() {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
         app.session_id = Some("s1".into());
         app.input = "/model".into();
@@ -1299,7 +1303,7 @@ mod external_editor_tests {
         )
         .unwrap();
 
-        assert_eq!(app.popup, app::Popup::ModelSelect);
+        assert_eq!(app.navigation.popup, Popup::ModelSelect);
         assert!(app.model_filter.is_empty());
     }
 
@@ -1307,7 +1311,7 @@ mod external_editor_tests {
     fn chat_double_esc_cancels_running_tool_phase() {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.activity = ActivityState::RunningTool {
             name: "read_tool".into(),
         };
@@ -1341,7 +1345,7 @@ mod external_editor_tests {
     fn chat_input_is_blocked_while_undo_is_pending() {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
         app.activity = ActivityState::SessionOp(SessionOp::Undo);
         app.input = "draft".into();
@@ -1385,7 +1389,7 @@ mod external_editor_tests {
     fn chat_input_is_blocked_while_cancel_confirm_is_active() {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
         app.activity = ActivityState::RunningTool {
             name: "read_tool".into(),
@@ -1507,7 +1511,7 @@ pub async fn run() -> anyhow::Result<()> {
     }
     if let Some(session_id) = cli.session.clone() {
         app.session_id = Some(session_id);
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
     }
     // -- ACP auto-start ---------------------------------------------------------
     let (sup_event_tx, mut sup_event_rx) = mpsc::unbounded_channel::<server_manager::ServerEvent>();
@@ -1986,7 +1990,7 @@ mod sessions_key_tests {
         app.session_cursor = 4; // ShowMore row
         let action = apply_sessions_key(&mut app, KeyCode::Enter);
         assert_eq!(action, SessionKeyAction::None);
-        assert_eq!(app.popup, crate::app::Popup::SessionSelect);
+        assert_eq!(app.navigation.popup, Popup::SessionSelect);
         assert_eq!(app.session_cursor, 0);
         assert!(app.session_filter.is_empty());
     }
@@ -2004,7 +2008,7 @@ mod sessions_key_tests {
         let action = apply_sessions_key(&mut app, KeyCode::Enter);
 
         assert_eq!(action, SessionKeyAction::None);
-        assert_eq!(app.popup, crate::app::Popup::SessionSelect);
+        assert_eq!(app.navigation.popup, Popup::SessionSelect);
         assert_eq!(app.session_popup_tab, 0);
         assert_eq!(app.session_cursor, 0);
     }
@@ -2078,7 +2082,6 @@ mod sessions_key_tests {
 #[cfg(test)]
 mod session_popup_key_tests {
     use super::*;
-    use crate::app::Popup;
     use crate::command::Command;
     use crate::domain::session::{SessionGroup, SessionSummary};
     use crate::handlers::*;
@@ -2116,7 +2119,7 @@ mod session_popup_key_tests {
     #[test]
     fn popup_down_moves_cursor_forward() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
         // visible: [GroupHeader, Session(s1), Session(s2)]
         assert_eq!(app.session_cursor, 0);
@@ -2129,7 +2132,7 @@ mod session_popup_key_tests {
     #[test]
     fn popup_down_clamps_at_last_item() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(Some("/a"), &["s1"])];
         // visible: [GroupHeader(0), Session(1)] — max idx = 1
         app.session_cursor = 1;
@@ -2140,7 +2143,7 @@ mod session_popup_key_tests {
     #[test]
     fn popup_up_moves_cursor_back() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
         app.session_cursor = 2;
         apply_popup_session_key(&mut app, KeyCode::Up);
@@ -2150,7 +2153,7 @@ mod session_popup_key_tests {
     #[test]
     fn popup_up_does_not_go_below_zero() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(Some("/a"), &["s1"])];
         app.session_cursor = 0;
         apply_popup_session_key(&mut app, KeyCode::Up);
@@ -2160,7 +2163,7 @@ mod session_popup_key_tests {
     #[test]
     fn popup_page_down_uses_visible_rows_with_overlap() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(
             Some("/a"),
             &["s1", "s2", "s3", "s4", "s5", "s6", "s7"],
@@ -2177,7 +2180,7 @@ mod session_popup_key_tests {
     #[test]
     fn popup_page_up_uses_visible_rows_with_overlap() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(
             Some("/a"),
             &["s1", "s2", "s3", "s4", "s5", "s6", "s7"],
@@ -2195,7 +2198,7 @@ mod session_popup_key_tests {
     #[test]
     fn popup_page_keys_fallback_to_single_row_when_visible_rows_unknown() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(Some("/a"), &["s1", "s2", "s3"])];
 
         apply_popup_session_key(&mut app, KeyCode::PageDown);
@@ -2210,7 +2213,7 @@ mod session_popup_key_tests {
     #[test]
     fn popup_enter_on_header_collapses_group() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(Some("/a"), &["s1"])];
         app.session_cursor = 0; // GroupHeader
         let action = apply_popup_session_key(&mut app, KeyCode::Enter);
@@ -2223,7 +2226,7 @@ mod session_popup_key_tests {
     #[test]
     fn popup_enter_on_collapsed_header_expands_group() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(Some("/a"), &["s1"])];
         app.popup_collapsed_groups.insert("/a".to_string());
         app.session_cursor = 0;
@@ -2235,7 +2238,7 @@ mod session_popup_key_tests {
     #[test]
     fn popup_collapse_clamps_cursor() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         // [GroupHeader(0), Session(s1, 1), Session(s2, 2)]
         app.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
         app.session_cursor = 0; // header
@@ -2251,7 +2254,7 @@ mod session_popup_key_tests {
     #[test]
     fn popup_enter_on_session_returns_load_and_closes_popup() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(Some("/a"), &["abc12345"])];
         app.session_cursor = 1; // Session row
         let action = apply_popup_session_key(&mut app, KeyCode::Enter);
@@ -2263,13 +2266,13 @@ mod session_popup_key_tests {
                 cwd: Some("/a".to_string()),
             }
         );
-        assert_eq!(app.popup, Popup::None);
+        assert_eq!(app.navigation.popup, Popup::None);
     }
 
     #[test]
     fn popup_delete_on_remote_session_returns_dismiss_and_removes() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(Some("/a"), &["remote-1", "s2"])];
         app.session_groups[0].sessions[0].node_id = Some("node-1".into());
         app.session_cursor = 1;
@@ -2291,7 +2294,7 @@ mod session_popup_key_tests {
     #[test]
     fn popup_enter_can_reach_session_beyond_start_page_cap() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         // 5 sessions — start page would cap at 3; popup shows all
         app.session_groups = vec![make_group(Some("/a"), &["s1", "s2", "s3", "s4", "s5"])];
         // visible: [Header(0), s1(1), s2(2), s3(3), s4(4), s5(5)]
@@ -2310,7 +2313,7 @@ mod session_popup_key_tests {
     #[test]
     fn popup_enter_on_expandable_root_loads_session() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(Some("/a"), &["root"])];
         app.session_groups[0].sessions[0].fork_count = 1;
         app.session_cursor = 1;
@@ -2326,13 +2329,13 @@ mod session_popup_key_tests {
             }
         );
         assert!(!app.expanded_session_children.contains("root"));
-        assert_eq!(app.popup, Popup::None);
+        assert_eq!(app.navigation.popup, Popup::None);
     }
 
     #[test]
     fn popup_ctrl_o_on_expandable_root_requests_children() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(Some("/a"), &["root"])];
         app.session_groups[0].sessions[0].fork_count = 1;
         app.session_cursor = 1;
@@ -2346,7 +2349,7 @@ mod session_popup_key_tests {
         .unwrap();
 
         assert!(app.expanded_session_children.contains("root"));
-        assert_eq!(app.popup, Popup::SessionSelect);
+        assert_eq!(app.navigation.popup, Popup::SessionSelect);
         assert!(matches!(
             cmd_rx.try_recv(),
             Ok(Command::ListSessionChildren {
@@ -2359,7 +2362,7 @@ mod session_popup_key_tests {
     #[test]
     fn popup_ctrl_o_on_expanded_root_collapses_without_loading_session() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(Some("/a"), &["root"])];
         app.session_groups[0].sessions[0].fork_count = 1;
         app.expanded_session_children.insert("root".to_string());
@@ -2374,14 +2377,14 @@ mod session_popup_key_tests {
         .unwrap();
 
         assert!(!app.expanded_session_children.contains("root"));
-        assert_eq!(app.popup, Popup::SessionSelect);
+        assert_eq!(app.navigation.popup, Popup::SessionSelect);
         assert!(cmd_rx.try_recv().is_err());
     }
 
     #[test]
     fn popup_plain_o_still_filters_instead_of_toggling_forks() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(Some("/a"), &["root"])];
         app.session_groups[0].sessions[0].fork_count = 1;
         app.session_cursor = 1;
@@ -2396,14 +2399,14 @@ mod session_popup_key_tests {
 
         assert_eq!(app.session_filter, "o");
         assert!(!app.expanded_session_children.contains("root"));
-        assert_eq!(app.popup, Popup::SessionSelect);
+        assert_eq!(app.navigation.popup, Popup::SessionSelect);
         assert!(cmd_rx.try_recv().is_err());
     }
 
     #[test]
     fn popup_enter_on_expanded_child_loads_session() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(Some("/a"), &["root"])];
         app.session_groups[0].sessions[0].fork_count = 1;
         app.session_groups[0].sessions[0].children = vec![SessionSummary {
@@ -2425,13 +2428,13 @@ mod session_popup_key_tests {
                 cwd: Some("/a".to_string()),
             }
         );
-        assert_eq!(app.popup, Popup::None);
+        assert_eq!(app.navigation.popup, Popup::None);
     }
 
     #[test]
     fn popup_enter_on_load_more_returns_action_and_keeps_popup_open() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group_with_cursor(
             Some("/workspace/project"),
             &["s1"],
@@ -2448,7 +2451,7 @@ mod session_popup_key_tests {
                 parent_path: Vec::new()
             }
         );
-        assert_eq!(app.popup, Popup::SessionSelect);
+        assert_eq!(app.navigation.popup, Popup::SessionSelect);
     }
 
     // ── Delete on Session removes it ─────────────────────────────────────────
@@ -2456,7 +2459,7 @@ mod session_popup_key_tests {
     #[test]
     fn popup_delete_on_session_returns_delete_and_removes() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
         app.session_cursor = 1; // Session s1
         let action = apply_popup_session_key(&mut app, KeyCode::Delete);
@@ -2473,7 +2476,7 @@ mod session_popup_key_tests {
     #[test]
     fn popup_delete_removes_empty_group() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(Some("/a"), &["only"])];
         app.session_cursor = 1;
         apply_popup_session_key(&mut app, KeyCode::Delete);
@@ -2483,7 +2486,7 @@ mod session_popup_key_tests {
     #[test]
     fn popup_delete_on_header_is_noop() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(Some("/a"), &["s1"])];
         app.session_cursor = 0; // GroupHeader
         let action = apply_popup_session_key(&mut app, KeyCode::Delete);
@@ -2496,9 +2499,9 @@ mod session_popup_key_tests {
     #[test]
     fn popup_esc_closes_popup() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         apply_popup_session_key(&mut app, KeyCode::Esc);
-        assert_eq!(app.popup, Popup::None);
+        assert_eq!(app.navigation.popup, Popup::None);
     }
 
     // ── Filter: Char appends, Backspace removes, both reset cursor ────────────
@@ -2506,7 +2509,7 @@ mod session_popup_key_tests {
     #[test]
     fn popup_char_appends_to_filter_and_resets_cursor() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(Some("/a"), &["s1"])];
         app.session_cursor = 1;
         apply_popup_session_key(&mut app, KeyCode::Char('x'));
@@ -2517,7 +2520,7 @@ mod session_popup_key_tests {
     #[test]
     fn popup_ctrl_n_opens_new_session_popup() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.conn = crate::app::ConnState::Connected;
         app.launch_cwd = Some("/launch".into());
 
@@ -2534,7 +2537,7 @@ mod session_popup_key_tests {
         )
         .unwrap();
 
-        assert_eq!(app.popup, Popup::NewSession);
+        assert_eq!(app.navigation.popup, Popup::NewSession);
         assert_eq!(app.new_session_path, "/launch");
         assert!(cmd_rx.try_recv().is_err());
     }
@@ -2542,7 +2545,7 @@ mod session_popup_key_tests {
     #[test]
     fn popup_plain_n_still_filters_instead_of_creating_session() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(Some("/a"), &["s1"])];
 
         let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
@@ -2553,7 +2556,7 @@ mod session_popup_key_tests {
         )
         .unwrap();
 
-        assert_eq!(app.popup, Popup::SessionSelect);
+        assert_eq!(app.navigation.popup, Popup::SessionSelect);
         assert_eq!(app.session_filter, "n");
         assert!(cmd_rx.try_recv().is_err());
     }
@@ -2578,7 +2581,7 @@ mod session_popup_key_tests {
         )
         .unwrap();
 
-        assert_eq!(app.popup, Popup::NewSession);
+        assert_eq!(app.navigation.popup, Popup::NewSession);
         assert_eq!(app.new_session_path, "/launch");
         assert!(rx.try_recv().is_err());
     }
@@ -2602,7 +2605,7 @@ mod session_popup_key_tests {
         )
         .unwrap();
 
-        assert_eq!(app.popup, Popup::SessionSelect);
+        assert_eq!(app.navigation.popup, Popup::SessionSelect);
         assert_eq!(app.session_popup_tab, 0);
     }
 
@@ -2618,7 +2621,7 @@ mod session_popup_key_tests {
         )
         .unwrap();
 
-        assert_eq!(app.popup, Popup::Log);
+        assert_eq!(app.navigation.popup, Popup::Log);
         assert_eq!(app.diagnostics.log_cursor, 0);
         assert!(app.diagnostics.log_filter.is_empty());
     }
@@ -2626,7 +2629,7 @@ mod session_popup_key_tests {
     #[test]
     fn log_popup_filters_cycles_level_and_closes() {
         let mut app = App::new();
-        app.popup = Popup::Log;
+        app.navigation.popup = Popup::Log;
         app.diagnostics.log_cursor = 2;
         app.diagnostics.log_level_filter = LogLevel::Info;
 
@@ -2662,14 +2665,14 @@ mod session_popup_key_tests {
             &tx,
         )
         .unwrap();
-        assert_eq!(app.popup, Popup::None);
+        assert_eq!(app.navigation.popup, Popup::None);
     }
 
     #[test]
     fn new_session_popup_enter_with_empty_path_uses_launch_cwd() {
         let mut app = App::new();
         app.conn = crate::app::ConnState::Connected;
-        app.popup = Popup::NewSession;
+        app.navigation.popup = Popup::NewSession;
         app.launch_cwd = Some("/launch".into());
         app.new_session_path.clear();
         app.new_session_cursor = 0;
@@ -2682,7 +2685,7 @@ mod session_popup_key_tests {
         )
         .unwrap();
 
-        assert_eq!(app.popup, Popup::None);
+        assert_eq!(app.navigation.popup, Popup::None);
         assert!(matches!(
             rx.try_recv(),
             Ok(Command::NewSession {
@@ -2696,7 +2699,7 @@ mod session_popup_key_tests {
     fn new_session_popup_enter_normalizes_relative_path_to_absolute() {
         let mut app = App::new();
         app.conn = crate::app::ConnState::Connected;
-        app.popup = Popup::NewSession;
+        app.navigation.popup = Popup::NewSession;
         app.launch_cwd = Some("/launch".into());
         app.new_session_path = "proj/subdir".into();
         app.new_session_cursor = app.new_session_path.len();
@@ -2721,7 +2724,7 @@ mod session_popup_key_tests {
     #[test]
     fn new_session_popup_tab_accepts_selected_completion() {
         let mut app = App::new();
-        app.popup = Popup::NewSession;
+        app.navigation.popup = Popup::NewSession;
         app.new_session_completion = Some(crate::app::PathCompletionState {
             query: "pro".into(),
             selected_index: 0,
@@ -2747,7 +2750,7 @@ mod session_popup_key_tests {
     fn handle_key_routes_tab_to_new_session_popup_before_global_mode_switch() {
         let mut app = App::new();
         app.conn = crate::app::ConnState::Connected;
-        app.popup = Popup::NewSession;
+        app.navigation.popup = Popup::NewSession;
         app.agent_mode = "build".into();
         app.new_session_completion = Some(crate::app::PathCompletionState {
             query: "pro".into(),
@@ -2775,7 +2778,7 @@ mod session_popup_key_tests {
     #[test]
     fn popup_backspace_removes_last_filter_char_and_resets_cursor() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_filter = "ab".to_string();
         app.session_cursor = 2;
         apply_popup_session_key(&mut app, KeyCode::Backspace);
@@ -2788,7 +2791,7 @@ mod session_popup_key_tests {
     #[test]
     fn popup_down_crosses_group_boundary() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![
             make_group(Some("/a"), &["s1"]),
             make_group(Some("/b"), &["s2"]),
@@ -2806,7 +2809,7 @@ mod session_popup_key_tests {
     #[test]
     fn popup_collapse_independent_of_start_page() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(Some("/a"), &["s1"])];
         // collapse in popup
         app.session_cursor = 0;
@@ -2820,7 +2823,6 @@ mod session_popup_key_tests {
 #[cfg(test)]
 mod delegate_popup_key_tests {
     use super::*;
-    use crate::app::Popup;
     use crate::domain::activity::{
         DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus,
     };
@@ -2845,7 +2847,7 @@ mod delegate_popup_key_tests {
     fn setup_delegate_app() -> App {
         let mut app = App::new();
         app.session_id = Some("parent-1".into());
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_popup_tab = 1;
         app.delegate_entries = vec![
             make_entry("d1", "Build feature", Some("child-1")),
@@ -2931,13 +2933,13 @@ mod delegate_popup_key_tests {
                 cwd: None,
             }
         );
-        assert_eq!(app.popup, Popup::None);
+        assert_eq!(app.navigation.popup, Popup::None);
     }
 
     #[test]
     fn delegate_enter_noop_when_child_session_is_unavailable() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_popup_tab = 1;
         app.delegate_entries = vec![DelegateEntry {
             delegation_id: "d1".into(),
@@ -2953,7 +2955,7 @@ mod delegate_popup_key_tests {
         }];
         let action = apply_delegate_popup_key(&mut app, KeyCode::Enter);
         assert_eq!(action, SessionKeyAction::None);
-        assert_eq!(app.popup, Popup::SessionSelect);
+        assert_eq!(app.navigation.popup, Popup::SessionSelect);
     }
 
     #[test]
@@ -3003,14 +3005,14 @@ mod delegate_popup_key_tests {
                 cwd: None,
             }
         );
-        assert_eq!(app.popup, Popup::None);
+        assert_eq!(app.navigation.popup, Popup::None);
     }
 
     #[test]
     fn delegate_esc_closes_popup() {
         let mut app = setup_delegate_app();
         apply_delegate_popup_key(&mut app, KeyCode::Esc);
-        assert_eq!(app.popup, Popup::None);
+        assert_eq!(app.navigation.popup, Popup::None);
     }
 
     #[test]
@@ -3239,7 +3241,7 @@ mod reasoning_effort_integration_tests {
         let _guard = PersistenceGuard::new("main-test");
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
         app.agent_mode = "plan".into();
         app.model_popup_agent_tab = 0;
@@ -3264,7 +3266,7 @@ mod reasoning_effort_integration_tests {
         )
         .unwrap();
 
-        assert_eq!(app.popup, app::Popup::ModelSelect);
+        assert_eq!(app.navigation.popup, Popup::ModelSelect);
         assert_eq!(app.model_filter, "");
         let expected = app.model_popup_open_cursor();
         assert_eq!(app.model_cursor, expected);
@@ -3278,7 +3280,7 @@ mod reasoning_effort_integration_tests {
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
         app.session_id = Some("s1".into());
-        app.popup = app::Popup::ModelSelect;
+        app.navigation.popup = Popup::ModelSelect;
         app.agent_mode = "build".into();
         app.model_popup_agent_tab = 0;
         app.current_provider = Some("anthropic".into());
@@ -3319,7 +3321,7 @@ mod reasoning_effort_integration_tests {
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
         app.session_id = Some("s1".into());
-        app.popup = app::Popup::ModelSelect;
+        app.navigation.popup = Popup::ModelSelect;
         app.agent_mode = "build".into();
         app.model_popup_agent_tab = 0;
         app.current_provider = Some("anthropic".into());
@@ -3432,7 +3434,7 @@ mod auth_tests {
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
         app.auth.providers = providers;
-        app.popup = app::Popup::ProviderAuth;
+        app.navigation.popup = Popup::ProviderAuth;
         app
     }
 
@@ -3456,7 +3458,7 @@ mod auth_tests {
             message: "old notice".into(),
         });
         app.open_auth_popup();
-        assert_eq!(app.popup, app::Popup::ProviderAuth);
+        assert_eq!(app.navigation.popup, Popup::ProviderAuth);
         assert_eq!(app.auth.cursor, 0);
         assert!(app.auth.filter.is_empty());
         assert!(app.auth.selected.is_none());
@@ -3474,7 +3476,7 @@ mod auth_tests {
         let mut app = make_app_with_providers(vec![make_provider("OpenAI")]);
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         handle_auth_popup_key(&mut app, key(KeyCode::Esc), &tx).unwrap();
-        assert_eq!(app.popup, app::Popup::None);
+        assert_eq!(app.navigation.popup, Popup::None);
     }
 
     #[test]
@@ -3493,7 +3495,7 @@ mod auth_tests {
         });
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         handle_auth_popup_key(&mut app, key(KeyCode::Esc), &tx).unwrap();
-        assert_eq!(app.popup, app::Popup::ProviderAuth);
+        assert_eq!(app.navigation.popup, Popup::ProviderAuth);
         assert!(app.auth.selected.is_none());
         assert!(app.auth.last_result.is_none());
         assert!(app.auth.ui_notice.is_none());
@@ -3914,7 +3916,7 @@ mod auth_tests {
     #[test]
     fn native_oauth_flow_started_event_sets_flow_state() {
         let mut app = App::new();
-        app.popup = app::Popup::ProviderAuth;
+        app.navigation.popup = Popup::ProviderAuth;
 
         app.auth.last_result = Some(OAuthResult {
             provider: "openai".into(),
@@ -4150,12 +4152,12 @@ mod auth_tests {
         // Activate chord mode
         let ctrl_x = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL);
         handle_key(&mut app, ctrl_x, &tx).unwrap();
-        assert!(app.chord);
+        assert!(app.navigation.chord);
 
         // Press 'a'
         handle_key(&mut app, key(KeyCode::Char('a')), &tx).unwrap();
-        assert_eq!(app.popup, app::Popup::ProviderAuth);
-        assert!(!app.chord);
+        assert_eq!(app.navigation.popup, Popup::ProviderAuth);
+        assert!(!app.navigation.chord);
 
         let msg = rx.try_recv().expect("message sent");
         assert!(matches!(msg, Command::ListAuthProviders));

--- a/src/session.rs
+++ b/src/session.rs
@@ -6,11 +6,12 @@ use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
 
 use crate::app::{
-    App, FileIndexEntryLite, MAX_RECENT_SESSIONS, MAX_VISIBLE_GROUPS, PathCompletionState, Popup,
+    App, FileIndexEntryLite, MAX_RECENT_SESSIONS, MAX_VISIBLE_GROUPS, PathCompletionState,
     PopupItem, StartPageItem,
 };
 use crate::domain::activity::{DelegateEntry, SessionActivity};
 use crate::domain::session::{SessionChildrenPage, SessionGroup, SessionSummary};
+use crate::navigation_state::Popup;
 
 /// Returns indices of sessions in `group` whose title or ID matches `q`.
 /// When `q` is empty every session matches in original order.
@@ -502,14 +503,14 @@ impl App {
     }
 
     pub fn open_delegate_popup(&mut self) {
-        self.popup = Popup::SessionSelect;
+        self.navigation.popup = Popup::SessionSelect;
         self.session_popup_tab = 1;
         self.delegate_cursor = 0;
         self.delegate_filter.clear();
     }
 
     pub fn open_new_session_popup(&mut self) {
-        self.popup = Popup::NewSession;
+        self.navigation.popup = Popup::NewSession;
         self.new_session_path = self.resolve_new_session_default_cwd().unwrap_or_default();
         self.new_session_cursor = self.new_session_path.chars().count();
         self.refresh_new_session_completion();

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -36,7 +36,8 @@ use ratatui::{
 
 use unicode_width::UnicodeWidthChar;
 
-use crate::app::{App, ConnState, Popup, Screen};
+use crate::app::{App, ConnState};
+use crate::navigation_state::{Popup, Screen};
 use crate::theme::Theme;
 
 #[derive(Debug, Clone, Default)]
@@ -389,13 +390,13 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     let area = f.area();
     f.render_widget(Block::default().style(Theme::base()), area);
 
-    match app.screen {
+    match app.navigation.screen {
         Screen::Sessions => draw_start(f, app),
         Screen::Chat => draw_chat(f, app),
         Screen::Delegate => draw_delegate_view(f, app),
     }
 
-    match app.popup {
+    match app.navigation.popup {
         Popup::CommandPalette => draw_command_palette_popup(f, app),
         Popup::Mesh => draw_mesh_popup(f, app),
         Popup::MeshInvite => draw_mesh_invite_popup(f, app),
@@ -446,7 +447,7 @@ fn draw_header(
         Span::styled(" query", Theme::title()),
         Span::styled("mt", Theme::title_accent()),
     ];
-    if app.chord {
+    if app.navigation.chord {
         spans.push(Span::styled(" C-x", Theme::status_accent()));
     }
     spans.extend(left);
@@ -470,7 +471,7 @@ fn draw_header(
 mod tests {
     use super::*;
     use crate::acp_state::{AcpAppEvent, AcpSessionUpdate};
-    use crate::app::{App, Screen};
+    use crate::app::App;
     use crate::auth_state::{AuthPanel, AuthUiNotice};
     use crate::diagnostics::LogLevel;
     use crate::domain::activity::{
@@ -701,11 +702,9 @@ mod tests {
 
     #[test]
     fn draw_fork_popup_renders_turns_as_table() {
-        use crate::app::Popup;
-
         let mut app = App::new();
-        app.screen = Screen::Chat;
-        app.popup = Popup::ForkTurnSelect;
+        app.navigation.screen = Screen::Chat;
+        app.navigation.popup = Popup::ForkTurnSelect;
         app.messages = vec![
             ChatEntry::User {
                 text: "alpha prompt".into(),
@@ -774,7 +773,7 @@ mod tests {
     #[test]
     fn draw_chat_shows_multi_session_badge_for_other_recent_sessions() {
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.session_id = Some("session-a".into());
         app.agent_mode = "build".into();
         app.current_provider = Some("anthropic".into());
@@ -842,7 +841,7 @@ mod tests {
     #[test]
     fn draw_chat_shows_delegate_badge_when_entries_exist() {
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.session_id = Some("s1".into());
         app.agent_mode = "build".into();
         app.current_provider = Some("anthropic".into());
@@ -903,7 +902,7 @@ mod tests {
     #[test]
     fn draw_chat_shows_delegate_awaiting_input_badge() {
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.session_id = Some("s1".into());
         app.agent_mode = "build".into();
         app.current_provider = Some("anthropic".into());
@@ -946,7 +945,7 @@ mod tests {
         use crate::theme::Theme;
 
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.session_id = Some("s1".into());
         app.agent_mode = "build".into();
         app.current_provider = Some("anthropic".into());
@@ -975,11 +974,9 @@ mod tests {
 
     #[test]
     fn draw_delegate_popup_uses_aligned_stat_columns_without_header() {
-        use crate::app::Popup;
-
         let mut app = App::new();
-        app.screen = Screen::Chat;
-        app.popup = Popup::SessionSelect;
+        app.navigation.screen = Screen::Chat;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_popup_tab = 1;
         app.session_id = Some("parent".into());
         app.delegate_entries = vec![
@@ -1040,11 +1037,9 @@ mod tests {
 
     #[test]
     fn draw_delegate_popup_shows_question_pending_marker_and_hint() {
-        use crate::app::Popup;
-
         let mut app = App::new();
-        app.screen = Screen::Chat;
-        app.popup = Popup::SessionSelect;
+        app.navigation.screen = Screen::Chat;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_popup_tab = 1;
         app.delegate_cursor = 1;
         app.delegate_entries = vec![DelegateEntry {
@@ -1090,11 +1085,9 @@ mod tests {
 
     #[test]
     fn draw_delegate_popup_hides_cost_column_when_all_rows_have_zero_cost() {
-        use crate::app::Popup;
-
         let mut app = App::new();
-        app.screen = Screen::Chat;
-        app.popup = Popup::SessionSelect;
+        app.navigation.screen = Screen::Chat;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_popup_tab = 1;
         app.delegate_entries = vec![
             DelegateEntry {
@@ -1159,11 +1152,9 @@ mod tests {
 
     #[test]
     fn draw_delegate_popup_truncates_long_objectives_with_unicode_ellipsis() {
-        use crate::app::Popup;
-
         let mut app = App::new();
-        app.screen = Screen::Chat;
-        app.popup = Popup::SessionSelect;
+        app.navigation.screen = Screen::Chat;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_popup_tab = 1;
         app.delegate_entries = vec![DelegateEntry {
             delegation_id: "del-1".into(),
@@ -1201,12 +1192,11 @@ mod tests {
 
     #[test]
     fn draw_delegate_popup_failed_symbol_uses_dim_surface_background() {
-        use crate::app::Popup;
         use crate::theme::Theme;
 
         let mut app = App::new();
-        app.screen = Screen::Chat;
-        app.popup = Popup::SessionSelect;
+        app.navigation.screen = Screen::Chat;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_popup_tab = 1;
         app.delegate_cursor = 0; // keep first row selected; failed row remains unselected
         app.delegate_entries = vec![
@@ -1250,12 +1240,11 @@ mod tests {
 
     #[test]
     fn draw_delegate_popup_highlights_full_selected_row() {
-        use crate::app::Popup;
         use crate::theme::Theme;
 
         let mut app = App::new();
-        app.screen = Screen::Chat;
-        app.popup = Popup::SessionSelect;
+        app.navigation.screen = Screen::Chat;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_popup_tab = 1;
         app.delegate_cursor = 1;
         app.delegate_entries = vec![
@@ -1339,11 +1328,9 @@ mod tests {
 
     #[test]
     fn draw_delegate_popup_shows_agent_name_column() {
-        use crate::app::Popup;
-
         let mut app = App::new();
-        app.screen = Screen::Chat;
-        app.popup = Popup::SessionSelect;
+        app.navigation.screen = Screen::Chat;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_popup_tab = 1;
         app.session_id = Some("parent".into());
         app.delegate_entries = vec![
@@ -1399,7 +1386,7 @@ mod tests {
         use crate::theme::Theme;
 
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.agent_mode = "build".into();
         app.messages.push(ChatEntry::ToolCall {
             tool_call_id: None,
@@ -1534,7 +1521,7 @@ mod tests {
     #[test]
     fn delegate_tool_call_shows_awaiting_input_marker() {
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.agent_mode = "build".into();
         app.messages.push(ChatEntry::ToolCall {
             tool_call_id: None,
@@ -1578,7 +1565,7 @@ mod tests {
     #[test]
     fn draw_chat_preserves_hard_line_breaks_in_input() {
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.agent_mode = "build".into();
         app.input = "alpha\nbeta".into();
         app.input_cursor = app.input.len();
@@ -1600,7 +1587,7 @@ mod tests {
     #[test]
     fn draw_chat_places_cursor_on_next_row_after_newline() {
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.agent_mode = "build".into();
         app.input = "alpha\nbeta".into();
         app.input_cursor = "alpha\n".len();
@@ -1646,7 +1633,7 @@ mod tests {
     #[test]
     fn draw_chat_does_not_panic_with_empty_elicitation_fields() {
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.agent_mode = "build".into();
         app.elicitation = Some(ElicitationState::new_for_test(vec![]));
         app.elicitation_ui = Some(ElicitationUiState::default());
@@ -1657,7 +1644,7 @@ mod tests {
     #[test]
     fn draw_chat_custom_elicitation_wraps_and_expands_with_prefix() {
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.agent_mode = "build".into();
         let mut state = ElicitationState::new_for_test(vec![ElicitationField {
             name: "choice".into(),
@@ -1698,7 +1685,7 @@ mod tests {
     #[test]
     fn draw_chat_wraps_long_elicitation_question() {
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         let mut state = ElicitationState::new_for_test(vec![ElicitationField {
             name: "choice".into(),
             title: "Choice".into(),
@@ -1730,7 +1717,7 @@ mod tests {
     #[test]
     fn draw_chat_wraps_long_elicitation_answers() {
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         app.elicitation = Some(ElicitationState::new_for_test(vec![ElicitationField {
             name: "choice".into(),
             title: "Choice".into(),
@@ -1759,7 +1746,7 @@ mod tests {
     #[test]
     fn draw_delegate_view_shows_elicitation_popup_and_input_hint() {
         let mut app = App::new();
-        app.screen = Screen::Delegate;
+        app.navigation.screen = Screen::Delegate;
         app.agent_mode = "build".into();
         app.messages.push(ChatEntry::Assistant {
             content: "Delegate context".into(),
@@ -1813,7 +1800,7 @@ mod tests {
     #[test]
     fn draw_delegate_view_without_elicitation_remains_read_only() {
         let mut app = App::new();
-        app.screen = Screen::Delegate;
+        app.navigation.screen = Screen::Delegate;
         app.agent_mode = "build".into();
         app.messages.push(ChatEntry::Assistant {
             content: "Read-only child output".into(),
@@ -1841,7 +1828,7 @@ mod tests {
     #[test]
     fn draw_session_popup_shows_active_marker_for_current_session() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_id = Some("s2".into());
         app.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
 
@@ -1862,7 +1849,7 @@ mod tests {
     #[test]
     fn draw_session_popup_highlights_active_session_id() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_id = Some("s2".into());
         app.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
 
@@ -1882,7 +1869,7 @@ mod tests {
     #[test]
     fn draw_session_popup_shows_fork_count_marker() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(Some("/a"), &["s1"])];
         app.session_groups[0].sessions[0].fork_count = 3;
         app.session_cursor = 1;
@@ -1910,7 +1897,7 @@ mod tests {
     #[test]
     fn draw_session_popup_truncates_long_titles_with_unicode_ellipsis() {
         let mut app = App::new();
-        app.popup = Popup::SessionSelect;
+        app.navigation.popup = Popup::SessionSelect;
         app.session_groups = vec![make_group(Some("/a"), &["session-12345678"])];
         app.session_groups[0].sessions[0].title =
             Some("This is a very long session title that should truncate in the popup".into());
@@ -1934,7 +1921,7 @@ mod tests {
     #[test]
     fn draw_auth_popup_filters_provider_rows_and_keeps_filtered_cursor() {
         let mut app = App::new();
-        app.popup = Popup::ProviderAuth;
+        app.navigation.popup = Popup::ProviderAuth;
         app.auth.providers = vec![
             auth_provider("openai", "OpenAI", true),
             auth_provider("groq", "Groq", false),
@@ -1960,7 +1947,7 @@ mod tests {
     #[test]
     fn draw_auth_popup_masks_api_key_and_uses_utf8_byte_cursor() {
         let mut app = App::new();
-        app.popup = Popup::ProviderAuth;
+        app.navigation.popup = Popup::ProviderAuth;
         app.auth.providers = vec![auth_provider("groq", "Groq", false)];
         app.auth.selected = Some(0);
         app.auth.panel = AuthPanel::ApiKeyInput;
@@ -1984,7 +1971,7 @@ mod tests {
     #[test]
     fn draw_auth_popup_renders_redirect_and_device_oauth_panels() {
         let mut app = App::new();
-        app.popup = Popup::ProviderAuth;
+        app.navigation.popup = Popup::ProviderAuth;
         app.auth.providers = vec![auth_provider("codex", "Codex", true)];
         app.auth.selected = Some(0);
         app.auth.panel = AuthPanel::OAuthFlow;
@@ -2014,7 +2001,7 @@ mod tests {
     #[test]
     fn draw_auth_popup_prefers_notice_and_renders_clipboard_fallback_overlay() {
         let mut app = App::new();
-        app.popup = Popup::ProviderAuth;
+        app.navigation.popup = Popup::ProviderAuth;
         app.auth.providers = vec![auth_provider("openai", "OpenAI", true)];
         app.auth.selected = Some(0);
         app.auth.last_result = Some(OAuthResult {
@@ -2044,7 +2031,7 @@ mod tests {
     #[test]
     fn draw_model_popup_groups_models_by_provider() {
         let mut app = App::new();
-        app.popup = Popup::ModelSelect;
+        app.navigation.popup = Popup::ModelSelect;
         app.agent_mode = "build".into();
         app.model_popup_agent_tab = 0;
         app.current_provider = Some("anthropic".into());
@@ -2101,7 +2088,7 @@ mod tests {
     #[test]
     fn draw_model_popup_highlights_hint_keys() {
         let mut app = App::new();
-        app.popup = Popup::ModelSelect;
+        app.navigation.popup = Popup::ModelSelect;
 
         let backend = ratatui::backend::TestBackend::new(80, 20);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
@@ -2122,7 +2109,7 @@ mod tests {
     #[test]
     fn draw_model_popup_live_marker_uses_status_accent_on_session_tab() {
         let mut app = App::new();
-        app.popup = Popup::ModelSelect;
+        app.navigation.popup = Popup::ModelSelect;
         app.agent_mode = "build".into();
         app.model_popup_agent_tab = 0;
         app.current_provider = Some("anthropic".into());
@@ -2171,7 +2158,7 @@ mod tests {
     #[test]
     fn draw_model_popup_marks_only_remote_live_row_when_duplicates() {
         let mut app = App::new();
-        app.popup = Popup::ModelSelect;
+        app.navigation.popup = Popup::ModelSelect;
         app.agent_mode = "build".into();
         app.model_popup_agent_tab = 0;
         app.current_provider = Some("codex".into());
@@ -2222,7 +2209,7 @@ mod tests {
     #[test]
     fn draw_mesh_popup_shows_nodes_sessions_and_hints() {
         let mut app = App::new();
-        app.popup = Popup::Mesh;
+        app.navigation.popup = Popup::Mesh;
         app.mesh.mesh_nodes = vec![crate::domain::mesh::RemoteNodeInfo {
             id: "node-1".into(),
             label: "framework".into(),
@@ -2253,7 +2240,7 @@ mod tests {
     #[test]
     fn draw_mesh_popup_shows_invite_form_defaults() {
         let mut app = App::new();
-        app.popup = Popup::Mesh;
+        app.navigation.popup = Popup::Mesh;
         app.open_mesh_invite_form();
 
         let backend = ratatui::backend::TestBackend::new(100, 24);
@@ -2271,7 +2258,7 @@ mod tests {
     #[test]
     fn draw_mesh_popup_shows_invite_url_and_qr() {
         let mut app = App::new();
-        app.popup = Popup::Mesh;
+        app.navigation.popup = Popup::Mesh;
         app.apply_mesh_invite_created(crate::domain::mesh::MeshInviteCreatedInfo {
             invite_id: "invite-1".into(),
             url: "qmt://mesh/join/token".into(),
@@ -2299,10 +2286,10 @@ mod tests {
     #[test]
     fn draw_command_palette_popup_aligns_columns_and_highlights_selection() {
         let mut app = App::new();
-        app.popup = Popup::CommandPalette;
-        app.screen = Screen::Chat;
-        app.command_palette_filter = "session switcher".into();
-        app.command_palette_cursor = 0;
+        app.navigation.popup = Popup::CommandPalette;
+        app.navigation.screen = Screen::Chat;
+        app.navigation.command_palette_filter = "session switcher".into();
+        app.navigation.command_palette_cursor = 0;
 
         let backend = ratatui::backend::TestBackend::new(100, 24);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
@@ -2332,7 +2319,7 @@ mod tests {
     #[test]
     fn draw_theme_popup_highlights_hint_keys() {
         let mut app = App::new();
-        app.popup = Popup::ThemeSelect;
+        app.navigation.popup = Popup::ThemeSelect;
 
         let backend = ratatui::backend::TestBackend::new(80, 20);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
@@ -2355,7 +2342,7 @@ mod tests {
     #[test]
     fn draw_model_popup_shows_current_mode_model_on_short_terminal() {
         let mut app = App::new();
-        app.popup = Popup::ModelSelect;
+        app.navigation.popup = Popup::ModelSelect;
         app.agent_mode = "build".into();
         app.models = (0..12)
             .map(|i| ModelEntry {
@@ -2392,8 +2379,8 @@ mod tests {
     #[test]
     fn draw_theme_popup_truncates_long_labels_with_unicode_ellipsis() {
         let mut app = App::new();
-        app.popup = Popup::ThemeSelect;
-        app.theme_filter = "Penumbra Dark Contrast Plus Plus".into();
+        app.navigation.popup = Popup::ThemeSelect;
+        app.navigation.theme_filter = "Penumbra Dark Contrast Plus Plus".into();
 
         let backend = ratatui::backend::TestBackend::new(40, 20);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
@@ -2412,7 +2399,7 @@ mod tests {
     #[test]
     fn draw_theme_popup_uses_bounded_width_on_wide_terminal() {
         let mut app = App::new();
-        app.popup = Popup::ThemeSelect;
+        app.navigation.popup = Popup::ThemeSelect;
 
         let backend = ratatui::backend::TestBackend::new(120, 24);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
@@ -2433,8 +2420,8 @@ mod tests {
         crate::theme::Theme::begin_frame();
 
         let mut app = App::new();
-        app.popup = Popup::ThemeSelect;
-        app.theme_cursor = 20;
+        app.navigation.popup = Popup::ThemeSelect;
+        app.navigation.theme_cursor = 20;
 
         let current_label = crate::theme::Theme::available_themes()[20].label;
         let backend = ratatui::backend::TestBackend::new(80, 10);
@@ -2463,8 +2450,8 @@ mod tests {
         crate::theme::Theme::begin_frame();
 
         let mut app = App::new();
-        app.popup = Popup::ThemeSelect;
-        app.theme_cursor = 20;
+        app.navigation.popup = Popup::ThemeSelect;
+        app.navigation.theme_cursor = 20;
 
         let current_label = crate::theme::Theme::available_themes()[20].label;
         let backend = ratatui::backend::TestBackend::new(80, 10);
@@ -2489,7 +2476,7 @@ mod tests {
     #[test]
     fn draw_new_session_popup_shows_compact_default_cwd_hint() {
         let mut app = App::new();
-        app.popup = Popup::NewSession;
+        app.navigation.popup = Popup::NewSession;
         app.new_session_path = "/launch".into();
         app.new_session_cursor = app.new_session_path.len();
         app.new_session_completion = Some(crate::app::PathCompletionState {
@@ -2559,7 +2546,7 @@ mod tests {
     #[test]
     fn draw_log_popup_shows_filter_level_and_entries() {
         let mut app = App::new();
-        app.popup = Popup::Log;
+        app.navigation.popup = Popup::Log;
         app.diagnostics.log_filter = "server".into();
         app.diagnostics.log_level_filter = LogLevel::Info;
         app.push_log(LogLevel::Info, "server", "starting local server");
@@ -3208,7 +3195,7 @@ mod tests {
     fn direct_elicitation_fixture_renders_active_popup() {
         // Legacy envelope parsing is covered outside the UI; render an active popup directly.
         let mut app = App::new();
-        app.screen = Screen::Delegate;
+        app.navigation.screen = Screen::Delegate;
         let mut state = ElicitationState::new_for_test(vec![ElicitationField {
             name: "answer".into(),
             title: "Answer".into(),
@@ -3249,7 +3236,7 @@ mod tests {
     #[test]
     fn session_switch_rebuilds_chat_cards_without_parent_bleed() {
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         load_session(&mut app, "parent-session", "agent-1");
         replay_session(
             &mut app,
@@ -3278,7 +3265,7 @@ mod tests {
     #[test]
     fn session_switch_rebuilds_delegate_view_without_parent_bleed() {
         let mut app = App::new();
-        app.screen = Screen::Chat;
+        app.navigation.screen = Screen::Chat;
         load_session(&mut app, "parent-session", "agent-1");
         replay_session(
             &mut app,
@@ -3295,7 +3282,7 @@ mod tests {
                 assistant_update("delegate reply 2", "delegate-assistant-2"),
             ],
         );
-        assert_eq!(app.screen, Screen::Delegate);
+        assert_eq!(app.navigation.screen, Screen::Delegate);
         let rendered = buffer_text(&render_delegate_buffer(&mut app, 80, 16));
         assert!(rendered.contains("delegate prompt 1"));
         assert!(rendered.contains("delegate reply 2"));

--- a/src/ui/popups.rs
+++ b/src/ui/popups.rs
@@ -1932,7 +1932,7 @@ pub(super) fn draw_command_palette_popup(f: &mut Frame, app: &App) {
     const SHORTCUT_COL_W: usize = 10;
 
     let area = f.area();
-    let commands = app.filtered_command_palette_commands();
+    let commands = app.navigation.filtered_command_palette_commands();
     let desired_h = (commands.len() as u16).saturating_add(7);
     let popup_width = area
         .width
@@ -1985,11 +1985,11 @@ pub(super) fn draw_command_palette_popup(f: &mut Frame, app: &App) {
 
     let avail = chunks[1].width.saturating_sub(2) as usize;
     let (filter_display, filter_cur) = scroll_input(
-        &app.command_palette_filter,
-        app.command_palette_filter.len(),
+        &app.navigation.command_palette_filter,
+        app.navigation.command_palette_filter.len(),
         avail,
     );
-    let placeholder = if app.command_palette_filter.is_empty() {
+    let placeholder = if app.navigation.command_palette_filter.is_empty() {
         "type to filter..."
     } else {
         ""
@@ -2017,7 +2017,7 @@ pub(super) fn draw_command_palette_popup(f: &mut Frame, app: &App) {
             .iter()
             .enumerate()
             .map(|(i, command)| {
-                let selected = i == app.command_palette_cursor;
+                let selected = i == app.navigation.command_palette_cursor;
                 let row_style = if selected {
                     Theme::selected()
                 } else {
@@ -2051,7 +2051,8 @@ pub(super) fn draw_command_palette_popup(f: &mut Frame, app: &App) {
         .highlight_symbol("");
     let visible_rows = chunks[3].height as usize;
     let selected = (!commands.is_empty()).then_some(
-        app.command_palette_cursor
+        app.navigation
+            .command_palette_cursor
             .min(commands.len().saturating_sub(1)),
     );
     let offset = selected
@@ -2124,8 +2125,11 @@ pub(super) fn draw_theme_popup(f: &mut Frame, app: &App) {
 
     // filter
     let avail = chunks[1].width.saturating_sub(2) as usize;
-    let (theme_filter_display, theme_filter_cur) =
-        scroll_input(&app.theme_filter, app.theme_filter.len(), avail);
+    let (theme_filter_display, theme_filter_cur) = scroll_input(
+        &app.navigation.theme_filter,
+        app.navigation.theme_filter.len(),
+        avail,
+    );
     let filter_line = Line::from(vec![
         Span::styled("> ", Theme::popup_title()),
         Span::styled(theme_filter_display, Theme::popup_bg()),
@@ -2138,16 +2142,7 @@ pub(super) fn draw_theme_popup(f: &mut Frame, app: &App) {
 
     // theme list
     let all_themes = Theme::available_themes();
-    let filter_lower = app.theme_filter.to_lowercase();
-    let filtered: Vec<(usize, &crate::themes_gen::Base16Palette)> = all_themes
-        .iter()
-        .enumerate()
-        .filter(|(_, t)| {
-            filter_lower.is_empty()
-                || t.label.to_lowercase().contains(&filter_lower)
-                || t.id.to_lowercase().contains(&filter_lower)
-        })
-        .collect();
+    let filtered = app.navigation.filtered_themes(all_themes);
 
     let current_idx = Theme::current_index();
     let list_w = chunks[3].width as usize;
@@ -2156,18 +2151,25 @@ pub(super) fn draw_theme_popup(f: &mut Frame, app: &App) {
         .iter()
         .enumerate()
         .map(|(i, (orig_idx, t))| {
-            build_theme_list_item(t, *orig_idx, current_idx, list_w, i == app.theme_cursor)
+            build_theme_list_item(
+                t,
+                *orig_idx,
+                current_idx,
+                list_w,
+                i == app.navigation.theme_cursor,
+            )
         })
         .collect();
 
     let list = List::new(items).block(Block::default().style(Theme::popup_bg()));
     let visible_rows = chunks[3].height as usize;
     let offset = app
+        .navigation
         .theme_cursor
         .saturating_sub(visible_rows.saturating_sub(1));
     let mut state = ListState::default()
         .with_offset(offset)
-        .with_selected(Some(app.theme_cursor));
+        .with_selected(Some(app.navigation.theme_cursor));
     f.render_stateful_widget(list, chunks[3], &mut state);
 
     // hint
@@ -2474,7 +2476,7 @@ pub(super) fn draw_help_popup(f: &mut Frame, app: &App) {
     }
 
     let list = List::new(items).block(Block::default().style(Theme::popup_bg()));
-    let mut state = ListState::default().with_offset(app.help_scroll);
+    let mut state = ListState::default().with_offset(app.navigation.help_scroll);
     f.render_stateful_widget(list, chunks[2], &mut state);
 
     // hint


### PR DESCRIPTION
## What changed

- extract the complete eight-field navigation/UI routing slice into private `NavigationState`
- move `Screen`, `Popup`, command-palette metadata, and pure palette/theme/help operations into `src/navigation_state.rs`
- replace eight flat `App` fields with one crate-visible `navigation` owner and mechanically migrate ACP, mesh, session, runtime, handler, and UI routing
- retain palette action execution, commands, persistence, diagnostics, session identity, feature popup data, and theme effects in their existing coordinator modules

## Behavior preserved

- Ctrl-P replacement/reset precedence and Ctrl-X clearing before second-key routing
- popup/global/tab/screen/mouse routing order and `Delegate` remaining distinct from `Chat`
- palette matching/order/wrapping, theme clamping/no-match/out-of-range Enter behavior, and unbounded help scrolling
- mesh invite, auth detail, fork success/retain, remote attach/detach, session transition, startup, and slash-command routing

## Validation

- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --all-targets --all-features`
- `cargo test --all-targets --all-features -- --quiet` (834 passed, 0 failed/ignored; 2.70s harness, 2.877s wall)
- `git diff --check`
- boundary searches: zero flat navigation accesses/declarations, zero old App-owned moved-type imports, one private module/owner field, zero forbidden owner dependencies/forwards/public exports, four diagnostics compatibility tags, exact 10-file source allowlist

## Metrics

- 49 Rust files / 43,509 physical LOC
- 99 direct `App` fields, down from 106
- `src/navigation_state.rs`: 530 LOC (298 owner/runtime, 232 tests), 18 focused tests
- 834 test declarations; five files containing an `App` impl

## Status

Source-complete and review/integration-pending. Phase 4, the NavigationState checkbox, aggregate low-coupling work, manual TUI smoke testing, Phase 11 visibility cleanup, and later state groups remain incomplete. No next group is included.
