### PR TITLE
refactor: extract models state

### DIFF
--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -200,13 +200,12 @@ impl crate::app::App {
                     self.apply_profile_catalog(profiles, active_profile_id);
                 }
                 self.agent_id = Some(agent_id.clone());
-                self.agents = vec![AgentInfo {
+                self.models.initialize_primary_agent(AgentInfo {
                     id: agent_id,
                     name: agent_name,
                     description: None,
                     capabilities: Vec::new(),
-                }];
-                self.agents_profile_id = None;
+                });
                 if let Some(mode) = agent_mode {
                     self.agent_mode = mode;
                     if self.agent_mode != "review" {
@@ -214,7 +213,7 @@ impl crate::app::App {
                     }
                 }
                 if let Some(effort) = reasoning_effort {
-                    self.reasoning_effort = effort;
+                    self.models.reasoning_effort = effort;
                 }
                 self.auth.ui_notice = None;
                 self.set_status(LogLevel::Info, "connection", "connected");
@@ -229,9 +228,9 @@ impl crate::app::App {
             }
             AcpAppEvent::ReasoningEffort { reasoning_effort } => {
                 if let Some(validated) =
-                    crate::app::validate_reasoning_effort(reasoning_effort.as_deref())
+                    crate::models_state::validate_reasoning_effort(reasoning_effort.as_deref())
                 {
-                    self.reasoning_effort = validated;
+                    self.models.reasoning_effort = validated;
                 }
                 vec![]
             }
@@ -241,15 +240,11 @@ impl crate::app::App {
             } => self.apply_profile_catalog(profiles, active_profile_id),
             AcpAppEvent::ProfileAgents { profile_id, agents } => {
                 if self.desired_agents_profile_id() == Some(profile_id.as_str()) {
-                    self.agents = agents;
-                    self.agents_profile_id = Some(profile_id);
-                    self.model_popup_agent_tab = self
-                        .model_popup_agent_tab
-                        .min(self.model_popup_tab_count().saturating_sub(1));
+                    self.models.replace_profile_agents(profile_id, agents);
                     if self.parent_session_id.is_none()
                         && let (Some(session_id), Some(profile_id)) = (
                             self.session_id.as_deref(),
-                            self.agents_profile_id.as_deref(),
+                            self.models.agents_profile_id.as_deref(),
                         )
                     {
                         return self.delegate_model_commands_for_session(session_id, profile_id);
@@ -281,9 +276,8 @@ impl crate::app::App {
                 context_limit,
                 provider_node_id,
             } => {
-                self.current_provider = Some(provider);
-                self.current_model = Some(model);
-                self.current_model_node_id = provider_node_id;
+                self.models
+                    .replace_live_selection(provider, model, provider_node_id);
                 if let Some(limit) = context_limit {
                     self.context_limit = limit;
                 }
@@ -495,15 +489,10 @@ impl crate::app::App {
                 vec![]
             }
             AcpAppEvent::Models { models, meta } => {
-                self.models = models;
-                let remote_models = self.models.iter().filter(|m| m.node_id.is_some()).count();
+                let (total_models, remote_models) = self.models.replace_catalog(models);
                 let remote_nodes = meta.as_ref().map(|m| m.remote_node_count).unwrap_or(0);
                 let timeouts = meta.as_ref().map(|m| m.remote_timeout_count).unwrap_or(0);
-                let mut line = format!(
-                    "models: {} total, {} remote",
-                    self.models.len(),
-                    remote_models
-                );
+                let mut line = format!("models: {total_models} total, {remote_models} remote");
                 if remote_nodes > 0 || timeouts > 0 {
                     line.push_str(&format!(
                         " (inventory nodes={remote_nodes}, timeouts={timeouts})"
@@ -581,12 +570,10 @@ impl crate::app::App {
             .apply_catalog(profiles, backend_active_profile_id);
         let desired_profile_id = self.desired_agents_profile_id().map(str::to_string);
         if active_profile_changed
-            || self.agents_profile_id.as_deref() != desired_profile_id.as_deref()
-            || self.agents.len() <= 1
+            || self.models.agents_profile_id.as_deref() != desired_profile_id.as_deref()
+            || self.models.agents.len() <= 1
         {
-            self.agents.clear();
-            self.agents_profile_id = None;
-            self.model_popup_agent_tab = 0;
+            self.models.clear_profile_agents();
             return desired_profile_id
                 .map(|profile_id| vec![Command::ListProfileAgents { profile_id }])
                 .unwrap_or_default();
@@ -778,7 +765,7 @@ impl crate::app::App {
             agent_id: self.agent_id.clone(),
         }];
         if let Some(profile_id) = self.current_session_profile_id().map(str::to_string) {
-            if self.agents_profile_id.as_deref() == Some(profile_id.as_str()) {
+            if self.models.agents_profile_id.as_deref() == Some(profile_id.as_str()) {
                 commands.extend(self.delegate_model_commands_for_session(&session_id, &profile_id));
             } else {
                 commands.push(Command::ListProfileAgents { profile_id });
@@ -814,7 +801,7 @@ impl crate::app::App {
         if self.parent_session_id.is_none()
             && let Some(profile_id) = self.current_session_profile_id().map(str::to_string)
         {
-            if self.agents_profile_id.as_deref() == Some(profile_id.as_str()) {
+            if self.models.agents_profile_id.as_deref() == Some(profile_id.as_str()) {
                 commands.extend(self.delegate_model_commands_for_session(&session_id, &profile_id));
             } else {
                 commands.push(Command::ListProfileAgents { profile_id });
@@ -2219,7 +2206,15 @@ mod tests {
         let mut app = App::new();
         app.profiles.profiles = vec![profile("fast")];
         app.profiles.active_profile_id = Some("fast".into());
-        app.agents.clear();
+        app.models.agents.clear();
+        app.models.model_popup_agent_tab = 3;
+        app.models.model_filter = "keep".into();
+        app.models.delegate_model_preferences.insert(
+            "fast".into(),
+            [("coder".into(), DelegateModelPreference::default())]
+                .into_iter()
+                .collect(),
+        );
 
         let commands = app.handle_acp_event(AcpAppEvent::Initialized {
             agent_id: "agent-1".into(),
@@ -2233,8 +2228,15 @@ mod tests {
         assert!(commands.is_empty());
         assert_eq!(app.profiles.profiles.len(), 1);
         assert_eq!(app.profiles.active_profile_id.as_deref(), Some("fast"));
-        assert_eq!(app.agents.len(), 1);
-        assert_eq!(app.agents_profile_id, None);
+        assert_eq!(app.models.agents.len(), 1);
+        assert_eq!(app.models.agents_profile_id, None);
+        assert_eq!(app.models.model_popup_agent_tab, 3);
+        assert_eq!(app.models.model_filter, "keep");
+        assert!(
+            app.models
+                .get_delegate_model_preference("fast", "coder")
+                .is_some()
+        );
     }
 
     #[test]
@@ -2252,8 +2254,8 @@ mod tests {
 
         assert!(commands.is_empty());
         assert_eq!(app.profiles.active_profile_id.as_deref(), Some("fast"));
-        assert_eq!(app.agents.len(), 1);
-        assert_eq!(app.agents_profile_id, None);
+        assert_eq!(app.models.agents.len(), 1);
+        assert_eq!(app.models.agents_profile_id, None);
     }
 
     #[test]
@@ -2562,7 +2564,7 @@ mod tests {
                 capabilities: Vec::new(),
             }],
         });
-        assert!(app.agents.is_empty());
+        assert!(app.models.agents.is_empty());
 
         app.handle_acp_event(AcpAppEvent::ProfileAgents {
             profile_id: "quorum".into(),
@@ -2581,9 +2583,9 @@ mod tests {
                 },
             ],
         });
-        assert_eq!(app.agents_profile_id.as_deref(), Some("quorum"));
-        assert_eq!(app.model_popup_tab_count(), 2);
-        assert_eq!(app.model_popup_tab_agent_id(1), Some("coder"));
+        assert_eq!(app.models.agents_profile_id.as_deref(), Some("quorum"));
+        assert_eq!(app.models.model_popup_tab_count(), 2);
+        assert_eq!(app.models.model_popup_tab_agent_id(1), Some("coder"));
     }
 
     #[test]
@@ -2592,7 +2594,7 @@ mod tests {
         app.session_id = Some("parent".into());
         app.profiles
             .bind_session_profile("parent".into(), "quorum".into());
-        app.delegate_model_preferences.insert(
+        app.models.delegate_model_preferences.insert(
             "quorum".into(),
             [(
                 "coder".into(),
@@ -3029,6 +3031,32 @@ mod tests {
         assert!(app.pending_session_group_loads.is_empty());
     }
 
+    fn seed_model_state(app: &mut App) {
+        app.models.current_provider = Some("provider".into());
+        app.models.current_model = Some("model".into());
+        app.models.reasoning_effort = Some("high".into());
+        app.models.models = vec![crate::models_state::ModelsState::test_model_entry(
+            "provider/model",
+            "provider",
+            "model",
+            None,
+            None,
+        )];
+        app.models.model_filter = "filter".into();
+        app.models.model_cursor = 5;
+        app.models.model_popup_agent_tab = 2;
+    }
+
+    fn assert_seeded_model_state(app: &App) {
+        assert_eq!(app.models.current_provider.as_deref(), Some("provider"));
+        assert_eq!(app.models.current_model.as_deref(), Some("model"));
+        assert_eq!(app.models.reasoning_effort.as_deref(), Some("high"));
+        assert_eq!(app.models.models.len(), 1);
+        assert_eq!(app.models.model_filter, "filter");
+        assert_eq!(app.models.model_cursor, 5);
+        assert_eq!(app.models.model_popup_agent_tab, 2);
+    }
+
     #[test]
     fn native_session_created_resets_view_and_subscribes() {
         let mut app = App::new();
@@ -3049,6 +3077,7 @@ mod tests {
         }];
         app.mesh.mesh_node_count = Some(1);
         app.mesh.mesh_invite_name = "preserved".into();
+        seed_model_state(&mut app);
 
         let replies = app.handle_acp_event(AcpAppEvent::SessionCreated {
             agent_id: "agent-1".into(),
@@ -3068,6 +3097,7 @@ mod tests {
         assert_eq!(app.mesh.mesh_node_count, Some(1));
         assert_eq!(app.mesh.selected_mesh_node_id(), Some("node-1"));
         assert_eq!(app.mesh.mesh_invite_name, "preserved");
+        assert_seeded_model_state(&app);
         assert!(matches!(
             replies.as_slice(),
             [
@@ -3117,6 +3147,7 @@ mod tests {
         app.elicitation = Some(ElicitationState::new_for_test(Vec::new()));
         app.elicitation_ui = Some(crate::ui::ElicitationUiState::default());
         app.session_stats.total_tool_calls = 2;
+        seed_model_state(&mut app);
         app.delegate_entries.push(DelegateEntry {
             delegation_id: "delegate-1".into(),
             child_session_id: Some("child".into()),
@@ -3150,6 +3181,7 @@ mod tests {
         assert!(app.elicitation.is_none());
         assert_eq!(app.session_stats.total_tool_calls, 0);
         assert_eq!(app.delegate_entries.len(), 1);
+        assert_seeded_model_state(&app);
         assert!(matches!(
             replies.as_slice(),
             [Command::SetAgentMode { mode }] if mode == "plan"
@@ -3199,6 +3231,71 @@ mod tests {
     }
 
     #[test]
+    fn model_catalog_events_preserve_state_and_log_exact_inventory_summary() {
+        let mut app = App::new();
+        app.models.current_provider = Some("old-provider".into());
+        app.models.current_model = Some("old-model".into());
+        app.models.current_model_node_id = Some("old-node".into());
+        app.models.model_cursor = 9;
+        app.models.model_filter = "stale".into();
+        app.models.model_popup_agent_tab = 3;
+        app.models.reasoning_effort = Some("high".into());
+
+        app.handle_acp_event(AcpAppEvent::Models {
+            models: vec![
+                crate::models_state::ModelsState::test_model_entry(
+                    "local", "provider", "local", None, None,
+                ),
+                crate::models_state::ModelsState::test_model_entry(
+                    "remote",
+                    "provider",
+                    "remote",
+                    Some("node-1"),
+                    Some("peer"),
+                ),
+            ],
+            meta: Some(AcpModelsMetaInfo {
+                remote_node_count: 2,
+                remote_timeout_count: 1,
+            }),
+        });
+
+        assert_eq!(app.models.models.len(), 2);
+        assert_eq!(app.models.current_provider.as_deref(), Some("old-provider"));
+        assert_eq!(app.models.current_model.as_deref(), Some("old-model"));
+        assert_eq!(
+            app.models.current_model_node_id.as_deref(),
+            Some("old-node")
+        );
+        assert_eq!(app.models.model_cursor, 9);
+        assert_eq!(app.models.model_filter, "stale");
+        assert_eq!(app.models.model_popup_agent_tab, 3);
+        assert_eq!(app.models.reasoning_effort.as_deref(), Some("high"));
+        assert_eq!(
+            app.diagnostics
+                .logs
+                .last()
+                .map(|entry| entry.message.as_str()),
+            Some("models: 2 total, 1 remote (inventory nodes=2, timeouts=1)")
+        );
+
+        app.handle_acp_event(AcpAppEvent::Models {
+            models: Vec::new(),
+            meta: Some(AcpModelsMetaInfo::default()),
+        });
+        assert!(app.models.models.is_empty());
+        assert_eq!(
+            app.diagnostics
+                .logs
+                .last()
+                .map(|entry| entry.message.as_str()),
+            Some("models: 0 total, 0 remote")
+        );
+        assert_eq!(app.models.model_cursor, 9);
+        assert_eq!(app.models.model_filter, "stale");
+    }
+
+    #[test]
     fn native_provider_changed_updates_selection_and_preserves_limit_when_absent() {
         let mut app = App::new();
         app.context_limit = 4_096;
@@ -3209,10 +3306,13 @@ mod tests {
             context_limit: Some(128_000),
             provider_node_id: Some("node-1".into()),
         });
-        assert_eq!(app.current_provider.as_deref(), Some("remote-provider"));
-        assert_eq!(app.current_model.as_deref(), Some("model-1"));
+        assert_eq!(
+            app.models.current_provider.as_deref(),
+            Some("remote-provider")
+        );
+        assert_eq!(app.models.current_model.as_deref(), Some("model-1"));
         assert_eq!(app.context_limit, 128_000);
-        assert_eq!(app.current_model_node_id.as_deref(), Some("node-1"));
+        assert_eq!(app.models.current_model_node_id.as_deref(), Some("node-1"));
 
         app.handle_acp_event(AcpAppEvent::ProviderChanged {
             provider: "local-provider".into(),
@@ -3220,10 +3320,13 @@ mod tests {
             context_limit: None,
             provider_node_id: None,
         });
-        assert_eq!(app.current_provider.as_deref(), Some("local-provider"));
-        assert_eq!(app.current_model.as_deref(), Some("model-2"));
+        assert_eq!(
+            app.models.current_provider.as_deref(),
+            Some("local-provider")
+        );
+        assert_eq!(app.models.current_model.as_deref(), Some("model-2"));
         assert_eq!(app.context_limit, 128_000);
-        assert_eq!(app.current_model_node_id, None);
+        assert_eq!(app.models.current_model_node_id, None);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,9 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
-use fuzzy_matcher::FuzzyMatcher;
-use fuzzy_matcher::skim::SkimMatcherV2;
-
 use crate::auth_state::AuthState;
 use crate::command::Command;
 use crate::diagnostics::{AppLogEntry, DiagnosticsState, LogLevel};
@@ -14,8 +11,6 @@ use crate::domain::activity::{
 use crate::domain::chat::{ChatEntry, format_outcome_labels};
 use crate::domain::elicitation::ElicitationState;
 use crate::domain::mesh::RemoteSessionLocation;
-use crate::domain::model::{DelegateModelPreference, ModelEntry};
-use crate::domain::profile::AgentInfo;
 use crate::domain::session::{
     ForkBoundaryKind, ForkTurnItem, SessionGroup, UndoFrame, UndoFrameStatus, UndoStackSnapshot,
     UndoState, UndoableTurn,
@@ -23,6 +18,7 @@ use crate::domain::session::{
 use crate::highlight::Highlighter;
 use crate::markdown::CardBlock;
 use crate::mesh_state::MeshState;
+use crate::models_state::ModelsState;
 use crate::navigation_state::{NavigationState, Popup};
 use crate::profiles_state::ProfilesState;
 use crate::protocol::audit::EventKind;
@@ -334,19 +330,6 @@ pub fn session_group_count_text(session_count: usize, session_total: Option<u64>
         .unwrap_or_else(|| session_count.to_string())
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ModelPopupItem {
-    ProviderHeader {
-        provider: String,
-        model_count: usize,
-        /// When set, header shows `@ {node}` right-aligned (remote mesh group).
-        node_suffix: Option<String>,
-    },
-    Model {
-        model_idx: usize,
-    },
-}
-
 pub struct App {
     pub(crate) navigation: NavigationState,
 
@@ -433,30 +416,11 @@ pub struct App {
     // thinking display
     pub show_thinking: bool,
 
-    // reasoning effort
-    /// Current reasoning-effort level. `None` = "auto" (server default).
-    /// Matches `reasoningEffort: string | null` in the web UI.
-    pub reasoning_effort: Option<String>,
     // profile info
     pub(crate) profiles: ProfilesState,
 
-    // model info
-    pub current_model: Option<String>,
-    pub current_provider: Option<String>,
-    /// Mesh node for the active catalog model (`None` = local provider host).
-    pub current_model_node_id: Option<String>,
-    pub models: Vec<ModelEntry>,
-    pub model_cursor: usize,
-    pub model_filter: String,
-
-    // delegate agent model preferences
-    /// Agents for `agents_profile_id`. Index zero is the primary session agent.
-    pub agents: Vec<AgentInfo>,
-    pub agents_profile_id: Option<String>,
-    /// Currently selected tab index: zero is the session, remaining tabs are delegates.
-    pub model_popup_agent_tab: usize,
-    /// Explicit model preferences scoped by profile ID and delegate agent ID.
-    pub delegate_model_preferences: HashMap<String, HashMap<String, DelegateModelPreference>>,
+    // model, reasoning effort, and profile-agent state
+    pub(crate) models: ModelsState,
 
     // in-memory logs popup and status line
     pub(crate) diagnostics: DiagnosticsState,
@@ -522,23 +486,6 @@ pub struct App {
 
     pub tick: u64,
     pub should_quit: bool,
-}
-
-/// Validate and normalize a reasoning-effort string.
-///
-/// * Returns `Some(Some(normalized))` for valid explicit levels:
-///   `"low"`, `"medium"` (also accepts alias `"med"`), `"high"`, `"max"`.
-/// * Returns `Some(None)` for `"auto"`, empty string, or `None`.
-/// * Returns `None` for any invalid/unrecognized level.
-pub fn validate_reasoning_effort(s: Option<&str>) -> Option<Option<String>> {
-    match s {
-        None | Some("auto") | Some("") => Some(None),
-        Some("low") => Some(Some("low".to_string())),
-        Some("medium") | Some("med") => Some(Some("medium".to_string())),
-        Some("high") => Some(Some("high".to_string())),
-        Some("max") => Some(Some("max".to_string())),
-        Some(_) => None,
-    }
 }
 
 fn move_wrapping_cursor(cursor: usize, len: usize, delta: isize) -> usize {
@@ -646,18 +593,8 @@ impl App {
             elicitation: None,
             elicitation_ui: None,
             show_thinking: true,
-            reasoning_effort: None,
             profiles: ProfilesState::new(),
-            current_model: None,
-            current_provider: None,
-            current_model_node_id: None,
-            models: Vec::new(),
-            model_cursor: 0,
-            model_filter: String::new(),
-            agents: Vec::new(),
-            agents_profile_id: None,
-            model_popup_agent_tab: 0,
-            delegate_model_preferences: HashMap::new(),
+            models: ModelsState::new(),
             diagnostics: DiagnosticsState::new(),
             undo_state: None,
             undoable_turns: Vec::new(),
@@ -709,18 +646,8 @@ impl App {
         self.card_cache.invalidate();
     }
 
-    /// Short display label for the current reasoning effort level.
-    /// Matches the five values used in the web UI: auto / low / medium / high / max.
-    pub fn reasoning_effort_label(&self) -> &str {
-        self.reasoning_effort.as_deref().unwrap_or("auto")
-    }
-
-    /// Valid reasoning effort levels (excluding "auto" which maps to `None`).
-    pub const EFFORT_LEVELS: &[&str] = &["low", "medium", "high", "max"];
-
     /// Cycle through `[auto, low, medium, high, max]` (wraps around).
-    /// Updates `self.reasoning_effort` optimistically, saves the new value as
-    /// the preference for the current `(mode, provider, model)` context, and
+    /// Updates the nested reasoning state optimistically and
     /// returns the [`Command`] to forward to the server.
     ///
     /// Returns `None` if the current value is not a recognized level; in that
@@ -728,40 +655,17 @@ impl App {
     /// should surface a warning to the user instead of silently coercing the
     /// unknown value to `low`).
     pub fn cycle_reasoning_effort(&mut self) -> Option<Command> {
-        const LEVELS: &[Option<&str>] =
-            &[None, Some("low"), Some("medium"), Some("high"), Some("max")];
-        let current = self.reasoning_effort.as_deref();
-        let Some(idx) = LEVELS.iter().position(|l| l.as_deref() == current) else {
-            // Unknown current value: leave state unchanged and let the caller
-            // surface a warning to the user instead of silently coercing to low.
-            return None;
-        };
-        let next = LEVELS[(idx + 1) % LEVELS.len()];
-        Some(
-            self.set_reasoning_effort(next)
-                .expect("cycle always produces a valid level"),
-        )
+        let reasoning_effort = self.models.cycle_reasoning_effort()?;
+        Some(Command::SetReasoningEffort { reasoning_effort })
     }
 
     /// Set the reasoning effort to a specific level.
     /// `None` or `Some("auto")` both map to the "auto" (no override) state.
-    /// Updates `self.reasoning_effort` and returns the [`Command`] to forward to the server.
+    /// Updates nested reasoning state and returns the [`Command`] to forward to the server.
     /// Returns `None` if the level is invalid (state is unchanged).
     pub fn set_reasoning_effort(&mut self, level: Option<&str>) -> Option<Command> {
-        match validate_reasoning_effort(level) {
-            Some(normalized) => {
-                self.reasoning_effort = normalized;
-                let effort_str = self
-                    .reasoning_effort
-                    .as_deref()
-                    .unwrap_or("auto")
-                    .to_string();
-                Some(Command::SetReasoningEffort {
-                    reasoning_effort: effort_str,
-                })
-            }
-            None => None,
-        }
+        let reasoning_effort = self.models.set_reasoning_effort(level)?;
+        Some(Command::SetReasoningEffort { reasoning_effort })
     }
 
     /// Route to a freshly reset auth popup while preserving provider data.
@@ -791,146 +695,6 @@ impl App {
     pub fn open_profile_popup(&mut self) {
         self.navigation.popup = Popup::ProfileSelect;
         self.profiles.reset_for_open();
-    }
-
-    pub fn filtered_models(&self) -> Vec<&ModelEntry> {
-        if self.model_filter.is_empty() {
-            self.models.iter().collect()
-        } else {
-            let matcher = SkimMatcherV2::default();
-            let mut scored: Vec<(i64, &ModelEntry)> = self
-                .models
-                .iter()
-                .filter_map(|m| {
-                    let score = [&m.label, &m.provider, &m.model]
-                        .iter()
-                        .filter_map(|field| matcher.fuzzy_match(field, &self.model_filter))
-                        .max();
-                    score.map(|s| (s, m))
-                })
-                .collect();
-            scored.sort_by_key(|item| std::cmp::Reverse(item.0));
-            scored.into_iter().map(|(_, m)| m).collect()
-        }
-    }
-
-    fn model_index_for_entry(&self, entry: &ModelEntry) -> Option<usize> {
-        self.models
-            .iter()
-            .position(|m| m.id == entry.id && m.node_id == entry.node_id)
-    }
-
-    /// Match catalog row to a provider/model pair, disambiguating local vs mesh.
-    pub fn model_entry_matches_node(
-        entry: &ModelEntry,
-        provider: &str,
-        model: &str,
-        node_id: Option<&str>,
-    ) -> bool {
-        if entry.provider != provider || entry.model != model {
-            return false;
-        }
-        match node_id {
-            Some(node) => entry.node_id.as_deref() == Some(node),
-            None => entry.node_id.is_none(),
-        }
-    }
-
-    pub fn apply_model_selection_from_entry(&mut self, entry: &ModelEntry) {
-        self.current_provider = Some(entry.provider.clone());
-        self.current_model = Some(entry.model.clone());
-        self.current_model_node_id = entry.node_id.clone();
-    }
-
-    pub fn live_model_selection_matches_entry(&self, entry: &ModelEntry) -> bool {
-        let (Some(cp), Some(cm)) = (
-            self.current_provider.as_deref(),
-            self.current_model.as_deref(),
-        ) else {
-            return false;
-        };
-        Self::model_entry_matches_node(entry, cp, cm, self.current_model_node_id.as_deref())
-    }
-
-    pub fn model_popup_open_cursor(&self) -> usize {
-        let items = self.visible_model_popup_items();
-        items
-            .iter()
-            .position(|item| match item {
-                ModelPopupItem::Model { model_idx } => self
-                    .models
-                    .get(*model_idx)
-                    .is_some_and(|e| self.live_model_selection_matches_entry(e)),
-                _ => false,
-            })
-            .or_else(|| {
-                items
-                    .iter()
-                    .position(|item| matches!(item, ModelPopupItem::Model { .. }))
-            })
-            .unwrap_or(0)
-    }
-
-    pub fn visible_model_popup_items(&self) -> Vec<ModelPopupItem> {
-        let filtered = self.filtered_models();
-        let mut items = Vec::new();
-
-        #[derive(Eq, PartialEq, Ord, PartialOrd)]
-        struct GroupKey {
-            provider: String,
-            node_id: Option<String>,
-        }
-
-        let mut groups: std::collections::BTreeMap<GroupKey, Vec<&ModelEntry>> =
-            std::collections::BTreeMap::new();
-        for model in filtered.iter() {
-            let key = GroupKey {
-                provider: model.provider.clone(),
-                node_id: model.node_id.clone(),
-            };
-            groups.entry(key).or_default().push(model);
-        }
-
-        for (key, models_in_group) in groups {
-            let node_suffix = key.node_id.as_ref().map(|nid| {
-                models_in_group
-                    .first()
-                    .and_then(|m| m.node_label.clone())
-                    .unwrap_or_else(|| nid.clone())
-            });
-            items.push(ModelPopupItem::ProviderHeader {
-                provider: key.provider.clone(),
-                model_count: models_in_group.len(),
-                node_suffix,
-            });
-            for model in models_in_group {
-                if let Some(model_idx) = self.model_index_for_entry(model) {
-                    items.push(ModelPopupItem::Model { model_idx });
-                }
-            }
-        }
-
-        items
-    }
-
-    #[cfg(test)]
-    pub(crate) fn test_model_entry(
-        id: &str,
-        provider: &str,
-        model: &str,
-        node_id: Option<&str>,
-        node_label: Option<&str>,
-    ) -> ModelEntry {
-        ModelEntry {
-            id: id.into(),
-            label: model.into(),
-            provider: provider.into(),
-            model: model.into(),
-            node_id: node_id.map(str::to_string),
-            node_label: node_label.map(str::to_string),
-            family: None,
-            quant: None,
-        }
     }
 
     // phase 11 compatibility forward
@@ -1458,49 +1222,7 @@ impl App {
         }
     }
 
-    // ── delegate model preferences ───────────────────────────────────────────
-
-    /// Whether there are multiple agents (multi-agent / delegation mode).
-    pub fn is_multi_agent(&self) -> bool {
-        self.agents.len() > 1
-    }
-
-    /// Tabs: 0 = session model; 1.. = delegate agents when `agents.len() > 1`.
-    pub fn model_popup_tab_count(&self) -> usize {
-        if self.agents.len() > 1 {
-            self.agents.len()
-        } else {
-            1
-        }
-    }
-
-    pub fn model_popup_has_tabs(&self) -> bool {
-        self.agents.len() > 1
-    }
-
-    pub fn model_popup_tab_label(&self, tab_idx: usize) -> &str {
-        if tab_idx == 0 {
-            "session"
-        } else {
-            self.agents
-                .get(tab_idx)
-                .map(|a| a.name.as_str())
-                .unwrap_or("???")
-        }
-    }
-
-    /// `None` on session tab; delegate agent id on agent tabs.
-    pub fn model_popup_tab_agent_id(&self, tab_idx: usize) -> Option<&str> {
-        if tab_idx == 0 {
-            None
-        } else {
-            self.agents.get(tab_idx).map(|a| a.id.as_str())
-        }
-    }
-
-    pub fn model_popup_is_session_tab(&self, tab_idx: usize) -> bool {
-        tab_idx == 0
-    }
+    // ── delegate model preference coordination ───────────────────────────────
 
     pub fn delegate_preference_profile_id(&self) -> Option<&str> {
         self.current_session_profile_id()
@@ -1511,53 +1233,20 @@ impl App {
         self.delegate_preference_profile_id()
     }
 
-    pub fn set_delegate_model_preference(
-        &mut self,
-        profile_id: &str,
-        agent_id: &str,
-        model: &ModelEntry,
-    ) {
-        self.delegate_model_preferences
-            .entry(profile_id.to_string())
-            .or_default()
-            .insert(
-                agent_id.to_string(),
-                DelegateModelPreference {
-                    model_id: model.id.clone(),
-                    provider: model.provider.clone(),
-                    model: model.model.clone(),
-                    node_id: model.node_id.clone(),
-                },
-            );
-    }
-
-    pub fn clear_delegate_model_preference(&mut self, profile_id: &str, agent_id: &str) {
-        if let Some(preferences) = self.delegate_model_preferences.get_mut(profile_id) {
-            preferences.remove(agent_id);
-            if preferences.is_empty() {
-                self.delegate_model_preferences.remove(profile_id);
-            }
-        }
-    }
-
-    pub fn get_delegate_model_preference(
-        &self,
-        profile_id: &str,
-        agent_id: &str,
-    ) -> Option<&DelegateModelPreference> {
-        self.delegate_model_preferences
-            .get(profile_id)
-            .and_then(|preferences| preferences.get(agent_id))
-    }
-
     pub fn delegate_model_commands_for_session(
         &self,
         session_id: &str,
         profile_id: &str,
     ) -> Vec<Command> {
-        let known_agents: HashSet<&str> =
-            self.agents.iter().skip(1).map(|a| a.id.as_str()).collect();
-        self.delegate_model_preferences
+        let known_agents: HashSet<&str> = self
+            .models
+            .agents
+            .iter()
+            .skip(1)
+            .map(|agent| agent.id.as_str())
+            .collect();
+        self.models
+            .delegate_model_preferences
             .get(profile_id)
             .into_iter()
             .flat_map(|preferences| preferences.iter())
@@ -1573,122 +1262,58 @@ impl App {
 
     /// Cursor position for a delegate agent's preferred model in the popup list.
     pub fn delegate_model_cursor(&self, agent_id: &str) -> usize {
-        let items = self.visible_model_popup_items();
-        let Some(profile_id) = self.delegate_preference_profile_id() else {
-            return items
-                .iter()
-                .position(|item| matches!(item, ModelPopupItem::Model { .. }))
-                .unwrap_or(0);
-        };
-        let Some(preference) = self.get_delegate_model_preference(profile_id, agent_id) else {
-            return items
-                .iter()
-                .position(|item| matches!(item, ModelPopupItem::Model { .. }))
-                .unwrap_or(0);
-        };
-        items
-            .iter()
-            .position(|item| match item {
-                ModelPopupItem::Model { model_idx } => {
-                    self.models[*model_idx].id == preference.model_id
-                        && self.models[*model_idx].node_id == preference.node_id
-                }
-                _ => false,
-            })
-            .unwrap_or(0)
+        self.models
+            .delegate_model_cursor(self.delegate_preference_profile_id(), agent_id)
     }
 }
 
-// ── reasoning_effort_tests ────────────────────────────────────────────────────
+// ── app coordinator and session tests ─────────────────────────────────────────
 
 #[cfg(test)]
 mod reasoning_effort_tests {
     use super::*;
     use crate::domain::session::SessionSummary;
 
-    // ── reasoning_effort_label ────────────────────────────────────────────────
-
-    #[test]
-    fn label_none_is_auto() {
-        let app = App::new();
-        assert_eq!(app.reasoning_effort_label(), "auto");
-    }
-
-    #[test]
-    fn label_low() {
-        let mut app = App::new();
-        app.reasoning_effort = Some("low".into());
-        assert_eq!(app.reasoning_effort_label(), "low");
-    }
-
-    #[test]
-    fn label_medium() {
-        let mut app = App::new();
-        app.reasoning_effort = Some("medium".into());
-        assert_eq!(app.reasoning_effort_label(), "medium");
-    }
-
-    #[test]
-    fn label_high() {
-        let mut app = App::new();
-        app.reasoning_effort = Some("high".into());
-        assert_eq!(app.reasoning_effort_label(), "high");
-    }
-
-    #[test]
-    fn label_max() {
-        let mut app = App::new();
-        app.reasoning_effort = Some("max".into());
-        assert_eq!(app.reasoning_effort_label(), "max");
-    }
-
-    #[test]
-    fn label_unknown_passes_through() {
-        let mut app = App::new();
-        app.reasoning_effort = Some("ultra".into());
-        assert_eq!(app.reasoning_effort_label(), "ultra");
-    }
-
     // ── cycle_reasoning_effort ────────────────────────────────────────────────
 
     #[test]
     fn cycle_from_auto_to_low() {
         let mut app = App::new();
-        assert_eq!(app.reasoning_effort, None);
+        assert_eq!(app.models.reasoning_effort, None);
         app.cycle_reasoning_effort();
-        assert_eq!(app.reasoning_effort, Some("low".into()));
+        assert_eq!(app.models.reasoning_effort, Some("low".into()));
     }
 
     #[test]
     fn cycle_from_low_to_medium() {
         let mut app = App::new();
-        app.reasoning_effort = Some("low".into());
+        app.models.reasoning_effort = Some("low".into());
         app.cycle_reasoning_effort();
-        assert_eq!(app.reasoning_effort, Some("medium".into()));
+        assert_eq!(app.models.reasoning_effort, Some("medium".into()));
     }
 
     #[test]
     fn cycle_from_medium_to_high() {
         let mut app = App::new();
-        app.reasoning_effort = Some("medium".into());
+        app.models.reasoning_effort = Some("medium".into());
         app.cycle_reasoning_effort();
-        assert_eq!(app.reasoning_effort, Some("high".into()));
+        assert_eq!(app.models.reasoning_effort, Some("high".into()));
     }
 
     #[test]
     fn cycle_from_high_to_max() {
         let mut app = App::new();
-        app.reasoning_effort = Some("high".into());
+        app.models.reasoning_effort = Some("high".into());
         app.cycle_reasoning_effort();
-        assert_eq!(app.reasoning_effort, Some("max".into()));
+        assert_eq!(app.models.reasoning_effort, Some("max".into()));
     }
 
     #[test]
     fn cycle_from_max_wraps_to_auto() {
         let mut app = App::new();
-        app.reasoning_effort = Some("max".into());
+        app.models.reasoning_effort = Some("max".into());
         app.cycle_reasoning_effort();
-        assert_eq!(app.reasoning_effort, None);
+        assert_eq!(app.models.reasoning_effort, None);
     }
 
     #[test]
@@ -1698,13 +1323,13 @@ mod reasoning_effort_tests {
         for _ in 0..5 {
             app.cycle_reasoning_effort();
         }
-        assert_eq!(app.reasoning_effort, None);
+        assert_eq!(app.models.reasoning_effort, None);
     }
 
     #[test]
     fn cycle_reasoning_effort_unknown_value_noop() {
         let mut app = App::new();
-        app.reasoning_effort = Some("invalid_level".into());
+        app.models.reasoning_effort = Some("invalid_level".into());
         let result = app.cycle_reasoning_effort();
         // unknown current value → no-op: returns None and leaves state unchanged
         assert!(
@@ -1712,7 +1337,7 @@ mod reasoning_effort_tests {
             "cycling an unknown value should return None"
         );
         assert_eq!(
-            app.reasoning_effort,
+            app.models.reasoning_effort,
             Some("invalid_level".into()),
             "state must not change when cycling an unknown value"
         );
@@ -1734,7 +1359,7 @@ mod reasoning_effort_tests {
     #[test]
     fn cycle_to_auto_sends_auto_string() {
         let mut app = App::new();
-        app.reasoning_effort = Some("max".into());
+        app.models.reasoning_effort = Some("max".into());
         let msg = app.cycle_reasoning_effort().expect("max is a valid level");
         // max → auto: server expects "auto" string (not null)
         match msg {
@@ -1751,7 +1376,7 @@ mod reasoning_effort_tests {
     fn set_reasoning_effort_high_returns_correct_msg() {
         let mut app = App::new();
         let msg = app.set_reasoning_effort(Some("high"));
-        assert_eq!(app.reasoning_effort, Some("high".into()));
+        assert_eq!(app.models.reasoning_effort, Some("high".into()));
         match msg {
             Some(Command::SetReasoningEffort { reasoning_effort }) => {
                 assert_eq!(reasoning_effort, "high");
@@ -1763,9 +1388,9 @@ mod reasoning_effort_tests {
     #[test]
     fn set_reasoning_effort_auto_clears_to_none() {
         let mut app = App::new();
-        app.reasoning_effort = Some("max".into());
+        app.models.reasoning_effort = Some("max".into());
         let msg = app.set_reasoning_effort(Some("auto"));
-        assert_eq!(app.reasoning_effort, None);
+        assert_eq!(app.models.reasoning_effort, None);
         match msg {
             Some(Command::SetReasoningEffort { reasoning_effort }) => {
                 assert_eq!(reasoning_effort, "auto");
@@ -1777,9 +1402,9 @@ mod reasoning_effort_tests {
     #[test]
     fn set_reasoning_effort_none_clears_to_auto() {
         let mut app = App::new();
-        app.reasoning_effort = Some("low".into());
+        app.models.reasoning_effort = Some("low".into());
         let msg = app.set_reasoning_effort(None);
-        assert_eq!(app.reasoning_effort, None);
+        assert_eq!(app.models.reasoning_effort, None);
         match msg {
             Some(Command::SetReasoningEffort { reasoning_effort }) => {
                 assert_eq!(reasoning_effort, "auto");
@@ -1791,22 +1416,10 @@ mod reasoning_effort_tests {
     #[test]
     fn set_reasoning_effort_invalid_value_rejected() {
         let mut app = App::new();
-        app.reasoning_effort = Some("medium".into());
+        app.models.reasoning_effort = Some("medium".into());
         let msg = app.set_reasoning_effort(Some("ultra"));
-        assert_eq!(app.reasoning_effort, Some("medium".into()));
+        assert_eq!(app.models.reasoning_effort, Some("medium".into()));
         assert!(msg.is_none());
-    }
-
-    #[test]
-    fn validate_reasoning_effort_normalizes_med() {
-        assert_eq!(
-            validate_reasoning_effort(Some("med")),
-            Some(Some("medium".to_string()))
-        );
-        assert_eq!(
-            validate_reasoning_effort(Some("MED")),
-            None // case-sensitive
-        );
     }
 
     // ── state message populates reasoning_effort ──────────────────────────────
@@ -2280,47 +1893,6 @@ mod delegate_entry_tests {
     // ── delegation result suppression ────────────────────────────────────────
 
     // ── delegation duration tracking ─────────────────────────────────────────
-}
-
-#[cfg(test)]
-mod model_node_selection_tests {
-    use super::*;
-
-    #[test]
-    fn live_selection_matches_only_one_of_local_and_remote_duplicate() {
-        let mut app = App::new();
-        let local = App::test_model_entry("codex/local", "codex", "gpt-5", None, None);
-        let remote = App::test_model_entry(
-            "codex@n1/remote",
-            "codex",
-            "gpt-5",
-            Some("n1"),
-            Some("peer"),
-        );
-        app.models = vec![local.clone(), remote.clone()];
-        app.apply_model_selection_from_entry(&remote);
-
-        assert!(app.live_model_selection_matches_entry(&remote));
-        assert!(!app.live_model_selection_matches_entry(&local));
-    }
-
-    #[test]
-    fn model_popup_open_cursor_points_at_remote_when_node_id_set() {
-        let mut app = App::new();
-        app.models = vec![
-            App::test_model_entry("codex/local", "codex", "gpt-5", None, None),
-            App::test_model_entry("codex@n1/gpt-5", "codex", "gpt-5", Some("n1"), Some("box")),
-        ];
-        let remote = app.models[1].clone();
-        app.apply_model_selection_from_entry(&remote);
-        let items = app.visible_model_popup_items();
-        let cursor = app.model_popup_open_cursor();
-        let item = &items[cursor];
-        assert!(
-            matches!(item, ModelPopupItem::Model { model_idx } if app.models[*model_idx].node_id.is_some()),
-            "cursor should be on remote row"
-        );
-    }
 }
 
 // ── session_mode_tests ────────────────────────────────────────────────────────
@@ -3993,154 +3565,5 @@ mod popup_item_tests {
         app.input_cursor = 6;
         app.slash_state = None;
         assert!(!app.accept_selected_slash_completion());
-    }
-}
-
-// ── delegate_model_preference_tests ──────────────────────────────────────────
-
-#[cfg(test)]
-mod delegate_model_preference_tests {
-    use super::*;
-    use crate::domain::model::ModelEntry;
-    use crate::domain::profile::AgentInfo;
-
-    fn make_agent(id: &str, name: &str) -> AgentInfo {
-        AgentInfo {
-            id: id.into(),
-            name: name.into(),
-            description: None,
-            capabilities: Vec::new(),
-        }
-    }
-
-    fn make_model(provider: &str, model: &str) -> ModelEntry {
-        ModelEntry {
-            id: format!("{provider}/{model}"),
-            label: format!("{provider}/{model}"),
-            provider: provider.into(),
-            model: model.into(),
-            node_id: None,
-            node_label: None,
-            family: None,
-            quant: None,
-        }
-    }
-
-    #[test]
-    fn is_multi_agent_false_when_no_agents() {
-        let app = App::new();
-        assert!(!app.is_multi_agent());
-    }
-
-    #[test]
-    fn is_multi_agent_false_when_single_agent() {
-        let mut app = App::new();
-        app.agents = vec![make_agent("main", "Main")];
-        assert!(!app.is_multi_agent());
-    }
-
-    #[test]
-    fn is_multi_agent_true_when_two_agents() {
-        let mut app = App::new();
-        app.agents = vec![make_agent("main", "Main"), make_agent("coder", "Coder")];
-        assert!(app.is_multi_agent());
-    }
-
-    #[test]
-    fn tab_label_session_at_zero() {
-        let app = App::new();
-        assert_eq!(app.model_popup_tab_label(0), "session");
-    }
-
-    #[test]
-    fn tab_label_delegate_agent_at_one_when_multi_agent() {
-        let mut app = App::new();
-        app.agents = vec![make_agent("main", "Main"), make_agent("coder", "Coder")];
-        assert_eq!(app.model_popup_tab_label(1), "Coder");
-    }
-
-    #[test]
-    fn tab_agent_id_none_on_session_tab() {
-        let app = App::new();
-        assert_eq!(app.model_popup_tab_agent_id(0), None);
-    }
-
-    #[test]
-    fn tab_agent_id_some_for_delegate_tab() {
-        let mut app = App::new();
-        app.agents = vec![make_agent("main", "Main"), make_agent("coder", "Coder")];
-        assert_eq!(app.model_popup_tab_agent_id(1), Some("coder"));
-    }
-
-    #[test]
-    fn tab_count_single_agent_or_empty() {
-        let app = App::new();
-        assert_eq!(app.model_popup_tab_count(), 1);
-        let mut single = App::new();
-        single.agents = vec![make_agent("main", "Main")];
-        assert_eq!(single.model_popup_tab_count(), 1);
-    }
-
-    #[test]
-    fn tab_count_multi_agent_matches_agent_list() {
-        let mut app = App::new();
-        app.agents = vec![make_agent("main", "Main"), make_agent("coder", "Coder")];
-        assert_eq!(app.model_popup_tab_count(), 2);
-        assert!(app.model_popup_has_tabs());
-        app.agents.push(make_agent("reviewer", "Reviewer"));
-        assert_eq!(app.model_popup_tab_count(), 3);
-        assert!(app.model_popup_has_tabs());
-    }
-
-    #[test]
-    fn delegate_pref_round_trip() {
-        let mut app = App::new();
-        let model = make_model("anthropic", "claude-sonnet");
-        app.set_delegate_model_preference("profile", "coder", &model);
-        assert_eq!(
-            app.get_delegate_model_preference("profile", "coder")
-                .map(|preference| preference.model_id.as_str()),
-            Some("anthropic/claude-sonnet")
-        );
-    }
-
-    #[test]
-    fn delegate_pref_missing_returns_none() {
-        let app = App::new();
-        assert_eq!(app.get_delegate_model_preference("profile", "coder"), None);
-    }
-
-    #[test]
-    fn delegate_model_cursor_with_preference() {
-        let mut app = App::new();
-        app.models = vec![
-            make_model("openai", "gpt-4o"),
-            make_model("anthropic", "claude-sonnet"),
-        ];
-        app.profiles.active_profile_id = Some("profile".into());
-        app.set_delegate_model_preference("profile", "coder", &app.models[1].clone());
-        let cursor = app.delegate_model_cursor("coder");
-        // Should point to the second item (index 1 in models, but popup items
-        // include provider headers — exact index depends on visible_model_popup_items).
-        let items = app.visible_model_popup_items();
-        match &items[cursor] {
-            ModelPopupItem::Model { model_idx } => {
-                assert_eq!(app.models[*model_idx].model, "claude-sonnet");
-            }
-            _ => panic!("expected Model item at cursor"),
-        }
-    }
-
-    #[test]
-    fn delegate_model_cursor_without_preference() {
-        let mut app = App::new();
-        app.models = vec![
-            make_model("openai", "gpt-4o"),
-            make_model("anthropic", "claude-sonnet"),
-        ];
-        let cursor = app.delegate_model_cursor("coder");
-        // Should land on the first Model item.
-        let items = app.visible_model_popup_items();
-        assert!(matches!(&items[cursor], ModelPopupItem::Model { .. }));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -156,10 +156,10 @@ impl TuiConfig {
         let mut merged = self.clone();
         merged.theme = Some(crate::theme::Theme::current_id().to_string());
         merged.show_thinking = Some(app.show_thinking);
-        merged.profile_delegate_models = app.delegate_model_preferences.clone();
+        merged.profile_delegate_models = app.models.delegate_model_preferences.clone();
         merged.profile.id = app.profiles.active_profile_id.clone();
         if let Some(profile_id) = app.profiles.active_profile_id.as_deref()
-            && let Some(preferences) = app.delegate_model_preferences.get(profile_id)
+            && let Some(preferences) = app.models.delegate_model_preferences.get(profile_id)
         {
             merged
                 .delegate_models
@@ -395,8 +395,10 @@ mod tests {
             quant: None,
         };
         app.profiles.active_profile_id = Some("quorum".into());
-        app.set_delegate_model_preference("quorum", "coder", &coder);
-        app.set_delegate_model_preference("quorum", "planner", &planner);
+        app.models
+            .set_delegate_model_preference("quorum", "coder", &coder);
+        app.models
+            .set_delegate_model_preference("quorum", "planner", &planner);
 
         let cfg = TuiConfig::load().with_app_settings(&app);
         cfg.save();

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -250,9 +250,7 @@ fn open_model_popup(app: &mut App, cmd_tx: &mpsc::UnboundedSender<Command>) -> a
         return Ok(());
     }
     app.navigation.popup = Popup::ModelSelect;
-    app.model_filter.clear();
-    app.model_popup_agent_tab = 0;
-    app.model_cursor = app.model_popup_open_cursor();
+    app.models.reset_for_open();
     cmd_tx.send(Command::ListAllModels { refresh: true })?;
     Ok(())
 }
@@ -555,7 +553,7 @@ pub(crate) fn handle_key(
                 app.set_status(
                     LogLevel::Info,
                     "model",
-                    format!("thinking: {}", app.reasoning_effort_label()),
+                    format!("thinking: {}", app.models.reasoning_effort_label()),
                 );
             }
             None => {
@@ -564,7 +562,7 @@ pub(crate) fn handle_key(
                     "model",
                     format!(
                         "unknown reasoning effort {:?}; cannot cycle",
-                        app.reasoning_effort
+                        app.models.reasoning_effort
                     ),
                 );
             }
@@ -1456,9 +1454,7 @@ pub(crate) fn handle_profile_popup_key(
             {
                 app.profiles.active_profile_id = Some(profile_id.clone());
                 if app.current_session_profile_id().is_none() {
-                    app.agents.clear();
-                    app.agents_profile_id = None;
-                    app.model_popup_agent_tab = 0;
+                    app.models.clear_profile_agents();
                     cmd_tx.send(Command::ListProfileAgents {
                         profile_id: profile_id.clone(),
                     })?;
@@ -1826,13 +1822,11 @@ fn try_execute_slash_command(
                 return Ok(SlashResult::Handled);
             }
             app.navigation.popup = Popup::ModelSelect;
-            app.model_popup_agent_tab = 0;
             if arg.is_empty() {
-                app.model_filter.clear();
-                app.model_cursor = app.model_popup_open_cursor();
+                app.models.reset_for_open();
             } else {
-                app.model_filter = arg;
-                app.model_cursor = 0;
+                app.models.model_popup_agent_tab = 0;
+                app.models.replace_filter(arg);
             }
         }
         "mode" => {
@@ -1883,11 +1877,11 @@ fn try_execute_slash_command(
                 app.set_status(
                     LogLevel::Info,
                     "model",
-                    format!("thinking: {}", app.reasoning_effort_label()),
+                    format!("thinking: {}", app.models.reasoning_effort_label()),
                 );
             } else {
                 let level = arg.to_lowercase();
-                if app::validate_reasoning_effort(Some(&level)).is_none() {
+                if crate::models_state::validate_reasoning_effort(Some(&level)).is_none() {
                     app.set_status(
                         LogLevel::Warn,
                         "model",
@@ -1905,7 +1899,7 @@ fn try_execute_slash_command(
                     app.set_status(
                         LogLevel::Info,
                         "model",
-                        format!("thinking: {}", app.reasoning_effort_label()),
+                        format!("thinking: {}", app.models.reasoning_effort_label()),
                     );
                 }
             }
@@ -1926,9 +1920,7 @@ fn try_execute_slash_command(
             } else if let Some(profile_id) = app.profiles.find_profile_id(&arg) {
                 app.profiles.active_profile_id = Some(profile_id.clone());
                 if app.current_session_profile_id().is_none() {
-                    app.agents.clear();
-                    app.agents_profile_id = None;
-                    app.model_popup_agent_tab = 0;
+                    app.models.clear_profile_agents();
                     cmd_tx.send(Command::ListProfileAgents {
                         profile_id: profile_id.clone(),
                     })?;
@@ -2389,63 +2381,57 @@ pub(crate) fn handle_model_popup_key(
             app.navigation.popup = Popup::None;
         }
         KeyCode::Tab | KeyCode::BackTab => {
-            if !app.model_popup_has_tabs() {
+            if !app.models.model_popup_has_tabs() {
                 return Ok(());
             }
-            let n = app.model_popup_tab_count();
-            if key.code == KeyCode::BackTab {
-                app.model_popup_agent_tab = if app.model_popup_agent_tab == 0 {
-                    n - 1
-                } else {
-                    app.model_popup_agent_tab - 1
-                };
-            } else {
-                app.model_popup_agent_tab = (app.model_popup_agent_tab + 1) % n;
-            }
-            app.model_filter.clear();
-            app.model_cursor = if app.model_popup_is_session_tab(app.model_popup_agent_tab) {
-                app.model_popup_open_cursor()
-            } else if let Some(aid) = app
-                .model_popup_tab_agent_id(app.model_popup_agent_tab)
-                .map(str::to_string)
+            let agent_id = app
+                .models
+                .switch_model_popup_tab(key.code == KeyCode::BackTab);
+            app.models.model_cursor = if app
+                .models
+                .model_popup_is_session_tab(app.models.model_popup_agent_tab)
             {
-                app.delegate_model_cursor(&aid)
+                app.models.model_popup_open_cursor()
+            } else if let Some(agent_id) = agent_id {
+                app.delegate_model_cursor(&agent_id)
             } else {
                 0
             };
         }
-        KeyCode::Up => {
-            app.model_cursor = app.model_cursor.saturating_sub(1);
-        }
-        KeyCode::Down => {
-            let max = app.visible_model_popup_items().len().saturating_sub(1);
-            app.model_cursor = (app.model_cursor + 1).min(max);
-        }
+        KeyCode::Up => app.models.move_model_cursor_up(),
+        KeyCode::Down => app.models.move_model_cursor_down(),
         KeyCode::Enter => {
             let selected: Option<ModelEntry> = app
+                .models
                 .visible_model_popup_items()
-                .get(app.model_cursor)
+                .get(app.models.model_cursor)
                 .and_then(|item| match item {
-                    crate::app::ModelPopupItem::Model { model_idx } => app.models.get(*model_idx),
-                    crate::app::ModelPopupItem::ProviderHeader { .. } => None,
+                    crate::models_state::ModelPopupItem::Model { model_idx } => {
+                        app.models.models.get(*model_idx)
+                    }
+                    crate::models_state::ModelPopupItem::ProviderHeader { .. } => None,
                 })
                 .cloned();
             if let Some(model) = selected {
                 let tab_label = app
-                    .model_popup_tab_label(app.model_popup_agent_tab)
+                    .models
+                    .model_popup_tab_label(app.models.model_popup_agent_tab)
                     .to_string();
-                if app.model_popup_is_session_tab(app.model_popup_agent_tab) {
+                if app
+                    .models
+                    .model_popup_is_session_tab(app.models.model_popup_agent_tab)
+                {
                     if !app.current_session_is_remote() {
-                        if let Some(sid) = app.session_id.clone() {
+                        if let Some(session_id) = app.session_id.clone() {
                             cmd_tx.send(Command::SetSessionModel {
-                                session_id: sid,
+                                session_id,
                                 model_id: model.id.clone(),
                                 node_id: model.node_id.clone(),
                             })?;
                         }
-                        app.apply_model_selection_from_entry(&model);
-                        if app.reasoning_effort.is_some() {
-                            app.reasoning_effort = None;
+                        app.models.apply_model_selection_from_entry(&model);
+                        if app.models.reasoning_effort.is_some() {
+                            app.models.reasoning_effort = None;
                             cmd_tx.send(Command::SetReasoningEffort {
                                 reasoning_effort: "auto".into(),
                             })?;
@@ -2453,12 +2439,14 @@ pub(crate) fn handle_model_popup_key(
                     }
                     app.set_status(LogLevel::Info, "model", format!("session: {}", model.label));
                 } else if let Some(agent_id) = app
-                    .model_popup_tab_agent_id(app.model_popup_agent_tab)
+                    .models
+                    .model_popup_tab_agent_id(app.models.model_popup_agent_tab)
                     .map(str::to_string)
                     && let Some(profile_id) =
                         app.delegate_preference_profile_id().map(str::to_string)
                 {
-                    app.set_delegate_model_preference(&profile_id, &agent_id, &model);
+                    app.models
+                        .set_delegate_model_preference(&profile_id, &agent_id, &model);
                     if app.parent_session_id.is_none()
                         && let Some(session_id) = app.session_id.clone()
                     {
@@ -2478,13 +2466,19 @@ pub(crate) fn handle_model_popup_key(
                 save_config(app);
             }
         }
-        KeyCode::Delete if !app.model_popup_is_session_tab(app.model_popup_agent_tab) => {
+        KeyCode::Delete
+            if !app
+                .models
+                .model_popup_is_session_tab(app.models.model_popup_agent_tab) =>
+        {
             if let Some(agent_id) = app
-                .model_popup_tab_agent_id(app.model_popup_agent_tab)
+                .models
+                .model_popup_tab_agent_id(app.models.model_popup_agent_tab)
                 .map(str::to_string)
                 && let Some(profile_id) = app.delegate_preference_profile_id().map(str::to_string)
             {
-                app.clear_delegate_model_preference(&profile_id, &agent_id);
+                app.models
+                    .clear_delegate_model_preference(&profile_id, &agent_id);
                 if app.parent_session_id.is_none()
                     && let Some(session_id) = app.session_id.clone()
                 {
@@ -2503,13 +2497,9 @@ pub(crate) fn handle_model_popup_key(
                 save_config(app);
             }
         }
-        KeyCode::Backspace => {
-            app.model_filter.pop();
-            app.model_cursor = 0;
-        }
+        KeyCode::Backspace => app.models.model_filter_backspace(),
         KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
-            app.model_filter.push(c);
-            app.model_cursor = 0;
+            app.models.model_filter_insert(c);
         }
         _ => {}
     }
@@ -3174,21 +3164,21 @@ mod model_popup_tests {
         app.profiles
             .bind_session_profile("s1".into(), "profile".into());
         app.agent_mode = "plan".into();
-        app.current_provider = Some("openai".into());
-        app.current_model = Some("gpt-4o".into());
-        app.agents = vec![make_agent("main", "Main"), make_agent("coder", "Coder")];
-        app.models = vec![
+        app.models.current_provider = Some("openai".into());
+        app.models.current_model = Some("gpt-4o".into());
+        app.models.agents = vec![make_agent("main", "Main"), make_agent("coder", "Coder")];
+        app.models.models = vec![
             make_model("openai", "gpt-4o"),
             make_model("anthropic", "claude-sonnet"),
         ];
-        app.model_popup_agent_tab = 1; // delegate tab
-        let items = app.visible_model_popup_items();
-        app.model_cursor = items
+        app.models.model_popup_agent_tab = 1; // delegate tab
+        let items = app.models.visible_model_popup_items();
+        app.models.model_cursor = items
             .iter()
             .position(|i| {
                 matches!(
                     i,
-                    crate::app::ModelPopupItem::Model { model_idx } if app.models[*model_idx].model == "claude-sonnet"
+                    crate::models_state::ModelPopupItem::Model { model_idx } if app.models.models[*model_idx].model == "claude-sonnet"
                 )
             })
             .unwrap();
@@ -3207,10 +3197,11 @@ mod model_popup_tests {
                 && agent_id == "coder"
                 && model_id.as_deref() == Some("anthropic/claude-sonnet")
         ));
-        assert_eq!(app.current_provider.as_deref(), Some("openai"));
-        assert_eq!(app.current_model.as_deref(), Some("gpt-4o"));
+        assert_eq!(app.models.current_provider.as_deref(), Some("openai"));
+        assert_eq!(app.models.current_model.as_deref(), Some("gpt-4o"));
         assert_eq!(
-            app.get_delegate_model_preference("profile", "coder")
+            app.models
+                .get_delegate_model_preference("profile", "coder")
                 .map(|preference| preference.model_id.as_str()),
             Some("anthropic/claude-sonnet")
         );
@@ -3225,19 +3216,21 @@ mod model_popup_tests {
         app.profiles.active_profile_id = Some("profile".into());
         app.profiles
             .bind_session_profile("s1".into(), "profile".into());
-        app.agents = vec![
+        app.models.agents = vec![
             make_agent("primary", "Session"),
             make_agent("coder", "Coder"),
         ];
-        app.model_popup_agent_tab = 1;
+        app.models.model_popup_agent_tab = 1;
         let model = make_model("anthropic", "claude-sonnet");
-        app.set_delegate_model_preference("profile", "coder", &model);
+        app.models
+            .set_delegate_model_preference("profile", "coder", &model);
 
         let (tx, mut rx) = mpsc::unbounded_channel();
         handle_model_popup_key(&mut app, key(KeyCode::Delete), &tx).unwrap();
 
         assert!(
-            app.get_delegate_model_preference("profile", "coder")
+            app.models
+                .get_delegate_model_preference("profile", "coder")
                 .is_none()
         );
         assert!(matches!(
@@ -3261,20 +3254,21 @@ mod model_popup_tests {
         app.profiles.active_profile_id = Some("profile".into());
         app.profiles
             .bind_session_profile("child".into(), "profile".into());
-        app.agents = vec![
+        app.models.agents = vec![
             make_agent("primary", "Session"),
             make_agent("coder", "Coder"),
         ];
-        app.models = vec![make_model("anthropic", "claude-sonnet")];
-        app.model_popup_agent_tab = 1;
-        app.model_cursor = 1;
+        app.models.models = vec![make_model("anthropic", "claude-sonnet")];
+        app.models.model_popup_agent_tab = 1;
+        app.models.model_cursor = 1;
 
         let (tx, mut rx) = mpsc::unbounded_channel();
         handle_model_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
 
         assert!(rx.try_recv().is_err());
         assert!(
-            app.get_delegate_model_preference("profile", "coder")
+            app.models
+                .get_delegate_model_preference("profile", "coder")
                 .is_some()
         );
     }
@@ -3286,22 +3280,22 @@ mod model_popup_tests {
         app.navigation.popup = Popup::ModelSelect;
         app.session_id = Some("s1".into());
         app.agent_mode = "build".into();
-        app.current_provider = Some("openai".into());
-        app.current_model = Some("gpt-4o".into());
-        app.reasoning_effort = Some("high".into());
+        app.models.current_provider = Some("openai".into());
+        app.models.current_model = Some("gpt-4o".into());
+        app.models.reasoning_effort = Some("high".into());
 
-        app.models = vec![
+        app.models.models = vec![
             make_model("openai", "gpt-4o"),
             make_model("anthropic", "claude-sonnet"),
         ];
-        app.model_popup_agent_tab = 0;
-        let items = app.visible_model_popup_items();
-        app.model_cursor = items
+        app.models.model_popup_agent_tab = 0;
+        let items = app.models.visible_model_popup_items();
+        app.models.model_cursor = items
             .iter()
             .position(|i| {
                 matches!(
                     i,
-                    crate::app::ModelPopupItem::Model { model_idx } if app.models[*model_idx].model == "claude-sonnet"
+                    crate::models_state::ModelPopupItem::Model { model_idx } if app.models.models[*model_idx].model == "claude-sonnet"
                 )
             })
             .unwrap();
@@ -3317,9 +3311,9 @@ mod model_popup_tests {
         );
         assert!(rx.try_recv().is_err());
 
-        assert_eq!(app.current_provider.as_deref(), Some("anthropic"));
-        assert_eq!(app.current_model.as_deref(), Some("claude-sonnet"));
-        assert_eq!(app.reasoning_effort, None);
+        assert_eq!(app.models.current_provider.as_deref(), Some("anthropic"));
+        assert_eq!(app.models.current_model.as_deref(), Some("claude-sonnet"));
+        assert_eq!(app.models.reasoning_effort, None);
     }
 
     #[test]
@@ -3329,9 +3323,9 @@ mod model_popup_tests {
         app.navigation.popup = Popup::ModelSelect;
         app.session_id = Some("s1".into());
         app.agent_mode = "build".into();
-        app.current_provider = Some("openai".into());
-        app.current_model = Some("gpt-4o".into());
-        app.models = vec![
+        app.models.current_provider = Some("openai".into());
+        app.models.current_model = Some("gpt-4o".into());
+        app.models.models = vec![
             make_model("openai", "gpt-4o"),
             ModelEntry {
                 id: "mesh/anthropic/claude".into(),
@@ -3344,14 +3338,14 @@ mod model_popup_tests {
                 quant: None,
             },
         ];
-        app.model_popup_agent_tab = 0;
-        let items = app.visible_model_popup_items();
-        app.model_cursor = items
+        app.models.model_popup_agent_tab = 0;
+        let items = app.models.visible_model_popup_items();
+        app.models.model_cursor = items
             .iter()
             .position(|i| {
                 matches!(
                     i,
-                    crate::app::ModelPopupItem::Model { model_idx } if app.models[*model_idx].node_id.is_some()
+                    crate::models_state::ModelPopupItem::Model { model_idx } if app.models.models[*model_idx].node_id.is_some()
                 )
             })
             .unwrap();
@@ -3369,9 +3363,9 @@ mod model_popup_tests {
             other => panic!("unexpected {other:?}"),
         }
         assert!(rx.try_recv().is_err());
-        assert_eq!(app.current_provider.as_deref(), Some("anthropic"));
-        assert_eq!(app.current_model.as_deref(), Some("claude"));
-        assert_eq!(app.current_model_node_id.as_deref(), Some("node-a"));
+        assert_eq!(app.models.current_provider.as_deref(), Some("anthropic"));
+        assert_eq!(app.models.current_model.as_deref(), Some("claude"));
+        assert_eq!(app.models.current_model_node_id.as_deref(), Some("node-a"));
     }
 
     #[test]
@@ -3389,12 +3383,13 @@ mod model_popup_tests {
             }],
             ..Default::default()
         }];
-        app.models = vec![make_model("anthropic", "claude-sonnet")];
-        app.model_popup_agent_tab = 0;
-        app.model_cursor = app
+        app.models.models = vec![make_model("anthropic", "claude-sonnet")];
+        app.models.model_popup_agent_tab = 0;
+        app.models.model_cursor = app
+            .models
             .visible_model_popup_items()
             .iter()
-            .position(|i| matches!(i, crate::app::ModelPopupItem::Model { .. }))
+            .position(|i| matches!(i, crate::models_state::ModelPopupItem::Model { .. }))
             .unwrap();
 
         let (tx, mut rx) = mpsc::unbounded_channel();
@@ -3408,16 +3403,19 @@ mod model_popup_tests {
         app.conn = app::ConnState::Connected;
         app.navigation.screen = Screen::Chat;
         app.agent_mode = "review".into();
-        app.current_provider = Some("openai".into());
-        app.current_model = Some("gpt-4o".into());
-        app.models = vec![make_model("openai", "gpt-4o")];
+        app.models.current_provider = Some("openai".into());
+        app.models.current_model = Some("gpt-4o".into());
+        app.models.models = vec![make_model("openai", "gpt-4o")];
 
         let (tx, _rx) = mpsc::unbounded_channel();
         handle_chord(&mut app, key(KeyCode::Char('m')), &tx).unwrap();
 
         assert!(matches!(app.navigation.popup, Popup::ModelSelect));
-        assert_eq!(app.model_popup_agent_tab, 0);
-        assert_eq!(app.model_cursor, app.model_popup_open_cursor());
+        assert_eq!(app.models.model_popup_agent_tab, 0);
+        assert_eq!(
+            app.models.model_cursor,
+            app.models.model_popup_open_cursor()
+        );
     }
 
     #[test]
@@ -3426,9 +3424,9 @@ mod model_popup_tests {
         app.conn = app::ConnState::Connected;
         app.navigation.screen = Screen::Chat;
         app.agent_mode = "review".into();
-        app.current_provider = Some("openai".into());
-        app.current_model = Some("gpt-4o".into());
-        app.models = vec![make_model("openai", "gpt-4o")];
+        app.models.current_provider = Some("openai".into());
+        app.models.current_model = Some("gpt-4o".into());
+        app.models.models = vec![make_model("openai", "gpt-4o")];
         app.input = "/model".into();
         app.input_cursor = app.input.len();
 
@@ -3437,8 +3435,11 @@ mod model_popup_tests {
 
         assert!(matches!(action, AppAction::None));
         assert!(matches!(app.navigation.popup, Popup::ModelSelect));
-        assert_eq!(app.model_popup_agent_tab, 0);
-        assert_eq!(app.model_cursor, app.model_popup_open_cursor());
+        assert_eq!(app.models.model_popup_agent_tab, 0);
+        assert_eq!(
+            app.models.model_cursor,
+            app.models.model_popup_open_cursor()
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod input;
 mod markdown;
 mod mesh;
 mod mesh_state;
+mod models_state;
 mod navigation_state;
 mod profiles_state;
 mod protocol;

--- a/src/models_state.rs
+++ b/src/models_state.rs
@@ -1,0 +1,925 @@
+use std::collections::{BTreeMap, HashMap};
+
+use fuzzy_matcher::FuzzyMatcher;
+use fuzzy_matcher::skim::SkimMatcherV2;
+
+use crate::domain::model::{DelegateModelPreference, ModelEntry};
+use crate::domain::profile::AgentInfo;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ModelPopupItem {
+    /// When set, `node_suffix` renders the remote mesh node on the right.
+    ProviderHeader {
+        provider: String,
+        model_count: usize,
+        node_suffix: Option<String>,
+    },
+    Model {
+        model_idx: usize,
+    },
+}
+
+pub(crate) struct ModelsState {
+    pub(crate) reasoning_effort: Option<String>,
+    pub(crate) current_model: Option<String>,
+    pub(crate) current_provider: Option<String>,
+    pub(crate) current_model_node_id: Option<String>,
+    pub(crate) models: Vec<ModelEntry>,
+    pub(crate) model_cursor: usize,
+    pub(crate) model_filter: String,
+    pub(crate) agents: Vec<AgentInfo>,
+    pub(crate) agents_profile_id: Option<String>,
+    pub(crate) model_popup_agent_tab: usize,
+    pub(crate) delegate_model_preferences:
+        HashMap<String, HashMap<String, DelegateModelPreference>>,
+}
+
+/// Validate and normalize a reasoning-effort string.
+///
+/// Returns `Some(None)` for the automatic level and `None` for an invalid level.
+pub(crate) fn validate_reasoning_effort(s: Option<&str>) -> Option<Option<String>> {
+    match s {
+        None | Some("auto") | Some("") => Some(None),
+        Some("low") => Some(Some("low".to_string())),
+        Some("medium") | Some("med") => Some(Some("medium".to_string())),
+        Some("high") => Some(Some("high".to_string())),
+        Some("max") => Some(Some("max".to_string())),
+        Some(_) => None,
+    }
+}
+
+impl ModelsState {
+    /// Valid explicit reasoning levels; automatic effort is represented by `None`.
+    pub const EFFORT_LEVELS: &[&str] = &["low", "medium", "high", "max"];
+
+    pub(crate) fn new() -> Self {
+        Self {
+            reasoning_effort: None,
+            current_model: None,
+            current_provider: None,
+            current_model_node_id: None,
+            models: Vec::new(),
+            model_cursor: 0,
+            model_filter: String::new(),
+            agents: Vec::new(),
+            agents_profile_id: None,
+            model_popup_agent_tab: 0,
+            delegate_model_preferences: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn reasoning_effort_label(&self) -> &str {
+        self.reasoning_effort.as_deref().unwrap_or("auto")
+    }
+
+    /// Set a validated effort and return the wire value expected by the server.
+    pub(crate) fn set_reasoning_effort(&mut self, level: Option<&str>) -> Option<String> {
+        let normalized = validate_reasoning_effort(level)?;
+        self.reasoning_effort = normalized;
+        Some(self.reasoning_effort_label().to_string())
+    }
+
+    /// Advance `auto -> low -> medium -> high -> max -> auto`.
+    pub(crate) fn cycle_reasoning_effort(&mut self) -> Option<String> {
+        const LEVELS: &[Option<&str>] =
+            &[None, Some("low"), Some("medium"), Some("high"), Some("max")];
+        let current = self.reasoning_effort.as_deref();
+        let idx = LEVELS
+            .iter()
+            .position(|level| level.as_deref() == current)?;
+        self.set_reasoning_effort(LEVELS[(idx + 1) % LEVELS.len()])
+    }
+
+    /// Replace the authoritative catalog without reconciling any other model state.
+    pub(crate) fn replace_catalog(&mut self, models: Vec<ModelEntry>) -> (usize, usize) {
+        self.models = models;
+        let remote = self
+            .models
+            .iter()
+            .filter(|model| model.node_id.is_some())
+            .count();
+        (self.models.len(), remote)
+    }
+
+    pub(crate) fn replace_live_selection(
+        &mut self,
+        provider: String,
+        model: String,
+        node_id: Option<String>,
+    ) {
+        self.current_provider = Some(provider);
+        self.current_model = Some(model);
+        self.current_model_node_id = node_id;
+    }
+
+    pub(crate) fn apply_model_selection_from_entry(&mut self, entry: &ModelEntry) {
+        self.replace_live_selection(
+            entry.provider.clone(),
+            entry.model.clone(),
+            entry.node_id.clone(),
+        );
+    }
+
+    pub(crate) fn filtered_models(&self) -> Vec<&ModelEntry> {
+        if self.model_filter.is_empty() {
+            self.models.iter().collect()
+        } else {
+            let matcher = SkimMatcherV2::default();
+            let mut scored: Vec<(i64, &ModelEntry)> = self
+                .models
+                .iter()
+                .filter_map(|model| {
+                    let score = [&model.label, &model.provider, &model.model]
+                        .iter()
+                        .filter_map(|field| matcher.fuzzy_match(field, &self.model_filter))
+                        .max();
+                    score.map(|score| (score, model))
+                })
+                .collect();
+            scored.sort_by_key(|item| std::cmp::Reverse(item.0));
+            scored.into_iter().map(|(_, model)| model).collect()
+        }
+    }
+
+    pub(crate) fn model_index_for_entry(&self, entry: &ModelEntry) -> Option<usize> {
+        self.models
+            .iter()
+            .position(|model| model.id == entry.id && model.node_id == entry.node_id)
+    }
+
+    /// Match a catalog row to a provider/model pair, disambiguating local and mesh rows.
+    pub(crate) fn model_entry_matches_node(
+        entry: &ModelEntry,
+        provider: &str,
+        model: &str,
+        node_id: Option<&str>,
+    ) -> bool {
+        if entry.provider != provider || entry.model != model {
+            return false;
+        }
+        match node_id {
+            Some(node) => entry.node_id.as_deref() == Some(node),
+            None => entry.node_id.is_none(),
+        }
+    }
+
+    pub(crate) fn live_model_selection_matches_entry(&self, entry: &ModelEntry) -> bool {
+        let (Some(provider), Some(model)) = (
+            self.current_provider.as_deref(),
+            self.current_model.as_deref(),
+        ) else {
+            return false;
+        };
+        Self::model_entry_matches_node(
+            entry,
+            provider,
+            model,
+            self.current_model_node_id.as_deref(),
+        )
+    }
+
+    pub(crate) fn model_popup_open_cursor(&self) -> usize {
+        let items = self.visible_model_popup_items();
+        items
+            .iter()
+            .position(|item| match item {
+                ModelPopupItem::Model { model_idx } => self
+                    .models
+                    .get(*model_idx)
+                    .is_some_and(|entry| self.live_model_selection_matches_entry(entry)),
+                ModelPopupItem::ProviderHeader { .. } => false,
+            })
+            .or_else(|| Self::first_model_cursor(&items))
+            .unwrap_or(0)
+    }
+
+    pub(crate) fn visible_model_popup_items(&self) -> Vec<ModelPopupItem> {
+        let filtered = self.filtered_models();
+        let mut groups: BTreeMap<(String, Option<String>), Vec<&ModelEntry>> = BTreeMap::new();
+        for model in filtered {
+            groups
+                .entry((model.provider.clone(), model.node_id.clone()))
+                .or_default()
+                .push(model);
+        }
+
+        let mut items = Vec::new();
+        for ((provider, node_id), models_in_group) in groups {
+            let node_suffix = node_id.as_ref().map(|node_id| {
+                models_in_group
+                    .first()
+                    .and_then(|model| model.node_label.clone())
+                    .unwrap_or_else(|| node_id.clone())
+            });
+            items.push(ModelPopupItem::ProviderHeader {
+                provider,
+                model_count: models_in_group.len(),
+                node_suffix,
+            });
+            for model in models_in_group {
+                if let Some(model_idx) = self.model_index_for_entry(model) {
+                    items.push(ModelPopupItem::Model { model_idx });
+                }
+            }
+        }
+        items
+    }
+
+    pub(crate) fn reset_for_open(&mut self) {
+        self.model_filter.clear();
+        self.model_popup_agent_tab = 0;
+        self.model_cursor = self.model_popup_open_cursor();
+    }
+
+    pub(crate) fn replace_filter(&mut self, filter: String) {
+        self.model_filter = filter;
+        self.model_cursor = 0;
+    }
+
+    pub(crate) fn model_filter_insert(&mut self, character: char) {
+        self.model_filter.push(character);
+        self.model_cursor = 0;
+    }
+
+    pub(crate) fn model_filter_backspace(&mut self) {
+        self.model_filter.pop();
+        self.model_cursor = 0;
+    }
+
+    pub(crate) fn move_model_cursor_up(&mut self) {
+        self.model_cursor = self.model_cursor.saturating_sub(1);
+    }
+
+    pub(crate) fn move_model_cursor_down(&mut self) {
+        let max = self.visible_model_popup_items().len().saturating_sub(1);
+        self.model_cursor = (self.model_cursor + 1).min(max);
+    }
+
+    /// Switch popup tabs and return the newly selected delegate agent, if any.
+    pub(crate) fn switch_model_popup_tab(&mut self, backwards: bool) -> Option<String> {
+        if !self.model_popup_has_tabs() {
+            return None;
+        }
+        let tab_count = self.model_popup_tab_count();
+        self.model_popup_agent_tab = if backwards {
+            if self.model_popup_agent_tab == 0 {
+                tab_count - 1
+            } else {
+                self.model_popup_agent_tab - 1
+            }
+        } else {
+            (self.model_popup_agent_tab + 1) % tab_count
+        };
+        self.model_filter.clear();
+        self.model_popup_tab_agent_id(self.model_popup_agent_tab)
+            .map(str::to_string)
+    }
+
+    pub(crate) fn initialize_primary_agent(&mut self, agent: AgentInfo) {
+        self.agents = vec![agent];
+        self.agents_profile_id = None;
+    }
+
+    pub(crate) fn replace_profile_agents(&mut self, profile_id: String, agents: Vec<AgentInfo>) {
+        self.agents = agents;
+        self.agents_profile_id = Some(profile_id);
+        self.model_popup_agent_tab = self
+            .model_popup_agent_tab
+            .min(self.model_popup_tab_count().saturating_sub(1));
+    }
+
+    pub(crate) fn clear_profile_agents(&mut self) {
+        self.agents.clear();
+        self.agents_profile_id = None;
+        self.model_popup_agent_tab = 0;
+    }
+
+    pub(crate) fn is_multi_agent(&self) -> bool {
+        self.agents.len() > 1
+    }
+
+    /// Tabs are the session plus direct agent indices when delegates are available.
+    pub(crate) fn model_popup_tab_count(&self) -> usize {
+        if self.is_multi_agent() {
+            self.agents.len()
+        } else {
+            1
+        }
+    }
+
+    pub(crate) fn model_popup_has_tabs(&self) -> bool {
+        self.is_multi_agent()
+    }
+
+    pub(crate) fn model_popup_tab_label(&self, tab_idx: usize) -> &str {
+        if self.model_popup_is_session_tab(tab_idx) {
+            "session"
+        } else {
+            self.agents
+                .get(tab_idx)
+                .map(|agent| agent.name.as_str())
+                .unwrap_or("???")
+        }
+    }
+
+    pub(crate) fn model_popup_tab_agent_id(&self, tab_idx: usize) -> Option<&str> {
+        if self.model_popup_is_session_tab(tab_idx) {
+            None
+        } else {
+            self.agents.get(tab_idx).map(|agent| agent.id.as_str())
+        }
+    }
+
+    pub(crate) fn model_popup_is_session_tab(&self, tab_idx: usize) -> bool {
+        tab_idx == 0
+    }
+
+    pub(crate) fn set_delegate_model_preference(
+        &mut self,
+        profile_id: &str,
+        agent_id: &str,
+        model: &ModelEntry,
+    ) {
+        self.delegate_model_preferences
+            .entry(profile_id.to_string())
+            .or_default()
+            .insert(
+                agent_id.to_string(),
+                DelegateModelPreference {
+                    model_id: model.id.clone(),
+                    provider: model.provider.clone(),
+                    model: model.model.clone(),
+                    node_id: model.node_id.clone(),
+                },
+            );
+    }
+
+    pub(crate) fn clear_delegate_model_preference(&mut self, profile_id: &str, agent_id: &str) {
+        if let Some(preferences) = self.delegate_model_preferences.get_mut(profile_id) {
+            preferences.remove(agent_id);
+            if preferences.is_empty() {
+                self.delegate_model_preferences.remove(profile_id);
+            }
+        }
+    }
+
+    pub(crate) fn get_delegate_model_preference(
+        &self,
+        profile_id: &str,
+        agent_id: &str,
+    ) -> Option<&DelegateModelPreference> {
+        self.delegate_model_preferences
+            .get(profile_id)
+            .and_then(|preferences| preferences.get(agent_id))
+    }
+
+    pub(crate) fn delegate_model_cursor(&self, profile_id: Option<&str>, agent_id: &str) -> usize {
+        let items = self.visible_model_popup_items();
+        let Some(profile_id) = profile_id else {
+            return Self::first_model_cursor(&items).unwrap_or(0);
+        };
+        let Some(preference) = self.get_delegate_model_preference(profile_id, agent_id) else {
+            return Self::first_model_cursor(&items).unwrap_or(0);
+        };
+        items
+            .iter()
+            .position(|item| match item {
+                ModelPopupItem::Model { model_idx } => {
+                    self.models[*model_idx].id == preference.model_id
+                        && self.models[*model_idx].node_id == preference.node_id
+                }
+                ModelPopupItem::ProviderHeader { .. } => false,
+            })
+            .unwrap_or(0)
+    }
+
+    fn first_model_cursor(items: &[ModelPopupItem]) -> Option<usize> {
+        items
+            .iter()
+            .position(|item| matches!(item, ModelPopupItem::Model { .. }))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_model_entry(
+        id: &str,
+        provider: &str,
+        model: &str,
+        node_id: Option<&str>,
+        node_label: Option<&str>,
+    ) -> ModelEntry {
+        ModelEntry {
+            id: id.into(),
+            label: model.into(),
+            provider: provider.into(),
+            model: model.into(),
+            node_id: node_id.map(str::to_string),
+            node_label: node_label.map(str::to_string),
+            family: None,
+            quant: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn model(
+        id: &str,
+        label: &str,
+        provider: &str,
+        model: &str,
+        node_id: Option<&str>,
+        node_label: Option<&str>,
+    ) -> ModelEntry {
+        ModelEntry {
+            id: id.into(),
+            label: label.into(),
+            provider: provider.into(),
+            model: model.into(),
+            node_id: node_id.map(str::to_string),
+            node_label: node_label.map(str::to_string),
+            family: None,
+            quant: None,
+        }
+    }
+
+    fn agent(id: &str, name: &str) -> AgentInfo {
+        AgentInfo {
+            id: id.into(),
+            name: name.into(),
+            description: None,
+            capabilities: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn constructor_uses_exact_defaults() {
+        let state = ModelsState::new();
+        assert_eq!(state.reasoning_effort, None);
+        assert_eq!(state.current_model, None);
+        assert_eq!(state.current_provider, None);
+        assert_eq!(state.current_model_node_id, None);
+        assert!(state.models.is_empty());
+        assert_eq!(state.model_cursor, 0);
+        assert!(state.model_filter.is_empty());
+        assert!(state.agents.is_empty());
+        assert_eq!(state.agents_profile_id, None);
+        assert_eq!(state.model_popup_agent_tab, 0);
+        assert!(state.delegate_model_preferences.is_empty());
+    }
+
+    #[test]
+    fn reasoning_validation_normalizes_only_supported_case_sensitive_values() {
+        assert_eq!(ModelsState::EFFORT_LEVELS, ["low", "medium", "high", "max"]);
+        assert_eq!(validate_reasoning_effort(None), Some(None));
+        assert_eq!(validate_reasoning_effort(Some("")), Some(None));
+        assert_eq!(validate_reasoning_effort(Some("auto")), Some(None));
+        assert_eq!(
+            validate_reasoning_effort(Some("low")),
+            Some(Some("low".into()))
+        );
+        assert_eq!(
+            validate_reasoning_effort(Some("medium")),
+            Some(Some("medium".into()))
+        );
+        assert_eq!(
+            validate_reasoning_effort(Some("med")),
+            Some(Some("medium".into()))
+        );
+        assert_eq!(
+            validate_reasoning_effort(Some("high")),
+            Some(Some("high".into()))
+        );
+        assert_eq!(
+            validate_reasoning_effort(Some("max")),
+            Some(Some("max".into()))
+        );
+        assert_eq!(validate_reasoning_effort(Some("MED")), None);
+        assert_eq!(validate_reasoning_effort(Some("ultra")), None);
+    }
+
+    #[test]
+    fn reasoning_label_cycle_and_unknown_state_preserve_contract() {
+        let mut state = ModelsState::new();
+        assert_eq!(state.reasoning_effort_label(), "auto");
+        for expected in ["low", "medium", "high", "max", "auto"] {
+            assert_eq!(state.cycle_reasoning_effort().as_deref(), Some(expected));
+            assert_eq!(state.reasoning_effort_label(), expected);
+        }
+        state.reasoning_effort = Some("ultra".into());
+        assert_eq!(state.reasoning_effort_label(), "ultra");
+        assert_eq!(state.cycle_reasoning_effort(), None);
+        assert_eq!(state.reasoning_effort.as_deref(), Some("ultra"));
+    }
+
+    #[test]
+    fn invalid_reasoning_set_does_not_mutate_state() {
+        let mut state = ModelsState::new();
+        state.reasoning_effort = Some("high".into());
+        assert_eq!(state.set_reasoning_effort(Some("HIGH")), None);
+        assert_eq!(state.reasoning_effort.as_deref(), Some("high"));
+        assert_eq!(
+            state.set_reasoning_effort(Some("auto")).as_deref(),
+            Some("auto")
+        );
+        assert_eq!(state.reasoning_effort, None);
+    }
+
+    #[test]
+    fn authoritative_catalog_replacement_reports_counts_and_preserves_stale_state() {
+        let mut state = ModelsState::new();
+        state.current_model = Some("old-model".into());
+        state.current_provider = Some("old-provider".into());
+        state.current_model_node_id = Some("old-node".into());
+        state.model_cursor = 9;
+        state.model_filter = "old-filter".into();
+        state.model_popup_agent_tab = 3;
+        state.reasoning_effort = Some("high".into());
+        state.set_delegate_model_preference(
+            "profile",
+            "coder",
+            &model("old", "old", "old-provider", "old-model", None, None),
+        );
+
+        let counts = state.replace_catalog(vec![
+            model("local", "local", "p", "m", None, None),
+            model("remote", "remote", "p", "m", Some("node"), None),
+        ]);
+        assert_eq!(counts, (2, 1));
+        assert_eq!(state.current_model.as_deref(), Some("old-model"));
+        assert_eq!(state.current_provider.as_deref(), Some("old-provider"));
+        assert_eq!(state.current_model_node_id.as_deref(), Some("old-node"));
+        assert_eq!(state.model_cursor, 9);
+        assert_eq!(state.model_filter, "old-filter");
+        assert_eq!(state.model_popup_agent_tab, 3);
+        assert_eq!(state.reasoning_effort.as_deref(), Some("high"));
+        assert!(
+            state
+                .get_delegate_model_preference("profile", "coder")
+                .is_some()
+        );
+
+        assert_eq!(state.replace_catalog(Vec::new()), (0, 0));
+        assert_eq!(state.model_cursor, 9);
+        assert_eq!(state.model_filter, "old-filter");
+    }
+
+    #[test]
+    fn filtering_searches_only_label_provider_and_model_with_stable_ties() {
+        let mut state = ModelsState::new();
+        state.models = vec![
+            model("first-id", "same", "provider", "model", None, None),
+            model("second-id", "same", "provider", "model", None, None),
+            model(
+                "secret-id-match",
+                "other",
+                "elsewhere",
+                "different",
+                None,
+                None,
+            ),
+            ModelEntry {
+                family: Some("secret-id-match".into()),
+                quant: Some("secret-id-match".into()),
+                node_label: Some("secret-id-match".into()),
+                ..model(
+                    "excluded",
+                    "other",
+                    "elsewhere",
+                    "different",
+                    Some("secret-id-match"),
+                    None,
+                )
+            },
+        ];
+        assert_eq!(
+            state
+                .filtered_models()
+                .into_iter()
+                .map(|entry| entry.id.as_str())
+                .collect::<Vec<_>>(),
+            ["first-id", "second-id", "secret-id-match", "excluded"]
+        );
+
+        state.model_filter = "same".into();
+        assert_eq!(
+            state
+                .filtered_models()
+                .into_iter()
+                .map(|entry| entry.id.as_str())
+                .collect::<Vec<_>>(),
+            ["first-id", "second-id"]
+        );
+        state.model_filter = "secret-id-match".into();
+        assert!(state.filtered_models().is_empty());
+    }
+
+    #[test]
+    fn filtering_matches_each_searchable_field() {
+        let mut state = ModelsState::new();
+        state.models = vec![
+            model("provider-hit", "zzz", "alpha", "zzz", None, None),
+            model("model-hit", "zzz", "zzz", "alpha", None, None),
+            model("label-hit", "alpha", "zzz", "zzz", None, None),
+        ];
+        state.model_filter = "alpha".into();
+        let ids: Vec<&str> = state
+            .filtered_models()
+            .into_iter()
+            .map(|entry| entry.id.as_str())
+            .collect();
+        assert_eq!(ids.len(), 3);
+        assert!(ids.contains(&"provider-hit"));
+        assert!(ids.contains(&"model-hit"));
+        assert!(ids.contains(&"label-hit"));
+    }
+
+    #[test]
+    fn filtering_uses_the_maximum_score_across_searchable_fields() {
+        let mut state = ModelsState::new();
+        state.models = vec![
+            model("best", "zz", "alpha", "al", None, None),
+            model("weaker", "al", "zz", "zz", None, None),
+        ];
+        state.model_filter = "alpha".into();
+        let ids: Vec<&str> = state
+            .filtered_models()
+            .into_iter()
+            .map(|entry| entry.id.as_str())
+            .collect();
+        assert_eq!(ids.first().copied(), Some("best"));
+    }
+
+    #[test]
+    fn visible_items_group_by_provider_and_node_with_local_first() {
+        let mut state = ModelsState::new();
+        state.models = vec![
+            model(
+                "z-remote-2",
+                "r2",
+                "zeta",
+                "r2",
+                Some("node-b"),
+                Some("box"),
+            ),
+            model("a-remote", "ar", "alpha", "ar", Some("node-a"), None),
+            model("z-local-1", "l1", "zeta", "l1", None, None),
+            model(
+                "z-remote-1",
+                "r1",
+                "zeta",
+                "r1",
+                Some("node-b"),
+                Some("box"),
+            ),
+            model("z-local-2", "l2", "zeta", "l2", None, None),
+        ];
+
+        assert_eq!(
+            state.visible_model_popup_items(),
+            vec![
+                ModelPopupItem::ProviderHeader {
+                    provider: "alpha".into(),
+                    model_count: 1,
+                    node_suffix: Some("node-a".into()),
+                },
+                ModelPopupItem::Model { model_idx: 1 },
+                ModelPopupItem::ProviderHeader {
+                    provider: "zeta".into(),
+                    model_count: 2,
+                    node_suffix: None,
+                },
+                ModelPopupItem::Model { model_idx: 2 },
+                ModelPopupItem::Model { model_idx: 4 },
+                ModelPopupItem::ProviderHeader {
+                    provider: "zeta".into(),
+                    model_count: 2,
+                    node_suffix: Some("box".into()),
+                },
+                ModelPopupItem::Model { model_idx: 0 },
+                ModelPopupItem::Model { model_idx: 3 },
+            ]
+        );
+    }
+
+    #[test]
+    fn model_identity_and_live_selection_include_exact_node_identity() {
+        let local = model("same", "local", "p", "m", None, None);
+        let remote = model("same", "remote", "p", "m", Some("node"), None);
+        let other_remote = model("same", "remote", "p", "m", Some("other"), None);
+        let mut state = ModelsState::new();
+        state.models = vec![local.clone(), remote.clone(), other_remote.clone()];
+        assert_eq!(state.model_index_for_entry(&local), Some(0));
+        assert_eq!(state.model_index_for_entry(&remote), Some(1));
+
+        state.apply_model_selection_from_entry(&remote);
+        assert!(state.live_model_selection_matches_entry(&remote));
+        assert!(!state.live_model_selection_matches_entry(&local));
+        assert!(!state.live_model_selection_matches_entry(&other_remote));
+        assert!(ModelsState::model_entry_matches_node(
+            &local, "p", "m", None
+        ));
+        assert!(!ModelsState::model_entry_matches_node(
+            &remote, "p", "m", None
+        ));
+    }
+
+    #[test]
+    fn popup_reset_cursor_and_filter_edits_preserve_header_inclusive_semantics() {
+        let mut state = ModelsState::new();
+        state.models = vec![
+            model("local", "local", "p", "m", None, None),
+            model("remote", "remote", "p", "m", Some("node"), None),
+        ];
+        state.apply_model_selection_from_entry(&state.models[1].clone());
+        state.model_cursor = 99;
+        state.model_filter = "stale".into();
+        state.model_popup_agent_tab = 7;
+        state.reset_for_open();
+        assert_eq!(state.model_filter, "");
+        assert_eq!(state.model_popup_agent_tab, 0);
+        assert!(matches!(
+            state.visible_model_popup_items()[state.model_cursor],
+            ModelPopupItem::Model { model_idx: 1 }
+        ));
+
+        state.model_filter_insert('x');
+        assert_eq!(state.model_cursor, 0);
+        state.model_cursor = 8;
+        state.model_filter_backspace();
+        assert_eq!(state.model_cursor, 0);
+        state.replace_filter("none".into());
+        assert_eq!(state.model_filter, "none");
+        assert_eq!(state.model_cursor, 0);
+        state.move_model_cursor_down();
+        assert_eq!(state.model_cursor, 0);
+        state.move_model_cursor_up();
+        assert_eq!(state.model_cursor, 0);
+    }
+
+    #[test]
+    fn cursor_navigation_selects_headers_and_clamps_to_visible_items() {
+        let mut state = ModelsState::new();
+        state.models = vec![model("local", "local", "p", "m", None, None)];
+        assert_eq!(state.visible_model_popup_items().len(), 2);
+        state.move_model_cursor_up();
+        assert_eq!(state.model_cursor, 0);
+        state.move_model_cursor_down();
+        assert_eq!(state.model_cursor, 1);
+        state.move_model_cursor_down();
+        assert_eq!(state.model_cursor, 1);
+    }
+
+    #[test]
+    fn tabs_wrap_clear_filter_and_map_directly_to_agent_indices() {
+        let mut state = ModelsState::new();
+        assert_eq!(state.model_popup_tab_count(), 1);
+        assert!(!state.model_popup_has_tabs());
+        state.agents = vec![
+            agent("main", "Main"),
+            agent("coder", "Coder"),
+            agent("reviewer", "Reviewer"),
+        ];
+        state.model_filter = "query".into();
+        assert_eq!(
+            state.switch_model_popup_tab(false).as_deref(),
+            Some("coder")
+        );
+        assert_eq!(state.model_popup_agent_tab, 1);
+        assert_eq!(state.model_filter, "");
+        assert_eq!(state.model_popup_tab_label(0), "session");
+        assert_eq!(state.model_popup_tab_label(1), "Coder");
+        assert_eq!(state.model_popup_tab_agent_id(0), None);
+        assert_eq!(state.model_popup_tab_agent_id(2), Some("reviewer"));
+        assert_eq!(state.model_popup_tab_label(99), "???");
+        assert_eq!(state.model_popup_tab_agent_id(99), None);
+
+        state.model_popup_agent_tab = 0;
+        assert_eq!(
+            state.switch_model_popup_tab(true).as_deref(),
+            Some("reviewer")
+        );
+        state.model_popup_agent_tab = 2;
+        assert_eq!(state.switch_model_popup_tab(false), None);
+        assert_eq!(state.model_popup_agent_tab, 0);
+    }
+
+    #[test]
+    fn agent_initialization_replacement_clamping_and_clear_preserve_boundaries() {
+        let mut state = ModelsState::new();
+        state.model_popup_agent_tab = 4;
+        state
+            .delegate_model_preferences
+            .insert("profile".into(), HashMap::new());
+        state.initialize_primary_agent(agent("main", "Main"));
+        assert_eq!(state.agents.len(), 1);
+        assert_eq!(state.agents_profile_id, None);
+        assert_eq!(state.model_popup_agent_tab, 4);
+        assert!(state.delegate_model_preferences.contains_key("profile"));
+
+        state.replace_profile_agents(
+            "profile".into(),
+            vec![agent("main", "Main"), agent("coder", "Coder")],
+        );
+        assert_eq!(state.agents_profile_id.as_deref(), Some("profile"));
+        assert_eq!(state.model_popup_agent_tab, 1);
+        state.clear_profile_agents();
+        assert!(state.agents.is_empty());
+        assert_eq!(state.agents_profile_id, None);
+        assert_eq!(state.model_popup_agent_tab, 0);
+        assert!(state.delegate_model_preferences.contains_key("profile"));
+    }
+
+    #[test]
+    fn preferences_copy_remote_identity_and_prune_empty_profiles() {
+        let mut state = ModelsState::new();
+        let remote = model(
+            "remote-id",
+            "remote",
+            "provider",
+            "model",
+            Some("node"),
+            None,
+        );
+        state.set_delegate_model_preference("profile", "coder", &remote);
+        let preference = state
+            .get_delegate_model_preference("profile", "coder")
+            .expect("stored preference");
+        assert_eq!(preference.model_id, "remote-id");
+        assert_eq!(preference.provider, "provider");
+        assert_eq!(preference.model, "model");
+        assert_eq!(preference.node_id.as_deref(), Some("node"));
+
+        state.clear_delegate_model_preference("profile", "coder");
+        assert!(!state.delegate_model_preferences.contains_key("profile"));
+    }
+
+    #[test]
+    fn live_selection_replacement_stores_exact_provider_model_and_node() {
+        let mut state = ModelsState::new();
+        state.replace_live_selection("provider".into(), "model".into(), Some("node".into()));
+        assert_eq!(state.current_provider.as_deref(), Some("provider"));
+        assert_eq!(state.current_model.as_deref(), Some("model"));
+        assert_eq!(state.current_model_node_id.as_deref(), Some("node"));
+    }
+
+    #[test]
+    fn popup_open_cursor_falls_back_to_first_model_or_zero() {
+        let mut state = ModelsState::new();
+        assert_eq!(state.model_popup_open_cursor(), 0);
+        state.models = vec![model("local", "local", "p", "m", None, None)];
+        assert_eq!(state.model_popup_open_cursor(), 1);
+    }
+
+    #[test]
+    fn tab_switch_without_delegates_preserves_popup_state() {
+        let mut state = ModelsState::new();
+        state.model_popup_agent_tab = 4;
+        state.model_filter = "filter".into();
+        assert_eq!(state.switch_model_popup_tab(false), None);
+        assert_eq!(state.model_popup_agent_tab, 4);
+        assert_eq!(state.model_filter, "filter");
+    }
+
+    #[test]
+    fn empty_profile_agent_replacement_clamps_tab_and_retains_profile_identity() {
+        let mut state = ModelsState::new();
+        state.model_popup_agent_tab = 3;
+        state.replace_profile_agents("profile".into(), Vec::new());
+        assert!(state.agents.is_empty());
+        assert_eq!(state.agents_profile_id.as_deref(), Some("profile"));
+        assert_eq!(state.model_popup_agent_tab, 0);
+    }
+
+    #[test]
+    fn clearing_missing_preference_does_not_remove_other_agents() {
+        let mut state = ModelsState::new();
+        let local = model("local", "local", "p", "m", None, None);
+        state.set_delegate_model_preference("profile", "coder", &local);
+        state.clear_delegate_model_preference("profile", "reviewer");
+        assert!(
+            state
+                .get_delegate_model_preference("profile", "coder")
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn delegate_cursor_uses_profile_preference_and_exact_node() {
+        let mut state = ModelsState::new();
+        let local = model("same", "local", "p", "m", None, None);
+        let remote = model("same", "remote", "p", "m", Some("node"), None);
+        state.models = vec![local, remote.clone()];
+        state.set_delegate_model_preference("profile", "coder", &remote);
+        let cursor = state.delegate_model_cursor(Some("profile"), "coder");
+        assert!(matches!(
+            state.visible_model_popup_items()[cursor],
+            ModelPopupItem::Model { model_idx: 1 }
+        ));
+        assert!(matches!(
+            state.visible_model_popup_items()[state.delegate_model_cursor(None, "coder")],
+            ModelPopupItem::Model { .. }
+        ));
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -992,7 +992,7 @@ mod external_editor_tests {
         )
         .unwrap();
 
-        assert_eq!(app.reasoning_effort, Some("high".into()));
+        assert_eq!(app.models.reasoning_effort, Some("high".into()));
         assert!(matches!(
             rx.try_recv().expect("SetReasoningEffort sent"),
             Command::SetReasoningEffort { reasoning_effort } if reasoning_effort == "high"
@@ -1008,7 +1008,7 @@ mod external_editor_tests {
         app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
         app.session_id = Some("s1".into());
-        app.reasoning_effort = Some("max".into());
+        app.models.reasoning_effort = Some("max".into());
         app.input = "/thinking auto".into();
         app.input_cursor = "/thinking auto".len();
 
@@ -1019,7 +1019,7 @@ mod external_editor_tests {
         )
         .unwrap();
 
-        assert_eq!(app.reasoning_effort, None);
+        assert_eq!(app.models.reasoning_effort, None);
         assert!(matches!(
             rx.try_recv().expect("SetReasoningEffort sent"),
             Command::SetReasoningEffort { reasoning_effort } if reasoning_effort == "auto"
@@ -1045,7 +1045,7 @@ mod external_editor_tests {
         )
         .unwrap();
 
-        assert_eq!(app.reasoning_effort, Some("medium".into()));
+        assert_eq!(app.models.reasoning_effort, Some("medium".into()));
         assert!(matches!(
             rx.try_recv().expect("SetReasoningEffort sent"),
             Command::SetReasoningEffort { reasoning_effort } if reasoning_effort == "medium"
@@ -1057,7 +1057,7 @@ mod external_editor_tests {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.reasoning_effort = Some("high".into());
+        app.models.reasoning_effort = Some("high".into());
         app.input = "/thinking".into();
         app.input_cursor = "/thinking".len();
 
@@ -1094,7 +1094,7 @@ mod external_editor_tests {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.reasoning_effort = Some("high".into());
+        app.models.reasoning_effort = Some("high".into());
         app.input = "/thinking max".into();
         app.input_cursor = "/thinking max".len();
 
@@ -1106,7 +1106,7 @@ mod external_editor_tests {
         .unwrap();
 
         // state must not change when disconnected
-        assert_eq!(app.reasoning_effort, Some("high".into()));
+        assert_eq!(app.models.reasoning_effort, Some("high".into()));
         assert!(app.diagnostics.status.contains("not connected"));
     }
 
@@ -1282,8 +1282,8 @@ mod external_editor_tests {
         .unwrap();
 
         assert_eq!(app.navigation.popup, Popup::ModelSelect);
-        assert_eq!(app.model_filter, "sonnet");
-        assert_eq!(app.model_cursor, 0);
+        assert_eq!(app.models.model_filter, "sonnet");
+        assert_eq!(app.models.model_cursor, 0);
     }
 
     #[test]
@@ -1304,7 +1304,7 @@ mod external_editor_tests {
         .unwrap();
 
         assert_eq!(app.navigation.popup, Popup::ModelSelect);
-        assert!(app.model_filter.is_empty());
+        assert!(app.models.model_filter.is_empty());
     }
 
     #[test]
@@ -1485,9 +1485,10 @@ pub async fn run() -> anyhow::Result<()> {
     app.launch_cwd = detect_launch_cwd();
     app.profiles.active_profile_id = cfg.profile.id.clone();
     app.show_thinking = cfg.show_thinking.unwrap_or(true);
-    app.delegate_model_preferences = cfg.profile_delegate_models.clone();
+    app.models.delegate_model_preferences = cfg.profile_delegate_models.clone();
     if let Some(profile_id) = cfg.profile.id.as_deref() {
         let legacy_preferences = app
+            .models
             .delegate_model_preferences
             .entry(profile_id.to_string())
             .or_default();
@@ -3055,11 +3056,11 @@ mod chord_reasoning_effort_tests {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
-        assert_eq!(app.reasoning_effort, None);
+        assert_eq!(app.models.reasoning_effort, None);
 
         handle_key(&mut app, ctrl_t(), &tx).unwrap();
 
-        assert_eq!(app.reasoning_effort, Some("low".into()));
+        assert_eq!(app.models.reasoning_effort, Some("low".into()));
         let msg = rx.try_recv().expect("expected SetReasoningEffort message");
         match msg {
             Command::SetReasoningEffort { reasoning_effort } => {
@@ -3076,11 +3077,11 @@ mod chord_reasoning_effort_tests {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
-        app.reasoning_effort = Some("max".into());
+        app.models.reasoning_effort = Some("max".into());
 
         handle_key(&mut app, ctrl_t(), &tx).unwrap();
 
-        assert_eq!(app.reasoning_effort, None);
+        assert_eq!(app.models.reasoning_effort, None);
         let msg = rx.try_recv().expect("expected SetReasoningEffort message");
         match msg {
             Command::SetReasoningEffort { reasoning_effort } => {
@@ -3110,12 +3111,12 @@ mod chord_reasoning_effort_tests {
     fn ctrl_t_when_disconnected_does_not_change_state() {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.reasoning_effort = Some("high".into());
+        app.models.reasoning_effort = Some("high".into());
 
         handle_key(&mut app, ctrl_t(), &tx).unwrap();
 
         // state must not change when disconnected
-        assert_eq!(app.reasoning_effort, Some("high".into()));
+        assert_eq!(app.models.reasoning_effort, Some("high".into()));
         assert!(app.diagnostics.status.contains("not connected"));
     }
 }
@@ -3164,7 +3165,7 @@ mod reasoning_effort_integration_tests {
         )
         .unwrap();
 
-        assert_eq!(app.reasoning_effort, Some("low".into()));
+        assert_eq!(app.models.reasoning_effort, Some("low".into()));
         assert!(matches!(
             rx.try_recv(),
             Ok(Command::SetReasoningEffort { reasoning_effort }) if reasoning_effort == "low"
@@ -3180,15 +3181,15 @@ mod reasoning_effort_integration_tests {
         app.conn = app::ConnState::Connected;
         app.session_id = Some("s1".into());
         app.agent_mode = "build".into();
-        app.current_provider = Some("anthropic".into());
-        app.current_model = Some("claude-sonnet".into());
-        app.reasoning_effort = Some("high".into());
+        app.models.current_provider = Some("anthropic".into());
+        app.models.current_model = Some("claude-sonnet".into());
+        app.models.reasoning_effort = Some("high".into());
 
         handle_key(&mut app, tab_key(), &tx).unwrap();
 
         assert_eq!(app.agent_mode, "plan");
-        assert_eq!(app.current_model.as_deref(), Some("claude-sonnet"));
-        assert_eq!(app.reasoning_effort, Some("high".into()));
+        assert_eq!(app.models.current_model.as_deref(), Some("claude-sonnet"));
+        assert_eq!(app.models.reasoning_effort, Some("high".into()));
 
         let msgs: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
         assert!(
@@ -3213,17 +3214,17 @@ mod reasoning_effort_integration_tests {
         app.conn = app::ConnState::Connected;
         app.session_id = Some("s1".into());
         app.agent_mode = "build".into();
-        app.current_provider = Some("anthropic".into());
-        app.current_model = Some("claude-sonnet".into());
-        app.reasoning_effort = Some("high".into());
+        app.models.current_provider = Some("anthropic".into());
+        app.models.current_model = Some("claude-sonnet".into());
+        app.models.reasoning_effort = Some("high".into());
         // No plan cache entry
 
         handle_key(&mut app, tab_key(), &tx).unwrap();
 
         // Mode switched but model/effort unchanged (no cache to restore from)
         assert_eq!(app.agent_mode, "plan");
-        assert_eq!(app.reasoning_effort, Some("high".into()));
-        assert_eq!(app.current_model.as_deref(), Some("claude-sonnet"));
+        assert_eq!(app.models.reasoning_effort, Some("high".into()));
+        assert_eq!(app.models.current_model.as_deref(), Some("claude-sonnet"));
         let msgs: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
         assert!(
             !msgs
@@ -3244,10 +3245,10 @@ mod reasoning_effort_integration_tests {
         app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
         app.agent_mode = "plan".into();
-        app.model_popup_agent_tab = 0;
-        app.current_provider = Some("anthropic".into());
-        app.current_model = Some("claude-sonnet".into());
-        app.models = vec![
+        app.models.model_popup_agent_tab = 0;
+        app.models.current_provider = Some("anthropic".into());
+        app.models.current_model = Some("claude-sonnet".into());
+        app.models.models = vec![
             make_model("anthropic", "claude-sonnet"),
             make_model("openai", "gpt-4o"),
             make_model("openai", "o3-mini"),
@@ -3267,9 +3268,9 @@ mod reasoning_effort_integration_tests {
         .unwrap();
 
         assert_eq!(app.navigation.popup, Popup::ModelSelect);
-        assert_eq!(app.model_filter, "");
-        let expected = app.model_popup_open_cursor();
-        assert_eq!(app.model_cursor, expected);
+        assert_eq!(app.models.model_filter, "");
+        let expected = app.models.model_popup_open_cursor();
+        assert_eq!(app.models.model_cursor, expected);
     }
 
     #[test]
@@ -3282,15 +3283,16 @@ mod reasoning_effort_integration_tests {
         app.session_id = Some("s1".into());
         app.navigation.popup = Popup::ModelSelect;
         app.agent_mode = "build".into();
-        app.model_popup_agent_tab = 0;
-        app.current_provider = Some("anthropic".into());
-        app.current_model = Some("claude-sonnet".into());
-        app.reasoning_effort = Some("high".into());
-        app.models = vec![make_model("anthropic", "claude-opus")];
-        app.model_cursor = app
+        app.models.model_popup_agent_tab = 0;
+        app.models.current_provider = Some("anthropic".into());
+        app.models.current_model = Some("claude-sonnet".into());
+        app.models.reasoning_effort = Some("high".into());
+        app.models.models = vec![make_model("anthropic", "claude-opus")];
+        app.models.model_cursor = app
+            .models
             .visible_model_popup_items()
             .iter()
-            .position(|i| matches!(i, app::ModelPopupItem::Model { .. }))
+            .position(|i| matches!(i, crate::models_state::ModelPopupItem::Model { .. }))
             .unwrap();
 
         handle_key(
@@ -3300,7 +3302,7 @@ mod reasoning_effort_integration_tests {
         )
         .unwrap();
 
-        assert_eq!(app.reasoning_effort, None);
+        assert_eq!(app.models.reasoning_effort, None);
 
         let msgs: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
         assert!(
@@ -3323,15 +3325,16 @@ mod reasoning_effort_integration_tests {
         app.session_id = Some("s1".into());
         app.navigation.popup = Popup::ModelSelect;
         app.agent_mode = "build".into();
-        app.model_popup_agent_tab = 0;
-        app.current_provider = Some("anthropic".into());
-        app.current_model = Some("claude-sonnet".into());
-        app.reasoning_effort = None; // already auto
-        app.models = vec![make_model("anthropic", "claude-opus")];
-        app.model_cursor = app
+        app.models.model_popup_agent_tab = 0;
+        app.models.current_provider = Some("anthropic".into());
+        app.models.current_model = Some("claude-sonnet".into());
+        app.models.reasoning_effort = None; // already auto
+        app.models.models = vec![make_model("anthropic", "claude-opus")];
+        app.models.model_cursor = app
+            .models
             .visible_model_popup_items()
             .iter()
-            .position(|i| matches!(i, app::ModelPopupItem::Model { .. }))
+            .position(|i| matches!(i, crate::models_state::ModelPopupItem::Model { .. }))
             .unwrap();
 
         handle_key(
@@ -3356,7 +3359,7 @@ mod reasoning_effort_integration_tests {
         app.handle_acp_event(AcpAppEvent::ReasoningEffort {
             reasoning_effort: Some("medium".into()),
         });
-        assert_eq!(app.reasoning_effort, Some("medium".into()));
+        assert_eq!(app.models.reasoning_effort, Some("medium".into()));
     }
 }
 

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -690,13 +690,21 @@ fn format_status_duration(duration: std::time::Duration) -> String {
 
 /// Build left + right span vectors for the chat/delegate header bar.
 fn build_chat_header_spans(app: &App) -> (Vec<Span<'static>>, Vec<Span<'static>>) {
-    let model_str = match (&app.current_provider, &app.current_model) {
+    let model_str = match (&app.models.current_provider, &app.models.current_model) {
         (Some(p), Some(m)) => {
-            if let Some(node_id) = app.current_model_node_id.as_deref() {
+            if let Some(node_id) = app.models.current_model_node_id.as_deref() {
                 let label = app
                     .models
+                    .models
                     .iter()
-                    .find(|e| App::model_entry_matches_node(e, p, m, Some(node_id)))
+                    .find(|entry| {
+                        crate::models_state::ModelsState::model_entry_matches_node(
+                            entry,
+                            p,
+                            m,
+                            Some(node_id),
+                        )
+                    })
                     .and_then(|e| e.node_label.as_deref())
                     .unwrap_or(node_id);
                 format!("{p}/{m}@{label}")
@@ -789,7 +797,7 @@ fn build_chat_header_spans(app: &App) -> (Vec<Span<'static>>, Vec<Span<'static>>
         right_spans.push(span);
     }
 
-    let effort_label = app.reasoning_effort_label().to_string();
+    let effort_label = app.models.reasoning_effort_label().to_string();
     right_spans.push(Span::styled(
         format!(" {model_str}"),
         Theme::status_accent(),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -776,8 +776,8 @@ mod tests {
         app.navigation.screen = Screen::Chat;
         app.session_id = Some("session-a".into());
         app.agent_mode = "build".into();
-        app.current_provider = Some("anthropic".into());
-        app.current_model = Some("claude-sonnet".into());
+        app.models.current_provider = Some("anthropic".into());
+        app.models.current_model = Some("claude-sonnet".into());
         app.session_activity.insert(
             "session-a".into(),
             SessionActivity {
@@ -844,8 +844,8 @@ mod tests {
         app.navigation.screen = Screen::Chat;
         app.session_id = Some("s1".into());
         app.agent_mode = "build".into();
-        app.current_provider = Some("anthropic".into());
-        app.current_model = Some("claude-sonnet".into());
+        app.models.current_provider = Some("anthropic".into());
+        app.models.current_model = Some("claude-sonnet".into());
 
         // No delegates → no badge
         let buffer = render_chat_buffer(&mut app, 100, 8);
@@ -905,8 +905,8 @@ mod tests {
         app.navigation.screen = Screen::Chat;
         app.session_id = Some("s1".into());
         app.agent_mode = "build".into();
-        app.current_provider = Some("anthropic".into());
-        app.current_model = Some("claude-sonnet".into());
+        app.models.current_provider = Some("anthropic".into());
+        app.models.current_model = Some("claude-sonnet".into());
         app.delegate_entries = vec![DelegateEntry {
             delegation_id: "d1".into(),
             child_session_id: Some("c1".into()),
@@ -948,8 +948,8 @@ mod tests {
         app.navigation.screen = Screen::Chat;
         app.session_id = Some("s1".into());
         app.agent_mode = "build".into();
-        app.current_provider = Some("anthropic".into());
-        app.current_model = Some("claude-sonnet".into());
+        app.models.current_provider = Some("anthropic".into());
+        app.models.current_model = Some("claude-sonnet".into());
         app.delegate_entries = vec![DelegateEntry {
             delegation_id: "d1".into(),
             child_session_id: Some("c1".into()),
@@ -2033,10 +2033,10 @@ mod tests {
         let mut app = App::new();
         app.navigation.popup = Popup::ModelSelect;
         app.agent_mode = "build".into();
-        app.model_popup_agent_tab = 0;
-        app.current_provider = Some("anthropic".into());
-        app.current_model = Some("claude-sonnet".into());
-        app.models = vec![
+        app.models.model_popup_agent_tab = 0;
+        app.models.current_provider = Some("anthropic".into());
+        app.models.current_model = Some("claude-sonnet".into());
+        app.models.models = vec![
             ModelEntry {
                 id: "anthropic/claude-sonnet".into(),
                 label: "Claude Sonnet".into(),
@@ -2111,10 +2111,10 @@ mod tests {
         let mut app = App::new();
         app.navigation.popup = Popup::ModelSelect;
         app.agent_mode = "build".into();
-        app.model_popup_agent_tab = 0;
-        app.current_provider = Some("anthropic".into());
-        app.current_model = Some("claude-sonnet".into());
-        app.models = vec![
+        app.models.model_popup_agent_tab = 0;
+        app.models.current_provider = Some("anthropic".into());
+        app.models.current_model = Some("claude-sonnet".into());
+        app.models.models = vec![
             ModelEntry {
                 id: "anthropic/claude-sonnet".into(),
                 label: "Claude Sonnet".into(),
@@ -2160,11 +2160,11 @@ mod tests {
         let mut app = App::new();
         app.navigation.popup = Popup::ModelSelect;
         app.agent_mode = "build".into();
-        app.model_popup_agent_tab = 0;
-        app.current_provider = Some("codex".into());
-        app.current_model = Some("gpt-5".into());
-        app.current_model_node_id = Some("node-1".into());
-        app.models = vec![
+        app.models.model_popup_agent_tab = 0;
+        app.models.current_provider = Some("codex".into());
+        app.models.current_model = Some("gpt-5".into());
+        app.models.current_model_node_id = Some("node-1".into());
+        app.models.models = vec![
             ModelEntry {
                 id: "codex/gpt-5".into(),
                 label: "gpt-5".into(),
@@ -2344,7 +2344,7 @@ mod tests {
         let mut app = App::new();
         app.navigation.popup = Popup::ModelSelect;
         app.agent_mode = "build".into();
-        app.models = (0..12)
+        app.models.models = (0..12)
             .map(|i| ModelEntry {
                 id: format!("anthropic/model-{i}"),
                 label: format!("Model {i}"),
@@ -2356,9 +2356,9 @@ mod tests {
                 quant: None,
             })
             .collect();
-        app.current_provider = Some("anthropic".into());
-        app.current_model = Some("model-8".into());
-        app.model_cursor = app.model_popup_open_cursor();
+        app.models.current_provider = Some("anthropic".into());
+        app.models.current_model = Some("model-8".into());
+        app.models.model_cursor = app.models.model_popup_open_cursor();
 
         let backend = ratatui::backend::TestBackend::new(80, 10);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();

--- a/src/ui/popups.rs
+++ b/src/ui/popups.rs
@@ -14,6 +14,7 @@ use crate::domain::activity::DelegateStats;
 use crate::domain::auth::{OAuthFlowKind, OAuthStatus};
 use crate::domain::model::ModelEntry;
 use crate::domain::profile::ProfileInfo;
+use crate::models_state::ModelPopupItem;
 use crate::theme::Theme;
 
 use super::chat::{CHECK_CHECKED, CHECK_FAILED, SpinnerKind, spinner};
@@ -89,7 +90,10 @@ fn popup_log_level_style(level: LogLevel) -> ratatui::style::Style {
 /// Whether the given model matches a delegate agent's preferred model.
 fn popup_delegate_marker(app: &App, model: &ModelEntry, agent_id: &str) -> bool {
     app.delegate_preference_profile_id()
-        .and_then(|profile_id| app.get_delegate_model_preference(profile_id, agent_id))
+        .and_then(|profile_id| {
+            app.models
+                .get_delegate_model_preference(profile_id, agent_id)
+        })
         .is_some_and(|preference| {
             preference.model_id == model.id && preference.node_id == model.node_id
         })
@@ -98,14 +102,12 @@ fn popup_delegate_marker(app: &App, model: &ModelEntry, agent_id: &str) -> bool 
 // ── Model popup ───────────────────────────────────────────────────────────────
 
 pub(super) fn draw_model_popup(f: &mut Frame, app: &App) {
-    use crate::app::ModelPopupItem;
-
     const MODEL_MARKER_COL_W: u16 = 4;
     const MODEL_LABEL_MAX_W: u16 = 48;
     const MODEL_POPUP_MAX_W: u16 = MODEL_MARKER_COL_W + MODEL_LABEL_MAX_W + 2;
     const MODEL_POPUP_MIN_W: u16 = 30;
 
-    let has_tabs = app.model_popup_has_tabs();
+    let has_tabs = app.models.model_popup_has_tabs();
 
     let area = f.area();
     let popup_width = area
@@ -169,9 +171,9 @@ pub(super) fn draw_model_popup(f: &mut Frame, app: &App) {
     // Tab bar (multi-agent only)
     if let Some(ti) = tab_idx {
         let mut tab_spans = Vec::new();
-        for i in 0..app.model_popup_tab_count() {
-            let label = app.model_popup_tab_label(i);
-            let is_active = i == app.model_popup_agent_tab;
+        for i in 0..app.models.model_popup_tab_count() {
+            let label = app.models.model_popup_tab_label(i);
+            let is_active = i == app.models.model_popup_agent_tab;
             let style = if is_active {
                 Theme::popup_title().add_modifier(Modifier::UNDERLINED)
             } else {
@@ -191,8 +193,11 @@ pub(super) fn draw_model_popup(f: &mut Frame, app: &App) {
     // Filter input
     let filter_area = chunks[filter_idx];
     let avail = filter_area.width.saturating_sub(2) as usize;
-    let (model_filter_display, model_filter_cur) =
-        scroll_input(&app.model_filter, app.model_filter.len(), avail);
+    let (model_filter_display, model_filter_cur) = scroll_input(
+        &app.models.model_filter,
+        app.models.model_filter.len(),
+        avail,
+    );
     let filter_line = Line::from(vec![
         Span::styled("> ", Theme::popup_title()),
         Span::styled(model_filter_display, Theme::popup_bg()),
@@ -203,15 +208,19 @@ pub(super) fn draw_model_popup(f: &mut Frame, app: &App) {
     );
     f.set_cursor_position((filter_area.x + 2 + model_filter_cur as u16, filter_area.y));
 
-    let on_session_tab = app.model_popup_is_session_tab(app.model_popup_agent_tab);
+    let on_session_tab = app
+        .models
+        .model_popup_is_session_tab(app.models.model_popup_agent_tab);
     let active_agent_id = app
-        .model_popup_tab_agent_id(app.model_popup_agent_tab)
+        .models
+        .model_popup_tab_agent_id(app.models.model_popup_agent_tab)
         .map(str::to_string);
 
     let list_area = chunks[list_idx];
     let list_w = list_area.width as usize;
 
     let items: Vec<ListItem> = app
+        .models
         .visible_model_popup_items()
         .iter()
         .enumerate()
@@ -221,7 +230,7 @@ pub(super) fn draw_model_popup(f: &mut Frame, app: &App) {
                 model_count,
                 node_suffix,
             } => {
-                let selected = i == app.model_cursor;
+                let selected = i == app.models.model_cursor;
                 let marker = COLLAPSE_CLOSED;
                 let count = format!(" {model_count}");
                 let marker_style = if selected {
@@ -263,10 +272,11 @@ pub(super) fn draw_model_popup(f: &mut Frame, app: &App) {
                 ListItem::new(Line::from(line_spans))
             }
             ModelPopupItem::Model { model_idx } => {
-                let selected = i == app.model_cursor;
-                let model = &app.models[*model_idx];
+                let selected = i == app.models.model_cursor;
+                let model = &app.models.models[*model_idx];
 
-                let show_live = on_session_tab && app.live_model_selection_matches_entry(model);
+                let show_live =
+                    on_session_tab && app.models.live_model_selection_matches_entry(model);
                 let show_delegate = active_agent_id
                     .as_deref()
                     .is_some_and(|aid| popup_delegate_marker(app, model, aid));
@@ -322,11 +332,12 @@ pub(super) fn draw_model_popup(f: &mut Frame, app: &App) {
     let list = List::new(items).block(Block::default().style(Theme::popup_bg()));
     let visible_rows = list_area.height as usize;
     let offset = app
+        .models
         .model_cursor
         .saturating_sub(visible_rows.saturating_sub(1));
     let mut state = ListState::default()
         .with_offset(offset)
-        .with_selected(Some(app.model_cursor));
+        .with_selected(Some(app.models.model_cursor));
     f.render_stateful_widget(list, list_area, &mut state);
 
     let mut hint_spans = vec![


### PR DESCRIPTION
## what changed
- add private `models_state` owner for the 11 model, reasoning, profile-agent, popup, and delegate-preference fields
- move pure model catalog, filtering, grouping, selection, popup navigation, tab, reasoning, and preference behavior out of `app`
- retain command construction, acp routing/logging, session/profile coordination, persistence/startup migration, connectivity checks, and rendering at existing boundaries
- preserve stale catalog state, exact local/remote identity, fuzzy filtering/grouping, reasoning normalization/cycling, profile-agent response behavior, command order, remote-session no-ops, and config schema

## validation
- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --all-targets --all-features`
- `cargo test --all-targets --all-features` (834 passed)
- `git diff --check`

## boundary evidence
- exactly one private `mod models_state;` and one `app.models: ModelsState`
- 11 owner fields; direct `app` fields reduced from 99 to 89
- zero flat model accesses/declarations, old `app::ModelPopupItem` paths, or old pure model methods on `app`
- zero forbidden owner imports, public facade/re-export, alias, `deref`, serde derive, generic state hierarchy, or second state group
- exactly four existing diagnostics compatibility tags remain
- exactly the approved 10 source files changed

## status
- based exactly on integrated navigation state commit `bc6b5d0ad0c171286fa4a6c49f9be06bd11d18ed`
- this pr is source-complete and review-ready; no integration claim is made
- `sessionsstate`, broad phase 4 acceptance, manual smoke, and phase 11 cleanup remain out of scope
