### PR TITLE
refactor: extract sessions state

### DIFF
--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -3,7 +3,6 @@ use std::collections::HashSet;
 use serde_json::Value;
 
 use crate::acp_client::DelegateModelOverrideInfo;
-use crate::app::POPUP_SESSION_PAGE_TARGET;
 use crate::command::{Command, SessionListRequest};
 use crate::diagnostics::LogLevel;
 use crate::domain::activity::{
@@ -20,8 +19,7 @@ use crate::domain::mesh::{
 use crate::domain::model::ModelEntry;
 use crate::domain::profile::{AgentInfo, ProfileInfo};
 use crate::domain::session::{
-    ForkResult, RedoResult, SessionGroup, SessionListPage, SessionSummary, UndoResult,
-    UndoStackSnapshot, UndoableTurn,
+    ForkResult, RedoResult, SessionListPage, UndoResult, UndoStackSnapshot, UndoableTurn,
 };
 use crate::domain::tool::ToolDetail;
 use crate::navigation_state::{Popup, Screen};
@@ -199,7 +197,7 @@ impl crate::app::App {
                 if !profiles.is_empty() {
                     self.apply_profile_catalog(profiles, active_profile_id);
                 }
-                self.agent_id = Some(agent_id.clone());
+                self.sessions.agent_id = Some(agent_id.clone());
                 self.models.initialize_primary_agent(AgentInfo {
                     id: agent_id,
                     name: agent_name,
@@ -207,10 +205,7 @@ impl crate::app::App {
                     capabilities: Vec::new(),
                 });
                 if let Some(mode) = agent_mode {
-                    self.agent_mode = mode;
-                    if self.agent_mode != "review" {
-                        self.mode_before_review = None;
-                    }
+                    self.sessions.replace_agent_mode(mode);
                 }
                 if let Some(effort) = reasoning_effort {
                     self.models.reasoning_effort = effort;
@@ -220,10 +215,7 @@ impl crate::app::App {
                 vec![]
             }
             AcpAppEvent::AgentMode { mode } => {
-                self.agent_mode = mode;
-                if self.agent_mode != "review" {
-                    self.mode_before_review = None;
-                }
+                self.sessions.replace_agent_mode(mode);
                 vec![]
             }
             AcpAppEvent::ReasoningEffort { reasoning_effort } => {
@@ -243,7 +235,7 @@ impl crate::app::App {
                     self.models.replace_profile_agents(profile_id, agents);
                     if self.parent_session_id.is_none()
                         && let (Some(session_id), Some(profile_id)) = (
-                            self.session_id.as_deref(),
+                            self.sessions.session_id.as_deref(),
                             self.models.agents_profile_id.as_deref(),
                         )
                     {
@@ -378,11 +370,11 @@ impl crate::app::App {
                         self.streaming_content_message_id = None;
                         self.streaming_cache.invalidate();
                         self.set_status(LogLevel::Info, "session", "undone - reloading session");
-                        if let Some(ref sid) = self.session_id {
+                        if let Some(ref sid) = self.sessions.session_id {
                             return Command::load_session_commands(
                                 sid.clone(),
                                 self.current_session_cwd(),
-                                self.agent_id.clone(),
+                                self.sessions.agent_id.clone(),
                             )
                             .into();
                         }
@@ -415,11 +407,11 @@ impl crate::app::App {
                         self.undo_state =
                             self.build_undo_state_from_server_stack(&stack, None, None);
                         self.set_status(LogLevel::Info, "session", "redone - reloading session");
-                        if let Some(ref sid) = self.session_id {
+                        if let Some(ref sid) = self.sessions.session_id {
                             return Command::load_session_commands(
                                 sid.clone(),
                                 self.current_session_cwd(),
-                                self.agent_id.clone(),
+                                self.sessions.agent_id.clone(),
                             )
                             .into();
                         }
@@ -449,7 +441,7 @@ impl crate::app::App {
                         return Command::load_session_commands(
                             forked_session_id,
                             self.current_session_cwd(),
-                            self.agent_id.clone(),
+                            self.sessions.agent_id.clone(),
                         )
                         .into();
                     }
@@ -481,7 +473,7 @@ impl crate::app::App {
                 session_id,
                 updates,
             } => {
-                if self.session_id.as_deref() == Some(session_id.as_str()) {
+                if self.sessions.session_id.as_deref() == Some(session_id.as_str()) {
                     for update in updates {
                         self.apply_acp_delegation_update(update);
                     }
@@ -587,163 +579,40 @@ impl crate::app::App {
         page: SessionListPage,
     ) -> Vec<Command> {
         let SessionListPage {
-            mut groups,
+            groups,
             next_cursor,
             total_count: _,
         } = page;
-        for group in &mut groups {
-            group.total_count = None;
-            for session in &group.sessions {
-                if let Some(node_id) = session
-                    .node_id
-                    .as_deref()
-                    .filter(|id| !id.trim().is_empty())
-                {
-                    self.remember_remote_session_location(
-                        &session.session_id,
-                        node_id,
-                        session.cwd.clone(),
-                    );
-                }
-            }
-            group.sessions.sort_by(|a, b| {
-                b.updated_at
-                    .cmp(&a.updated_at)
-                    .then_with(|| b.session_id.cmp(&a.session_id))
-            });
-            group.latest_activity = group
-                .sessions
-                .first()
-                .and_then(|session| session.updated_at.clone());
-        }
-
-        let mut commands = Vec::new();
         match request {
             SessionListRequest::Discovery => {
-                self.session_discovery_in_progress = false;
-                for mut group in groups {
-                    group.next_cursor = None;
-                    match group.cwd.clone() {
-                        Some(cwd) => {
-                            let hydrated = self.hydrated_session_groups.contains(&cwd);
-                            if let Some(existing) = self
-                                .session_groups
-                                .iter_mut()
-                                .find(|existing| existing.cwd.as_deref() == Some(cwd.as_str()))
-                            {
-                                if !hydrated {
-                                    merge_session_page(
-                                        existing,
-                                        group.sessions,
-                                        Some(POPUP_SESSION_PAGE_TARGET),
-                                    );
-                                }
-                            } else {
-                                group.sessions.truncate(POPUP_SESSION_PAGE_TARGET);
-                                self.session_groups.push(group);
-                            }
-
-                            if !hydrated
-                                && self.pending_session_group_loads.insert(Some(cwd.clone()))
-                            {
-                                commands.push(Command::list_sessions_workspace(cwd));
-                            }
-                        }
-                        None => {
-                            if let Some(existing) = self
-                                .session_groups
-                                .iter_mut()
-                                .find(|existing| existing.cwd.is_none())
-                            {
-                                merge_session_page(
-                                    existing,
-                                    group.sessions,
-                                    Some(POPUP_SESSION_PAGE_TARGET),
-                                );
-                            } else {
-                                group.sessions.truncate(POPUP_SESSION_PAGE_TARGET);
-                                self.session_groups.push(group);
-                            }
-                        }
-                    }
-                }
-
-                if let Some(cursor) = next_cursor
-                    && self.session_discovery_cursors.insert(cursor.clone())
-                {
-                    self.session_discovery_in_progress = true;
+                let (workspaces, next_discovery_cursor) =
+                    self.sessions.apply_discovery_page(groups, next_cursor);
+                let mut commands = workspaces
+                    .into_iter()
+                    .map(Command::list_sessions_workspace)
+                    .collect::<Vec<_>>();
+                if let Some(cursor) = next_discovery_cursor {
                     commands.push(Command::list_sessions_discovery(Some(cursor)));
                 }
+                commands
             }
             SessionListRequest::WorkspaceFirstPage { cwd } => {
-                self.pending_session_group_loads.remove(&Some(cwd.clone()));
-                self.hydrated_session_groups.insert(cwd.clone());
-                let mut group = groups
-                    .into_iter()
-                    .find(|group| group.cwd.as_deref() == Some(cwd.as_str()))
-                    .unwrap_or_else(|| SessionGroup {
-                        cwd: Some(cwd.clone()),
-                        ..SessionGroup::default()
-                    });
-                group.cwd = Some(cwd.clone());
-                group.total_count = None;
-
-                if group.sessions.is_empty() {
-                    self.session_groups
-                        .retain(|existing| existing.cwd.as_deref() != Some(cwd.as_str()));
-                } else if let Some(existing) = self
-                    .session_groups
-                    .iter_mut()
-                    .find(|existing| existing.cwd.as_deref() == Some(cwd.as_str()))
-                {
-                    *existing = group;
-                } else {
-                    self.session_groups.push(group);
-                }
+                self.sessions.apply_workspace_first_page(cwd, groups);
+                Vec::new()
             }
             SessionListRequest::WorkspaceContinuation { cwd } => {
-                self.pending_session_group_loads.remove(&Some(cwd.clone()));
-                let page = groups
-                    .into_iter()
-                    .find(|group| group.cwd.as_deref() == Some(cwd.as_str()))
-                    .unwrap_or_else(|| SessionGroup {
-                        cwd: Some(cwd.clone()),
-                        ..SessionGroup::default()
-                    });
-                if let Some(existing) = self
-                    .session_groups
-                    .iter_mut()
-                    .find(|existing| existing.cwd.as_deref() == Some(cwd.as_str()))
-                {
-                    existing.next_cursor = page.next_cursor.clone();
-                    merge_session_page(existing, page.sessions, None);
-                } else if !page.sessions.is_empty() {
-                    self.session_groups.push(page);
-                }
+                self.sessions.apply_workspace_continuation(cwd, groups);
+                Vec::new()
             }
         }
-
-        self.session_groups
-            .retain(|group| !group.sessions.is_empty());
-        self.session_groups.sort_by(|a, b| {
-            b.latest_activity
-                .cmp(&a.latest_activity)
-                .then_with(|| a.cwd.cmp(&b.cwd))
-        });
-
-        let visible_len = self.visible_start_items().len();
-        if self.session_cursor >= visible_len && visible_len > 0 {
-            self.session_cursor = visible_len - 1;
-        }
-        commands
     }
 
     fn apply_acp_session_list_failure(&mut self, request: &SessionListRequest) {
         match request {
-            SessionListRequest::Discovery => self.session_discovery_in_progress = false,
+            SessionListRequest::Discovery => self.sessions.fail_discovery(),
             SessionListRequest::WorkspaceFirstPage { cwd }
             | SessionListRequest::WorkspaceContinuation { cwd } => {
-                self.pending_session_group_loads.remove(&Some(cwd.clone()));
+                self.sessions.fail_workspace_request(cwd);
             }
         }
     }
@@ -754,15 +623,15 @@ impl crate::app::App {
         session_id: String,
         profile_id: Option<String>,
     ) -> Vec<Command> {
-        self.session_id = Some(session_id.clone());
+        self.sessions.session_id = Some(session_id.clone());
         self.apply_session_profile_binding(&session_id, profile_id);
-        self.agent_id = Some(agent_id);
+        self.sessions.agent_id = Some(agent_id);
         self.reset_active_session_view();
         self.navigation.screen = Screen::Chat;
         self.set_status(LogLevel::Info, "session", "session created");
         let mut commands = vec![Command::SubscribeSession {
             session_id: session_id.clone(),
-            agent_id: self.agent_id.clone(),
+            agent_id: self.sessions.agent_id.clone(),
         }];
         if let Some(profile_id) = self.current_session_profile_id().map(str::to_string) {
             if self.models.agents_profile_id.as_deref() == Some(profile_id.as_str()) {
@@ -781,13 +650,14 @@ impl crate::app::App {
         profile_id: Option<String>,
     ) -> Vec<Command> {
         self.activity = ActivityState::Idle;
-        self.parent_session_id = self
-            .pending_parent_session_id
-            .take()
-            .or_else(|| self.session_parent_id(&session_id).map(str::to_owned));
+        self.parent_session_id = self.pending_parent_session_id.take().or_else(|| {
+            self.sessions
+                .session_parent_id(&session_id)
+                .map(str::to_owned)
+        });
         self.apply_session_profile_binding(&session_id, profile_id);
-        self.session_id = Some(session_id.clone());
-        self.agent_id = Some(agent_id);
+        self.sessions.session_id = Some(session_id.clone());
+        self.sessions.agent_id = Some(agent_id);
         self.reset_active_session_view();
         self.navigation.screen = if self.parent_session_id.is_some() {
             Screen::Delegate
@@ -796,7 +666,7 @@ impl crate::app::App {
         };
         self.set_status(LogLevel::Debug, "activity", "ready");
         let mut commands = vec![Command::SetAgentMode {
-            mode: self.agent_mode.clone(),
+            mode: self.sessions.agent_mode.clone(),
         }];
         if self.parent_session_id.is_none()
             && let Some(profile_id) = self.current_session_profile_id().map(str::to_string)
@@ -843,7 +713,7 @@ impl crate::app::App {
         self.elicitation = None;
         self.elicitation_ui = None;
         self.clear_cancel_confirm();
-        self.mode_before_review = None;
+        self.sessions.mode_before_review = None;
         self.cumulative_cost = None;
         self.session_stats = crate::domain::activity::SessionStatsLite::default();
     }
@@ -888,7 +758,7 @@ impl crate::app::App {
     }
 
     fn apply_acp_delegation_update(&mut self, update: DelegationUpdate) {
-        if self.session_id.as_deref() != Some(update.session_id.as_str()) {
+        if self.sessions.session_id.as_deref() != Some(update.session_id.as_str()) {
             return;
         }
         let existing_index = self
@@ -1087,12 +957,12 @@ impl crate::app::App {
         update: AcpSessionUpdate,
         is_replay: bool,
     ) {
-        if self.session_id.as_deref() != Some(session_id) {
-            self.note_session_activity(session_id);
+        if self.sessions.session_id.as_deref() != Some(session_id) {
+            self.sessions.note_session_activity(session_id);
             self.apply_acp_delegate_child_update(session_id, &update);
             return;
         }
-        self.note_session_activity(session_id);
+        self.sessions.note_session_activity(session_id);
 
         match update {
             AcpSessionUpdate::TurnStarted => {
@@ -1716,32 +1586,6 @@ impl crate::app::App {
     }
 }
 
-fn merge_session_page(group: &mut SessionGroup, sessions: Vec<SessionSummary>, cap: Option<usize>) {
-    let mut seen = group
-        .sessions
-        .iter()
-        .map(|session| session.session_id.clone())
-        .collect::<HashSet<_>>();
-    group.sessions.extend(
-        sessions
-            .into_iter()
-            .filter(|session| seen.insert(session.session_id.clone())),
-    );
-    group.sessions.sort_by(|a, b| {
-        b.updated_at
-            .cmp(&a.updated_at)
-            .then_with(|| b.session_id.cmp(&a.session_id))
-    });
-    if let Some(cap) = cap {
-        group.sessions.truncate(cap);
-    }
-    group.latest_activity = group
-        .sessions
-        .first()
-        .and_then(|session| session.updated_at.clone());
-    group.total_count = None;
-}
-
 fn normalize_replay_updates(updates: Vec<AcpSessionUpdate>) -> Vec<AcpSessionUpdate> {
     let finalized_messages = finalized_assistant_messages(&updates);
     let mut normalized = Vec::with_capacity(updates.len());
@@ -2087,7 +1931,9 @@ mod tests {
     use crate::domain::activity::{PendingDelegateToolCall, SessionOp};
     use crate::domain::mesh::{RemoteNodeInfo, RemoteSessionInfo};
     use crate::domain::model::DelegateModelPreference;
-    use crate::domain::session::{SessionListPage, UndoFrame, UndoFrameStatus, UndoState};
+    use crate::domain::session::{
+        SessionGroup, SessionListPage, SessionSummary, UndoFrame, UndoFrameStatus, UndoState,
+    };
 
     const TEST_SESSION_ID: &str = "session-1";
     const TEST_ASSISTANT_ID: &str = "a1";
@@ -2116,7 +1962,7 @@ mod tests {
 
     fn app_with_active_session() -> App {
         let mut app = App::new();
-        app.session_id = Some(TEST_SESSION_ID.into());
+        app.sessions.session_id = Some(TEST_SESSION_ID.into());
         app
     }
 
@@ -2360,7 +2206,8 @@ mod tests {
     #[test]
     fn loading_missing_remote_profile_removes_stale_binding() {
         let mut app = App::new();
-        app.remember_remote_session_node("remote-1", "node-1");
+        app.sessions
+            .remember_remote_session_node("remote-1", "node-1");
         app.profiles
             .bind_session_profile("remote-1".into(), "fast".into());
 
@@ -2591,7 +2438,7 @@ mod tests {
     #[test]
     fn profile_agents_reapply_profile_scoped_preferences_to_parent_session() {
         let mut app = App::new();
-        app.session_id = Some("parent".into());
+        app.sessions.session_id = Some("parent".into());
         app.profiles
             .bind_session_profile("parent".into(), "quorum".into());
         app.models.delegate_model_preferences.insert(
@@ -2750,9 +2597,12 @@ mod tests {
             app.mesh.selected_remote_sessions()[0].title.as_deref(),
             Some("Boundary")
         );
-        assert_eq!(app.session_remote_node_id("session-1"), Some("node-1"));
         assert_eq!(
-            app.session_remote_cwd("session-1"),
+            app.sessions.session_remote_node_id("session-1"),
+            Some("node-1")
+        );
+        assert_eq!(
+            app.sessions.session_remote_cwd("session-1"),
             Some("/remote/repo".into())
         );
     }
@@ -2777,7 +2627,7 @@ mod tests {
     #[test]
     fn native_remote_attach_loads_and_subscribes_once() {
         let mut app = App::new();
-        app.agent_id = Some("agent-1".into());
+        app.sessions.agent_id = Some("agent-1".into());
 
         let replies = app.handle_acp_event(AcpAppEvent::RemoteSessionAttached(
             RemoteSessionAttachInfo {
@@ -2793,7 +2643,10 @@ mod tests {
             },
         ));
 
-        assert_eq!(app.session_remote_node_id("remote-1"), Some("node-1"));
+        assert_eq!(
+            app.sessions.session_remote_node_id("remote-1"),
+            Some("node-1")
+        );
         assert!(matches!(
             replies.as_slice(),
             [
@@ -2808,9 +2661,13 @@ mod tests {
     #[test]
     fn native_remote_attach_uses_remote_cwd_and_detached_refreshes_sessions() {
         let mut app = App::new();
-        app.agent_id = Some("agent-1".into());
+        app.sessions.agent_id = Some("agent-1".into());
         app.launch_cwd = Some("/launch".into());
-        app.remember_remote_session_location("remote-1", "node-1", Some("/remote/repo".into()));
+        app.sessions.remember_remote_session_location(
+            "remote-1",
+            "node-1",
+            Some("/remote/repo".into()),
+        );
 
         let attached = app.handle_acp_event(AcpAppEvent::RemoteSessionAttached(
             RemoteSessionAttachInfo {
@@ -2841,8 +2698,11 @@ mod tests {
                 snapshot: None,
             },
         ));
-        assert_eq!(app.session_remote_node_id("remote-2"), Some("node-2"));
-        assert_eq!(app.session_remote_cwd("remote-2"), None);
+        assert_eq!(
+            app.sessions.session_remote_node_id("remote-2"),
+            Some("node-2")
+        );
+        assert_eq!(app.sessions.session_remote_cwd("remote-2"), None);
         assert_eq!(
             detached,
             vec![Command::ListRemoteSessions {
@@ -2856,7 +2716,11 @@ mod tests {
     #[test]
     fn acp_node_less_session_page_does_not_overwrite_remote_location() {
         let mut app = App::new();
-        app.remember_remote_session_location("remote-1", "node-1", Some("/remote/repo".into()));
+        app.sessions.remember_remote_session_location(
+            "remote-1",
+            "node-1",
+            Some("/remote/repo".into()),
+        );
 
         app.handle_acp_event(AcpAppEvent::SessionList {
             request: SessionListRequest::Discovery,
@@ -2874,7 +2738,7 @@ mod tests {
             ),
         });
 
-        let location = &app.remote_session_locations["remote-1"];
+        let location = &app.sessions.remote_session_locations["remote-1"];
         assert_eq!(location.node_id, "node-1");
         assert_eq!(location.cwd.as_deref(), Some("/remote/repo"));
     }
@@ -2882,7 +2746,7 @@ mod tests {
     #[test]
     fn acp_discovery_hydrates_workspaces_and_replays_root_cursor() {
         let mut app = App::new();
-        app.session_discovery_in_progress = true;
+        app.sessions.session_discovery_in_progress = true;
 
         let replies = app.handle_acp_event(AcpAppEvent::SessionList {
             request: SessionListRequest::Discovery,
@@ -2892,12 +2756,13 @@ mod tests {
             ),
         });
 
-        assert!(app.session_discovery_in_progress);
+        assert!(app.sessions.session_discovery_in_progress);
         assert!(
-            app.pending_session_group_loads
+            app.sessions
+                .pending_session_group_loads
                 .contains(&Some("/repo".into()))
         );
-        assert_eq!(app.session_groups[0].next_cursor, None);
+        assert_eq!(app.sessions.session_groups[0].next_cursor, None);
         assert!(replies.iter().any(|reply| matches!(
             reply,
             Command::ListSessions {
@@ -2918,8 +2783,10 @@ mod tests {
     #[test]
     fn acp_workspace_first_page_replaces_discovery_preview() {
         let mut app = App::new();
-        app.session_groups = vec![session_group("/repo", &["preview"])];
-        app.pending_session_group_loads.insert(Some("/repo".into()));
+        app.sessions.session_groups = vec![session_group("/repo", &["preview"])];
+        app.sessions
+            .pending_session_group_loads
+            .insert(Some("/repo".into()));
         let mut page = session_group("/repo", &["new-1", "new-2"]);
         page.next_cursor = Some("opaque-workspace-2".into());
 
@@ -2930,11 +2797,11 @@ mod tests {
             page: session_list_page(vec![page], Some("opaque-workspace-2")),
         });
 
-        assert!(app.hydrated_session_groups.contains("/repo"));
-        assert!(app.pending_session_group_loads.is_empty());
-        assert_eq!(app.session_groups[0].total_count, None);
+        assert!(app.sessions.hydrated_session_groups.contains("/repo"));
+        assert!(app.sessions.pending_session_group_loads.is_empty());
+        assert_eq!(app.sessions.session_groups[0].total_count, None);
         assert_eq!(
-            app.session_groups[0]
+            app.sessions.session_groups[0]
                 .sessions
                 .iter()
                 .map(|session| session.session_id.as_str())
@@ -2942,7 +2809,7 @@ mod tests {
             vec!["new-2", "new-1"]
         );
         assert_eq!(
-            app.session_groups[0].next_cursor.as_deref(),
+            app.sessions.session_groups[0].next_cursor.as_deref(),
             Some("opaque-workspace-2")
         );
     }
@@ -2950,9 +2817,9 @@ mod tests {
     #[test]
     fn acp_discovery_merges_later_workspaces_without_overwriting_hydrated_groups() {
         let mut app = App::new();
-        app.session_discovery_in_progress = true;
-        app.hydrated_session_groups.insert("/repo".into());
-        app.session_groups = vec![session_group("/repo", &["authoritative"])];
+        app.sessions.session_discovery_in_progress = true;
+        app.sessions.hydrated_session_groups.insert("/repo".into());
+        app.sessions.session_groups = vec![session_group("/repo", &["authoritative"])];
 
         let replies = app.handle_acp_event(AcpAppEvent::SessionList {
             request: SessionListRequest::Discovery,
@@ -2966,13 +2833,15 @@ mod tests {
         });
 
         let repo = app
+            .sessions
             .session_groups
             .iter()
             .find(|group| group.cwd.as_deref() == Some("/repo"))
             .unwrap();
         assert_eq!(repo.sessions[0].session_id, "authoritative");
         assert!(
-            app.session_groups
+            app.sessions
+                .session_groups
                 .iter()
                 .any(|group| group.cwd.as_deref() == Some("/later"))
         );
@@ -2988,8 +2857,10 @@ mod tests {
     #[test]
     fn acp_group_session_page_merges_group_and_dedupes() {
         let mut app = App::new();
-        app.session_groups = vec![session_group("/repo", &["s1"])];
-        app.pending_session_group_loads.insert(Some("/repo".into()));
+        app.sessions.session_groups = vec![session_group("/repo", &["s1"])];
+        app.sessions
+            .pending_session_group_loads
+            .insert(Some("/repo".into()));
 
         let mut group = session_group("/repo", &["s1", "s2"]);
         group.next_cursor = Some("cursor-2".into());
@@ -3000,14 +2871,14 @@ mod tests {
             page: session_list_page(vec![group], Some("cursor-2")),
         });
 
-        assert!(app.pending_session_group_loads.is_empty());
-        assert_eq!(app.session_groups.len(), 1);
+        assert!(app.sessions.pending_session_group_loads.is_empty());
+        assert_eq!(app.sessions.session_groups.len(), 1);
         assert_eq!(
-            app.session_groups[0].next_cursor.as_deref(),
+            app.sessions.session_groups[0].next_cursor.as_deref(),
             Some("cursor-2")
         );
         assert_eq!(
-            app.session_groups[0]
+            app.sessions.session_groups[0]
                 .sessions
                 .iter()
                 .map(|session| session.session_id.as_str())
@@ -3019,7 +2890,9 @@ mod tests {
     #[test]
     fn acp_session_list_failure_clears_scoped_pending_state() {
         let mut app = App::new();
-        app.pending_session_group_loads.insert(Some("/repo".into()));
+        app.sessions
+            .pending_session_group_loads
+            .insert(Some("/repo".into()));
 
         app.handle_acp_event(AcpAppEvent::SessionListFailed {
             request: SessionListRequest::WorkspaceContinuation {
@@ -3028,7 +2901,7 @@ mod tests {
             message: "failed".into(),
         });
 
-        assert!(app.pending_session_group_loads.is_empty());
+        assert!(app.sessions.pending_session_group_loads.is_empty());
     }
 
     fn seed_model_state(app: &mut App) {
@@ -3085,8 +2958,8 @@ mod tests {
             profile_id: Some("code".into()),
         });
 
-        assert_eq!(app.session_id.as_deref(), Some("session-1"));
-        assert_eq!(app.agent_id.as_deref(), Some("agent-1"));
+        assert_eq!(app.sessions.session_id.as_deref(), Some("session-1"));
+        assert_eq!(app.sessions.agent_id.as_deref(), Some("agent-1"));
         assert_eq!(app.navigation.screen, Screen::Chat);
         assert!(app.messages.is_empty());
         assert!(app.streaming_content.is_empty());
@@ -3112,7 +2985,7 @@ mod tests {
     #[test]
     fn native_session_loaded_discovers_parent_preserves_delegate_state_and_resets_view() {
         let mut app = App::new();
-        app.agent_mode = "plan".into();
+        app.sessions.agent_mode = "plan".into();
         let mut child = SessionSummary {
             session_id: "child".into(),
             parent_session_id: Some("parent".into()),
@@ -3128,7 +3001,7 @@ mod tests {
             ..Default::default()
         };
         parent.children = vec![child];
-        app.session_groups = vec![SessionGroup {
+        app.sessions.session_groups = vec![SessionGroup {
             cwd: Some("/repo".into()),
             sessions: vec![parent],
             ..Default::default()
@@ -3332,21 +3205,21 @@ mod tests {
     #[test]
     fn native_agent_mode_updates_mode_and_clears_review_return_state() {
         let mut app = App::new();
-        app.agent_mode = "review".into();
-        app.mode_before_review = Some("plan".into());
+        app.sessions.agent_mode = "review".into();
+        app.sessions.mode_before_review = Some("plan".into());
 
         app.handle_acp_event(AcpAppEvent::AgentMode {
             mode: "build".into(),
         });
-        assert_eq!(app.agent_mode, "build");
-        assert_eq!(app.mode_before_review, None);
+        assert_eq!(app.sessions.agent_mode, "build");
+        assert_eq!(app.sessions.mode_before_review, None);
 
-        app.mode_before_review = Some("plan".into());
+        app.sessions.mode_before_review = Some("plan".into());
         app.handle_acp_event(AcpAppEvent::AgentMode {
             mode: "review".into(),
         });
-        assert_eq!(app.agent_mode, "review");
-        assert_eq!(app.mode_before_review.as_deref(), Some("plan"));
+        assert_eq!(app.sessions.agent_mode, "review");
+        assert_eq!(app.sessions.mode_before_review.as_deref(), Some("plan"));
     }
 
     #[test]
@@ -3760,7 +3633,7 @@ mod tests {
     #[test]
     fn native_tool_call_start_keeps_shell_details() {
         let mut app = App::new();
-        app.session_id = Some("session-1".into());
+        app.sessions.session_id = Some("session-1".into());
 
         app.handle_acp_event(AcpAppEvent::SessionUpdate {
             session_id: "session-1".into(),
@@ -3788,7 +3661,7 @@ mod tests {
     #[test]
     fn native_usage_update_updates_status_metrics() {
         let mut app = App::new();
-        app.session_id = Some("session-1".into());
+        app.sessions.session_id = Some("session-1".into());
 
         app.handle_acp_event(AcpAppEvent::SessionUpdate {
             session_id: "session-1".into(),
@@ -3815,7 +3688,7 @@ mod tests {
     #[test]
     fn native_timing_update_adds_active_time() {
         let mut app = App::new();
-        app.session_id = Some("session-1".into());
+        app.sessions.session_id = Some("session-1".into());
 
         app.handle_acp_event(AcpAppEvent::SessionUpdate {
             session_id: "session-1".into(),
@@ -3839,7 +3712,7 @@ mod tests {
     #[test]
     fn native_live_turn_updates_realtime_elapsed() {
         let mut app = App::new();
-        app.session_id = Some("session-1".into());
+        app.sessions.session_id = Some("session-1".into());
 
         app.handle_acp_event(AcpAppEvent::SessionUpdate {
             session_id: "session-1".into(),
@@ -3875,7 +3748,7 @@ mod tests {
     #[test]
     fn native_replay_turn_does_not_start_realtime_elapsed() {
         let mut app = App::new();
-        app.session_id = Some("session-1".into());
+        app.sessions.session_id = Some("session-1".into());
 
         app.handle_acp_event(AcpAppEvent::SessionUpdate {
             session_id: "session-1".into(),
@@ -3915,7 +3788,7 @@ mod tests {
     #[test]
     fn native_acp_error_closes_realtime_elapsed() {
         let mut app = App::new();
-        app.session_id = Some("session-1".into());
+        app.sessions.session_id = Some("session-1".into());
 
         app.handle_acp_event(AcpAppEvent::SessionUpdate {
             session_id: "session-1".into(),
@@ -3940,7 +3813,7 @@ mod tests {
     #[test]
     fn native_tool_call_end_updates_shell_output_tail() {
         let mut app = App::new();
-        app.session_id = Some("session-1".into());
+        app.sessions.session_id = Some("session-1".into());
         app.handle_acp_event(AcpAppEvent::SessionUpdate {
             session_id: "session-1".into(),
             is_replay: false,
@@ -3977,7 +3850,7 @@ mod tests {
     #[test]
     fn native_tool_call_start_keeps_read_tool_range() {
         let mut app = App::new();
-        app.session_id = Some("session-1".into());
+        app.sessions.session_id = Some("session-1".into());
 
         app.handle_acp_event(AcpAppEvent::SessionUpdate {
             session_id: "session-1".into(),
@@ -4005,8 +3878,8 @@ mod tests {
     #[test]
     fn native_undo_result_success_updates_state_and_reloads_session() {
         let mut app = App::new();
-        app.session_id = Some("session-1".into());
-        app.agent_id = Some("agent-1".into());
+        app.sessions.session_id = Some("session-1".into());
+        app.sessions.agent_id = Some("agent-1".into());
         app.activity = ActivityState::SessionOp(SessionOp::Undo);
         app.undoable_turns.push(UndoableTurn {
             turn_id: "u1".into(),
@@ -4045,7 +3918,7 @@ mod tests {
     #[test]
     fn native_undo_rejection_without_target_uses_stack_tail_without_reload() {
         let mut app = App::new();
-        app.session_id = Some("session-1".into());
+        app.sessions.session_id = Some("session-1".into());
         app.activity = ActivityState::SessionOp(SessionOp::Undo);
         app.streaming_content = "keep streaming content".into();
         app.undoable_turns = vec![
@@ -4133,8 +4006,8 @@ mod tests {
     #[test]
     fn native_redo_result_success_rebuilds_state_and_reloads_session() {
         let mut app = App::new();
-        app.session_id = Some("session-1".into());
-        app.agent_id = Some("agent-1".into());
+        app.sessions.session_id = Some("session-1".into());
+        app.sessions.agent_id = Some("agent-1".into());
         app.activity = ActivityState::SessionOp(SessionOp::Redo);
 
         let replies = app.handle_acp_event(AcpAppEvent::RedoResult(RedoResult::Applied {
@@ -4184,7 +4057,7 @@ mod tests {
     #[test]
     fn native_fork_result_success_loads_forked_session() {
         let mut app = App::new();
-        app.agent_id = Some("agent-1".into());
+        app.sessions.agent_id = Some("agent-1".into());
         app.navigation.popup = Popup::ForkTurnSelect;
         app.pending_fork_message_id = Some("msg-1".into());
 
@@ -4256,7 +4129,7 @@ mod tests {
     #[test]
     fn native_session_update_for_other_session_marks_activity_only() {
         let mut app = App::new();
-        app.session_id = Some("active".into());
+        app.sessions.session_id = Some("active".into());
 
         app.handle_acp_event(AcpAppEvent::SessionUpdate {
             session_id: "other".into(),
@@ -4269,13 +4142,13 @@ mod tests {
         });
 
         assert!(app.messages.is_empty());
-        assert!(app.session_activity.contains_key("other"));
+        assert!(app.sessions.session_activity.contains_key("other"));
     }
 
     #[test]
     fn native_session_replay_applies_history_as_one_event() {
         let mut app = App::new();
-        app.session_id = Some("session-1".into());
+        app.sessions.session_id = Some("session-1".into());
 
         let replies = app.handle_acp_event(AcpAppEvent::SessionReplay {
             session_id: "session-1".into(),
@@ -4305,7 +4178,7 @@ mod tests {
     #[test]
     fn native_session_replay_coalesces_deltas_without_crossing_tool_order() {
         let mut app = App::new();
-        app.session_id = Some("session-1".into());
+        app.sessions.session_id = Some("session-1".into());
 
         app.handle_acp_event(AcpAppEvent::SessionReplay {
             session_id: "session-1".into(),
@@ -4354,7 +4227,7 @@ mod tests {
     #[test]
     fn native_session_replay_prefers_final_assistant_message() {
         let mut app = App::new();
-        app.session_id = Some("session-1".into());
+        app.sessions.session_id = Some("session-1".into());
 
         app.handle_acp_event(AcpAppEvent::SessionReplay {
             session_id: "session-1".into(),
@@ -4385,7 +4258,7 @@ mod tests {
     #[test]
     fn native_session_replay_merges_adjacent_assistant_chunks_from_loading_notifications() {
         let mut app = App::new();
-        app.session_id = Some("session-1".into());
+        app.sessions.session_id = Some("session-1".into());
 
         app.handle_acp_event(AcpAppEvent::SessionReplay {
             session_id: "session-1".into(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,14 +6,13 @@ use crate::command::Command;
 use crate::diagnostics::{AppLogEntry, DiagnosticsState, LogLevel};
 use crate::domain::activity::{
     ActivityState, DelegateChildState, DelegateEntry, DelegateStats, PendingDelegateToolCall,
-    SessionActivity, SessionOp, SessionStatsLite,
+    SessionOp, SessionStatsLite,
 };
 use crate::domain::chat::{ChatEntry, format_outcome_labels};
 use crate::domain::elicitation::ElicitationState;
-use crate::domain::mesh::RemoteSessionLocation;
 use crate::domain::session::{
-    ForkBoundaryKind, ForkTurnItem, SessionGroup, UndoFrame, UndoFrameStatus, UndoStackSnapshot,
-    UndoState, UndoableTurn,
+    ForkBoundaryKind, ForkTurnItem, UndoFrame, UndoFrameStatus, UndoStackSnapshot, UndoState,
+    UndoableTurn,
 };
 use crate::highlight::Highlighter;
 use crate::markdown::CardBlock;
@@ -22,6 +21,7 @@ use crate::models_state::ModelsState;
 use crate::navigation_state::{NavigationState, Popup};
 use crate::profiles_state::ProfilesState;
 use crate::protocol::audit::EventKind;
+use crate::session_state::SessionsState;
 use crate::ui::{CardCache, ElicitationUiState};
 
 /// Cache for rendered streaming markdown to avoid re-parsing every frame.
@@ -217,13 +217,6 @@ pub struct SlashCompletionState {
     pub results: Vec<&'static crate::slash::SlashCommandDef>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PathCompletionState {
-    pub query: String,
-    pub selected_index: usize,
-    pub results: Vec<FileIndexEntryLite>,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConnState {
     Connecting,
@@ -240,142 +233,16 @@ pub enum ConnectionEvent {
 
 const CANCEL_CONFIRM_TIMEOUT: Duration = Duration::from_millis(1000);
 
-/// A single visible row on the start-page session list.
-///
-/// Built by [`App::visible_start_items`] each render frame, respecting the
-/// current filter and per-group collapse state.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum StartPageItem {
-    /// A group header row (cwd label + count + collapsed state).
-    GroupHeader {
-        /// The cwd key used to look up collapse state (mirrors `SessionGroup::cwd`).
-        cwd: Option<String>,
-        /// Loaded sessions in this group (unfiltered).
-        session_count: usize,
-        /// Total sessions in this group from the backend, when known.
-        session_total: Option<u64>,
-        /// Whether the group is currently collapsed.
-        collapsed: bool,
-    },
-    /// A session row inside an expanded group.
-    Session {
-        /// Index into `App::session_groups`.
-        group_idx: usize,
-        /// Index path from root session to this visible session.
-        path: Vec<usize>,
-        /// Visual nesting depth: 0 for roots, 1+ for fork children.
-        depth: usize,
-    },
-    /// A "... show all" row shown when a group has more sessions than are
-    /// currently visible on the start page.
-    ShowMore {
-        /// Index into `App::session_groups`.
-        group_idx: usize,
-        /// Number of loaded sessions hidden beyond the first `MAX_RECENT_SESSIONS`.
-        remaining: usize,
-        /// Whether the backend has another page for this group.
-        has_more: bool,
-    },
-}
-
-/// Maximum number of recent sessions shown per group on the start page.
-pub const MAX_RECENT_SESSIONS: usize = 3;
-/// Maximum discovery-preview sessions retained before the workspace page arrives.
-pub const POPUP_SESSION_PAGE_TARGET: usize = 10;
-pub const SESSION_CHILD_PAGE_LIMIT: u32 = 10;
-
-/// Maximum number of workspace groups shown on the start page.
-/// Groups beyond this cap are hidden from the start page but remain accessible
-/// through the session popup.
-pub const MAX_VISIBLE_GROUPS: usize = 3;
-
-/// A single visible row in the sessions popup.
-///
-/// Built by [`App::visible_popup_items`]. Unlike [`StartPageItem`] there is no
-/// `ShowMore` variant — the popup always shows all sessions and all groups.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PopupItem {
-    /// A group header row (cwd label + count + collapsed state).
-    GroupHeader {
-        /// The cwd key used to look up collapse state (mirrors `SessionGroup::cwd`).
-        cwd: Option<String>,
-        /// Loaded sessions in this group (unfiltered).
-        session_count: usize,
-        /// Total sessions in this group from the backend, when known.
-        session_total: Option<u64>,
-        /// Whether the group is currently collapsed in the popup.
-        collapsed: bool,
-    },
-    /// A session row inside an expanded group.
-    Session {
-        /// Index into `App::session_groups`.
-        group_idx: usize,
-        /// Index path from root session to this visible session.
-        path: Vec<usize>,
-        /// Visual nesting depth: 0 for roots, 1+ for fork children.
-        depth: usize,
-    },
-    /// A "... load more..." row that fetches the next page for one group or parent fork.
-    LoadMore {
-        /// Index into `App::session_groups`.
-        group_idx: usize,
-        /// Parent session path when loading more fork children; empty for a cwd group page.
-        parent_path: Vec<usize>,
-    },
-}
-
-pub fn session_group_count_text(session_count: usize, session_total: Option<u64>) -> String {
-    session_total
-        .map(|total| format!("{session_count}/{total}"))
-        .unwrap_or_else(|| session_count.to_string())
-}
-
 pub struct App {
     pub(crate) navigation: NavigationState,
 
     // sessions
-    /// Session groups as received from the server (preserve group structure for start page).
-    pub session_groups: Vec<SessionGroup>,
-    pub session_cursor: usize,
-    pub session_filter: String,
-    /// Active tab in the session popup: 0 = sessions, 1 = delegates.
-    pub session_popup_tab: usize,
-    /// Groups whose header has been collapsed by the user on the start page.
-    pub collapsed_groups: HashSet<String>,
-    /// Groups whose header has been collapsed by the user in the session popup.
-    /// Separate from `collapsed_groups` so start-page and popup states are independent.
-    pub popup_collapsed_groups: HashSet<String>,
-    /// Whether global ACP session discovery has another request in flight.
-    pub session_discovery_in_progress: bool,
-    /// Opaque global cursors already queued during the current discovery pass.
-    pub session_discovery_cursors: HashSet<String>,
-    /// CWDs with an outstanding first-page or continuation request.
-    pub pending_session_group_loads: HashSet<Option<String>>,
-    /// CWDs whose authoritative first workspace page has been loaded.
-    pub hydrated_session_groups: HashSet<String>,
-    /// Root session IDs expanded to show fork children.
-    pub expanded_session_children: HashSet<String>,
-    /// Parent session IDs with an outstanding child-page request.
-    pub pending_session_child_loads: HashSet<String>,
-    /// Scroll offset for the start-page session list (in visible rows).
-    pub start_page_scroll: usize,
-    /// Last rendered visible row count for the sessions tab in the popup.
-    pub session_popup_visible_rows: usize,
+    pub(crate) sessions: SessionsState,
     /// Last rendered visible row count for the delegates tab in the popup.
     pub delegate_popup_visible_rows: usize,
 
-    // active session
-    pub session_id: Option<String>,
-    pub agent_id: Option<String>,
-    pub agent_mode: String,
-    pub mode_before_review: Option<String>,
+    // active session startup context
     pub launch_cwd: Option<String>,
-    pub new_session_path: String,
-    pub new_session_cursor: usize,
-    pub new_session_completion: Option<PathCompletionState>,
-    pub session_activity: HashMap<String, SessionActivity>,
-    /// Remote locations retained from ACP and mesh session metadata.
-    pub remote_session_locations: HashMap<String, RemoteSessionLocation>,
 
     // chat
     pub messages: Vec<ChatEntry>,
@@ -498,24 +365,13 @@ fn move_wrapping_cursor(cursor: usize, len: usize, delta: isize) -> usize {
 
 impl App {
     pub fn begin_session_discovery(&mut self) -> Option<Command> {
-        if self.session_discovery_in_progress || !self.pending_session_group_loads.is_empty() {
-            return None;
-        }
-        self.session_groups.clear();
-        self.session_discovery_cursors.clear();
-        self.pending_session_group_loads.clear();
-        self.hydrated_session_groups.clear();
-        self.session_discovery_in_progress = true;
-        Some(Command::list_sessions_browse())
+        self.sessions
+            .prepare_session_discovery()
+            .then(Command::list_sessions_browse)
     }
 
     pub fn session_group_page_request(&mut self, group_idx: usize) -> Option<Command> {
-        let group = self.session_groups.get(group_idx)?;
-        let cursor = group.next_cursor.clone()?;
-        let cwd = group.cwd.clone()?;
-        if !self.pending_session_group_loads.insert(Some(cwd.clone())) {
-            return None;
-        }
+        let (cwd, cursor) = self.sessions.prepare_session_group_page(group_idx)?;
         Some(Command::list_sessions_group(cwd, cursor))
     }
 
@@ -524,46 +380,22 @@ impl App {
         group_idx: usize,
         parent_path: &[usize],
     ) -> Option<Command> {
-        let parent = self.session_by_path(group_idx, parent_path)?;
-        let parent_session_id = parent.session_id.clone();
-        let cursor = parent.children_next_cursor.clone();
-        self.pending_session_child_loads
-            .insert(parent_session_id.clone());
+        let (parent_session_id, cursor) = self
+            .sessions
+            .prepare_session_child_page(group_idx, parent_path)?;
         Some(Command::list_session_children(
             parent_session_id,
             cursor,
-            SESSION_CHILD_PAGE_LIMIT,
+            crate::session_state::SESSION_CHILD_PAGE_LIMIT,
         ))
     }
 
     pub fn new() -> Self {
         Self {
             navigation: NavigationState::new(),
-            session_groups: Vec::new(),
-            session_cursor: 0,
-            session_filter: String::new(),
-            session_popup_tab: 0,
-            collapsed_groups: HashSet::new(),
-            popup_collapsed_groups: HashSet::new(),
-            session_discovery_in_progress: false,
-            session_discovery_cursors: HashSet::new(),
-            pending_session_group_loads: HashSet::new(),
-            hydrated_session_groups: HashSet::new(),
-            expanded_session_children: HashSet::new(),
-            pending_session_child_loads: HashSet::new(),
-            start_page_scroll: 0,
-            session_popup_visible_rows: 0,
+            sessions: SessionsState::new(),
             delegate_popup_visible_rows: 0,
-            session_id: None,
-            agent_id: None,
-            agent_mode: "build".into(),
-            mode_before_review: None,
             launch_cwd: None,
-            new_session_path: String::new(),
-            new_session_cursor: 0,
-            new_session_completion: None,
-            session_activity: HashMap::new(),
-            remote_session_locations: HashMap::new(),
             messages: Vec::new(),
             pending_prompt_seq: 0,
             input: String::new(),
@@ -675,7 +507,8 @@ impl App {
     }
 
     pub fn current_session_profile_id(&self) -> Option<&str> {
-        self.session_id
+        self.sessions
+            .session_id
             .as_deref()
             .and_then(|session_id| self.profiles.session_profile_id(session_id))
     }
@@ -684,7 +517,7 @@ impl App {
         self.current_session_profile_id()
             .map(|profile_id| self.profiles.profile_display_name(profile_id))
             .unwrap_or_else(|| {
-                if self.current_session_is_remote() {
+                if self.sessions.current_session_is_remote() {
                     "remote".to_string()
                 } else {
                     self.profiles.active_profile_label()
@@ -1030,7 +863,7 @@ impl App {
                 self.set_status(
                     LogLevel::Info,
                     "connection",
-                    if self.session_id.is_some() {
+                    if self.sessions.session_id.is_some() {
                         "reconnected".to_string()
                     } else {
                         "connected".to_string()
@@ -1040,8 +873,8 @@ impl App {
             ConnectionEvent::Disconnected { reason } => {
                 self.conn = ConnState::Disconnected;
                 self.reconnect_delay_ms = None;
-                self.session_discovery_in_progress = false;
-                self.pending_session_group_loads.clear();
+                self.sessions.session_discovery_in_progress = false;
+                self.sessions.pending_session_group_loads.clear();
                 self.set_status(
                     LogLevel::Warn,
                     "connection",
@@ -1210,18 +1043,6 @@ impl App {
         self.refresh_transient_status();
     }
 
-    pub fn next_mode(&self) -> String {
-        match self.agent_mode.as_str() {
-            "build" => "plan".into(),
-            "plan" => "build".into(),
-            "review" => self
-                .mode_before_review
-                .clone()
-                .unwrap_or_else(|| "build".into()),
-            _ => "build".into(),
-        }
-    }
-
     // ── delegate model preference coordination ───────────────────────────────
 
     pub fn delegate_preference_profile_id(&self) -> Option<&str> {
@@ -1272,7 +1093,9 @@ impl App {
 #[cfg(test)]
 mod reasoning_effort_tests {
     use super::*;
-    use crate::domain::session::SessionSummary;
+    use crate::domain::activity::SessionActivity;
+    use crate::domain::session::{SessionGroup, SessionSummary};
+    use crate::session_state::PathCompletionState;
 
     // ── cycle_reasoning_effort ────────────────────────────────────────────────
 
@@ -1429,54 +1252,54 @@ mod reasoning_effort_tests {
     #[test]
     fn active_session_count_requires_multiple_recent_sessions() {
         let mut app = App::new();
-        app.note_session_activity("session-a");
-        assert_eq!(app.active_session_count(), 1);
+        app.sessions.note_session_activity("session-a");
+        assert_eq!(app.sessions.active_session_count(), 1);
 
-        app.note_session_activity("session-b");
-        assert_eq!(app.active_session_count(), 2);
+        app.sessions.note_session_activity("session-b");
+        assert_eq!(app.sessions.active_session_count(), 2);
     }
 
     #[test]
     fn other_active_session_count_excludes_current_session() {
         let mut app = App::new();
-        app.session_id = Some("session-a".into());
-        app.note_session_activity("session-a");
-        app.note_session_activity("session-b");
-        app.note_session_activity("session-c");
+        app.sessions.session_id = Some("session-a".into());
+        app.sessions.note_session_activity("session-a");
+        app.sessions.note_session_activity("session-b");
+        app.sessions.note_session_activity("session-c");
 
-        assert_eq!(app.other_active_session_count(), 2);
+        assert_eq!(app.sessions.other_active_session_count(), 2);
     }
 
     #[test]
     fn other_active_session_count_shows_other_session_when_current_is_idle() {
         let mut app = App::new();
-        app.session_id = Some("session-a".into());
-        app.note_session_activity("session-b");
+        app.sessions.session_id = Some("session-a".into());
+        app.sessions.note_session_activity("session-b");
 
-        assert_eq!(app.other_active_session_count(), 1);
+        assert_eq!(app.sessions.other_active_session_count(), 1);
     }
 
     #[test]
     fn active_session_count_excludes_stale_sessions() {
         let mut app = App::new();
-        app.note_session_activity("session-a");
-        app.session_activity.insert(
+        app.sessions.note_session_activity("session-a");
+        app.sessions.session_activity.insert(
             "session-b".into(),
             SessionActivity {
                 last_event_at: Instant::now() - Duration::from_secs(6),
             },
         );
 
-        assert_eq!(app.active_session_count(), 1);
-        assert_eq!(app.other_active_session_count(), 1);
+        assert_eq!(app.sessions.active_session_count(), 1);
+        assert_eq!(app.sessions.other_active_session_count(), 1);
     }
 
     #[test]
     fn resolve_new_session_default_cwd_prefers_active_session_cwd_then_group_then_launch() {
         let mut app = App::new();
         app.launch_cwd = Some("/launch".into());
-        app.session_id = Some("session-a".into());
-        app.session_groups = vec![SessionGroup {
+        app.sessions.session_id = Some("session-a".into());
+        app.sessions.session_groups = vec![SessionGroup {
             cwd: Some("/group".into()),
             latest_activity: None,
             sessions: vec![SessionSummary {
@@ -1496,13 +1319,13 @@ mod reasoning_effort_tests {
             Some("/session")
         );
 
-        app.session_groups[0].sessions[0].cwd = None;
+        app.sessions.session_groups[0].sessions[0].cwd = None;
         assert_eq!(
             app.resolve_new_session_default_cwd().as_deref(),
             Some("/group")
         );
 
-        app.session_groups.clear();
+        app.sessions.session_groups.clear();
         assert_eq!(
             app.resolve_new_session_default_cwd().as_deref(),
             Some("/launch")
@@ -1517,8 +1340,8 @@ mod reasoning_effort_tests {
         app.open_new_session_popup();
 
         assert_eq!(app.navigation.popup, Popup::NewSession);
-        assert_eq!(app.new_session_path, "/launch");
-        assert_eq!(app.new_session_cursor, "/launch".len());
+        assert_eq!(app.sessions.new_session_path, "/launch");
+        assert_eq!(app.sessions.new_session_cursor, "/launch".len());
     }
 
     #[test]
@@ -1557,7 +1380,7 @@ mod reasoning_effort_tests {
     #[test]
     fn accept_selected_new_session_completion_replaces_input() {
         let mut app = App::new();
-        app.new_session_completion = Some(PathCompletionState {
+        app.sessions.new_session_completion = Some(PathCompletionState {
             query: "pro".into(),
             selected_index: 0,
             results: vec![FileIndexEntryLite {
@@ -1567,8 +1390,8 @@ mod reasoning_effort_tests {
         });
 
         assert!(app.accept_selected_new_session_completion());
-        assert_eq!(app.new_session_path, "/launch/project-two/");
-        assert!(app.new_session_completion.is_none());
+        assert_eq!(app.sessions.new_session_path, "/launch/project-two/");
+        assert!(app.sessions.new_session_completion.is_none());
     }
 
     #[test]
@@ -1906,17 +1729,17 @@ mod session_mode_tests {
     #[test]
     fn next_mode_exits_review_to_previous_mode() {
         let mut app = App::new();
-        app.agent_mode = "review".into();
-        app.mode_before_review = Some("plan".into());
-        assert_eq!(app.next_mode(), "plan");
+        app.sessions.agent_mode = "review".into();
+        app.sessions.mode_before_review = Some("plan".into());
+        assert_eq!(app.sessions.next_mode(), "plan");
     }
 
     #[test]
     fn next_mode_from_review_defaults_to_build_without_previous_mode() {
         let mut app = App::new();
-        app.agent_mode = "review".into();
-        app.mode_before_review = None;
-        assert_eq!(app.next_mode(), "build");
+        app.sessions.agent_mode = "review".into();
+        app.sessions.mode_before_review = None;
+        assert_eq!(app.sessions.next_mode(), "build");
     }
 
     // ── SessionModeChanged in audit replay ────────────────────────────────────
@@ -2487,7 +2310,7 @@ mod tests {
             matches!(app.diagnostics.logs.last(), Some(entry) if entry.message == "connection lost - socket closed")
         );
 
-        app.session_id = Some("session-1".into());
+        app.sessions.session_id = Some("session-1".into());
         app.handle_connection_event(ConnectionEvent::Connected);
         assert_eq!(app.conn, ConnState::Connected);
         assert_eq!(app.reconnect_attempt, 0);
@@ -2592,7 +2415,8 @@ mod tests {
 #[cfg(test)]
 mod start_page_tests {
     use super::*;
-    use crate::domain::session::SessionSummary;
+    use crate::domain::session::{SessionGroup, SessionSummary};
+    use crate::session_state::{PopupItem, StartPageItem};
 
     fn make_group(cwd: Option<&str>, ids: &[(&str, Option<&str>)]) -> SessionGroup {
         SessionGroup {
@@ -2620,7 +2444,7 @@ mod start_page_tests {
     #[test]
     fn visible_items_empty_when_no_sessions() {
         let app = App::new();
-        let items = app.visible_start_items();
+        let items = app.sessions.visible_start_items();
         assert!(items.is_empty());
     }
 
@@ -2629,9 +2453,9 @@ mod start_page_tests {
     #[test]
     fn visible_items_header_then_sessions_expanded() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &[("s1", None), ("s2", None)])];
+        app.sessions.session_groups = vec![make_group(Some("/a"), &[("s1", None), ("s2", None)])];
 
-        let items = app.visible_start_items();
+        let items = app.sessions.visible_start_items();
         // 1 header + 2 sessions
         assert_eq!(items.len(), 3);
         assert!(matches!(&items[0], StartPageItem::GroupHeader { .. }));
@@ -2644,10 +2468,10 @@ mod start_page_tests {
     #[test]
     fn visible_items_collapsed_group_hides_sessions() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &[("s1", None), ("s2", None)])];
-        app.collapsed_groups.insert("/a".to_string());
+        app.sessions.session_groups = vec![make_group(Some("/a"), &[("s1", None), ("s2", None)])];
+        app.sessions.collapsed_groups.insert("/a".to_string());
 
-        let items = app.visible_start_items();
+        let items = app.sessions.visible_start_items();
         // only the header
         assert_eq!(items.len(), 1);
         assert!(matches!(
@@ -2664,12 +2488,12 @@ mod start_page_tests {
     #[test]
     fn visible_items_multiple_groups() {
         let mut app = App::new();
-        app.session_groups = vec![
+        app.sessions.session_groups = vec![
             make_group(Some("/a"), &[("s1", None)]),
             make_group(Some("/b"), &[("s2", None), ("s3", None)]),
         ];
 
-        let items = app.visible_start_items();
+        let items = app.sessions.visible_start_items();
         // group /a: 1 header + 1 session = 2
         // group /b: 1 header + 2 sessions = 3
         assert_eq!(items.len(), 5);
@@ -2680,13 +2504,13 @@ mod start_page_tests {
     #[test]
     fn visible_items_one_group_collapsed_other_expanded() {
         let mut app = App::new();
-        app.session_groups = vec![
+        app.sessions.session_groups = vec![
             make_group(Some("/a"), &[("s1", None)]),
             make_group(Some("/b"), &[("s2", None), ("s3", None)]),
         ];
-        app.collapsed_groups.insert("/a".to_string());
+        app.sessions.collapsed_groups.insert("/a".to_string());
 
-        let items = app.visible_start_items();
+        let items = app.sessions.visible_start_items();
         // /a collapsed: 1 header
         // /b expanded:  1 header + 2 sessions
         assert_eq!(items.len(), 4);
@@ -2711,13 +2535,13 @@ mod start_page_tests {
     #[test]
     fn visible_items_filter_hides_non_matching_sessions() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(
+        app.sessions.session_groups = vec![make_group(
             Some("/a"),
             &[("aaa", None), ("bbb", None), ("aab", None)],
         )];
-        app.session_filter = "aa".to_string();
+        app.sessions.session_filter = "aa".to_string();
 
-        let items = app.visible_start_items();
+        let items = app.sessions.visible_start_items();
         // header + "aaa" + "aab" (bbb filtered out by session_id)
         assert_eq!(items.len(), 3);
     }
@@ -2727,13 +2551,13 @@ mod start_page_tests {
     #[test]
     fn visible_items_filter_hides_groups_with_no_matches() {
         let mut app = App::new();
-        app.session_groups = vec![
+        app.sessions.session_groups = vec![
             make_group(Some("/a"), &[("aaa", None)]),
             make_group(Some("/b"), &[("bbb", None)]),
         ];
-        app.session_filter = "bbb".to_string();
+        app.sessions.session_filter = "bbb".to_string();
 
-        let items = app.visible_start_items();
+        let items = app.sessions.visible_start_items();
         // group /a has no matches → hidden entirely
         // group /b: header + "bbb"
         assert_eq!(items.len(), 2);
@@ -2749,12 +2573,12 @@ mod start_page_tests {
     #[test]
     fn visible_items_session_indices_correct() {
         let mut app = App::new();
-        app.session_groups = vec![
+        app.sessions.session_groups = vec![
             make_group(Some("/a"), &[("s0", None), ("s1", None)]),
             make_group(Some("/b"), &[("s2", None)]),
         ];
 
-        let items = app.visible_start_items();
+        let items = app.sessions.visible_start_items();
         // items[0]: GroupHeader /a
         // items[1]: Session group_idx=0, session_idx=0
         // items[2]: Session group_idx=0, session_idx=1
@@ -2791,8 +2615,8 @@ mod start_page_tests {
         let mut app = App::new();
         let mut group = make_group(Some("/a"), &[("root", Some("2024-01-04T00:00:00Z"))]);
         group.sessions[0].fork_count = 1;
-        app.session_groups = vec![group];
-        app.session_cursor = 1;
+        app.sessions.session_groups = vec![group];
+        app.sessions.session_cursor = 1;
 
         let action = crate::handlers::apply_session_fork_toggle_key(&mut app, false);
         assert_eq!(
@@ -2802,12 +2626,12 @@ mod start_page_tests {
                 parent_path: vec![0],
             }
         );
-        assert!(app.expanded_session_children.contains("root"));
-        assert!(app.pending_session_child_loads.is_empty());
+        assert!(app.sessions.expanded_session_children.contains("root"));
+        assert!(app.sessions.pending_session_child_loads.is_empty());
 
         let action = crate::handlers::apply_session_fork_toggle_key(&mut app, false);
         assert_eq!(action, crate::handlers::SessionKeyAction::None);
-        assert!(app.pending_session_child_loads.is_empty());
+        assert!(app.sessions.pending_session_child_loads.is_empty());
     }
 
     #[test]
@@ -2816,12 +2640,12 @@ mod start_page_tests {
         let mut group = make_group(Some("/a"), &[("remote", Some("2024-01-04T00:00:00Z"))]);
         group.sessions[0].fork_count = 1;
         group.sessions[0].node = Some("remote-host".to_string());
-        app.session_groups = vec![group];
+        app.sessions.session_groups = vec![group];
 
-        assert!(!app.expandable_root_session(0, &[0]));
-        assert!(!app.toggle_session_children(0, &[0]));
-        assert!(app.expanded_session_children.is_empty());
-        assert!(app.pending_session_child_loads.is_empty());
+        assert!(!app.sessions.expandable_root_session(0, &[0]));
+        assert!(!app.sessions.toggle_session_children(0, &[0]));
+        assert!(app.sessions.expanded_session_children.is_empty());
+        assert!(app.sessions.pending_session_child_loads.is_empty());
     }
 
     #[test]
@@ -2836,10 +2660,12 @@ mod start_page_tests {
             parent_session_id: Some("root".to_string()),
             ..Default::default()
         }];
-        app.expanded_session_children.insert("root".to_string());
-        app.session_groups = vec![group];
+        app.sessions
+            .expanded_session_children
+            .insert("root".to_string());
+        app.sessions.session_groups = vec![group];
 
-        let items = app.visible_popup_items();
+        let items = app.sessions.visible_popup_items();
 
         assert!(matches!(
             &items[2],
@@ -2863,13 +2689,13 @@ mod start_page_tests {
     #[test]
     fn group_header_session_count_reflects_total_not_filtered() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(
+        app.sessions.session_groups = vec![make_group(
             Some("/a"),
             &[("s1", None), ("s2", None), ("s3", None)],
         )];
-        app.session_groups[0].total_count = Some(8);
+        app.sessions.session_groups[0].total_count = Some(8);
 
-        let items = app.visible_start_items();
+        let items = app.sessions.visible_start_items();
         assert!(matches!(
             &items[0],
             StartPageItem::GroupHeader {
@@ -2883,9 +2709,9 @@ mod start_page_tests {
     #[test]
     fn group_header_session_total_falls_back_to_unknown() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &[("s1", None)])];
+        app.sessions.session_groups = vec![make_group(Some("/a"), &[("s1", None)])];
 
-        let items = app.visible_start_items();
+        let items = app.sessions.visible_start_items();
         assert!(matches!(
             &items[0],
             StartPageItem::GroupHeader {
@@ -2902,23 +2728,23 @@ mod start_page_tests {
     fn toggle_group_collapse_collapses_then_expands() {
         let mut app = App::new();
         let key = "/a".to_string();
-        assert!(!app.collapsed_groups.contains(&key));
+        assert!(!app.sessions.collapsed_groups.contains(&key));
 
-        app.toggle_group_collapse(Some("/a"));
-        assert!(app.collapsed_groups.contains(&key));
+        app.sessions.toggle_group_collapse(Some("/a"));
+        assert!(app.sessions.collapsed_groups.contains(&key));
 
-        app.toggle_group_collapse(Some("/a"));
-        assert!(!app.collapsed_groups.contains(&key));
+        app.sessions.toggle_group_collapse(Some("/a"));
+        assert!(!app.sessions.collapsed_groups.contains(&key));
     }
 
     #[test]
     fn toggle_group_collapse_none_cwd_uses_empty_string_key() {
         let mut app = App::new();
-        app.toggle_group_collapse(None);
-        assert!(app.collapsed_groups.contains(""));
+        app.sessions.toggle_group_collapse(None);
+        assert!(app.sessions.collapsed_groups.contains(""));
 
-        app.toggle_group_collapse(None);
-        assert!(!app.collapsed_groups.contains(""));
+        app.sessions.toggle_group_collapse(None);
+        assert!(!app.sessions.collapsed_groups.contains(""));
     }
 
     // ── MAX_RECENT_SESSIONS cap ───────────────────────────────────────────────
@@ -2926,11 +2752,11 @@ mod start_page_tests {
     #[test]
     fn visible_items_group_with_three_sessions_shows_no_show_more() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(
+        app.sessions.session_groups = vec![make_group(
             Some("/a"),
             &[("s1", None), ("s2", None), ("s3", None)],
         )];
-        let items = app.visible_start_items();
+        let items = app.sessions.visible_start_items();
         // header + 3 sessions, no ShowMore
         assert_eq!(items.len(), 4);
         assert!(
@@ -2943,11 +2769,11 @@ mod start_page_tests {
     #[test]
     fn visible_items_group_with_four_sessions_shows_show_more() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(
+        app.sessions.session_groups = vec![make_group(
             Some("/a"),
             &[("s1", None), ("s2", None), ("s3", None), ("s4", None)],
         )];
-        let items = app.visible_start_items();
+        let items = app.sessions.visible_start_items();
         // header + 3 sessions + ShowMore
         assert_eq!(items.len(), 5);
         assert!(matches!(
@@ -2959,7 +2785,7 @@ mod start_page_tests {
     #[test]
     fn visible_items_show_more_remaining_is_total_minus_three() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(
+        app.sessions.session_groups = vec![make_group(
             Some("/a"),
             &[
                 ("s1", None),
@@ -2975,7 +2801,7 @@ mod start_page_tests {
                 ("s11", None),
             ],
         )];
-        let items = app.visible_start_items();
+        let items = app.sessions.visible_start_items();
         assert!(matches!(
             items.last(),
             Some(StartPageItem::ShowMore {
@@ -2989,7 +2815,7 @@ mod start_page_tests {
     #[test]
     fn visible_items_filter_active_still_caps_sessions() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(
+        app.sessions.session_groups = vec![make_group(
             Some("/a"),
             &[
                 ("aaa1", None),
@@ -3005,8 +2831,8 @@ mod start_page_tests {
                 ("aaa11", None),
             ],
         )];
-        app.session_filter = "aaa".to_string();
-        let items = app.visible_start_items();
+        app.sessions.session_filter = "aaa".to_string();
+        let items = app.sessions.visible_start_items();
         assert_eq!(items.len(), 5);
         assert!(matches!(
             items.last(),
@@ -3019,12 +2845,12 @@ mod start_page_tests {
     #[test]
     fn visible_items_three_groups_shows_no_trailing_show_more() {
         let mut app = App::new();
-        app.session_groups = vec![
+        app.sessions.session_groups = vec![
             make_group(Some("/a"), &[("s1", None)]),
             make_group(Some("/b"), &[("s2", None)]),
             make_group(Some("/c"), &[("s3", None)]),
         ];
-        let items = app.visible_start_items();
+        let items = app.sessions.visible_start_items();
         // 3 headers + 3 sessions = 6, no trailing ShowMore
         assert_eq!(items.len(), 6);
         assert!(
@@ -3037,13 +2863,13 @@ mod start_page_tests {
     #[test]
     fn visible_items_four_groups_caps_at_three_no_trailing_show_more() {
         let mut app = App::new();
-        app.session_groups = vec![
+        app.sessions.session_groups = vec![
             make_group(Some("/a"), &[("s1", None)]),
             make_group(Some("/b"), &[("s2", None)]),
             make_group(Some("/c"), &[("s3", None)]),
             make_group(Some("/d"), &[("s4", None)]),
         ];
-        let items = app.visible_start_items();
+        let items = app.sessions.visible_start_items();
         // 3 groups (3 headers + 3 sessions) = 6, no trailing ShowMore
         assert_eq!(items.len(), 6);
         assert!(
@@ -3056,7 +2882,7 @@ mod start_page_tests {
     #[test]
     fn visible_items_six_groups_caps_at_three_no_trailing_show_more() {
         let mut app = App::new();
-        app.session_groups = vec![
+        app.sessions.session_groups = vec![
             make_group(Some("/a"), &[("s1", None)]),
             make_group(Some("/b"), &[("s2", None)]),
             make_group(Some("/c"), &[("s3", None)]),
@@ -3064,7 +2890,7 @@ mod start_page_tests {
             make_group(Some("/e"), &[("s5", None)]),
             make_group(Some("/f"), &[("s6", None)]),
         ];
-        let items = app.visible_start_items();
+        let items = app.sessions.visible_start_items();
         // 3 shown groups (3 headers + 3 sessions) = 6, no trailing ShowMore
         assert_eq!(items.len(), 6);
         assert!(
@@ -3077,14 +2903,14 @@ mod start_page_tests {
     #[test]
     fn visible_items_group_cap_applied_with_filter_active() {
         let mut app = App::new();
-        app.session_groups = vec![
+        app.sessions.session_groups = vec![
             make_group(Some("/a"), &[("aaa1", None)]),
             make_group(Some("/b"), &[("aaa2", None)]),
             make_group(Some("/c"), &[("aaa3", None)]),
             make_group(Some("/d"), &[("aaa4", None)]),
         ];
-        app.session_filter = "aaa".to_string();
-        let items = app.visible_start_items();
+        app.sessions.session_filter = "aaa".to_string();
+        let items = app.sessions.visible_start_items();
         // Filter active but group cap still applies → 3 groups, no trailing ShowMore
         let headers = items
             .iter()
@@ -3104,7 +2930,8 @@ mod start_page_tests {
 #[cfg(test)]
 mod popup_item_tests {
     use super::*;
-    use crate::domain::session::SessionSummary;
+    use crate::domain::session::{SessionGroup, SessionSummary};
+    use crate::session_state::PopupItem;
 
     fn make_group(cwd: Option<&str>, ids: &[&str]) -> SessionGroup {
         SessionGroup {
@@ -3132,7 +2959,7 @@ mod popup_item_tests {
     #[test]
     fn popup_items_empty_when_no_sessions() {
         let app = App::new();
-        assert!(app.visible_popup_items().is_empty());
+        assert!(app.sessions.visible_popup_items().is_empty());
     }
 
     // ── basic structure: header then sessions ─────────────────────────────────
@@ -3140,8 +2967,8 @@ mod popup_item_tests {
     #[test]
     fn popup_items_header_then_sessions() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
-        let items = app.visible_popup_items();
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
+        let items = app.sessions.visible_popup_items();
         // 1 header + 2 sessions
         assert_eq!(items.len(), 3);
         assert!(matches!(&items[0], PopupItem::GroupHeader { .. }));
@@ -3156,8 +2983,8 @@ mod popup_item_tests {
         let mut app = App::new();
         // 10 sessions - all should appear, no cap like start page
         let ids: Vec<&str> = vec!["s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8", "s9", "s10"];
-        app.session_groups = vec![make_group(Some("/a"), &ids)];
-        let items = app.visible_popup_items();
+        app.sessions.session_groups = vec![make_group(Some("/a"), &ids)];
+        let items = app.sessions.visible_popup_items();
         // 1 header + 10 sessions = 11
         assert_eq!(items.len(), 11);
         assert!(
@@ -3172,9 +2999,9 @@ mod popup_item_tests {
         let mut app = App::new();
         let mut group = make_group(Some("/workspace/project"), &["s1"]);
         group.next_cursor = Some("cursor-1".to_string());
-        app.session_groups = vec![group];
+        app.sessions.session_groups = vec![group];
 
-        let items = app.visible_popup_items();
+        let items = app.sessions.visible_popup_items();
 
         assert!(matches!(
             items.last(),
@@ -3192,12 +3019,13 @@ mod popup_item_tests {
         let mut app = App::new();
         let mut group = make_group(Some("/workspace/project"), &["s1"]);
         group.next_cursor = Some("opaque-workspace-2".to_string());
-        app.session_groups = vec![group];
-        app.pending_session_group_loads
+        app.sessions.session_groups = vec![group];
+        app.sessions
+            .pending_session_group_loads
             .insert(Some("/workspace/project".to_string()));
 
         assert!(app.session_group_page_request(0).is_none());
-        assert!(!app.visible_popup_items().iter().any(
+        assert!(!app.sessions.visible_popup_items().iter().any(
             |item| matches!(item, PopupItem::LoadMore { parent_path, .. } if parent_path.is_empty())
         ));
     }
@@ -3205,14 +3033,14 @@ mod popup_item_tests {
     #[test]
     fn popup_items_shows_all_groups_beyond_cap() {
         let mut app = App::new();
-        app.session_groups = vec![
+        app.sessions.session_groups = vec![
             make_group(Some("/a"), &["s1"]),
             make_group(Some("/b"), &["s2"]),
             make_group(Some("/c"), &["s3"]),
             make_group(Some("/d"), &["s4"]),
             make_group(Some("/e"), &["s5"]),
         ];
-        let items = app.visible_popup_items();
+        let items = app.sessions.visible_popup_items();
         let headers = items
             .iter()
             .filter(|i| matches!(i, PopupItem::GroupHeader { .. }))
@@ -3226,10 +3054,10 @@ mod popup_item_tests {
     #[test]
     fn popup_collapsed_is_independent_of_start_page_collapsed() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
         // Collapse on the start page should NOT affect the popup
-        app.collapsed_groups.insert("/a".to_string());
-        let items = app.visible_popup_items();
+        app.sessions.collapsed_groups.insert("/a".to_string());
+        let items = app.sessions.visible_popup_items();
         // Popup uses popup_collapsed_groups, not collapsed_groups
         // /a is expanded in popup → header + 2 sessions = 3
         assert_eq!(items.len(), 3);
@@ -3238,9 +3066,9 @@ mod popup_item_tests {
     #[test]
     fn popup_collapsed_hides_sessions() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
-        app.popup_collapsed_groups.insert("/a".to_string());
-        let items = app.visible_popup_items();
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
+        app.sessions.popup_collapsed_groups.insert("/a".to_string());
+        let items = app.sessions.visible_popup_items();
         // Only the header visible
         assert_eq!(items.len(), 1);
         assert!(matches!(
@@ -3255,9 +3083,9 @@ mod popup_item_tests {
     #[test]
     fn popup_expanded_shows_sessions() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["s1"])];
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
         // Not in popup_collapsed_groups → expanded
-        let items = app.visible_popup_items();
+        let items = app.sessions.visible_popup_items();
         assert_eq!(items.len(), 2);
         assert!(matches!(
             &items[0],
@@ -3273,11 +3101,11 @@ mod popup_item_tests {
     #[test]
     fn popup_items_multiple_groups() {
         let mut app = App::new();
-        app.session_groups = vec![
+        app.sessions.session_groups = vec![
             make_group(Some("/a"), &["s1"]),
             make_group(Some("/b"), &["s2", "s3"]),
         ];
-        let items = app.visible_popup_items();
+        let items = app.sessions.visible_popup_items();
         // /a: 1 header + 1 session; /b: 1 header + 2 sessions = 5
         assert_eq!(items.len(), 5);
     }
@@ -3285,12 +3113,12 @@ mod popup_item_tests {
     #[test]
     fn popup_one_group_collapsed_other_expanded() {
         let mut app = App::new();
-        app.session_groups = vec![
+        app.sessions.session_groups = vec![
             make_group(Some("/a"), &["s1"]),
             make_group(Some("/b"), &["s2", "s3"]),
         ];
-        app.popup_collapsed_groups.insert("/a".to_string());
-        let items = app.visible_popup_items();
+        app.sessions.popup_collapsed_groups.insert("/a".to_string());
+        let items = app.sessions.visible_popup_items();
         // /a collapsed: 1 header; /b expanded: 1 header + 2 sessions = 4
         assert_eq!(items.len(), 4);
         assert!(matches!(
@@ -3314,9 +3142,9 @@ mod popup_item_tests {
     #[test]
     fn popup_filter_hides_non_matching_sessions() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["aaa", "bbb", "aab"])];
-        app.session_filter = "aa".to_string();
-        let items = app.visible_popup_items();
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["aaa", "bbb", "aab"])];
+        app.sessions.session_filter = "aa".to_string();
+        let items = app.sessions.visible_popup_items();
         // header + "aaa" + "aab" (bbb filtered out by session_id)
         assert_eq!(items.len(), 3);
     }
@@ -3324,12 +3152,12 @@ mod popup_item_tests {
     #[test]
     fn popup_filter_hides_groups_with_no_matches() {
         let mut app = App::new();
-        app.session_groups = vec![
+        app.sessions.session_groups = vec![
             make_group(Some("/a"), &["aaa"]),
             make_group(Some("/b"), &["bbb"]),
         ];
-        app.session_filter = "bbb".to_string();
-        let items = app.visible_popup_items();
+        app.sessions.session_filter = "bbb".to_string();
+        let items = app.sessions.visible_popup_items();
         // /a has no matches → hidden; /b: header + "bbb" = 2
         assert_eq!(items.len(), 2);
         if let PopupItem::GroupHeader { cwd, .. } = &items[0] {
@@ -3344,11 +3172,11 @@ mod popup_item_tests {
     #[test]
     fn popup_items_session_indices_correct() {
         let mut app = App::new();
-        app.session_groups = vec![
+        app.sessions.session_groups = vec![
             make_group(Some("/a"), &["s0", "s1"]),
             make_group(Some("/b"), &["s2"]),
         ];
-        let items = app.visible_popup_items();
+        let items = app.sessions.visible_popup_items();
         // items[0]: GroupHeader /a
         // items[1]: Session group_idx=0, session_idx=0
         // items[2]: Session group_idx=0, session_idx=1
@@ -3385,9 +3213,9 @@ mod popup_item_tests {
     #[test]
     fn popup_group_header_session_count_reflects_total() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["s1", "s2", "s3"])];
-        app.session_groups[0].total_count = Some(8);
-        let items = app.visible_popup_items();
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2", "s3"])];
+        app.sessions.session_groups[0].total_count = Some(8);
+        let items = app.sessions.visible_popup_items();
         assert!(matches!(
             &items[0],
             PopupItem::GroupHeader {
@@ -3403,29 +3231,29 @@ mod popup_item_tests {
     #[test]
     fn toggle_popup_collapse_collapses_then_expands() {
         let mut app = App::new();
-        assert!(!app.popup_collapsed_groups.contains("/a"));
-        app.toggle_popup_group_collapse(Some("/a"));
-        assert!(app.popup_collapsed_groups.contains("/a"));
-        app.toggle_popup_group_collapse(Some("/a"));
-        assert!(!app.popup_collapsed_groups.contains("/a"));
+        assert!(!app.sessions.popup_collapsed_groups.contains("/a"));
+        app.sessions.toggle_popup_group_collapse(Some("/a"));
+        assert!(app.sessions.popup_collapsed_groups.contains("/a"));
+        app.sessions.toggle_popup_group_collapse(Some("/a"));
+        assert!(!app.sessions.popup_collapsed_groups.contains("/a"));
     }
 
     #[test]
     fn toggle_popup_collapse_none_cwd_uses_empty_string_key() {
         let mut app = App::new();
-        app.toggle_popup_group_collapse(None);
-        assert!(app.popup_collapsed_groups.contains(""));
-        app.toggle_popup_group_collapse(None);
-        assert!(!app.popup_collapsed_groups.contains(""));
+        app.sessions.toggle_popup_group_collapse(None);
+        assert!(app.sessions.popup_collapsed_groups.contains(""));
+        app.sessions.toggle_popup_group_collapse(None);
+        assert!(!app.sessions.popup_collapsed_groups.contains(""));
     }
 
     #[test]
     fn toggle_popup_collapse_does_not_affect_start_page_state() {
         let mut app = App::new();
-        app.toggle_popup_group_collapse(Some("/a"));
-        assert!(app.popup_collapsed_groups.contains("/a"));
+        app.sessions.toggle_popup_group_collapse(Some("/a"));
+        assert!(app.sessions.popup_collapsed_groups.contains("/a"));
         // start page collapsed_groups should be untouched
-        assert!(!app.collapsed_groups.contains("/a"));
+        assert!(!app.sessions.collapsed_groups.contains("/a"));
     }
 
     // ── slash completion state ─────────────────────────────────────────────────

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -263,9 +263,7 @@ fn open_session_popup(
         return Ok(());
     }
     app.navigation.popup = Popup::SessionSelect;
-    app.session_popup_tab = 0;
-    app.session_cursor = 0;
-    app.session_filter.clear();
+    app.sessions.reset_browser_for_open();
     if let Some(request) = app.begin_session_discovery() {
         cmd_tx.send(request)?;
     }
@@ -655,7 +653,7 @@ pub(crate) fn handle_key(
         if !can_send_server_commands(app) {
             return Ok(AppAction::None);
         }
-        switch_mode(app, cmd_tx, &app.next_mode())?;
+        switch_mode(app, cmd_tx, &app.sessions.next_mode())?;
         return Ok(AppAction::None);
     }
 
@@ -747,7 +745,7 @@ pub(crate) fn handle_chord(
                     cmd_tx,
                     parent_sid,
                     app.current_session_cwd(),
-                    app.agent_id.clone(),
+                    app.sessions.agent_id.clone(),
                 )?;
             } else {
                 app.set_status(LogLevel::Info, "session", "no parent session");
@@ -866,7 +864,7 @@ pub(crate) fn handle_sessions_key(
                 cmd_tx,
                 session_id,
                 cwd,
-                agent_id.or_else(|| app.agent_id.clone()),
+                agent_id.or_else(|| app.sessions.agent_id.clone()),
             )?;
         }
         SessionKeyAction::AttachRemoteSession {
@@ -912,11 +910,11 @@ pub(crate) fn handle_session_popup_key(
 ) -> anyhow::Result<()> {
     // Tab / BackTab: switch between sessions and delegates tabs
     if matches!(key.code, KeyCode::Tab | KeyCode::BackTab) {
-        app.session_popup_tab = 1 - app.session_popup_tab;
+        app.sessions.switch_session_popup_tab();
         return Ok(());
     }
 
-    if app.session_popup_tab == 1 {
+    if app.sessions.session_popup_tab == 1 {
         // Delegates tab
         return handle_delegate_popup_key(app, key, cmd_tx);
     }
@@ -963,7 +961,7 @@ pub(crate) fn handle_session_popup_key(
                 cmd_tx,
                 session_id,
                 cwd,
-                agent_id.or_else(|| app.agent_id.clone()),
+                agent_id.or_else(|| app.sessions.agent_id.clone()),
             )?;
         }
         SessionKeyAction::AttachRemoteSession {
@@ -1009,57 +1007,50 @@ pub(crate) fn apply_popup_session_key(
     app: &mut App,
     key: crossterm::event::KeyCode,
 ) -> SessionKeyAction {
-    use crate::app::PopupItem;
+    use crate::session_state::PopupItem;
 
     match key {
         KeyCode::Esc => {
             app.navigation.popup = Popup::None;
         }
-        KeyCode::Up => {
-            app.session_cursor = app.session_cursor.saturating_sub(1);
-        }
-        KeyCode::Down => {
-            let max = app.visible_popup_items().len().saturating_sub(1);
-            app.session_cursor = (app.session_cursor + 1).min(max);
-        }
+        KeyCode::Up => app.sessions.move_popup_cursor_up(),
+        KeyCode::Down => app.sessions.move_popup_cursor_down(),
         KeyCode::PageUp => {
-            let step = popup_page_step(app.session_popup_visible_rows);
-            app.session_cursor = app.session_cursor.saturating_sub(step);
+            let step = popup_page_step(app.sessions.session_popup_visible_rows);
+            app.sessions.move_popup_cursor_page(step, false);
         }
         KeyCode::PageDown => {
-            let max = app.visible_popup_items().len().saturating_sub(1);
-            let step = popup_page_step(app.session_popup_visible_rows);
-            app.session_cursor = app.session_cursor.saturating_add(step).min(max);
+            let step = popup_page_step(app.sessions.session_popup_visible_rows);
+            app.sessions.move_popup_cursor_page(step, true);
         }
         KeyCode::Enter => {
-            let items = app.visible_popup_items();
-            if let Some(item) = items.get(app.session_cursor).cloned() {
+            let items = app.sessions.visible_popup_items();
+            if let Some(item) = items.get(app.sessions.session_cursor).cloned() {
                 match item {
                     PopupItem::GroupHeader { cwd, .. } => {
-                        app.toggle_popup_group_collapse(cwd.as_deref());
-                        // Clamp cursor: collapsing may hide rows the cursor pointed at.
-                        let new_len = app.visible_popup_items().len();
-                        if new_len > 0 && app.session_cursor >= new_len {
-                            app.session_cursor = new_len - 1;
-                        }
+                        app.sessions.toggle_popup_group_collapse(cwd.as_deref());
+                        app.sessions.clamp_popup_cursor();
                     }
                     PopupItem::Session {
                         group_idx, path, ..
                     } => {
-                        let session = app.session_by_path(group_idx, &path).cloned();
+                        let session = app.sessions.session_by_path(group_idx, &path).cloned();
                         if let Some(session) = session {
                             app.navigation.popup = Popup::None;
                             let session_id = session.session_id;
-                            if let Some(node_id) =
-                                app.session_remote_node_id(&session_id).map(str::to_string)
+                            if let Some(node_id) = app
+                                .sessions
+                                .session_remote_node_id(&session_id)
+                                .map(str::to_string)
                             {
-                                app.remember_remote_session_node(&session_id, &node_id);
+                                app.sessions
+                                    .remember_remote_session_node(&session_id, &node_id);
                                 return SessionKeyAction::AttachRemoteSession {
                                     node_id,
                                     session_id,
                                 };
                             }
-                            if app.is_remote_session_id(&session_id) {
+                            if app.sessions.is_remote_session_id(&session_id) {
                                 app.set_status(
                                     LogLevel::Warn,
                                     "session",
@@ -1072,7 +1063,7 @@ pub(crate) fn apply_popup_session_key(
                                 agent_id: None,
                                 cwd: session
                                     .cwd
-                                    .or_else(|| app.session_groups[group_idx].cwd.clone()),
+                                    .or_else(|| app.sessions.session_groups[group_idx].cwd.clone()),
                             };
                         }
                     }
@@ -1089,31 +1080,17 @@ pub(crate) fn apply_popup_session_key(
             }
         }
         KeyCode::Delete => {
-            let items = app.visible_popup_items();
+            let items = app.sessions.visible_popup_items();
             if let Some(PopupItem::Session {
                 group_idx, path, ..
-            }) = items.get(app.session_cursor).cloned()
+            }) = items.get(app.sessions.session_cursor).cloned()
             {
-                let Some(session) = app.session_by_path(group_idx, &path).cloned() else {
+                let Some((session, is_remote)) =
+                    app.sessions.remove_session_at(group_idx, &path, true)
+                else {
                     return SessionKeyAction::None;
                 };
                 let sid = session.session_id;
-                let is_remote = app.is_remote_session_id(&sid);
-                // Optimistic remove
-                if path.len() == 1 {
-                    app.session_groups[group_idx].sessions.remove(path[0]);
-                } else if let Some(parent_path) = path.get(..path.len() - 1).map(Vec::from)
-                    && let Some(parent) = app.session_by_path_mut(group_idx, &parent_path)
-                    && let Some(child_idx) = path.last()
-                    && *child_idx < parent.children.len()
-                {
-                    parent.children.remove(*child_idx);
-                }
-                app.session_groups.retain(|g| !g.sessions.is_empty());
-                let new_len = app.visible_popup_items().len();
-                if new_len > 0 && app.session_cursor >= new_len {
-                    app.session_cursor = new_len - 1;
-                }
                 return if is_remote {
                     SessionKeyAction::DismissRemoteSession { session_id: sid }
                 } else {
@@ -1122,25 +1099,20 @@ pub(crate) fn apply_popup_session_key(
             }
             // Delete on a GroupHeader: no-op
         }
-        KeyCode::Backspace => {
-            app.session_filter.pop();
-            app.session_cursor = 0;
-        }
-        KeyCode::Char(c) => {
-            app.session_filter.push(c);
-            app.session_cursor = 0;
-        }
+        KeyCode::Backspace => app.sessions.popup_filter_backspace(),
+        KeyCode::Char(c) => app.sessions.popup_filter_insert(c),
         _ => {}
     }
     SessionKeyAction::None
 }
 
 pub(crate) fn apply_session_fork_toggle_key(app: &mut App, popup_items: bool) -> SessionKeyAction {
-    use crate::app::{PopupItem, StartPageItem};
+    use crate::session_state::{PopupItem, StartPageItem};
 
     let selected = if popup_items {
-        app.visible_popup_items()
-            .get(app.session_cursor)
+        app.sessions
+            .visible_popup_items()
+            .get(app.sessions.session_cursor)
             .cloned()
             .and_then(|item| match item {
                 PopupItem::Session {
@@ -1149,8 +1121,9 @@ pub(crate) fn apply_session_fork_toggle_key(app: &mut App, popup_items: bool) ->
                 _ => None,
             })
     } else {
-        app.visible_start_items()
-            .get(app.session_cursor)
+        app.sessions
+            .visible_start_items()
+            .get(app.sessions.session_cursor)
             .cloned()
             .and_then(|item| match item {
                 StartPageItem::Session {
@@ -1164,7 +1137,7 @@ pub(crate) fn apply_session_fork_toggle_key(app: &mut App, popup_items: bool) ->
         return SessionKeyAction::None;
     };
 
-    let should_load = app.toggle_session_children(group_idx, &path);
+    let should_load = app.sessions.toggle_session_children(group_idx, &path);
     if should_load {
         SessionKeyAction::LoadMoreSessions {
             group_idx,
@@ -1209,7 +1182,7 @@ fn handle_delegate_view_key(
                     cmd_tx,
                     parent_sid,
                     app.current_session_cwd(),
-                    app.agent_id.clone(),
+                    app.sessions.agent_id.clone(),
                 )?;
             }
         }
@@ -1242,7 +1215,7 @@ pub(crate) fn handle_delegate_popup_key(
                 cmd_tx,
                 session_id,
                 cwd,
-                agent_id.or_else(|| app.agent_id.clone()),
+                agent_id.or_else(|| app.sessions.agent_id.clone()),
             )?;
         }
         SessionKeyAction::NewSession
@@ -1300,7 +1273,7 @@ pub(crate) fn apply_delegate_popup_key(
                     app.pending_parent_session_id = app
                         .parent_session_id
                         .clone()
-                        .or_else(|| app.session_id.clone());
+                        .or_else(|| app.sessions.session_id.clone());
                     app.navigation.popup = Popup::None;
                     return SessionKeyAction::LoadSession {
                         session_id: sid,
@@ -1485,48 +1458,43 @@ pub(crate) fn handle_new_session_popup_key(
             app.navigation.popup = Popup::None;
         }
         KeyCode::Up => {
-            app.move_new_session_completion_selection(-1);
+            app.sessions.move_new_session_completion_selection(-1);
         }
         KeyCode::Down => {
-            app.move_new_session_completion_selection(1);
+            app.sessions.move_new_session_completion_selection(1);
         }
         KeyCode::Tab => {
             app.accept_selected_new_session_completion();
         }
         KeyCode::Left => {
-            app.new_session_cursor = app.new_session_cursor.saturating_sub(1);
+            app.sessions.move_new_session_cursor_left();
             app.refresh_new_session_completion();
         }
         KeyCode::Right => {
-            app.new_session_cursor = (app.new_session_cursor + 1).min(app.new_session_path.len());
+            app.sessions.move_new_session_cursor_right();
             app.refresh_new_session_completion();
         }
         KeyCode::Home => {
-            app.new_session_cursor = 0;
+            app.sessions.move_new_session_cursor_home();
             app.refresh_new_session_completion();
         }
         KeyCode::End => {
-            app.new_session_cursor = app.new_session_path.len();
+            app.sessions.move_new_session_cursor_end();
             app.refresh_new_session_completion();
         }
         KeyCode::Backspace => {
-            if app.new_session_cursor > 0 && !app.new_session_path.is_empty() {
-                let idx = app.new_session_cursor - 1;
-                app.new_session_path.remove(idx);
-                app.new_session_cursor = idx;
-            }
+            app.sessions.new_session_backspace();
             app.refresh_new_session_completion();
         }
         KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
-            app.new_session_path.insert(app.new_session_cursor, c);
-            app.new_session_cursor += 1;
+            app.sessions.new_session_insert(c);
             app.refresh_new_session_completion();
         }
         KeyCode::Enter => {
             if !can_send_server_commands(app) {
                 return Ok(());
             }
-            let cwd = app.normalize_new_session_path(&app.new_session_path);
+            let cwd = app.normalize_new_session_path(&app.sessions.new_session_path);
             app.navigation.popup = Popup::None;
             cmd_tx.send(Command::NewSession {
                 cwd,
@@ -1754,15 +1722,7 @@ fn switch_mode(
         mode: target.to_string(),
     })?;
 
-    if target == "review" {
-        if app.agent_mode != "review" {
-            app.mode_before_review = Some(app.agent_mode.clone());
-        }
-    } else {
-        app.mode_before_review = None;
-    }
-
-    app.agent_mode = target.to_string();
+    app.sessions.apply_mode_transition(target);
 
     save_config(app);
     Ok(())
@@ -1836,11 +1796,11 @@ fn try_execute_slash_command(
             }
             if arg.is_empty() {
                 // No arg: cycle to next mode (same as Tab).
-                switch_mode(app, cmd_tx, &app.next_mode())?;
+                switch_mode(app, cmd_tx, &app.sessions.next_mode())?;
             } else {
                 match arg.as_str() {
                     "build" | "plan" => {
-                        if app.agent_mode == arg {
+                        if app.sessions.agent_mode == arg {
                             app.set_status(
                                 LogLevel::Info,
                                 "mode",
@@ -1865,7 +1825,7 @@ fn try_execute_slash_command(
             if !can_send_server_commands(app) {
                 return Ok(SlashResult::Handled);
             }
-            if app.agent_mode == "review" {
+            if app.sessions.agent_mode == "review" {
                 app.set_status(LogLevel::Info, "mode", "already in review mode");
             } else {
                 switch_mode(app, cmd_tx, "review")?;
@@ -1945,9 +1905,7 @@ fn try_execute_slash_command(
                 return Ok(SlashResult::Handled);
             }
             app.navigation.popup = Popup::SessionSelect;
-            app.session_popup_tab = 0;
-            app.session_cursor = 0;
-            app.session_filter.clear();
+            app.sessions.reset_browser_for_open();
             if let Some(request) = app.begin_session_discovery() {
                 cmd_tx.send(request)?;
             }
@@ -2421,8 +2379,8 @@ pub(crate) fn handle_model_popup_key(
                     .models
                     .model_popup_is_session_tab(app.models.model_popup_agent_tab)
                 {
-                    if !app.current_session_is_remote() {
-                        if let Some(session_id) = app.session_id.clone() {
+                    if !app.sessions.current_session_is_remote() {
+                        if let Some(session_id) = app.sessions.session_id.clone() {
                             cmd_tx.send(Command::SetSessionModel {
                                 session_id,
                                 model_id: model.id.clone(),
@@ -2448,7 +2406,7 @@ pub(crate) fn handle_model_popup_key(
                     app.models
                         .set_delegate_model_preference(&profile_id, &agent_id, &model);
                     if app.parent_session_id.is_none()
-                        && let Some(session_id) = app.session_id.clone()
+                        && let Some(session_id) = app.sessions.session_id.clone()
                     {
                         cmd_tx.send(Command::SetDelegateModel {
                             session_id,
@@ -2480,7 +2438,7 @@ pub(crate) fn handle_model_popup_key(
                 app.models
                     .clear_delegate_model_preference(&profile_id, &agent_id);
                 if app.parent_session_id.is_none()
-                    && let Some(session_id) = app.session_id.clone()
+                    && let Some(session_id) = app.sessions.session_id.clone()
                 {
                     cmd_tx.send(Command::SetDelegateModel {
                         session_id,
@@ -2544,55 +2502,43 @@ pub(crate) fn apply_sessions_key(
     app: &mut App,
     key: crossterm::event::KeyCode,
 ) -> SessionKeyAction {
-    use crate::app::StartPageItem;
+    use crate::session_state::StartPageItem;
 
     match key {
-        KeyCode::Up => {
-            app.session_cursor = app.session_cursor.saturating_sub(1);
-            // Adjust scroll if needed (draw_start also does this, but keeping
-            // state consistent here means tests don't need a frame).
-            if app.session_cursor < app.start_page_scroll {
-                app.start_page_scroll = app.session_cursor;
-            }
-        }
-        KeyCode::Down => {
-            // Button slot is one past the last item (items.len()).
-            let max = app.visible_start_items().len(); // inclusive: button slot
-            if app.session_cursor < max {
-                app.session_cursor += 1;
-            }
-        }
+        KeyCode::Up => app.sessions.move_start_cursor_up(),
+        KeyCode::Down => app.sessions.move_start_cursor_down(),
         KeyCode::Enter => {
-            let items = app.visible_start_items();
+            let items = app.sessions.visible_start_items();
             // Cursor on the button slot (one past the last item)?
-            if app.session_cursor == items.len() {
+            if app.sessions.session_cursor == items.len() {
                 return SessionKeyAction::NewSession;
             }
-            if let Some(item) = items.get(app.session_cursor).cloned() {
+            if let Some(item) = items.get(app.sessions.session_cursor).cloned() {
                 match item {
                     StartPageItem::GroupHeader { cwd, .. } => {
-                        app.toggle_group_collapse(cwd.as_deref());
-                        // Clamp cursor after collapse may hide rows.
-                        let new_len = app.visible_start_items().len();
-                        if new_len > 0 && app.session_cursor >= new_len {
-                            app.session_cursor = new_len - 1;
-                        }
+                        app.sessions.toggle_group_collapse(cwd.as_deref());
+                        app.sessions.clamp_start_cursor();
                     }
                     StartPageItem::Session {
                         group_idx, path, ..
                     } => {
-                        if let Some(session) = app.session_by_path(group_idx, &path).cloned() {
+                        if let Some(session) =
+                            app.sessions.session_by_path(group_idx, &path).cloned()
+                        {
                             let session_id = session.session_id;
-                            if let Some(node_id) =
-                                app.session_remote_node_id(&session_id).map(str::to_string)
+                            if let Some(node_id) = app
+                                .sessions
+                                .session_remote_node_id(&session_id)
+                                .map(str::to_string)
                             {
-                                app.remember_remote_session_node(&session_id, &node_id);
+                                app.sessions
+                                    .remember_remote_session_node(&session_id, &node_id);
                                 return SessionKeyAction::AttachRemoteSession {
                                     node_id,
                                     session_id,
                                 };
                             }
-                            if app.is_remote_session_id(&session_id) {
+                            if app.sessions.is_remote_session_id(&session_id) {
                                 app.set_status(
                                     LogLevel::Warn,
                                     "session",
@@ -2605,45 +2551,29 @@ pub(crate) fn apply_sessions_key(
                                 agent_id: None,
                                 cwd: session
                                     .cwd
-                                    .or_else(|| app.session_groups[group_idx].cwd.clone()),
+                                    .or_else(|| app.sessions.session_groups[group_idx].cwd.clone()),
                             };
                         }
                     }
                     StartPageItem::ShowMore { .. } => {
                         app.navigation.popup = Popup::SessionSelect;
-                        app.session_popup_tab = 0;
-                        app.session_cursor = 0;
-                        app.session_filter.clear();
+                        app.sessions.reset_browser_for_open();
                     }
                 }
             }
         }
         KeyCode::Delete => {
-            let items = app.visible_start_items();
+            let items = app.sessions.visible_start_items();
             if let Some(StartPageItem::Session {
                 group_idx, path, ..
-            }) = items.get(app.session_cursor).cloned()
+            }) = items.get(app.sessions.session_cursor).cloned()
             {
-                let Some(session) = app.session_by_path(group_idx, &path).cloned() else {
+                let Some((session, is_remote)) =
+                    app.sessions.remove_session_at(group_idx, &path, false)
+                else {
                     return SessionKeyAction::None;
                 };
                 let sid = session.session_id;
-                let is_remote = app.is_remote_session_id(&sid);
-                // Optimistic remove
-                if path.len() == 1 {
-                    app.session_groups[group_idx].sessions.remove(path[0]);
-                } else if let Some(parent_path) = path.get(..path.len() - 1).map(Vec::from)
-                    && let Some(parent) = app.session_by_path_mut(group_idx, &parent_path)
-                    && let Some(child_idx) = path.last()
-                    && *child_idx < parent.children.len()
-                {
-                    parent.children.remove(*child_idx);
-                }
-                app.session_groups.retain(|g| !g.sessions.is_empty());
-                let new_len = app.visible_start_items().len();
-                if new_len > 0 && app.session_cursor >= new_len {
-                    app.session_cursor = new_len - 1;
-                }
                 return if is_remote {
                     SessionKeyAction::DismissRemoteSession { session_id: sid }
                 } else {
@@ -2652,16 +2582,8 @@ pub(crate) fn apply_sessions_key(
             }
             // Delete on a GroupHeader: no-op
         }
-        KeyCode::Backspace => {
-            app.session_filter.pop();
-            app.session_cursor = 0;
-            app.start_page_scroll = 0;
-        }
-        KeyCode::Char(c) => {
-            app.session_filter.push(c);
-            app.session_cursor = 0;
-            app.start_page_scroll = 0;
-        }
+        KeyCode::Backspace => app.sessions.start_filter_backspace(),
+        KeyCode::Char(c) => app.sessions.start_filter_insert(c),
         _ => {}
     }
     SessionKeyAction::None
@@ -2717,7 +2639,7 @@ mod model_popup_tests {
     #[test]
     fn start_page_enter_on_remote_session_attaches_instead_of_loading() {
         let mut app = App::new();
-        app.session_groups = vec![SessionGroup {
+        app.sessions.session_groups = vec![SessionGroup {
             sessions: vec![SessionSummary {
                 session_id: "remote-1".into(),
                 node_id: Some("node-1".into()),
@@ -2726,7 +2648,7 @@ mod model_popup_tests {
             }],
             ..Default::default()
         }];
-        app.session_cursor = 1;
+        app.sessions.session_cursor = 1;
 
         let action = apply_sessions_key(&mut app, KeyCode::Enter);
 
@@ -2743,7 +2665,7 @@ mod model_popup_tests {
     fn popup_enter_on_remote_session_attaches_instead_of_loading() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![SessionGroup {
+        app.sessions.session_groups = vec![SessionGroup {
             sessions: vec![SessionSummary {
                 session_id: "remote-1".into(),
                 node_id: Some("node-1".into()),
@@ -2752,7 +2674,7 @@ mod model_popup_tests {
             }],
             ..Default::default()
         }];
-        app.session_cursor = 1;
+        app.sessions.session_cursor = 1;
 
         let action = apply_popup_session_key(&mut app, KeyCode::Enter);
 
@@ -2796,11 +2718,11 @@ mod model_popup_tests {
     fn help_popup_routes_scroll_and_escape_before_screen_keys() {
         let mut app = App::new();
         app.navigation.open_help();
-        app.session_filter = "keep".into();
+        app.sessions.session_filter = "keep".into();
         let (tx, _rx) = mpsc::unbounded_channel();
 
         handle_key(&mut app, key(KeyCode::Char('x')), &tx).unwrap();
-        assert_eq!(app.session_filter, "keep");
+        assert_eq!(app.sessions.session_filter, "keep");
         assert_eq!(app.navigation.popup, Popup::Help);
 
         handle_key(&mut app, key(KeyCode::Down), &tx).unwrap();
@@ -3122,7 +3044,7 @@ mod model_popup_tests {
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
         app.navigation.popup = Popup::ProfileSelect;
-        app.session_id = Some("session".into());
+        app.sessions.session_id = Some("session".into());
         app.profiles
             .bind_session_profile("session".into(), "current".into());
         app.profiles.profiles = vec![make_profile("fast", "Fast")];
@@ -3140,8 +3062,8 @@ mod model_popup_tests {
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
         app.navigation.popup = Popup::NewSession;
-        app.new_session_path = "/repo".into();
-        app.new_session_cursor = app.new_session_path.len();
+        app.sessions.new_session_path = "/repo".into();
+        app.sessions.new_session_cursor = app.sessions.new_session_path.len();
         app.profiles.active_profile_id = Some("coder-delegate".into());
 
         let (tx, mut rx) = mpsc::unbounded_channel();
@@ -3159,11 +3081,11 @@ mod model_popup_tests {
         let _guard = TestPersistenceGuard::new("delegate-tab");
         let mut app = App::new();
         app.navigation.popup = Popup::ModelSelect;
-        app.session_id = Some("s1".into());
+        app.sessions.session_id = Some("s1".into());
         app.profiles.active_profile_id = Some("profile".into());
         app.profiles
             .bind_session_profile("s1".into(), "profile".into());
-        app.agent_mode = "plan".into();
+        app.sessions.agent_mode = "plan".into();
         app.models.current_provider = Some("openai".into());
         app.models.current_model = Some("gpt-4o".into());
         app.models.agents = vec![make_agent("main", "Main"), make_agent("coder", "Coder")];
@@ -3212,7 +3134,7 @@ mod model_popup_tests {
         let _guard = TestPersistenceGuard::new("delegate-reset");
         let mut app = App::new();
         app.navigation.popup = Popup::ModelSelect;
-        app.session_id = Some("s1".into());
+        app.sessions.session_id = Some("s1".into());
         app.profiles.active_profile_id = Some("profile".into());
         app.profiles
             .bind_session_profile("s1".into(), "profile".into());
@@ -3249,7 +3171,7 @@ mod model_popup_tests {
         let _guard = TestPersistenceGuard::new("delegate-child-model");
         let mut app = App::new();
         app.navigation.popup = Popup::ModelSelect;
-        app.session_id = Some("child".into());
+        app.sessions.session_id = Some("child".into());
         app.parent_session_id = Some("parent".into());
         app.profiles.active_profile_id = Some("profile".into());
         app.profiles
@@ -3278,8 +3200,8 @@ mod model_popup_tests {
         let _guard = TestPersistenceGuard::new("active-mode");
         let mut app = App::new();
         app.navigation.popup = Popup::ModelSelect;
-        app.session_id = Some("s1".into());
-        app.agent_mode = "build".into();
+        app.sessions.session_id = Some("s1".into());
+        app.sessions.agent_mode = "build".into();
         app.models.current_provider = Some("openai".into());
         app.models.current_model = Some("gpt-4o".into());
         app.models.reasoning_effort = Some("high".into());
@@ -3321,8 +3243,8 @@ mod model_popup_tests {
         let _guard = TestPersistenceGuard::new("remote-mesh-model");
         let mut app = App::new();
         app.navigation.popup = Popup::ModelSelect;
-        app.session_id = Some("s1".into());
-        app.agent_mode = "build".into();
+        app.sessions.session_id = Some("s1".into());
+        app.sessions.agent_mode = "build".into();
         app.models.current_provider = Some("openai".into());
         app.models.current_model = Some("gpt-4o".into());
         app.models.models = vec![
@@ -3373,9 +3295,9 @@ mod model_popup_tests {
         let _guard = TestPersistenceGuard::new("active-remote-mode");
         let mut app = App::new();
         app.navigation.popup = Popup::ModelSelect;
-        app.session_id = Some("remote-1".into());
-        app.agent_mode = "build".into();
-        app.session_groups = vec![SessionGroup {
+        app.sessions.session_id = Some("remote-1".into());
+        app.sessions.agent_mode = "build".into();
+        app.sessions.session_groups = vec![SessionGroup {
             sessions: vec![SessionSummary {
                 session_id: "remote-1".into(),
                 node_id: Some("node-1".into()),
@@ -3402,7 +3324,7 @@ mod model_popup_tests {
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
         app.navigation.screen = Screen::Chat;
-        app.agent_mode = "review".into();
+        app.sessions.agent_mode = "review".into();
         app.models.current_provider = Some("openai".into());
         app.models.current_model = Some("gpt-4o".into());
         app.models.models = vec![make_model("openai", "gpt-4o")];
@@ -3423,7 +3345,7 @@ mod model_popup_tests {
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
         app.navigation.screen = Screen::Chat;
-        app.agent_mode = "review".into();
+        app.sessions.agent_mode = "review".into();
         app.models.current_provider = Some("openai".into());
         app.models.current_model = Some("gpt-4o".into());
         app.models.models = vec![make_model("openai", "gpt-4o")];
@@ -3448,15 +3370,15 @@ mod model_popup_tests {
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
         app.navigation.screen = Screen::Chat;
-        app.agent_mode = "plan".into();
+        app.sessions.agent_mode = "plan".into();
         app.input = "/review".into();
         app.input_cursor = app.input.len();
 
         let (tx, mut rx) = mpsc::unbounded_channel();
         let action = handle_chat_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
         assert!(matches!(action, AppAction::None));
-        assert_eq!(app.agent_mode, "review");
-        assert_eq!(app.mode_before_review.as_deref(), Some("plan"));
+        assert_eq!(app.sessions.agent_mode, "review");
+        assert_eq!(app.sessions.mode_before_review.as_deref(), Some("plan"));
         assert!(matches!(
             rx.try_recv().expect("expected SetAgentMode(review)"),
             Command::SetAgentMode { mode } if mode == "review"
@@ -3464,8 +3386,8 @@ mod model_popup_tests {
         assert!(rx.try_recv().is_err());
 
         handle_key(&mut app, key(KeyCode::Tab), &tx).unwrap();
-        assert_eq!(app.agent_mode, "plan");
-        assert_eq!(app.mode_before_review, None);
+        assert_eq!(app.sessions.agent_mode, "plan");
+        assert_eq!(app.sessions.mode_before_review, None);
         assert!(matches!(
             rx.try_recv().expect("expected SetAgentMode(plan)"),
             Command::SetAgentMode { mode } if mode == "plan"
@@ -3480,7 +3402,7 @@ mod model_popup_tests {
         };
 
         let mut app = App::new();
-        app.agent_id = Some("planner".into());
+        app.sessions.agent_id = Some("planner".into());
         app.navigation.popup = Popup::SessionSelect;
         app.delegate_entries.push(DelegateEntry {
             delegation_id: "del-1".into(),
@@ -3515,16 +3437,16 @@ mod model_popup_tests {
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
         app.navigation.screen = Screen::Chat;
-        app.agent_mode = "review".into();
-        app.mode_before_review = Some("plan".into());
+        app.sessions.agent_mode = "review".into();
+        app.sessions.mode_before_review = Some("plan".into());
         app.input = "/review".into();
         app.input_cursor = app.input.len();
 
         let (tx, mut rx) = mpsc::unbounded_channel();
         let action = handle_chat_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
         assert!(matches!(action, AppAction::None));
-        assert_eq!(app.agent_mode, "review");
-        assert_eq!(app.mode_before_review.as_deref(), Some("plan"));
+        assert_eq!(app.sessions.agent_mode, "review");
+        assert_eq!(app.sessions.mode_before_review.as_deref(), Some("plan"));
         assert!(rx.try_recv().is_err());
         assert_eq!(app.diagnostics.status, "already in review mode");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ mod protocol;
 pub mod runtime;
 mod server_manager;
 mod session;
+mod session_state;
 mod slash;
 mod theme;
 mod themes_gen;

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -59,7 +59,7 @@ impl App {
 
     pub fn apply_remote_sessions(&mut self, list: RemoteSessionListInfo) {
         for session in &list.sessions {
-            self.remember_remote_session_location(
+            self.sessions.remember_remote_session_location(
                 &session.id,
                 &session.node_id,
                 session.cwd.clone(),
@@ -81,14 +81,15 @@ impl App {
     ) -> Vec<Command> {
         // ACP session/load is authoritative for history and typed config; applying this
         // extension snapshot/config directly would duplicate replay or configuration.
-        self.remember_remote_session_node(&attached.session_id, &attached.node_id);
+        self.sessions
+            .remember_remote_session_node(&attached.session_id, &attached.node_id);
         if attached.attached {
             self.navigation.popup = Popup::None;
             self.set_status(LogLevel::Info, "mesh", "remote session attached");
             Command::load_session_commands(
                 attached.session_id.clone(),
-                self.session_remote_cwd(&attached.session_id),
-                self.agent_id.clone(),
+                self.sessions.session_remote_cwd(&attached.session_id),
+                self.sessions.agent_id.clone(),
             )
             .into()
         } else {

--- a/src/runtime/event_loop.rs
+++ b/src/runtime/event_loop.rs
@@ -30,17 +30,17 @@ fn send_command(cmd_tx: &mpsc::UnboundedSender<Command>, command: Command) -> an
 }
 
 fn reconnect_session_commands(app: &mut App) -> Vec<Command> {
-    let Some(session_id) = app.session_id.clone() else {
+    let Some(session_id) = app.sessions.session_id.clone() else {
         return Vec::new();
     };
 
-    if let Some(node_id) = app.session_remote_node_id(&session_id) {
+    if let Some(node_id) = app.sessions.session_remote_node_id(&session_id) {
         return vec![Command::AttachRemoteSession {
             node_id: node_id.to_string(),
             session_id,
         }];
     }
-    if app.is_remote_session_id(&session_id) {
+    if app.sessions.is_remote_session_id(&session_id) {
         app.set_status(
             LogLevel::Warn,
             "session",
@@ -49,8 +49,12 @@ fn reconnect_session_commands(app: &mut App) -> Vec<Command> {
         return Vec::new();
     }
 
-    Command::load_session_commands(session_id, app.current_session_cwd(), app.agent_id.clone())
-        .into()
+    Command::load_session_commands(
+        session_id,
+        app.current_session_cwd(),
+        app.sessions.agent_id.clone(),
+    )
+    .into()
 }
 
 pub(super) async fn run_loop(
@@ -218,8 +222,12 @@ mod tests {
     #[test]
     fn reconnect_attaches_remembered_remote_session_without_loading() {
         let mut app = App::new();
-        app.session_id = Some("remote-1".into());
-        app.remember_remote_session_location("remote-1", "node-1", Some("/remote/repo".into()));
+        app.sessions.session_id = Some("remote-1".into());
+        app.sessions.remember_remote_session_location(
+            "remote-1",
+            "node-1",
+            Some("/remote/repo".into()),
+        );
 
         assert_eq!(
             reconnect_session_commands(&mut app),
@@ -233,8 +241,8 @@ mod tests {
     #[test]
     fn reconnect_warns_for_remote_session_missing_node() {
         let mut app = App::new();
-        app.session_id = Some("remote-1".into());
-        app.session_groups = vec![crate::domain::session::SessionGroup {
+        app.sessions.session_id = Some("remote-1".into());
+        app.sessions.session_groups = vec![crate::domain::session::SessionGroup {
             sessions: vec![crate::domain::session::SessionSummary {
                 session_id: "remote-1".into(),
                 node: Some("remote".into()),
@@ -250,8 +258,8 @@ mod tests {
     #[test]
     fn reconnect_loads_and_subscribes_local_session() {
         let mut app = App::new();
-        app.session_id = Some("local-1".into());
-        app.agent_id = Some("agent-1".into());
+        app.sessions.session_id = Some("local-1".into());
+        app.sessions.agent_id = Some("agent-1".into());
         app.launch_cwd = Some("/local/repo".into());
 
         assert_eq!(

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -85,7 +85,7 @@ mod tests {
     fn make_app_with_elicitation(state: ElicitationState) -> App {
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
-        app.session_id = Some("sess-1".into());
+        app.sessions.session_id = Some("sess-1".into());
         app.messages.push(ChatEntry::Elicitation {
             elicitation_id: state.elicitation_id.clone(),
             message: state.message.clone(),
@@ -883,8 +883,8 @@ mod external_editor_tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
-        app.session_id = Some("s1".into());
-        app.agent_mode = "build".into();
+        app.sessions.session_id = Some("s1".into());
+        app.sessions.agent_mode = "build".into();
         app.input = "/mode".into();
         app.input_cursor = "/mode".len();
 
@@ -895,7 +895,7 @@ mod external_editor_tests {
         )
         .unwrap();
 
-        assert_eq!(app.agent_mode, "plan");
+        assert_eq!(app.sessions.agent_mode, "plan");
         assert!(app.input.is_empty());
         // SetAgentMode should have been sent
         assert!(matches!(
@@ -912,8 +912,8 @@ mod external_editor_tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
-        app.session_id = Some("s1".into());
-        app.agent_mode = "build".into();
+        app.sessions.session_id = Some("s1".into());
+        app.sessions.agent_mode = "build".into();
         app.input = "/mode plan".into();
         app.input_cursor = "/mode plan".len();
 
@@ -924,7 +924,7 @@ mod external_editor_tests {
         )
         .unwrap();
 
-        assert_eq!(app.agent_mode, "plan");
+        assert_eq!(app.sessions.agent_mode, "plan");
         assert!(matches!(
             rx.try_recv().expect("SetAgentMode sent"),
             Command::SetAgentMode { mode } if mode == "plan"
@@ -937,8 +937,8 @@ mod external_editor_tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
-        app.session_id = Some("s1".into());
-        app.agent_mode = "build".into();
+        app.sessions.session_id = Some("s1".into());
+        app.sessions.agent_mode = "build".into();
         app.input = "/mode build".into();
         app.input_cursor = "/mode build".len();
 
@@ -949,7 +949,7 @@ mod external_editor_tests {
         )
         .unwrap();
 
-        assert_eq!(app.agent_mode, "build");
+        assert_eq!(app.sessions.agent_mode, "build");
         assert!(app.diagnostics.status.contains("already in build"));
     }
 
@@ -959,7 +959,7 @@ mod external_editor_tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
-        app.session_id = Some("s1".into());
+        app.sessions.session_id = Some("s1".into());
         app.input = "/mode xyz".into();
         app.input_cursor = "/mode xyz".len();
 
@@ -981,7 +981,7 @@ mod external_editor_tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
-        app.session_id = Some("s1".into());
+        app.sessions.session_id = Some("s1".into());
         app.input = "/thinking high".into();
         app.input_cursor = "/thinking high".len();
 
@@ -1007,7 +1007,7 @@ mod external_editor_tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
-        app.session_id = Some("s1".into());
+        app.sessions.session_id = Some("s1".into());
         app.models.reasoning_effort = Some("max".into());
         app.input = "/thinking auto".into();
         app.input_cursor = "/thinking auto".len();
@@ -1034,7 +1034,7 @@ mod external_editor_tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
-        app.session_id = Some("s1".into());
+        app.sessions.session_id = Some("s1".into());
         app.input = "/thinking med".into();
         app.input_cursor = "/thinking med".len();
 
@@ -1270,7 +1270,7 @@ mod external_editor_tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
-        app.session_id = Some("s1".into());
+        app.sessions.session_id = Some("s1".into());
         app.input = "/model sonnet".into();
         app.input_cursor = "/model sonnet".len();
 
@@ -1292,7 +1292,7 @@ mod external_editor_tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
-        app.session_id = Some("s1".into());
+        app.sessions.session_id = Some("s1".into());
         app.input = "/model".into();
         app.input_cursor = "/model".len();
 
@@ -1511,7 +1511,7 @@ pub async fn run() -> anyhow::Result<()> {
         }
     }
     if let Some(session_id) = cli.session.clone() {
-        app.session_id = Some(session_id);
+        app.sessions.session_id = Some(session_id);
         app.navigation.screen = Screen::Chat;
     }
     // -- ACP auto-start ---------------------------------------------------------
@@ -1606,7 +1606,7 @@ pub async fn run() -> anyhow::Result<()> {
 
     terminal::leave(&mut terminal)?;
 
-    if let Some(session_id) = &app.session_id {
+    if let Some(session_id) = &app.sessions.session_id {
         eprintln!("{}", restore_hint(session_id));
     }
 
@@ -1670,41 +1670,41 @@ mod sessions_key_tests {
     #[test]
     fn down_moves_cursor_forward() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
         // items: [GroupHeader, Session(s1), Session(s2)]
-        assert_eq!(app.session_cursor, 0);
+        assert_eq!(app.sessions.session_cursor, 0);
         apply_sessions_key(&mut app, KeyCode::Down);
-        assert_eq!(app.session_cursor, 1);
+        assert_eq!(app.sessions.session_cursor, 1);
         apply_sessions_key(&mut app, KeyCode::Down);
-        assert_eq!(app.session_cursor, 2);
+        assert_eq!(app.sessions.session_cursor, 2);
     }
 
     #[test]
     fn down_from_last_item_reaches_button_slot() {
         let mut app = App::new();
         // items: [GroupHeader(0), Session(1)] → button slot = 2
-        app.session_groups = vec![make_group(Some("/a"), &["s1"])];
-        app.session_cursor = 1; // last item (Session s1)
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
+        app.sessions.session_cursor = 1; // last item (Session s1)
         apply_sessions_key(&mut app, KeyCode::Down);
-        assert_eq!(app.session_cursor, 2); // moved to button slot
+        assert_eq!(app.sessions.session_cursor, 2); // moved to button slot
     }
 
     #[test]
     fn up_moves_cursor_back() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
-        app.session_cursor = 2;
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
+        app.sessions.session_cursor = 2;
         apply_sessions_key(&mut app, KeyCode::Up);
-        assert_eq!(app.session_cursor, 1);
+        assert_eq!(app.sessions.session_cursor, 1);
     }
 
     #[test]
     fn up_does_not_go_below_zero() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["s1"])];
-        app.session_cursor = 0;
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
+        app.sessions.session_cursor = 0;
         apply_sessions_key(&mut app, KeyCode::Up);
-        assert_eq!(app.session_cursor, 0);
+        assert_eq!(app.sessions.session_cursor, 0);
     }
 
     // ── Enter on GroupHeader toggles collapse ─────────────────────────────────
@@ -1712,22 +1712,22 @@ mod sessions_key_tests {
     #[test]
     fn enter_on_header_collapses_group() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["s1"])];
-        app.session_cursor = 0; // on the header
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
+        app.sessions.session_cursor = 0; // on the header
         let action = apply_sessions_key(&mut app, KeyCode::Enter);
         assert_eq!(action, SessionKeyAction::None);
-        assert!(app.collapsed_groups.contains("/a"));
+        assert!(app.sessions.collapsed_groups.contains("/a"));
     }
 
     #[test]
     fn enter_on_collapsed_header_expands_group() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["s1"])];
-        app.collapsed_groups.insert("/a".to_string());
-        app.session_cursor = 0; // on the header
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
+        app.sessions.collapsed_groups.insert("/a".to_string());
+        app.sessions.session_cursor = 0; // on the header
         let action = apply_sessions_key(&mut app, KeyCode::Enter);
         assert_eq!(action, SessionKeyAction::None);
-        assert!(!app.collapsed_groups.contains("/a"));
+        assert!(!app.sessions.collapsed_groups.contains("/a"));
     }
 
     // ── Enter on Session loads it ─────────────────────────────────────────────
@@ -1736,9 +1736,9 @@ mod sessions_key_tests {
     fn enter_on_session_emits_one_load_and_one_subscribe() {
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
-        app.agent_id = Some("agent-1".into());
-        app.session_groups = vec![make_group(Some("/a"), &["abc12345"])];
-        app.session_cursor = 1;
+        app.sessions.agent_id = Some("agent-1".into());
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["abc12345"])];
+        app.sessions.session_cursor = 1;
         let (tx, mut rx) = mpsc::unbounded_channel();
 
         handle_sessions_key(
@@ -1764,9 +1764,9 @@ mod sessions_key_tests {
     #[test]
     fn enter_on_remote_label_without_node_id_is_noop() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["remote-1"])];
-        app.session_groups[0].sessions[0].node = Some("remote node".into());
-        app.session_cursor = 1;
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["remote-1"])];
+        app.sessions.session_groups[0].sessions[0].node = Some("remote node".into());
+        app.sessions.session_cursor = 1;
 
         let action = apply_sessions_key(&mut app, KeyCode::Enter);
 
@@ -1776,9 +1776,9 @@ mod sessions_key_tests {
     #[test]
     fn enter_on_remote_session_remembers_node_id_for_reconnect() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["remote-1"])];
-        app.session_groups[0].sessions[0].node_id = Some("node-1".into());
-        app.session_cursor = 1;
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["remote-1"])];
+        app.sessions.session_groups[0].sessions[0].node_id = Some("node-1".into());
+        app.sessions.session_cursor = 1;
 
         let action = apply_sessions_key(&mut app, KeyCode::Enter);
 
@@ -1789,15 +1789,18 @@ mod sessions_key_tests {
                 session_id: "remote-1".into(),
             }
         );
-        assert_eq!(app.session_remote_node_id("remote-1"), Some("node-1"));
+        assert_eq!(
+            app.sessions.session_remote_node_id("remote-1"),
+            Some("node-1")
+        );
     }
 
     #[test]
     fn delete_on_remote_session_returns_dismiss_action_and_removes() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["remote-1", "s2"])];
-        app.session_groups[0].sessions[0].node_id = Some("node-1".into());
-        app.session_cursor = 1;
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["remote-1", "s2"])];
+        app.sessions.session_groups[0].sessions[0].node_id = Some("node-1".into());
+        app.sessions.session_cursor = 1;
 
         let action = apply_sessions_key(&mut app, KeyCode::Delete);
 
@@ -1807,16 +1810,16 @@ mod sessions_key_tests {
                 session_id: "remote-1".into()
             }
         );
-        assert_eq!(app.session_groups[0].sessions.len(), 1);
-        assert_eq!(app.session_groups[0].sessions[0].session_id, "s2");
+        assert_eq!(app.sessions.session_groups[0].sessions.len(), 1);
+        assert_eq!(app.sessions.session_groups[0].sessions[0].session_id, "s2");
     }
 
     #[test]
     fn enter_on_expandable_root_returns_load_action() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["root"])];
-        app.session_groups[0].sessions[0].fork_count = 1;
-        app.session_cursor = 1;
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["root"])];
+        app.sessions.session_groups[0].sessions[0].fork_count = 1;
+        app.sessions.session_cursor = 1;
 
         let action = apply_sessions_key(&mut app, KeyCode::Enter);
 
@@ -1828,15 +1831,15 @@ mod sessions_key_tests {
                 cwd: Some("/a".to_string()),
             }
         );
-        assert!(!app.expanded_session_children.contains("root"));
+        assert!(!app.sessions.expanded_session_children.contains("root"));
     }
 
     #[test]
     fn ctrl_o_on_expandable_root_requests_children() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["root"])];
-        app.session_groups[0].sessions[0].fork_count = 1;
-        app.session_cursor = 1;
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["root"])];
+        app.sessions.session_groups[0].sessions[0].fork_count = 1;
+        app.sessions.session_cursor = 1;
         let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
 
         handle_sessions_key(
@@ -1846,7 +1849,7 @@ mod sessions_key_tests {
         )
         .unwrap();
 
-        assert!(app.expanded_session_children.contains("root"));
+        assert!(app.sessions.expanded_session_children.contains("root"));
         assert!(matches!(
             cmd_rx.try_recv(),
             Ok(Command::ListSessionChildren {
@@ -1859,10 +1862,12 @@ mod sessions_key_tests {
     #[test]
     fn ctrl_o_on_expanded_root_collapses_without_loading_session() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["root"])];
-        app.session_groups[0].sessions[0].fork_count = 1;
-        app.expanded_session_children.insert("root".to_string());
-        app.session_cursor = 1;
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["root"])];
+        app.sessions.session_groups[0].sessions[0].fork_count = 1;
+        app.sessions
+            .expanded_session_children
+            .insert("root".to_string());
+        app.sessions.session_cursor = 1;
         let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
 
         handle_sessions_key(
@@ -1872,21 +1877,21 @@ mod sessions_key_tests {
         )
         .unwrap();
 
-        assert!(!app.expanded_session_children.contains("root"));
+        assert!(!app.sessions.expanded_session_children.contains("root"));
         assert!(cmd_rx.try_recv().is_err());
     }
 
     #[test]
     fn plain_o_still_filters_instead_of_toggling_forks() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["root"])];
-        app.session_groups[0].sessions[0].fork_count = 1;
-        app.session_cursor = 1;
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["root"])];
+        app.sessions.session_groups[0].sessions[0].fork_count = 1;
+        app.sessions.session_cursor = 1;
 
         apply_sessions_key(&mut app, KeyCode::Char('o'));
 
-        assert_eq!(app.session_filter, "o");
-        assert!(!app.expanded_session_children.contains("root"));
+        assert_eq!(app.sessions.session_filter, "o");
+        assert!(!app.sessions.expanded_session_children.contains("root"));
     }
 
     // ── Delete on Session removes it ─────────────────────────────────────────
@@ -1894,8 +1899,8 @@ mod sessions_key_tests {
     #[test]
     fn delete_on_session_returns_delete_action_and_removes() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
-        app.session_cursor = 1; // Session s1
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
+        app.sessions.session_cursor = 1; // Session s1
         let action = apply_sessions_key(&mut app, KeyCode::Delete);
         assert_eq!(
             action,
@@ -1904,29 +1909,29 @@ mod sessions_key_tests {
             }
         );
         // s1 removed; group still has s2
-        assert_eq!(app.session_groups[0].sessions.len(), 1);
-        assert_eq!(app.session_groups[0].sessions[0].session_id, "s2");
+        assert_eq!(app.sessions.session_groups[0].sessions.len(), 1);
+        assert_eq!(app.sessions.session_groups[0].sessions[0].session_id, "s2");
     }
 
     #[test]
     fn delete_removes_empty_group() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["only"])];
-        app.session_cursor = 1;
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["only"])];
+        app.sessions.session_cursor = 1;
         apply_sessions_key(&mut app, KeyCode::Delete);
         // Group removed entirely
-        assert!(app.session_groups.is_empty());
+        assert!(app.sessions.session_groups.is_empty());
     }
 
     #[test]
     fn delete_on_header_is_noop() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["s1"])];
-        app.session_cursor = 0; // GroupHeader
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
+        app.sessions.session_cursor = 0; // GroupHeader
         let action = apply_sessions_key(&mut app, KeyCode::Delete);
         assert_eq!(action, SessionKeyAction::None);
         // Session still there
-        assert_eq!(app.session_groups[0].sessions.len(), 1);
+        assert_eq!(app.sessions.session_groups[0].sessions.len(), 1);
     }
 
     // ── Char appends to filter and resets cursor ──────────────────────────────
@@ -1934,29 +1939,29 @@ mod sessions_key_tests {
     #[test]
     fn char_appends_to_filter_and_resets_cursor() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["s1"])];
-        app.session_cursor = 1;
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
+        app.sessions.session_cursor = 1;
         apply_sessions_key(&mut app, KeyCode::Char('x'));
-        assert_eq!(app.session_filter, "x");
-        assert_eq!(app.session_cursor, 0);
+        assert_eq!(app.sessions.session_filter, "x");
+        assert_eq!(app.sessions.session_cursor, 0);
     }
 
     #[test]
     fn backspace_removes_last_filter_char_and_resets_cursor() {
         let mut app = App::new();
-        app.session_filter = "ab".to_string();
-        app.session_cursor = 2;
+        app.sessions.session_filter = "ab".to_string();
+        app.sessions.session_cursor = 2;
         apply_sessions_key(&mut app, KeyCode::Backspace);
-        assert_eq!(app.session_filter, "a");
-        assert_eq!(app.session_cursor, 0);
+        assert_eq!(app.sessions.session_filter, "a");
+        assert_eq!(app.sessions.session_cursor, 0);
     }
 
     #[test]
     fn backspace_on_empty_filter_is_noop() {
         let mut app = App::new();
         apply_sessions_key(&mut app, KeyCode::Backspace);
-        assert_eq!(app.session_filter, "");
-        assert_eq!(app.session_cursor, 0);
+        assert_eq!(app.sessions.session_filter, "");
+        assert_eq!(app.sessions.session_cursor, 0);
     }
 
     // ── Collapse clamps cursor ────────────────────────────────────────────────
@@ -1964,8 +1969,8 @@ mod sessions_key_tests {
     #[test]
     fn collapse_clamps_cursor_when_selected_row_disappears() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
-        app.session_cursor = 2; // pointing at Session s2
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
+        app.sessions.session_cursor = 2; // pointing at Session s2
         // Collapsing /a while cursor is on s2 should clamp to the header (idx 0)
         apply_sessions_key(&mut app, KeyCode::Enter); // cursor=2 → on s2, wait...
         // Actually cursor=2 is Session s2; Enter sends LoadSession not collapse.
@@ -1973,12 +1978,12 @@ mod sessions_key_tests {
         // then collapse, then verify the previously-selected session index gets clamped.
         // Reset: cursor on header, collapse, cursor stays at 0.
         let mut app2 = App::new();
-        app2.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
-        app2.session_cursor = 0; // header
+        app2.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
+        app2.sessions.session_cursor = 0; // header
         apply_sessions_key(&mut app2, KeyCode::Enter); // collapse
         // 1 item visible (just header). cursor must be <= 0.
-        assert_eq!(app2.session_cursor, 0);
-        assert!(app2.collapsed_groups.contains("/a"));
+        assert_eq!(app2.sessions.session_cursor, 0);
+        assert!(app2.sessions.collapsed_groups.contains("/a"));
     }
 
     // ── ShowMore Enter opens session popup ────────────────────────────────────
@@ -1987,31 +1992,31 @@ mod sessions_key_tests {
     fn enter_on_show_more_opens_session_popup() {
         let mut app = App::new();
         // 4 sessions -> header(0) + 3 sessions + ShowMore(4)
-        app.session_groups = vec![make_group(Some("/a"), &["s1", "s2", "s3", "s4"])];
-        app.session_cursor = 4; // ShowMore row
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2", "s3", "s4"])];
+        app.sessions.session_cursor = 4; // ShowMore row
         let action = apply_sessions_key(&mut app, KeyCode::Enter);
         assert_eq!(action, SessionKeyAction::None);
         assert_eq!(app.navigation.popup, Popup::SessionSelect);
-        assert_eq!(app.session_cursor, 0);
-        assert!(app.session_filter.is_empty());
+        assert_eq!(app.sessions.session_cursor, 0);
+        assert!(app.sessions.session_filter.is_empty());
     }
 
     #[test]
     fn enter_on_show_more_with_backend_cursor_still_only_opens_popup() {
         let mut app = App::new();
-        app.session_groups = vec![make_group_with_cursor(
+        app.sessions.session_groups = vec![make_group_with_cursor(
             Some("/workspace/project"),
             &["s1", "s2", "s3"],
             "cursor-1",
         )];
-        app.session_cursor = 4; // ShowMore row created by next_cursor
+        app.sessions.session_cursor = 4; // ShowMore row created by next_cursor
 
         let action = apply_sessions_key(&mut app, KeyCode::Enter);
 
         assert_eq!(action, SessionKeyAction::None);
         assert_eq!(app.navigation.popup, Popup::SessionSelect);
-        assert_eq!(app.session_popup_tab, 0);
-        assert_eq!(app.session_cursor, 0);
+        assert_eq!(app.sessions.session_popup_tab, 0);
+        assert_eq!(app.sessions.session_cursor, 0);
     }
 
     // ── New Session button slot ───────────────────────────────────────────────
@@ -2021,37 +2026,37 @@ mod sessions_key_tests {
         let mut app = App::new();
         // 1 group with 1 session → items: [GroupHeader(0), Session(1)]
         // button slot = items.len() = 2
-        app.session_groups = vec![make_group(Some("/a"), &["s1"])];
-        app.session_cursor = 1; // on Session
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
+        app.sessions.session_cursor = 1; // on Session
         apply_sessions_key(&mut app, KeyCode::Down);
-        assert_eq!(app.session_cursor, 2); // on button slot
+        assert_eq!(app.sessions.session_cursor, 2); // on button slot
     }
 
     #[test]
     fn down_does_not_exceed_button_slot() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["s1"])];
-        app.session_cursor = 2; // already on button slot
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
+        app.sessions.session_cursor = 2; // already on button slot
         apply_sessions_key(&mut app, KeyCode::Down);
-        assert_eq!(app.session_cursor, 2); // stays
+        assert_eq!(app.sessions.session_cursor, 2); // stays
     }
 
     #[test]
     fn down_reaches_button_when_no_sessions() {
         let mut app = App::new();
         // No sessions → items is empty, button slot = 0
-        app.session_cursor = 0;
+        app.sessions.session_cursor = 0;
         apply_sessions_key(&mut app, KeyCode::Down);
         // items.len() == 0, button is slot 0, can't go further
-        assert_eq!(app.session_cursor, 0);
+        assert_eq!(app.sessions.session_cursor, 0);
     }
 
     #[test]
     fn enter_on_button_slot_returns_new_session() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["s1"])];
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
         // items: [GroupHeader(0), Session(1)] → button slot = 2
-        app.session_cursor = 2;
+        app.sessions.session_cursor = 2;
         let action = apply_sessions_key(&mut app, KeyCode::Enter);
         assert_eq!(action, SessionKeyAction::NewSession);
     }
@@ -2060,7 +2065,7 @@ mod sessions_key_tests {
     fn enter_on_button_slot_no_sessions_returns_new_session() {
         let mut app = App::new();
         // No items → button slot = 0
-        app.session_cursor = 0;
+        app.sessions.session_cursor = 0;
         let action = apply_sessions_key(&mut app, KeyCode::Enter);
         assert_eq!(action, SessionKeyAction::NewSession);
     }
@@ -2068,11 +2073,11 @@ mod sessions_key_tests {
     #[test]
     fn delete_on_button_slot_is_noop() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["s1"])];
-        app.session_cursor = 2; // button slot
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
+        app.sessions.session_cursor = 2; // button slot
         let action = apply_sessions_key(&mut app, KeyCode::Delete);
         assert_eq!(action, SessionKeyAction::None);
-        assert_eq!(app.session_groups[0].sessions.len(), 1); // unchanged
+        assert_eq!(app.sessions.session_groups[0].sessions.len(), 1); // unchanged
     }
 
     // ── q quits ───────────────────────────────────────────────────────────────
@@ -2121,92 +2126,92 @@ mod session_popup_key_tests {
     fn popup_down_moves_cursor_forward() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
         // visible: [GroupHeader, Session(s1), Session(s2)]
-        assert_eq!(app.session_cursor, 0);
+        assert_eq!(app.sessions.session_cursor, 0);
         apply_popup_session_key(&mut app, KeyCode::Down);
-        assert_eq!(app.session_cursor, 1);
+        assert_eq!(app.sessions.session_cursor, 1);
         apply_popup_session_key(&mut app, KeyCode::Down);
-        assert_eq!(app.session_cursor, 2);
+        assert_eq!(app.sessions.session_cursor, 2);
     }
 
     #[test]
     fn popup_down_clamps_at_last_item() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(Some("/a"), &["s1"])];
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
         // visible: [GroupHeader(0), Session(1)] — max idx = 1
-        app.session_cursor = 1;
+        app.sessions.session_cursor = 1;
         apply_popup_session_key(&mut app, KeyCode::Down);
-        assert_eq!(app.session_cursor, 1); // clamped, no button slot
+        assert_eq!(app.sessions.session_cursor, 1); // clamped, no button slot
     }
 
     #[test]
     fn popup_up_moves_cursor_back() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
-        app.session_cursor = 2;
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
+        app.sessions.session_cursor = 2;
         apply_popup_session_key(&mut app, KeyCode::Up);
-        assert_eq!(app.session_cursor, 1);
+        assert_eq!(app.sessions.session_cursor, 1);
     }
 
     #[test]
     fn popup_up_does_not_go_below_zero() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(Some("/a"), &["s1"])];
-        app.session_cursor = 0;
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
+        app.sessions.session_cursor = 0;
         apply_popup_session_key(&mut app, KeyCode::Up);
-        assert_eq!(app.session_cursor, 0);
+        assert_eq!(app.sessions.session_cursor, 0);
     }
 
     #[test]
     fn popup_page_down_uses_visible_rows_with_overlap() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(
+        app.sessions.session_groups = vec![make_group(
             Some("/a"),
             &["s1", "s2", "s3", "s4", "s5", "s6", "s7"],
         )];
-        app.session_popup_visible_rows = 4;
+        app.sessions.session_popup_visible_rows = 4;
 
         apply_popup_session_key(&mut app, KeyCode::PageDown);
-        assert_eq!(app.session_cursor, 3);
+        assert_eq!(app.sessions.session_cursor, 3);
 
         apply_popup_session_key(&mut app, KeyCode::PageDown);
-        assert_eq!(app.session_cursor, 6);
+        assert_eq!(app.sessions.session_cursor, 6);
     }
 
     #[test]
     fn popup_page_up_uses_visible_rows_with_overlap() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(
+        app.sessions.session_groups = vec![make_group(
             Some("/a"),
             &["s1", "s2", "s3", "s4", "s5", "s6", "s7"],
         )];
-        app.session_popup_visible_rows = 4;
-        app.session_cursor = 6;
+        app.sessions.session_popup_visible_rows = 4;
+        app.sessions.session_cursor = 6;
 
         apply_popup_session_key(&mut app, KeyCode::PageUp);
-        assert_eq!(app.session_cursor, 3);
+        assert_eq!(app.sessions.session_cursor, 3);
 
         apply_popup_session_key(&mut app, KeyCode::PageUp);
-        assert_eq!(app.session_cursor, 0);
+        assert_eq!(app.sessions.session_cursor, 0);
     }
 
     #[test]
     fn popup_page_keys_fallback_to_single_row_when_visible_rows_unknown() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(Some("/a"), &["s1", "s2", "s3"])];
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2", "s3"])];
 
         apply_popup_session_key(&mut app, KeyCode::PageDown);
-        assert_eq!(app.session_cursor, 1);
+        assert_eq!(app.sessions.session_cursor, 1);
 
         apply_popup_session_key(&mut app, KeyCode::PageUp);
-        assert_eq!(app.session_cursor, 0);
+        assert_eq!(app.sessions.session_cursor, 0);
     }
 
     // ── Enter on GroupHeader toggles popup collapse ───────────────────────────
@@ -2215,25 +2220,25 @@ mod session_popup_key_tests {
     fn popup_enter_on_header_collapses_group() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(Some("/a"), &["s1"])];
-        app.session_cursor = 0; // GroupHeader
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
+        app.sessions.session_cursor = 0; // GroupHeader
         let action = apply_popup_session_key(&mut app, KeyCode::Enter);
         assert_eq!(action, SessionKeyAction::None);
-        assert!(app.popup_collapsed_groups.contains("/a"));
+        assert!(app.sessions.popup_collapsed_groups.contains("/a"));
         // start-page state untouched
-        assert!(!app.collapsed_groups.contains("/a"));
+        assert!(!app.sessions.collapsed_groups.contains("/a"));
     }
 
     #[test]
     fn popup_enter_on_collapsed_header_expands_group() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(Some("/a"), &["s1"])];
-        app.popup_collapsed_groups.insert("/a".to_string());
-        app.session_cursor = 0;
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
+        app.sessions.popup_collapsed_groups.insert("/a".to_string());
+        app.sessions.session_cursor = 0;
         let action = apply_popup_session_key(&mut app, KeyCode::Enter);
         assert_eq!(action, SessionKeyAction::None);
-        assert!(!app.popup_collapsed_groups.contains("/a"));
+        assert!(!app.sessions.popup_collapsed_groups.contains("/a"));
     }
 
     #[test]
@@ -2241,13 +2246,13 @@ mod session_popup_key_tests {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
         // [GroupHeader(0), Session(s1, 1), Session(s2, 2)]
-        app.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
-        app.session_cursor = 0; // header
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
+        app.sessions.session_cursor = 0; // header
         // Collapse /a → only header remains
         apply_popup_session_key(&mut app, KeyCode::Enter);
         // Cursor must be 0 (clamped to header)
-        assert_eq!(app.session_cursor, 0);
-        assert!(app.popup_collapsed_groups.contains("/a"));
+        assert_eq!(app.sessions.session_cursor, 0);
+        assert!(app.sessions.popup_collapsed_groups.contains("/a"));
     }
 
     // ── Enter on Session loads it ─────────────────────────────────────────────
@@ -2256,8 +2261,8 @@ mod session_popup_key_tests {
     fn popup_enter_on_session_returns_load_and_closes_popup() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(Some("/a"), &["abc12345"])];
-        app.session_cursor = 1; // Session row
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["abc12345"])];
+        app.sessions.session_cursor = 1; // Session row
         let action = apply_popup_session_key(&mut app, KeyCode::Enter);
         assert_eq!(
             action,
@@ -2274,9 +2279,9 @@ mod session_popup_key_tests {
     fn popup_delete_on_remote_session_returns_dismiss_and_removes() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(Some("/a"), &["remote-1", "s2"])];
-        app.session_groups[0].sessions[0].node_id = Some("node-1".into());
-        app.session_cursor = 1;
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["remote-1", "s2"])];
+        app.sessions.session_groups[0].sessions[0].node_id = Some("node-1".into());
+        app.sessions.session_cursor = 1;
 
         let action = apply_popup_session_key(&mut app, KeyCode::Delete);
 
@@ -2286,8 +2291,8 @@ mod session_popup_key_tests {
                 session_id: "remote-1".into()
             }
         );
-        assert_eq!(app.session_groups[0].sessions.len(), 1);
-        assert_eq!(app.session_groups[0].sessions[0].session_id, "s2");
+        assert_eq!(app.sessions.session_groups[0].sessions.len(), 1);
+        assert_eq!(app.sessions.session_groups[0].sessions[0].session_id, "s2");
     }
 
     // ── Enter with all groups shows all sessions (no cap) ─────────────────────
@@ -2297,9 +2302,9 @@ mod session_popup_key_tests {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
         // 5 sessions — start page would cap at 3; popup shows all
-        app.session_groups = vec![make_group(Some("/a"), &["s1", "s2", "s3", "s4", "s5"])];
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2", "s3", "s4", "s5"])];
         // visible: [Header(0), s1(1), s2(2), s3(3), s4(4), s5(5)]
-        app.session_cursor = 5;
+        app.sessions.session_cursor = 5;
         let action = apply_popup_session_key(&mut app, KeyCode::Enter);
         assert_eq!(
             action,
@@ -2315,9 +2320,9 @@ mod session_popup_key_tests {
     fn popup_enter_on_expandable_root_loads_session() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(Some("/a"), &["root"])];
-        app.session_groups[0].sessions[0].fork_count = 1;
-        app.session_cursor = 1;
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["root"])];
+        app.sessions.session_groups[0].sessions[0].fork_count = 1;
+        app.sessions.session_cursor = 1;
 
         let action = apply_popup_session_key(&mut app, KeyCode::Enter);
 
@@ -2329,7 +2334,7 @@ mod session_popup_key_tests {
                 cwd: Some("/a".to_string()),
             }
         );
-        assert!(!app.expanded_session_children.contains("root"));
+        assert!(!app.sessions.expanded_session_children.contains("root"));
         assert_eq!(app.navigation.popup, Popup::None);
     }
 
@@ -2337,9 +2342,9 @@ mod session_popup_key_tests {
     fn popup_ctrl_o_on_expandable_root_requests_children() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(Some("/a"), &["root"])];
-        app.session_groups[0].sessions[0].fork_count = 1;
-        app.session_cursor = 1;
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["root"])];
+        app.sessions.session_groups[0].sessions[0].fork_count = 1;
+        app.sessions.session_cursor = 1;
         let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
 
         handle_session_popup_key(
@@ -2349,7 +2354,7 @@ mod session_popup_key_tests {
         )
         .unwrap();
 
-        assert!(app.expanded_session_children.contains("root"));
+        assert!(app.sessions.expanded_session_children.contains("root"));
         assert_eq!(app.navigation.popup, Popup::SessionSelect);
         assert!(matches!(
             cmd_rx.try_recv(),
@@ -2364,10 +2369,12 @@ mod session_popup_key_tests {
     fn popup_ctrl_o_on_expanded_root_collapses_without_loading_session() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(Some("/a"), &["root"])];
-        app.session_groups[0].sessions[0].fork_count = 1;
-        app.expanded_session_children.insert("root".to_string());
-        app.session_cursor = 1;
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["root"])];
+        app.sessions.session_groups[0].sessions[0].fork_count = 1;
+        app.sessions
+            .expanded_session_children
+            .insert("root".to_string());
+        app.sessions.session_cursor = 1;
         let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
 
         handle_session_popup_key(
@@ -2377,7 +2384,7 @@ mod session_popup_key_tests {
         )
         .unwrap();
 
-        assert!(!app.expanded_session_children.contains("root"));
+        assert!(!app.sessions.expanded_session_children.contains("root"));
         assert_eq!(app.navigation.popup, Popup::SessionSelect);
         assert!(cmd_rx.try_recv().is_err());
     }
@@ -2386,9 +2393,9 @@ mod session_popup_key_tests {
     fn popup_plain_o_still_filters_instead_of_toggling_forks() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(Some("/a"), &["root"])];
-        app.session_groups[0].sessions[0].fork_count = 1;
-        app.session_cursor = 1;
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["root"])];
+        app.sessions.session_groups[0].sessions[0].fork_count = 1;
+        app.sessions.session_cursor = 1;
         let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
 
         handle_session_popup_key(
@@ -2398,8 +2405,8 @@ mod session_popup_key_tests {
         )
         .unwrap();
 
-        assert_eq!(app.session_filter, "o");
-        assert!(!app.expanded_session_children.contains("root"));
+        assert_eq!(app.sessions.session_filter, "o");
+        assert!(!app.sessions.expanded_session_children.contains("root"));
         assert_eq!(app.navigation.popup, Popup::SessionSelect);
         assert!(cmd_rx.try_recv().is_err());
     }
@@ -2408,16 +2415,18 @@ mod session_popup_key_tests {
     fn popup_enter_on_expanded_child_loads_session() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(Some("/a"), &["root"])];
-        app.session_groups[0].sessions[0].fork_count = 1;
-        app.session_groups[0].sessions[0].children = vec![SessionSummary {
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["root"])];
+        app.sessions.session_groups[0].sessions[0].fork_count = 1;
+        app.sessions.session_groups[0].sessions[0].children = vec![SessionSummary {
             session_id: "child".to_string(),
             title: Some("child".to_string()),
             parent_session_id: Some("root".to_string()),
             ..Default::default()
         }];
-        app.expanded_session_children.insert("root".to_string());
-        app.session_cursor = 2;
+        app.sessions
+            .expanded_session_children
+            .insert("root".to_string());
+        app.sessions.session_cursor = 2;
 
         let action = apply_popup_session_key(&mut app, KeyCode::Enter);
 
@@ -2436,12 +2445,12 @@ mod session_popup_key_tests {
     fn popup_enter_on_load_more_returns_action_and_keeps_popup_open() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group_with_cursor(
+        app.sessions.session_groups = vec![make_group_with_cursor(
             Some("/workspace/project"),
             &["s1"],
             "cursor-1",
         )];
-        app.session_cursor = 2; // LoadMore row
+        app.sessions.session_cursor = 2; // LoadMore row
 
         let action = apply_popup_session_key(&mut app, KeyCode::Enter);
 
@@ -2461,8 +2470,8 @@ mod session_popup_key_tests {
     fn popup_delete_on_session_returns_delete_and_removes() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
-        app.session_cursor = 1; // Session s1
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
+        app.sessions.session_cursor = 1; // Session s1
         let action = apply_popup_session_key(&mut app, KeyCode::Delete);
         assert_eq!(
             action,
@@ -2470,29 +2479,29 @@ mod session_popup_key_tests {
                 session_id: "s1".to_string()
             }
         );
-        assert_eq!(app.session_groups[0].sessions.len(), 1);
-        assert_eq!(app.session_groups[0].sessions[0].session_id, "s2");
+        assert_eq!(app.sessions.session_groups[0].sessions.len(), 1);
+        assert_eq!(app.sessions.session_groups[0].sessions[0].session_id, "s2");
     }
 
     #[test]
     fn popup_delete_removes_empty_group() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(Some("/a"), &["only"])];
-        app.session_cursor = 1;
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["only"])];
+        app.sessions.session_cursor = 1;
         apply_popup_session_key(&mut app, KeyCode::Delete);
-        assert!(app.session_groups.is_empty());
+        assert!(app.sessions.session_groups.is_empty());
     }
 
     #[test]
     fn popup_delete_on_header_is_noop() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(Some("/a"), &["s1"])];
-        app.session_cursor = 0; // GroupHeader
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
+        app.sessions.session_cursor = 0; // GroupHeader
         let action = apply_popup_session_key(&mut app, KeyCode::Delete);
         assert_eq!(action, SessionKeyAction::None);
-        assert_eq!(app.session_groups[0].sessions.len(), 1);
+        assert_eq!(app.sessions.session_groups[0].sessions.len(), 1);
     }
 
     // ── Esc closes popup ──────────────────────────────────────────────────────
@@ -2511,11 +2520,11 @@ mod session_popup_key_tests {
     fn popup_char_appends_to_filter_and_resets_cursor() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(Some("/a"), &["s1"])];
-        app.session_cursor = 1;
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
+        app.sessions.session_cursor = 1;
         apply_popup_session_key(&mut app, KeyCode::Char('x'));
-        assert_eq!(app.session_filter, "x");
-        assert_eq!(app.session_cursor, 0);
+        assert_eq!(app.sessions.session_filter, "x");
+        assert_eq!(app.sessions.session_cursor, 0);
     }
 
     #[test]
@@ -2539,7 +2548,7 @@ mod session_popup_key_tests {
         .unwrap();
 
         assert_eq!(app.navigation.popup, Popup::NewSession);
-        assert_eq!(app.new_session_path, "/launch");
+        assert_eq!(app.sessions.new_session_path, "/launch");
         assert!(cmd_rx.try_recv().is_err());
     }
 
@@ -2547,7 +2556,7 @@ mod session_popup_key_tests {
     fn popup_plain_n_still_filters_instead_of_creating_session() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(Some("/a"), &["s1"])];
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
 
         let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
         handle_session_popup_key(
@@ -2558,7 +2567,7 @@ mod session_popup_key_tests {
         .unwrap();
 
         assert_eq!(app.navigation.popup, Popup::SessionSelect);
-        assert_eq!(app.session_filter, "n");
+        assert_eq!(app.sessions.session_filter, "n");
         assert!(cmd_rx.try_recv().is_err());
     }
 
@@ -2583,7 +2592,7 @@ mod session_popup_key_tests {
         .unwrap();
 
         assert_eq!(app.navigation.popup, Popup::NewSession);
-        assert_eq!(app.new_session_path, "/launch");
+        assert_eq!(app.sessions.new_session_path, "/launch");
         assert!(rx.try_recv().is_err());
     }
 
@@ -2607,7 +2616,7 @@ mod session_popup_key_tests {
         .unwrap();
 
         assert_eq!(app.navigation.popup, Popup::SessionSelect);
-        assert_eq!(app.session_popup_tab, 0);
+        assert_eq!(app.sessions.session_popup_tab, 0);
     }
 
     #[test]
@@ -2675,8 +2684,8 @@ mod session_popup_key_tests {
         app.conn = crate::app::ConnState::Connected;
         app.navigation.popup = Popup::NewSession;
         app.launch_cwd = Some("/launch".into());
-        app.new_session_path.clear();
-        app.new_session_cursor = 0;
+        app.sessions.new_session_path.clear();
+        app.sessions.new_session_cursor = 0;
 
         let (tx, mut rx) = mpsc::unbounded_channel();
         handle_new_session_popup_key(
@@ -2702,8 +2711,8 @@ mod session_popup_key_tests {
         app.conn = crate::app::ConnState::Connected;
         app.navigation.popup = Popup::NewSession;
         app.launch_cwd = Some("/launch".into());
-        app.new_session_path = "proj/subdir".into();
-        app.new_session_cursor = app.new_session_path.len();
+        app.sessions.new_session_path = "proj/subdir".into();
+        app.sessions.new_session_cursor = app.sessions.new_session_path.len();
 
         let (tx, mut rx) = mpsc::unbounded_channel();
         handle_new_session_popup_key(
@@ -2726,7 +2735,7 @@ mod session_popup_key_tests {
     fn new_session_popup_tab_accepts_selected_completion() {
         let mut app = App::new();
         app.navigation.popup = Popup::NewSession;
-        app.new_session_completion = Some(crate::app::PathCompletionState {
+        app.sessions.new_session_completion = Some(crate::session_state::PathCompletionState {
             query: "pro".into(),
             selected_index: 0,
             results: vec![crate::app::FileIndexEntryLite {
@@ -2743,8 +2752,8 @@ mod session_popup_key_tests {
         )
         .unwrap();
 
-        assert_eq!(app.new_session_path, "/launch/project/");
-        assert!(app.new_session_completion.is_none());
+        assert_eq!(app.sessions.new_session_path, "/launch/project/");
+        assert!(app.sessions.new_session_completion.is_none());
     }
 
     #[test]
@@ -2752,8 +2761,8 @@ mod session_popup_key_tests {
         let mut app = App::new();
         app.conn = crate::app::ConnState::Connected;
         app.navigation.popup = Popup::NewSession;
-        app.agent_mode = "build".into();
-        app.new_session_completion = Some(crate::app::PathCompletionState {
+        app.sessions.agent_mode = "build".into();
+        app.sessions.new_session_completion = Some(crate::session_state::PathCompletionState {
             query: "pro".into(),
             selected_index: 0,
             results: vec![crate::app::FileIndexEntryLite {
@@ -2770,9 +2779,9 @@ mod session_popup_key_tests {
         )
         .unwrap();
 
-        assert_eq!(app.new_session_path, "/launch/project/");
-        assert!(app.new_session_completion.is_none());
-        assert_eq!(app.agent_mode, "build");
+        assert_eq!(app.sessions.new_session_path, "/launch/project/");
+        assert!(app.sessions.new_session_completion.is_none());
+        assert_eq!(app.sessions.agent_mode, "build");
         assert!(rx.try_recv().is_err());
     }
 
@@ -2780,11 +2789,11 @@ mod session_popup_key_tests {
     fn popup_backspace_removes_last_filter_char_and_resets_cursor() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_filter = "ab".to_string();
-        app.session_cursor = 2;
+        app.sessions.session_filter = "ab".to_string();
+        app.sessions.session_cursor = 2;
         apply_popup_session_key(&mut app, KeyCode::Backspace);
-        assert_eq!(app.session_filter, "a");
-        assert_eq!(app.session_cursor, 0);
+        assert_eq!(app.sessions.session_filter, "a");
+        assert_eq!(app.sessions.session_cursor, 0);
     }
 
     // ── multiple groups: navigation crosses group boundaries ─────────────────
@@ -2793,16 +2802,16 @@ mod session_popup_key_tests {
     fn popup_down_crosses_group_boundary() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![
+        app.sessions.session_groups = vec![
             make_group(Some("/a"), &["s1"]),
             make_group(Some("/b"), &["s2"]),
         ];
         // visible: [Header /a (0), Session s1 (1), Header /b (2), Session s2 (3)]
-        app.session_cursor = 1; // s1
+        app.sessions.session_cursor = 1; // s1
         apply_popup_session_key(&mut app, KeyCode::Down);
-        assert_eq!(app.session_cursor, 2); // Header /b
+        assert_eq!(app.sessions.session_cursor, 2); // Header /b
         apply_popup_session_key(&mut app, KeyCode::Down);
-        assert_eq!(app.session_cursor, 3); // s2
+        assert_eq!(app.sessions.session_cursor, 3); // s2
     }
 
     // ── collapse in popup does not affect start-page navigation ──────────────
@@ -2811,13 +2820,13 @@ mod session_popup_key_tests {
     fn popup_collapse_independent_of_start_page() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(Some("/a"), &["s1"])];
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
         // collapse in popup
-        app.session_cursor = 0;
+        app.sessions.session_cursor = 0;
         apply_popup_session_key(&mut app, KeyCode::Enter);
-        assert!(app.popup_collapsed_groups.contains("/a"));
+        assert!(app.sessions.popup_collapsed_groups.contains("/a"));
         // start page state untouched
-        assert!(!app.collapsed_groups.contains("/a"));
+        assert!(!app.sessions.collapsed_groups.contains("/a"));
     }
 }
 
@@ -2847,9 +2856,9 @@ mod delegate_popup_key_tests {
 
     fn setup_delegate_app() -> App {
         let mut app = App::new();
-        app.session_id = Some("parent-1".into());
+        app.sessions.session_id = Some("parent-1".into());
         app.navigation.popup = Popup::SessionSelect;
-        app.session_popup_tab = 1;
+        app.sessions.session_popup_tab = 1;
         app.delegate_entries = vec![
             make_entry("d1", "Build feature", Some("child-1")),
             make_entry("d2", "Fix tests", Some("child-2")),
@@ -2941,7 +2950,7 @@ mod delegate_popup_key_tests {
     fn delegate_enter_noop_when_child_session_is_unavailable() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_popup_tab = 1;
+        app.sessions.session_popup_tab = 1;
         app.delegate_entries = vec![DelegateEntry {
             delegation_id: "d1".into(),
             child_session_id: None,
@@ -3021,7 +3030,7 @@ mod delegate_popup_key_tests {
         let mut app = setup_delegate_app();
         // Simulate being in a child session (parent_session_id is set).
         app.parent_session_id = Some("parent-1".into());
-        app.session_id = Some("child-old".into());
+        app.sessions.session_id = Some("child-old".into());
 
         let action = apply_delegate_popup_key(&mut app, KeyCode::Enter);
         assert!(
@@ -3179,15 +3188,15 @@ mod reasoning_effort_integration_tests {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
-        app.session_id = Some("s1".into());
-        app.agent_mode = "build".into();
+        app.sessions.session_id = Some("s1".into());
+        app.sessions.agent_mode = "build".into();
         app.models.current_provider = Some("anthropic".into());
         app.models.current_model = Some("claude-sonnet".into());
         app.models.reasoning_effort = Some("high".into());
 
         handle_key(&mut app, tab_key(), &tx).unwrap();
 
-        assert_eq!(app.agent_mode, "plan");
+        assert_eq!(app.sessions.agent_mode, "plan");
         assert_eq!(app.models.current_model.as_deref(), Some("claude-sonnet"));
         assert_eq!(app.models.reasoning_effort, Some("high".into()));
 
@@ -3212,8 +3221,8 @@ mod reasoning_effort_integration_tests {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
-        app.session_id = Some("s1".into());
-        app.agent_mode = "build".into();
+        app.sessions.session_id = Some("s1".into());
+        app.sessions.agent_mode = "build".into();
         app.models.current_provider = Some("anthropic".into());
         app.models.current_model = Some("claude-sonnet".into());
         app.models.reasoning_effort = Some("high".into());
@@ -3222,7 +3231,7 @@ mod reasoning_effort_integration_tests {
         handle_key(&mut app, tab_key(), &tx).unwrap();
 
         // Mode switched but model/effort unchanged (no cache to restore from)
-        assert_eq!(app.agent_mode, "plan");
+        assert_eq!(app.sessions.agent_mode, "plan");
         assert_eq!(app.models.reasoning_effort, Some("high".into()));
         assert_eq!(app.models.current_model.as_deref(), Some("claude-sonnet"));
         let msgs: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
@@ -3244,7 +3253,7 @@ mod reasoning_effort_integration_tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.conn = app::ConnState::Connected;
-        app.agent_mode = "plan".into();
+        app.sessions.agent_mode = "plan".into();
         app.models.model_popup_agent_tab = 0;
         app.models.current_provider = Some("anthropic".into());
         app.models.current_model = Some("claude-sonnet".into());
@@ -3280,9 +3289,9 @@ mod reasoning_effort_integration_tests {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
-        app.session_id = Some("s1".into());
+        app.sessions.session_id = Some("s1".into());
         app.navigation.popup = Popup::ModelSelect;
-        app.agent_mode = "build".into();
+        app.sessions.agent_mode = "build".into();
         app.models.model_popup_agent_tab = 0;
         app.models.current_provider = Some("anthropic".into());
         app.models.current_model = Some("claude-sonnet".into());
@@ -3322,9 +3331,9 @@ mod reasoning_effort_integration_tests {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.conn = app::ConnState::Connected;
-        app.session_id = Some("s1".into());
+        app.sessions.session_id = Some("s1".into());
         app.navigation.popup = Popup::ModelSelect;
-        app.agent_mode = "build".into();
+        app.sessions.agent_mode = "build".into();
         app.models.model_popup_agent_tab = 0;
         app.models.current_provider = Some("anthropic".into());
         app.models.current_model = Some("claude-sonnet".into());

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,447 +1,20 @@
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
 
 use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
 
-use crate::app::{
-    App, FileIndexEntryLite, MAX_RECENT_SESSIONS, MAX_VISIBLE_GROUPS, PathCompletionState,
-    PopupItem, StartPageItem,
-};
-use crate::domain::activity::{DelegateEntry, SessionActivity};
-use crate::domain::session::{SessionChildrenPage, SessionGroup, SessionSummary};
+use crate::app::{App, FileIndexEntryLite};
+use crate::domain::activity::DelegateEntry;
 use crate::navigation_state::Popup;
 
-/// Returns indices of sessions in `group` whose title or ID matches `q`.
-/// When `q` is empty every session matches in original order.
-/// When `q` is non-empty, results are sorted by fuzzy match score (best first).
-fn session_matches(session: &SessionSummary, q: &str) -> bool {
-    if q.is_empty() {
-        return true;
-    }
-    let matcher = SkimMatcherV2::default();
-    matcher
-        .fuzzy_match(session.title.as_deref().unwrap_or(""), q)
-        .is_some()
-        || matcher.fuzzy_match(&session.session_id, q).is_some()
-}
-
-fn matching_session_indices(group: &SessionGroup, q: &str) -> Vec<usize> {
-    if q.is_empty() {
-        return (0..group.sessions.len()).collect();
-    }
-    let matcher = SkimMatcherV2::default();
-    let mut scored: Vec<(i64, usize)> = group
-        .sessions
-        .iter()
-        .enumerate()
-        .filter_map(|(i, s)| {
-            let score = [
-                matcher.fuzzy_match(s.title.as_deref().unwrap_or(""), q),
-                matcher.fuzzy_match(&s.session_id, q),
-            ]
-            .into_iter()
-            .flatten()
-            .max();
-            score.map(|s| (s, i))
-        })
-        .collect();
-    scored.sort_by_key(|item| std::cmp::Reverse(item.0));
-    scored.into_iter().map(|(_, i)| i).collect()
-}
-
-fn session_by_id_mut<'a>(
-    sessions: &'a mut [SessionSummary],
-    session_id: &str,
-) -> Option<&'a mut SessionSummary> {
-    for session in sessions {
-        if session.session_id == session_id {
-            return Some(session);
-        }
-        if let Some(child) = session_by_id_mut(&mut session.children, session_id) {
-            return Some(child);
-        }
-    }
-    None
-}
-
-fn fork_browsing_child(session: &SessionSummary) -> bool {
-    session.fork_origin.as_deref() != Some("delegation")
-}
-
 impl App {
-    pub fn session_summary_by_id(&self, session_id: &str) -> Option<&SessionSummary> {
-        fn find<'a>(
-            sessions: &'a [SessionSummary],
-            session_id: &str,
-        ) -> Option<&'a SessionSummary> {
-            for session in sessions {
-                if session.session_id == session_id {
-                    return Some(session);
-                }
-                if let Some(child) = find(&session.children, session_id) {
-                    return Some(child);
-                }
-            }
-            None
-        }
-
-        self.session_groups
-            .iter()
-            .find_map(|group| find(&group.sessions, session_id))
-    }
-
-    pub fn session_parent_id(&self, session_id: &str) -> Option<&str> {
-        self.session_summary_by_id(session_id)
-            .and_then(|session| session.parent_session_id.as_deref())
-    }
-
-    pub fn remember_remote_session_location(
-        &mut self,
-        session_id: &str,
-        node_id: &str,
-        cwd: Option<String>,
-    ) {
-        let location = self
-            .remote_session_locations
-            .entry(session_id.to_string())
-            .or_default();
-        location.node_id = node_id.to_string();
-        if let Some(cwd) = cwd.filter(|cwd| !cwd.trim().is_empty()) {
-            location.cwd = Some(cwd);
-        }
-    }
-
-    pub fn remember_remote_session_node(&mut self, session_id: &str, node_id: &str) {
-        self.remember_remote_session_location(session_id, node_id, None);
-    }
-
-    pub fn session_remote_node_id(&self, session_id: &str) -> Option<&str> {
-        self.session_summary_by_id(session_id)
-            .and_then(|session| session.node_id.as_deref())
-            .or_else(|| {
-                self.remote_session_locations
-                    .get(session_id)
-                    .map(|location| location.node_id.as_str())
-            })
-    }
-
-    pub fn session_remote_cwd(&self, session_id: &str) -> Option<String> {
-        self.session_summary_by_id(session_id)
-            .filter(|session| session.node_id.is_some() || session.node.is_some())
-            .and_then(|session| session.cwd.as_deref())
-            .filter(|cwd| !cwd.trim().is_empty())
-            .map(str::to_string)
-            .or_else(|| {
-                self.remote_session_locations
-                    .get(session_id)
-                    .and_then(|location| location.cwd.as_deref())
-                    .filter(|cwd| !cwd.trim().is_empty())
-                    .map(str::to_string)
-            })
-    }
-
-    pub fn is_remote_session_id(&self, session_id: &str) -> bool {
-        self.session_remote_node_id(session_id).is_some()
-            || self
-                .session_summary_by_id(session_id)
-                .map(|session| session.node.is_some())
-                .unwrap_or(false)
-    }
-
-    pub fn current_session_is_remote(&self) -> bool {
-        self.session_id
-            .as_deref()
-            .map(|session_id| self.is_remote_session_id(session_id))
-            .unwrap_or(false)
-    }
-
     pub fn apply_session_profile_binding(&mut self, session_id: &str, profile_id: Option<String>) {
         if let Some(profile_id) = profile_id {
             self.profiles
                 .bind_session_profile(session_id.to_string(), profile_id);
-        } else if self.is_remote_session_id(session_id) {
+        } else if self.sessions.is_remote_session_id(session_id) {
             self.profiles.remove_session_profile(session_id);
         }
-    }
-
-    pub fn session_by_path(&self, group_idx: usize, path: &[usize]) -> Option<&SessionSummary> {
-        let (first, rest) = path.split_first()?;
-        let mut session = self.session_groups.get(group_idx)?.sessions.get(*first)?;
-        for idx in rest {
-            session = session.children.get(*idx)?;
-        }
-        Some(session)
-    }
-
-    pub fn session_by_path_mut(
-        &mut self,
-        group_idx: usize,
-        path: &[usize],
-    ) -> Option<&mut SessionSummary> {
-        fn descend<'a>(
-            sessions: &'a mut [SessionSummary],
-            path: &[usize],
-        ) -> Option<&'a mut SessionSummary> {
-            let (first, rest) = path.split_first()?;
-            let session = sessions.get_mut(*first)?;
-            if rest.is_empty() {
-                Some(session)
-            } else {
-                descend(&mut session.children, rest)
-            }
-        }
-        descend(&mut self.session_groups.get_mut(group_idx)?.sessions, path)
-    }
-
-    pub fn expandable_root_session(&self, group_idx: usize, path: &[usize]) -> bool {
-        let Some(session) = self.session_by_path(group_idx, path) else {
-            return false;
-        };
-        path.len() == 1
-            && session.parent_session_id.is_none()
-            && session.fork_count > 0
-            && session.node.is_none()
-            && session.node_id.is_none()
-    }
-
-    pub fn toggle_session_children(&mut self, group_idx: usize, path: &[usize]) -> bool {
-        if !self.expandable_root_session(group_idx, path) {
-            return false;
-        }
-        let Some(session) = self.session_by_path(group_idx, path) else {
-            return false;
-        };
-        let session_id = session.session_id.clone();
-        let should_load = session.children.is_empty()
-            && session.children_next_cursor.is_none()
-            && !self.pending_session_child_loads.contains(&session_id);
-        if !self.expanded_session_children.remove(&session_id) {
-            self.expanded_session_children.insert(session_id);
-            return should_load;
-        }
-        false
-    }
-
-    pub fn merge_session_children(&mut self, data: SessionChildrenPage) {
-        let remote_locations: Vec<(String, String, Option<String>)> = data
-            .sessions
-            .iter()
-            .filter_map(|session| {
-                Some((
-                    session.session_id.clone(),
-                    session.node_id.clone()?,
-                    session.cwd.clone(),
-                ))
-            })
-            .collect();
-        for (session_id, node_id, cwd) in remote_locations {
-            self.remember_remote_session_location(&session_id, &node_id, cwd);
-        }
-
-        let had_pending_request = self
-            .pending_session_child_loads
-            .remove(&data.parent_session_id);
-        if let Some(parent) = self
-            .session_groups
-            .iter_mut()
-            .find_map(|group| session_by_id_mut(&mut group.sessions, &data.parent_session_id))
-        {
-            let mut sessions: Vec<SessionSummary> = data
-                .sessions
-                .into_iter()
-                .filter(fork_browsing_child)
-                .collect();
-            let append = had_pending_request
-                && !parent.children.is_empty()
-                && parent.children_next_cursor.is_some();
-            if append {
-                let mut seen: HashSet<String> = parent
-                    .children
-                    .iter()
-                    .map(|session| session.session_id.clone())
-                    .collect();
-                parent.children.extend(
-                    sessions
-                        .into_iter()
-                        .filter(|session| seen.insert(session.session_id.clone())),
-                );
-            } else {
-                let mut seen = HashSet::new();
-                sessions.retain(|session| seen.insert(session.session_id.clone()));
-                parent.children = sessions;
-            }
-            parent.children_next_cursor = data.next_cursor;
-            parent.children_total_count = data.total_count;
-            parent.has_children = !parent.children.is_empty() || parent.fork_count > 0;
-            if let Some(total) = parent.children_total_count {
-                parent.fork_count = total;
-            }
-        }
-    }
-
-    /// Build the flat list of visible rows for the start-page session list.
-    ///
-    /// Each call re-evaluates the current `session_filter` and `collapsed_groups`.
-    /// Group headers are always included; session rows are included only when
-    /// the group is expanded *and* the session matches the filter.
-    /// Groups with zero matching sessions are omitted entirely when a filter is
-    /// active.
-    pub fn visible_start_items(&self) -> Vec<StartPageItem> {
-        let q = self.session_filter.to_lowercase();
-        let mut items = Vec::new();
-
-        let groups_iter = self
-            .session_groups
-            .iter()
-            .enumerate()
-            .take(MAX_VISIBLE_GROUPS);
-
-        for (group_idx, group) in groups_iter {
-            let collapse_key = group.cwd.clone().unwrap_or_default();
-            let collapsed = self.collapsed_groups.contains(&collapse_key);
-
-            let matching = matching_session_indices(group, &q);
-
-            // When a filter is active, skip groups with no matches entirely.
-            if !q.is_empty() && matching.is_empty() {
-                continue;
-            }
-
-            items.push(StartPageItem::GroupHeader {
-                cwd: group.cwd.clone(),
-                session_count: group.sessions.len(),
-                session_total: group.total_count,
-                collapsed,
-            });
-
-            if !collapsed {
-                // Cap at MAX_RECENT_SESSIONS and append a ShowMore row if needed.
-                let visible: Vec<usize> =
-                    matching.iter().copied().take(MAX_RECENT_SESSIONS).collect();
-                let hidden = matching.len().saturating_sub(MAX_RECENT_SESSIONS);
-
-                for session_idx in visible {
-                    let path = vec![session_idx];
-                    items.push(StartPageItem::Session {
-                        group_idx,
-                        path: path.clone(),
-                        depth: 0,
-                    });
-                    let session = &group.sessions[session_idx];
-                    if self.expanded_session_children.contains(&session.session_id) {
-                        for (child_idx, child) in session.children.iter().enumerate() {
-                            if session_matches(child, &q) {
-                                items.push(StartPageItem::Session {
-                                    group_idx,
-                                    path: vec![session_idx, child_idx],
-                                    depth: 1,
-                                });
-                            }
-                        }
-                    }
-                }
-
-                if hidden > 0 || group.next_cursor.is_some() {
-                    items.push(StartPageItem::ShowMore {
-                        group_idx,
-                        remaining: hidden,
-                        has_more: group.next_cursor.is_some(),
-                    });
-                }
-            }
-        }
-
-        items
-    }
-
-    /// Toggle the collapsed state of the group identified by `cwd`.
-    ///
-    /// `None` cwd is stored under the empty-string key so it can still be
-    /// toggled independently.
-    pub fn toggle_group_collapse(&mut self, cwd: Option<&str>) {
-        let key = cwd.unwrap_or("").to_string();
-        if !self.collapsed_groups.remove(&key) {
-            self.collapsed_groups.insert(key);
-        }
-    }
-
-    /// Toggle the collapsed state of a group *in the session popup*.
-    ///
-    /// Uses `popup_collapsed_groups` — fully independent of the start-page
-    /// `collapsed_groups` so the two views never interfere.
-    pub fn toggle_popup_group_collapse(&mut self, cwd: Option<&str>) {
-        let key = cwd.unwrap_or("").to_string();
-        if !self.popup_collapsed_groups.remove(&key) {
-            self.popup_collapsed_groups.insert(key);
-        }
-    }
-
-    /// Build the flat list of visible rows for the session popup.
-    ///
-    /// Mirrors [`visible_start_items`] but uses popup-local collapse state and
-    /// appends a per-group load-more row when the backend has another page.
-    pub fn visible_popup_items(&self) -> Vec<PopupItem> {
-        let q = self.session_filter.to_lowercase();
-        let mut items = Vec::new();
-
-        for (group_idx, group) in self.session_groups.iter().enumerate() {
-            let collapse_key = group.cwd.clone().unwrap_or_default();
-            let collapsed = self.popup_collapsed_groups.contains(&collapse_key);
-
-            let matching = matching_session_indices(group, &q);
-
-            // When a filter is active, skip groups with no matches entirely.
-            if !q.is_empty() && matching.is_empty() {
-                continue;
-            }
-
-            items.push(PopupItem::GroupHeader {
-                cwd: group.cwd.clone(),
-                session_count: group.sessions.len(),
-                session_total: group.total_count,
-                collapsed,
-            });
-
-            if !collapsed {
-                for session_idx in matching {
-                    items.push(PopupItem::Session {
-                        group_idx,
-                        path: vec![session_idx],
-                        depth: 0,
-                    });
-                    let session = &group.sessions[session_idx];
-                    if self.expanded_session_children.contains(&session.session_id) {
-                        for (child_idx, child) in session.children.iter().enumerate() {
-                            if session_matches(child, &q) {
-                                items.push(PopupItem::Session {
-                                    group_idx,
-                                    path: vec![session_idx, child_idx],
-                                    depth: 1,
-                                });
-                            }
-                        }
-                        if session.children_next_cursor.is_some() {
-                            items.push(PopupItem::LoadMore {
-                                group_idx,
-                                parent_path: vec![session_idx],
-                            });
-                        }
-                    }
-                }
-                if group.next_cursor.is_some()
-                    && !self.pending_session_group_loads.contains(&group.cwd)
-                {
-                    items.push(PopupItem::LoadMore {
-                        group_idx,
-                        parent_path: Vec::new(),
-                    });
-                }
-            }
-        }
-
-        items
     }
 
     /// Flat list of delegate entries that match `delegate_filter`.
@@ -475,8 +48,8 @@ impl App {
     }
 
     pub fn resolve_new_session_default_cwd(&self) -> Option<String> {
-        if let Some(active_session_id) = self.session_id.as_deref() {
-            for group in &self.session_groups {
+        if let Some(active_session_id) = self.sessions.session_id.as_deref() {
+            for group in &self.sessions.session_groups {
                 for session in &group.sessions {
                     if session.session_id == active_session_id {
                         if let Some(cwd) = session.cwd.as_ref().filter(|cwd| !cwd.trim().is_empty())
@@ -504,15 +77,15 @@ impl App {
 
     pub fn open_delegate_popup(&mut self) {
         self.navigation.popup = Popup::SessionSelect;
-        self.session_popup_tab = 1;
+        self.sessions.session_popup_tab = 1;
         self.delegate_cursor = 0;
         self.delegate_filter.clear();
     }
 
     pub fn open_new_session_popup(&mut self) {
         self.navigation.popup = Popup::NewSession;
-        self.new_session_path = self.resolve_new_session_default_cwd().unwrap_or_default();
-        self.new_session_cursor = self.new_session_path.chars().count();
+        self.sessions.new_session_path = self.resolve_new_session_default_cwd().unwrap_or_default();
+        self.sessions.new_session_cursor = self.sessions.new_session_path.chars().count();
         self.refresh_new_session_completion();
     }
 
@@ -665,30 +238,13 @@ impl App {
     }
 
     pub fn refresh_new_session_completion(&mut self) {
-        let query = self.new_session_path.clone();
+        let query = self.sessions.new_session_path.clone();
         let results = self.rank_path_completion_matches(&query);
-        self.new_session_completion = Some(PathCompletionState {
-            query,
-            selected_index: 0,
-            results,
-        });
-    }
-
-    pub fn move_new_session_completion_selection(&mut self, delta: isize) {
-        if let Some(completion) = self.new_session_completion.as_mut() {
-            let len = completion.results.len();
-            if len == 0 {
-                completion.selected_index = 0;
-                return;
-            }
-            let next =
-                (completion.selected_index as isize + delta).rem_euclid(len as isize) as usize;
-            completion.selected_index = next;
-        }
+        self.sessions.replace_new_session_completion(query, results);
     }
 
     pub fn accept_selected_new_session_completion(&mut self) -> bool {
-        let Some(completion) = self.new_session_completion.clone() else {
+        let Some(completion) = self.sessions.new_session_completion.clone() else {
             return false;
         };
         let Some(selected) = completion.results.get(completion.selected_index) else {
@@ -701,46 +257,15 @@ impl App {
         if selected.is_dir && !normalized.ends_with('/') {
             normalized.push('/');
         }
-        self.new_session_path = normalized;
-        self.new_session_cursor = self.new_session_path.len();
-        self.new_session_completion = None;
+        self.sessions.accept_new_session_completion(normalized);
         true
-    }
-
-    pub fn note_session_activity(&mut self, session_id: &str) {
-        self.session_activity.insert(
-            session_id.to_string(),
-            SessionActivity {
-                last_event_at: Instant::now(),
-            },
-        );
-    }
-
-    pub fn active_session_count(&self) -> usize {
-        const ACTIVE_SESSION_WINDOW: Duration = Duration::from_secs(5);
-        let now = Instant::now();
-        self.session_activity
-            .values()
-            .filter(|activity| now.duration_since(activity.last_event_at) <= ACTIVE_SESSION_WINDOW)
-            .count()
-    }
-
-    pub fn other_active_session_count(&self) -> usize {
-        const ACTIVE_SESSION_WINDOW: Duration = Duration::from_secs(5);
-        let now = Instant::now();
-        self.session_activity
-            .iter()
-            .filter(|(session_id, activity)| {
-                now.duration_since(activity.last_event_at) <= ACTIVE_SESSION_WINDOW
-                    && self.session_id.as_deref() != Some(session_id.as_str())
-            })
-            .count()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::session::{SessionChildrenPage, SessionGroup, SessionSummary};
 
     fn session(id: &str) -> SessionSummary {
         SessionSummary {
@@ -752,12 +277,20 @@ mod tests {
     #[test]
     fn remote_session_location_preserves_cwd_across_node_only_refreshes() {
         let mut app = App::new();
-        app.remember_remote_session_location("remote-1", "node-1", Some("/remote/repo".into()));
-        app.remember_remote_session_node("remote-1", "node-2");
+        app.sessions.remember_remote_session_location(
+            "remote-1",
+            "node-1",
+            Some("/remote/repo".into()),
+        );
+        app.sessions
+            .remember_remote_session_node("remote-1", "node-2");
 
-        assert_eq!(app.session_remote_node_id("remote-1"), Some("node-2"));
         assert_eq!(
-            app.session_remote_cwd("remote-1"),
+            app.sessions.session_remote_node_id("remote-1"),
+            Some("node-2")
+        );
+        assert_eq!(
+            app.sessions.session_remote_cwd("remote-1"),
             Some("/remote/repo".into())
         );
     }
@@ -771,7 +304,7 @@ mod tests {
             ..Default::default()
         }];
         app.profiles.active_profile_id = Some("fast".into());
-        app.session_id = Some("local".into());
+        app.sessions.session_id = Some("local".into());
 
         assert_eq!(app.current_profile_label(), "Fast");
 
@@ -779,8 +312,9 @@ mod tests {
             .bind_session_profile("local".into(), "unknown".into());
         assert_eq!(app.current_profile_label(), "unknown");
 
-        app.session_id = Some("remote".into());
-        app.remember_remote_session_node("remote", "node-1");
+        app.sessions.session_id = Some("remote".into());
+        app.sessions
+            .remember_remote_session_node("remote", "node-1");
         assert_eq!(app.current_profile_label(), "remote");
     }
 
@@ -809,7 +343,8 @@ mod tests {
     #[test]
     fn missing_remote_profile_removes_existing_binding() {
         let mut app = App::new();
-        app.remember_remote_session_node("remote", "node-1");
+        app.sessions
+            .remember_remote_session_node("remote", "node-1");
         app.profiles
             .bind_session_profile("remote".into(), "fast".into());
 
@@ -828,7 +363,7 @@ mod tests {
         child.children = vec![grandchild];
         let mut parent = session("parent");
         parent.children = vec![child];
-        app.session_groups = vec![
+        app.sessions.session_groups = vec![
             SessionGroup {
                 cwd: Some("/unrelated".into()),
                 sessions: vec![session("unrelated")],
@@ -841,10 +376,10 @@ mod tests {
             },
         ];
 
-        assert_eq!(app.session_parent_id("child"), Some("parent"));
-        assert_eq!(app.session_parent_id("grandchild"), Some("child"));
-        assert_eq!(app.session_parent_id("unrelated"), None);
-        assert_eq!(app.session_parent_id("missing"), None);
+        assert_eq!(app.sessions.session_parent_id("child"), Some("parent"));
+        assert_eq!(app.sessions.session_parent_id("grandchild"), Some("child"));
+        assert_eq!(app.sessions.session_parent_id("unrelated"), None);
+        assert_eq!(app.sessions.session_parent_id("missing"), None);
     }
 
     #[test]
@@ -854,26 +389,28 @@ mod tests {
         parent.children = vec![session("stale")];
         let mut root = session("root");
         root.children = vec![parent];
-        app.session_groups = vec![SessionGroup {
+        app.sessions.session_groups = vec![SessionGroup {
             cwd: Some("/repo".into()),
             sessions: vec![root],
             ..Default::default()
         }];
-        app.pending_session_child_loads.insert("parent".into());
+        app.sessions
+            .pending_session_child_loads
+            .insert("parent".into());
 
         let mut remote = session("remote-child");
         remote.node_id = Some("node-1".into());
         remote.cwd = Some("/remote/repo".into());
         let mut delegated = session("delegated-child");
         delegated.fork_origin = Some("delegation".into());
-        app.merge_session_children(SessionChildrenPage {
+        app.sessions.merge_session_children(SessionChildrenPage {
             parent_session_id: "parent".into(),
             sessions: vec![session("child-1"), remote, delegated, session("child-1")],
             next_cursor: Some("cursor-2".into()),
             total_count: Some(3),
         });
 
-        let parent = app.session_summary_by_id("parent").unwrap();
+        let parent = app.sessions.session_summary_by_id("parent").unwrap();
         assert_eq!(
             parent
                 .children
@@ -886,22 +423,27 @@ mod tests {
         assert_eq!(parent.children_total_count, Some(3));
         assert_eq!(parent.fork_count, 3);
         assert!(parent.has_children);
-        assert_eq!(app.session_remote_node_id("remote-child"), Some("node-1"));
         assert_eq!(
-            app.session_remote_cwd("remote-child"),
+            app.sessions.session_remote_node_id("remote-child"),
+            Some("node-1")
+        );
+        assert_eq!(
+            app.sessions.session_remote_cwd("remote-child"),
             Some("/remote/repo".into())
         );
-        assert!(app.pending_session_child_loads.is_empty());
+        assert!(app.sessions.pending_session_child_loads.is_empty());
 
-        app.pending_session_child_loads.insert("parent".into());
-        app.merge_session_children(SessionChildrenPage {
+        app.sessions
+            .pending_session_child_loads
+            .insert("parent".into());
+        app.sessions.merge_session_children(SessionChildrenPage {
             parent_session_id: "parent".into(),
             sessions: vec![session("remote-child"), session("child-2")],
             next_cursor: None,
             total_count: Some(3),
         });
 
-        let parent = app.session_summary_by_id("parent").unwrap();
+        let parent = app.sessions.session_summary_by_id("parent").unwrap();
         assert_eq!(
             parent
                 .children
@@ -911,14 +453,15 @@ mod tests {
             vec!["child-1", "remote-child", "child-2"]
         );
         assert_eq!(parent.children_next_cursor, None);
-        assert!(app.pending_session_child_loads.is_empty());
+        assert!(app.sessions.pending_session_child_loads.is_empty());
 
-        app.pending_session_child_loads
+        app.sessions
+            .pending_session_child_loads
             .insert("missing-parent".into());
-        app.merge_session_children(SessionChildrenPage {
+        app.sessions.merge_session_children(SessionChildrenPage {
             parent_session_id: "missing-parent".into(),
             ..Default::default()
         });
-        assert!(app.pending_session_child_loads.is_empty());
+        assert!(app.sessions.pending_session_child_loads.is_empty());
     }
 }

--- a/src/session_state.rs
+++ b/src/session_state.rs
@@ -1,0 +1,1312 @@
+use std::collections::{HashMap, HashSet};
+use std::time::{Duration, Instant};
+
+use fuzzy_matcher::FuzzyMatcher;
+use fuzzy_matcher::skim::SkimMatcherV2;
+
+use crate::app::FileIndexEntryLite;
+use crate::domain::activity::SessionActivity;
+use crate::domain::mesh::RemoteSessionLocation;
+use crate::domain::session::{SessionChildrenPage, SessionGroup, SessionSummary};
+
+/// Maximum number of recent sessions shown per group on the start page.
+pub(crate) const MAX_RECENT_SESSIONS: usize = 3;
+/// Maximum discovery-preview sessions retained before the workspace page arrives.
+pub(crate) const POPUP_SESSION_PAGE_TARGET: usize = 10;
+pub(crate) const SESSION_CHILD_PAGE_LIMIT: u32 = 10;
+/// Maximum number of workspace groups shown on the start page.
+pub(crate) const MAX_VISIBLE_GROUPS: usize = 3;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PathCompletionState {
+    pub(crate) query: String,
+    pub(crate) selected_index: usize,
+    pub(crate) results: Vec<FileIndexEntryLite>,
+}
+
+/// A single visible row on the start-page session list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum StartPageItem {
+    GroupHeader {
+        cwd: Option<String>,
+        session_count: usize,
+        session_total: Option<u64>,
+        collapsed: bool,
+    },
+    Session {
+        group_idx: usize,
+        path: Vec<usize>,
+        depth: usize,
+    },
+    ShowMore {
+        group_idx: usize,
+        remaining: usize,
+        has_more: bool,
+    },
+}
+
+/// A single visible row in the sessions popup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PopupItem {
+    GroupHeader {
+        cwd: Option<String>,
+        session_count: usize,
+        session_total: Option<u64>,
+        collapsed: bool,
+    },
+    Session {
+        group_idx: usize,
+        path: Vec<usize>,
+        depth: usize,
+    },
+    LoadMore {
+        group_idx: usize,
+        parent_path: Vec<usize>,
+    },
+}
+
+pub(crate) fn session_group_count_text(session_count: usize, session_total: Option<u64>) -> String {
+    session_total
+        .map(|total| format!("{session_count}/{total}"))
+        .unwrap_or_else(|| session_count.to_string())
+}
+
+pub(crate) struct SessionsState {
+    pub(crate) session_groups: Vec<SessionGroup>,
+    pub(crate) session_cursor: usize,
+    pub(crate) session_filter: String,
+    pub(crate) session_popup_tab: usize,
+    pub(crate) collapsed_groups: HashSet<String>,
+    pub(crate) popup_collapsed_groups: HashSet<String>,
+    pub(crate) session_discovery_in_progress: bool,
+    pub(crate) session_discovery_cursors: HashSet<String>,
+    pub(crate) pending_session_group_loads: HashSet<Option<String>>,
+    pub(crate) hydrated_session_groups: HashSet<String>,
+    pub(crate) expanded_session_children: HashSet<String>,
+    pub(crate) pending_session_child_loads: HashSet<String>,
+    pub(crate) start_page_scroll: usize,
+    pub(crate) session_popup_visible_rows: usize,
+    pub(crate) session_id: Option<String>,
+    pub(crate) agent_id: Option<String>,
+    pub(crate) agent_mode: String,
+    pub(crate) mode_before_review: Option<String>,
+    pub(crate) new_session_path: String,
+    pub(crate) new_session_cursor: usize,
+    pub(crate) new_session_completion: Option<PathCompletionState>,
+    pub(crate) session_activity: HashMap<String, SessionActivity>,
+    pub(crate) remote_session_locations: HashMap<String, RemoteSessionLocation>,
+}
+
+impl SessionsState {
+    pub(crate) fn new() -> Self {
+        Self {
+            session_groups: Vec::new(),
+            session_cursor: 0,
+            session_filter: String::new(),
+            session_popup_tab: 0,
+            collapsed_groups: HashSet::new(),
+            popup_collapsed_groups: HashSet::new(),
+            session_discovery_in_progress: false,
+            session_discovery_cursors: HashSet::new(),
+            pending_session_group_loads: HashSet::new(),
+            hydrated_session_groups: HashSet::new(),
+            expanded_session_children: HashSet::new(),
+            pending_session_child_loads: HashSet::new(),
+            start_page_scroll: 0,
+            session_popup_visible_rows: 0,
+            session_id: None,
+            agent_id: None,
+            agent_mode: "build".into(),
+            mode_before_review: None,
+            new_session_path: String::new(),
+            new_session_cursor: 0,
+            new_session_completion: None,
+            session_activity: HashMap::new(),
+            remote_session_locations: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn prepare_session_discovery(&mut self) -> bool {
+        if self.session_discovery_in_progress || !self.pending_session_group_loads.is_empty() {
+            return false;
+        }
+        self.session_groups.clear();
+        self.session_discovery_cursors.clear();
+        self.pending_session_group_loads.clear();
+        self.hydrated_session_groups.clear();
+        self.session_discovery_in_progress = true;
+        true
+    }
+
+    pub(crate) fn prepare_session_group_page(
+        &mut self,
+        group_idx: usize,
+    ) -> Option<(String, String)> {
+        let group = self.session_groups.get(group_idx)?;
+        let cursor = group.next_cursor.clone()?;
+        let cwd = group.cwd.clone()?;
+        if !self.pending_session_group_loads.insert(Some(cwd.clone())) {
+            return None;
+        }
+        Some((cwd, cursor))
+    }
+
+    pub(crate) fn prepare_session_child_page(
+        &mut self,
+        group_idx: usize,
+        parent_path: &[usize],
+    ) -> Option<(String, Option<String>)> {
+        let parent = self.session_by_path(group_idx, parent_path)?;
+        let parent_session_id = parent.session_id.clone();
+        let cursor = parent.children_next_cursor.clone();
+        if !self
+            .pending_session_child_loads
+            .insert(parent_session_id.clone())
+        {
+            return None;
+        }
+        Some((parent_session_id, cursor))
+    }
+
+    pub(crate) fn apply_discovery_page(
+        &mut self,
+        mut groups: Vec<SessionGroup>,
+        next_cursor: Option<String>,
+    ) -> (Vec<String>, Option<String>) {
+        self.normalize_session_groups(&mut groups);
+        self.session_discovery_in_progress = false;
+        let mut workspace_requests = Vec::new();
+
+        for mut group in groups {
+            group.next_cursor = None;
+            match group.cwd.clone() {
+                Some(cwd) => {
+                    let hydrated = self.hydrated_session_groups.contains(&cwd);
+                    if let Some(existing) = self
+                        .session_groups
+                        .iter_mut()
+                        .find(|existing| existing.cwd.as_deref() == Some(cwd.as_str()))
+                    {
+                        if !hydrated {
+                            Self::merge_session_page(
+                                existing,
+                                group.sessions,
+                                Some(POPUP_SESSION_PAGE_TARGET),
+                            );
+                        }
+                    } else {
+                        group.sessions.truncate(POPUP_SESSION_PAGE_TARGET);
+                        self.session_groups.push(group);
+                    }
+
+                    if !hydrated && self.pending_session_group_loads.insert(Some(cwd.clone())) {
+                        workspace_requests.push(cwd);
+                    }
+                }
+                None => {
+                    if let Some(existing) = self
+                        .session_groups
+                        .iter_mut()
+                        .find(|existing| existing.cwd.is_none())
+                    {
+                        Self::merge_session_page(
+                            existing,
+                            group.sessions,
+                            Some(POPUP_SESSION_PAGE_TARGET),
+                        );
+                    } else {
+                        group.sessions.truncate(POPUP_SESSION_PAGE_TARGET);
+                        self.session_groups.push(group);
+                    }
+                }
+            }
+        }
+
+        let next_request = next_cursor.filter(|cursor| {
+            let queued = self.session_discovery_cursors.insert(cursor.clone());
+            if queued {
+                self.session_discovery_in_progress = true;
+            }
+            queued
+        });
+        self.finish_catalog_update();
+        (workspace_requests, next_request)
+    }
+
+    pub(crate) fn apply_workspace_first_page(
+        &mut self,
+        cwd: String,
+        mut groups: Vec<SessionGroup>,
+    ) {
+        self.normalize_session_groups(&mut groups);
+        self.pending_session_group_loads.remove(&Some(cwd.clone()));
+        self.hydrated_session_groups.insert(cwd.clone());
+        let mut group = groups
+            .into_iter()
+            .find(|group| group.cwd.as_deref() == Some(cwd.as_str()))
+            .unwrap_or_else(|| SessionGroup {
+                cwd: Some(cwd.clone()),
+                ..SessionGroup::default()
+            });
+        group.cwd = Some(cwd.clone());
+        group.total_count = None;
+
+        if group.sessions.is_empty() {
+            self.session_groups
+                .retain(|existing| existing.cwd.as_deref() != Some(cwd.as_str()));
+        } else if let Some(existing) = self
+            .session_groups
+            .iter_mut()
+            .find(|existing| existing.cwd.as_deref() == Some(cwd.as_str()))
+        {
+            *existing = group;
+        } else {
+            self.session_groups.push(group);
+        }
+        self.finish_catalog_update();
+    }
+
+    pub(crate) fn apply_workspace_continuation(
+        &mut self,
+        cwd: String,
+        mut groups: Vec<SessionGroup>,
+    ) {
+        self.normalize_session_groups(&mut groups);
+        self.pending_session_group_loads.remove(&Some(cwd.clone()));
+        let page = groups
+            .into_iter()
+            .find(|group| group.cwd.as_deref() == Some(cwd.as_str()))
+            .unwrap_or_else(|| SessionGroup {
+                cwd: Some(cwd.clone()),
+                ..SessionGroup::default()
+            });
+        if let Some(existing) = self
+            .session_groups
+            .iter_mut()
+            .find(|existing| existing.cwd.as_deref() == Some(cwd.as_str()))
+        {
+            existing.next_cursor = page.next_cursor.clone();
+            Self::merge_session_page(existing, page.sessions, None);
+        } else if !page.sessions.is_empty() {
+            self.session_groups.push(page);
+        }
+        self.finish_catalog_update();
+    }
+
+    pub(crate) fn fail_discovery(&mut self) {
+        self.session_discovery_in_progress = false;
+    }
+
+    pub(crate) fn fail_workspace_request(&mut self, cwd: &str) {
+        self.pending_session_group_loads
+            .remove(&Some(cwd.to_string()));
+    }
+
+    fn normalize_session_groups(&mut self, groups: &mut [SessionGroup]) {
+        for group in groups {
+            group.total_count = None;
+            for session in &group.sessions {
+                if let Some(node_id) = session
+                    .node_id
+                    .as_deref()
+                    .filter(|id| !id.trim().is_empty())
+                {
+                    self.remember_remote_session_location(
+                        &session.session_id,
+                        node_id,
+                        session.cwd.clone(),
+                    );
+                }
+            }
+            group.sessions.sort_by(|a, b| {
+                b.updated_at
+                    .cmp(&a.updated_at)
+                    .then_with(|| b.session_id.cmp(&a.session_id))
+            });
+            group.latest_activity = group
+                .sessions
+                .first()
+                .and_then(|session| session.updated_at.clone());
+        }
+    }
+
+    fn finish_catalog_update(&mut self) {
+        self.session_groups
+            .retain(|group| !group.sessions.is_empty());
+        self.session_groups.sort_by(|a, b| {
+            b.latest_activity
+                .cmp(&a.latest_activity)
+                .then_with(|| a.cwd.cmp(&b.cwd))
+        });
+        self.clamp_start_cursor();
+    }
+
+    pub(crate) fn reset_browser_for_open(&mut self) {
+        self.session_popup_tab = 0;
+        self.session_cursor = 0;
+        self.session_filter.clear();
+    }
+
+    pub(crate) fn switch_session_popup_tab(&mut self) {
+        self.session_popup_tab = 1 - self.session_popup_tab;
+    }
+
+    pub(crate) fn move_start_cursor_up(&mut self) {
+        self.session_cursor = self.session_cursor.saturating_sub(1);
+        if self.session_cursor < self.start_page_scroll {
+            self.start_page_scroll = self.session_cursor;
+        }
+    }
+
+    pub(crate) fn move_start_cursor_down(&mut self) {
+        let max = self.visible_start_items().len();
+        if self.session_cursor < max {
+            self.session_cursor += 1;
+        }
+    }
+
+    pub(crate) fn move_popup_cursor_up(&mut self) {
+        self.session_cursor = self.session_cursor.saturating_sub(1);
+    }
+
+    pub(crate) fn move_popup_cursor_down(&mut self) {
+        let max = self.visible_popup_items().len().saturating_sub(1);
+        self.session_cursor = self.session_cursor.saturating_add(1).min(max);
+    }
+
+    pub(crate) fn move_popup_cursor_page(&mut self, step: usize, down: bool) {
+        if down {
+            let max = self.visible_popup_items().len().saturating_sub(1);
+            self.session_cursor = self.session_cursor.saturating_add(step).min(max);
+        } else {
+            self.session_cursor = self.session_cursor.saturating_sub(step);
+        }
+    }
+
+    pub(crate) fn start_filter_insert(&mut self, character: char) {
+        self.session_filter.push(character);
+        self.session_cursor = 0;
+        self.start_page_scroll = 0;
+    }
+
+    pub(crate) fn start_filter_backspace(&mut self) {
+        self.session_filter.pop();
+        self.session_cursor = 0;
+        self.start_page_scroll = 0;
+    }
+
+    pub(crate) fn popup_filter_insert(&mut self, character: char) {
+        self.session_filter.push(character);
+        self.session_cursor = 0;
+    }
+
+    pub(crate) fn popup_filter_backspace(&mut self) {
+        self.session_filter.pop();
+        self.session_cursor = 0;
+    }
+
+    pub(crate) fn clamp_start_cursor(&mut self) {
+        let visible_len = self.visible_start_items().len();
+        if visible_len > 0 && self.session_cursor >= visible_len {
+            self.session_cursor = visible_len - 1;
+        }
+    }
+
+    pub(crate) fn clamp_popup_cursor(&mut self) {
+        let visible_len = self.visible_popup_items().len();
+        if visible_len > 0 && self.session_cursor >= visible_len {
+            self.session_cursor = visible_len - 1;
+        }
+    }
+
+    pub(crate) fn remove_session_at(
+        &mut self,
+        group_idx: usize,
+        path: &[usize],
+        popup_items: bool,
+    ) -> Option<(SessionSummary, bool)> {
+        let session = self.session_by_path(group_idx, path)?.clone();
+        let is_remote = self.is_remote_session_id(&session.session_id);
+        if path.len() == 1 {
+            self.session_groups
+                .get_mut(group_idx)?
+                .sessions
+                .remove(path[0]);
+        } else if let Some(parent_path) = path.get(..path.len() - 1)
+            && let Some(parent) = self.session_by_path_mut(group_idx, parent_path)
+            && let Some(child_idx) = path.last()
+            && *child_idx < parent.children.len()
+        {
+            parent.children.remove(*child_idx);
+        }
+        self.session_groups
+            .retain(|group| !group.sessions.is_empty());
+        if popup_items {
+            self.clamp_popup_cursor();
+        } else {
+            self.clamp_start_cursor();
+        }
+        Some((session, is_remote))
+    }
+
+    pub(crate) fn session_summary_by_id(&self, session_id: &str) -> Option<&SessionSummary> {
+        fn find<'a>(
+            sessions: &'a [SessionSummary],
+            session_id: &str,
+        ) -> Option<&'a SessionSummary> {
+            for session in sessions {
+                if session.session_id == session_id {
+                    return Some(session);
+                }
+                if let Some(child) = find(&session.children, session_id) {
+                    return Some(child);
+                }
+            }
+            None
+        }
+
+        self.session_groups
+            .iter()
+            .find_map(|group| find(&group.sessions, session_id))
+    }
+
+    pub(crate) fn session_parent_id(&self, session_id: &str) -> Option<&str> {
+        self.session_summary_by_id(session_id)
+            .and_then(|session| session.parent_session_id.as_deref())
+    }
+
+    pub(crate) fn remember_remote_session_location(
+        &mut self,
+        session_id: &str,
+        node_id: &str,
+        cwd: Option<String>,
+    ) {
+        let location = self
+            .remote_session_locations
+            .entry(session_id.to_string())
+            .or_default();
+        location.node_id = node_id.to_string();
+        if let Some(cwd) = cwd.filter(|cwd| !cwd.trim().is_empty()) {
+            location.cwd = Some(cwd);
+        }
+    }
+
+    pub(crate) fn remember_remote_session_node(&mut self, session_id: &str, node_id: &str) {
+        self.remember_remote_session_location(session_id, node_id, None);
+    }
+
+    pub(crate) fn session_remote_node_id(&self, session_id: &str) -> Option<&str> {
+        self.session_summary_by_id(session_id)
+            .and_then(|session| session.node_id.as_deref())
+            .or_else(|| {
+                self.remote_session_locations
+                    .get(session_id)
+                    .map(|location| location.node_id.as_str())
+            })
+    }
+
+    pub(crate) fn session_remote_cwd(&self, session_id: &str) -> Option<String> {
+        self.session_summary_by_id(session_id)
+            .filter(|session| session.node_id.is_some() || session.node.is_some())
+            .and_then(|session| session.cwd.as_deref())
+            .filter(|cwd| !cwd.trim().is_empty())
+            .map(str::to_string)
+            .or_else(|| {
+                self.remote_session_locations
+                    .get(session_id)
+                    .and_then(|location| location.cwd.as_deref())
+                    .filter(|cwd| !cwd.trim().is_empty())
+                    .map(str::to_string)
+            })
+    }
+
+    pub(crate) fn is_remote_session_id(&self, session_id: &str) -> bool {
+        self.session_remote_node_id(session_id).is_some()
+            || self
+                .session_summary_by_id(session_id)
+                .map(|session| session.node.is_some())
+                .unwrap_or(false)
+    }
+
+    pub(crate) fn current_session_is_remote(&self) -> bool {
+        self.session_id
+            .as_deref()
+            .map(|session_id| self.is_remote_session_id(session_id))
+            .unwrap_or(false)
+    }
+
+    pub(crate) fn session_by_path(
+        &self,
+        group_idx: usize,
+        path: &[usize],
+    ) -> Option<&SessionSummary> {
+        let (first, rest) = path.split_first()?;
+        let mut session = self.session_groups.get(group_idx)?.sessions.get(*first)?;
+        for idx in rest {
+            session = session.children.get(*idx)?;
+        }
+        Some(session)
+    }
+
+    pub(crate) fn session_by_path_mut(
+        &mut self,
+        group_idx: usize,
+        path: &[usize],
+    ) -> Option<&mut SessionSummary> {
+        fn descend<'a>(
+            sessions: &'a mut [SessionSummary],
+            path: &[usize],
+        ) -> Option<&'a mut SessionSummary> {
+            let (first, rest) = path.split_first()?;
+            let session = sessions.get_mut(*first)?;
+            if rest.is_empty() {
+                Some(session)
+            } else {
+                descend(&mut session.children, rest)
+            }
+        }
+        descend(&mut self.session_groups.get_mut(group_idx)?.sessions, path)
+    }
+
+    pub(crate) fn expandable_root_session(&self, group_idx: usize, path: &[usize]) -> bool {
+        let Some(session) = self.session_by_path(group_idx, path) else {
+            return false;
+        };
+        path.len() == 1
+            && session.parent_session_id.is_none()
+            && session.fork_count > 0
+            && session.node.is_none()
+            && session.node_id.is_none()
+    }
+
+    pub(crate) fn toggle_session_children(&mut self, group_idx: usize, path: &[usize]) -> bool {
+        if !self.expandable_root_session(group_idx, path) {
+            return false;
+        }
+        let Some(session) = self.session_by_path(group_idx, path) else {
+            return false;
+        };
+        let session_id = session.session_id.clone();
+        let should_load = session.children.is_empty()
+            && session.children_next_cursor.is_none()
+            && !self.pending_session_child_loads.contains(&session_id);
+        if !self.expanded_session_children.remove(&session_id) {
+            self.expanded_session_children.insert(session_id);
+            return should_load;
+        }
+        false
+    }
+
+    pub(crate) fn merge_session_children(&mut self, data: SessionChildrenPage) {
+        let remote_locations: Vec<(String, String, Option<String>)> = data
+            .sessions
+            .iter()
+            .filter_map(|session| {
+                Some((
+                    session.session_id.clone(),
+                    session.node_id.clone()?,
+                    session.cwd.clone(),
+                ))
+            })
+            .collect();
+        for (session_id, node_id, cwd) in remote_locations {
+            self.remember_remote_session_location(&session_id, &node_id, cwd);
+        }
+
+        let had_pending_request = self
+            .pending_session_child_loads
+            .remove(&data.parent_session_id);
+        if let Some(parent) = self
+            .session_groups
+            .iter_mut()
+            .find_map(|group| session_by_id_mut(&mut group.sessions, &data.parent_session_id))
+        {
+            let mut sessions: Vec<SessionSummary> = data
+                .sessions
+                .into_iter()
+                .filter(fork_browsing_child)
+                .collect();
+            let append = had_pending_request
+                && !parent.children.is_empty()
+                && parent.children_next_cursor.is_some();
+            if append {
+                let mut seen: HashSet<String> = parent
+                    .children
+                    .iter()
+                    .map(|session| session.session_id.clone())
+                    .collect();
+                parent.children.extend(
+                    sessions
+                        .into_iter()
+                        .filter(|session| seen.insert(session.session_id.clone())),
+                );
+            } else {
+                let mut seen = HashSet::new();
+                sessions.retain(|session| seen.insert(session.session_id.clone()));
+                parent.children = sessions;
+            }
+            parent.children_next_cursor = data.next_cursor;
+            parent.children_total_count = data.total_count;
+            parent.has_children = !parent.children.is_empty() || parent.fork_count > 0;
+            if let Some(total) = parent.children_total_count {
+                parent.fork_count = total;
+            }
+        }
+    }
+
+    pub(crate) fn visible_start_items(&self) -> Vec<StartPageItem> {
+        let query = self.session_filter.to_lowercase();
+        let mut items = Vec::new();
+
+        for (group_idx, group) in self
+            .session_groups
+            .iter()
+            .enumerate()
+            .take(MAX_VISIBLE_GROUPS)
+        {
+            let collapse_key = group.cwd.clone().unwrap_or_default();
+            let collapsed = self.collapsed_groups.contains(&collapse_key);
+            let matching = matching_session_indices(group, &query);
+            if !query.is_empty() && matching.is_empty() {
+                continue;
+            }
+
+            items.push(StartPageItem::GroupHeader {
+                cwd: group.cwd.clone(),
+                session_count: group.sessions.len(),
+                session_total: group.total_count,
+                collapsed,
+            });
+
+            if !collapsed {
+                let visible: Vec<usize> =
+                    matching.iter().copied().take(MAX_RECENT_SESSIONS).collect();
+                let hidden = matching.len().saturating_sub(MAX_RECENT_SESSIONS);
+                for session_idx in visible {
+                    items.push(StartPageItem::Session {
+                        group_idx,
+                        path: vec![session_idx],
+                        depth: 0,
+                    });
+                    let session = &group.sessions[session_idx];
+                    if self.expanded_session_children.contains(&session.session_id) {
+                        for (child_idx, child) in session.children.iter().enumerate() {
+                            if session_matches(child, &query) {
+                                items.push(StartPageItem::Session {
+                                    group_idx,
+                                    path: vec![session_idx, child_idx],
+                                    depth: 1,
+                                });
+                            }
+                        }
+                    }
+                }
+
+                if hidden > 0 || group.next_cursor.is_some() {
+                    items.push(StartPageItem::ShowMore {
+                        group_idx,
+                        remaining: hidden,
+                        has_more: group.next_cursor.is_some(),
+                    });
+                }
+            }
+        }
+
+        items
+    }
+
+    pub(crate) fn toggle_group_collapse(&mut self, cwd: Option<&str>) {
+        let key = cwd.unwrap_or("").to_string();
+        if !self.collapsed_groups.remove(&key) {
+            self.collapsed_groups.insert(key);
+        }
+    }
+
+    pub(crate) fn toggle_popup_group_collapse(&mut self, cwd: Option<&str>) {
+        let key = cwd.unwrap_or("").to_string();
+        if !self.popup_collapsed_groups.remove(&key) {
+            self.popup_collapsed_groups.insert(key);
+        }
+    }
+
+    pub(crate) fn visible_popup_items(&self) -> Vec<PopupItem> {
+        let query = self.session_filter.to_lowercase();
+        let mut items = Vec::new();
+
+        for (group_idx, group) in self.session_groups.iter().enumerate() {
+            let collapse_key = group.cwd.clone().unwrap_or_default();
+            let collapsed = self.popup_collapsed_groups.contains(&collapse_key);
+            let matching = matching_session_indices(group, &query);
+            if !query.is_empty() && matching.is_empty() {
+                continue;
+            }
+
+            items.push(PopupItem::GroupHeader {
+                cwd: group.cwd.clone(),
+                session_count: group.sessions.len(),
+                session_total: group.total_count,
+                collapsed,
+            });
+
+            if !collapsed {
+                for session_idx in matching {
+                    items.push(PopupItem::Session {
+                        group_idx,
+                        path: vec![session_idx],
+                        depth: 0,
+                    });
+                    let session = &group.sessions[session_idx];
+                    if self.expanded_session_children.contains(&session.session_id) {
+                        for (child_idx, child) in session.children.iter().enumerate() {
+                            if session_matches(child, &query) {
+                                items.push(PopupItem::Session {
+                                    group_idx,
+                                    path: vec![session_idx, child_idx],
+                                    depth: 1,
+                                });
+                            }
+                        }
+                        if session.children_next_cursor.is_some() {
+                            items.push(PopupItem::LoadMore {
+                                group_idx,
+                                parent_path: vec![session_idx],
+                            });
+                        }
+                    }
+                }
+                if group.next_cursor.is_some()
+                    && !self.pending_session_group_loads.contains(&group.cwd)
+                {
+                    items.push(PopupItem::LoadMore {
+                        group_idx,
+                        parent_path: Vec::new(),
+                    });
+                }
+            }
+        }
+
+        items
+    }
+
+    pub(crate) fn merge_session_page(
+        group: &mut SessionGroup,
+        sessions: Vec<SessionSummary>,
+        cap: Option<usize>,
+    ) {
+        let mut seen = group
+            .sessions
+            .iter()
+            .map(|session| session.session_id.clone())
+            .collect::<HashSet<_>>();
+        group.sessions.extend(
+            sessions
+                .into_iter()
+                .filter(|session| seen.insert(session.session_id.clone())),
+        );
+        group.sessions.sort_by(|a, b| {
+            b.updated_at
+                .cmp(&a.updated_at)
+                .then_with(|| b.session_id.cmp(&a.session_id))
+        });
+        if let Some(cap) = cap {
+            group.sessions.truncate(cap);
+        }
+        group.latest_activity = group
+            .sessions
+            .first()
+            .and_then(|session| session.updated_at.clone());
+        group.total_count = None;
+    }
+
+    pub(crate) fn note_session_activity(&mut self, session_id: &str) {
+        self.session_activity.insert(
+            session_id.to_string(),
+            SessionActivity {
+                last_event_at: Instant::now(),
+            },
+        );
+    }
+
+    pub(crate) fn active_session_count(&self) -> usize {
+        const ACTIVE_SESSION_WINDOW: Duration = Duration::from_secs(5);
+        let now = Instant::now();
+        self.session_activity
+            .values()
+            .filter(|activity| now.duration_since(activity.last_event_at) <= ACTIVE_SESSION_WINDOW)
+            .count()
+    }
+
+    pub(crate) fn other_active_session_count(&self) -> usize {
+        const ACTIVE_SESSION_WINDOW: Duration = Duration::from_secs(5);
+        let now = Instant::now();
+        self.session_activity
+            .iter()
+            .filter(|(session_id, activity)| {
+                now.duration_since(activity.last_event_at) <= ACTIVE_SESSION_WINDOW
+                    && self.session_id.as_deref() != Some(session_id.as_str())
+            })
+            .count()
+    }
+
+    pub(crate) fn next_mode(&self) -> String {
+        match self.agent_mode.as_str() {
+            "build" => "plan".into(),
+            "plan" => "build".into(),
+            "review" => self
+                .mode_before_review
+                .clone()
+                .unwrap_or_else(|| "build".into()),
+            _ => "build".into(),
+        }
+    }
+
+    pub(crate) fn replace_agent_mode(&mut self, mode: String) {
+        self.agent_mode = mode;
+        if self.agent_mode != "review" {
+            self.mode_before_review = None;
+        }
+    }
+
+    pub(crate) fn apply_mode_transition(&mut self, target: &str) {
+        if target == "review" {
+            if self.agent_mode != "review" {
+                self.mode_before_review = Some(self.agent_mode.clone());
+            }
+        } else {
+            self.mode_before_review = None;
+        }
+        self.agent_mode = target.to_string();
+    }
+
+    pub(crate) fn move_new_session_cursor_left(&mut self) {
+        self.new_session_cursor = self.new_session_cursor.saturating_sub(1);
+    }
+
+    pub(crate) fn move_new_session_cursor_right(&mut self) {
+        self.new_session_cursor = (self.new_session_cursor + 1).min(self.new_session_path.len());
+    }
+
+    pub(crate) fn move_new_session_cursor_home(&mut self) {
+        self.new_session_cursor = 0;
+    }
+
+    pub(crate) fn move_new_session_cursor_end(&mut self) {
+        self.new_session_cursor = self.new_session_path.len();
+    }
+
+    pub(crate) fn new_session_backspace(&mut self) {
+        if self.new_session_cursor > 0 && !self.new_session_path.is_empty() {
+            let index = self.new_session_cursor - 1;
+            self.new_session_path.remove(index);
+            self.new_session_cursor = index;
+        }
+    }
+
+    pub(crate) fn new_session_insert(&mut self, character: char) {
+        self.new_session_path
+            .insert(self.new_session_cursor, character);
+        self.new_session_cursor += 1;
+    }
+
+    pub(crate) fn replace_new_session_completion(
+        &mut self,
+        query: String,
+        results: Vec<FileIndexEntryLite>,
+    ) {
+        self.new_session_completion = Some(PathCompletionState {
+            query,
+            selected_index: 0,
+            results,
+        });
+    }
+
+    pub(crate) fn accept_new_session_completion(&mut self, path: String) {
+        self.new_session_path = path;
+        self.new_session_cursor = self.new_session_path.len();
+        self.new_session_completion = None;
+    }
+
+    pub(crate) fn move_new_session_completion_selection(&mut self, delta: isize) {
+        if let Some(completion) = self.new_session_completion.as_mut() {
+            let len = completion.results.len();
+            if len == 0 {
+                completion.selected_index = 0;
+                return;
+            }
+            completion.selected_index =
+                (completion.selected_index as isize + delta).rem_euclid(len as isize) as usize;
+        }
+    }
+}
+
+fn session_matches(session: &SessionSummary, query: &str) -> bool {
+    if query.is_empty() {
+        return true;
+    }
+    let matcher = SkimMatcherV2::default();
+    matcher
+        .fuzzy_match(session.title.as_deref().unwrap_or(""), query)
+        .is_some()
+        || matcher.fuzzy_match(&session.session_id, query).is_some()
+}
+
+fn matching_session_indices(group: &SessionGroup, query: &str) -> Vec<usize> {
+    if query.is_empty() {
+        return (0..group.sessions.len()).collect();
+    }
+    let matcher = SkimMatcherV2::default();
+    let mut scored: Vec<(i64, usize)> = group
+        .sessions
+        .iter()
+        .enumerate()
+        .filter_map(|(index, session)| {
+            let score = [
+                matcher.fuzzy_match(session.title.as_deref().unwrap_or(""), query),
+                matcher.fuzzy_match(&session.session_id, query),
+            ]
+            .into_iter()
+            .flatten()
+            .max();
+            score.map(|score| (score, index))
+        })
+        .collect();
+    scored.sort_by_key(|item| std::cmp::Reverse(item.0));
+    scored.into_iter().map(|(_, index)| index).collect()
+}
+
+fn session_by_id_mut<'a>(
+    sessions: &'a mut [SessionSummary],
+    session_id: &str,
+) -> Option<&'a mut SessionSummary> {
+    for session in sessions {
+        if session.session_id == session_id {
+            return Some(session);
+        }
+        if let Some(child) = session_by_id_mut(&mut session.children, session_id) {
+            return Some(child);
+        }
+    }
+    None
+}
+
+fn fork_browsing_child(session: &SessionSummary) -> bool {
+    session.fork_origin.as_deref() != Some("delegation")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session(id: &str) -> SessionSummary {
+        SessionSummary {
+            session_id: id.into(),
+            ..Default::default()
+        }
+    }
+
+    fn group(cwd: &str, ids: &[&str]) -> SessionGroup {
+        SessionGroup {
+            cwd: Some(cwd.into()),
+            sessions: ids.iter().map(|id| session(id)).collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn constructor_uses_exact_defaults() {
+        let state = SessionsState::new();
+        assert!(state.session_groups.is_empty());
+        assert_eq!(state.session_cursor, 0);
+        assert!(state.session_filter.is_empty());
+        assert_eq!(state.session_popup_tab, 0);
+        assert!(state.collapsed_groups.is_empty());
+        assert!(state.popup_collapsed_groups.is_empty());
+        assert!(!state.session_discovery_in_progress);
+        assert!(state.session_discovery_cursors.is_empty());
+        assert!(state.pending_session_group_loads.is_empty());
+        assert!(state.hydrated_session_groups.is_empty());
+        assert!(state.expanded_session_children.is_empty());
+        assert!(state.pending_session_child_loads.is_empty());
+        assert_eq!(state.start_page_scroll, 0);
+        assert_eq!(state.session_popup_visible_rows, 0);
+        assert_eq!(state.session_id, None);
+        assert_eq!(state.agent_id, None);
+        assert_eq!(state.agent_mode, "build");
+        assert_eq!(state.mode_before_review, None);
+        assert!(state.new_session_path.is_empty());
+        assert_eq!(state.new_session_cursor, 0);
+        assert_eq!(state.new_session_completion, None);
+        assert!(state.session_activity.is_empty());
+        assert!(state.remote_session_locations.is_empty());
+    }
+
+    #[test]
+    fn discovery_preparation_rejects_pending_and_clears_only_catalog_state() {
+        let mut state = SessionsState::new();
+        state.session_groups = vec![group("/repo", &["s1"])];
+        state.session_discovery_cursors.insert("old".into());
+        state.hydrated_session_groups.insert("/repo".into());
+        state.expanded_session_children.insert("s1".into());
+        state.session_id = Some("active".into());
+        state
+            .pending_session_group_loads
+            .insert(Some("/repo".into()));
+
+        assert!(!state.prepare_session_discovery());
+        assert_eq!(state.session_groups.len(), 1);
+        state.pending_session_group_loads.clear();
+        assert!(state.prepare_session_discovery());
+        assert!(state.session_groups.is_empty());
+        assert!(state.session_discovery_cursors.is_empty());
+        assert!(state.hydrated_session_groups.is_empty());
+        assert!(state.session_discovery_in_progress);
+        assert!(state.expanded_session_children.contains("s1"));
+        assert_eq!(state.session_id.as_deref(), Some("active"));
+    }
+
+    #[test]
+    fn group_and_child_request_preparation_record_pending_before_deduplication() {
+        let mut state = SessionsState::new();
+        let mut root = session("root");
+        root.children_next_cursor = Some("child-cursor".into());
+        state.session_groups = vec![SessionGroup {
+            cwd: Some("/repo".into()),
+            sessions: vec![root],
+            next_cursor: Some("group-cursor".into()),
+            ..Default::default()
+        }];
+
+        assert_eq!(
+            state.prepare_session_group_page(0),
+            Some(("/repo".into(), "group-cursor".into()))
+        );
+        assert_eq!(state.prepare_session_group_page(0), None);
+        assert_eq!(
+            state.prepare_session_child_page(0, &[0]),
+            Some(("root".into(), Some("child-cursor".into())))
+        );
+        assert!(state.pending_session_child_loads.contains("root"));
+    }
+
+    #[test]
+    fn merge_page_deduplicates_sorts_and_caps() {
+        let mut existing = session("existing");
+        existing.updated_at = Some("2025-01-01".into());
+        let mut newer = session("newer");
+        newer.updated_at = Some("2025-02-01".into());
+        let mut group = SessionGroup {
+            sessions: vec![existing.clone()],
+            total_count: Some(9),
+            ..Default::default()
+        };
+
+        SessionsState::merge_session_page(&mut group, vec![existing, newer], Some(1));
+        assert_eq!(group.sessions.len(), 1);
+        assert_eq!(group.sessions[0].session_id, "newer");
+        assert_eq!(group.latest_activity.as_deref(), Some("2025-02-01"));
+        assert_eq!(group.total_count, None);
+    }
+
+    #[test]
+    fn zero_visible_rows_preserve_stale_cursor() {
+        let mut state = SessionsState::new();
+        state.session_cursor = 7;
+        state.clamp_start_cursor();
+        state.clamp_popup_cursor();
+        assert_eq!(state.session_cursor, 7);
+    }
+
+    #[test]
+    fn start_and_popup_collapses_are_independent() {
+        let mut state = SessionsState::new();
+        state.session_groups = vec![group("/repo", &["s1"])];
+        state.toggle_group_collapse(Some("/repo"));
+        assert_eq!(state.visible_start_items().len(), 1);
+        assert_eq!(state.visible_popup_items().len(), 2);
+        state.toggle_popup_group_collapse(Some("/repo"));
+        assert_eq!(state.visible_popup_items().len(), 1);
+    }
+
+    #[test]
+    fn cursor_filter_and_scroll_transitions_keep_view_contracts_distinct() {
+        let mut state = SessionsState::new();
+        state.session_cursor = 4;
+        state.start_page_scroll = 3;
+        state.start_filter_insert('x');
+        assert_eq!(state.session_filter, "x");
+        assert_eq!(state.session_cursor, 0);
+        assert_eq!(state.start_page_scroll, 0);
+
+        state.session_cursor = 4;
+        state.start_page_scroll = 3;
+        state.popup_filter_backspace();
+        assert_eq!(state.session_cursor, 0);
+        assert_eq!(state.start_page_scroll, 3);
+    }
+
+    #[test]
+    fn review_mode_transition_and_next_mode_preserve_return_mode() {
+        let mut state = SessionsState::new();
+        state.agent_mode = "plan".into();
+        state.apply_mode_transition("review");
+        assert_eq!(state.next_mode(), "plan");
+        assert_eq!(state.mode_before_review.as_deref(), Some("plan"));
+        state.apply_mode_transition("plan");
+        assert_eq!(state.mode_before_review, None);
+    }
+
+    #[test]
+    fn completion_selection_wraps_and_acceptance_clears_state() {
+        let mut state = SessionsState::new();
+        state.replace_new_session_completion(
+            "repo".into(),
+            vec![
+                FileIndexEntryLite {
+                    path: "/a".into(),
+                    is_dir: true,
+                },
+                FileIndexEntryLite {
+                    path: "/b".into(),
+                    is_dir: true,
+                },
+            ],
+        );
+        state.move_new_session_completion_selection(-1);
+        assert_eq!(
+            state
+                .new_session_completion
+                .as_ref()
+                .unwrap()
+                .selected_index,
+            1
+        );
+        state.accept_new_session_completion("/b/".into());
+        assert_eq!(state.new_session_path, "/b/");
+        assert_eq!(state.new_session_cursor, 3);
+        assert_eq!(state.new_session_completion, None);
+    }
+
+    #[test]
+    fn activity_window_excludes_only_current_session() {
+        let mut state = SessionsState::new();
+        state.session_id = Some("current".into());
+        state.note_session_activity("current");
+        state.note_session_activity("other");
+        state.session_activity.insert(
+            "stale".into(),
+            SessionActivity {
+                last_event_at: Instant::now() - Duration::from_secs(6),
+            },
+        );
+        assert_eq!(state.active_session_count(), 2);
+        assert_eq!(state.other_active_session_count(), 1);
+    }
+
+    #[test]
+    fn discovery_pages_protect_hydrated_groups_and_dedupe_cursors() {
+        let mut state = SessionsState::new();
+        state.session_discovery_in_progress = true;
+        state.hydrated_session_groups.insert("/repo".into());
+        state.session_groups = vec![group("/repo", &["authoritative"])];
+
+        let (workspaces, cursor) = state.apply_discovery_page(
+            vec![group("/repo", &["preview"]), group("/later", &["later-1"])],
+            Some("cursor-2".into()),
+        );
+        assert_eq!(workspaces, vec!["/later"]);
+        assert_eq!(cursor.as_deref(), Some("cursor-2"));
+        assert!(state.session_discovery_in_progress);
+        assert_eq!(
+            state
+                .session_groups
+                .iter()
+                .find(|group| group.cwd.as_deref() == Some("/repo"))
+                .unwrap()
+                .sessions[0]
+                .session_id,
+            "authoritative"
+        );
+
+        let (_, duplicate_cursor) = state.apply_discovery_page(Vec::new(), Some("cursor-2".into()));
+        assert_eq!(duplicate_cursor, None);
+        assert!(!state.session_discovery_in_progress);
+    }
+
+    #[test]
+    fn child_merge_replaces_then_appends_deduped_non_delegate_children() {
+        let mut parent = session("parent");
+        parent.children = vec![session("stale")];
+        let mut state = SessionsState::new();
+        state.session_groups = vec![SessionGroup {
+            sessions: vec![parent],
+            ..Default::default()
+        }];
+        state.pending_session_child_loads.insert("parent".into());
+        let mut delegated = session("delegated");
+        delegated.fork_origin = Some("delegation".into());
+
+        state.merge_session_children(SessionChildrenPage {
+            parent_session_id: "parent".into(),
+            sessions: vec![session("child-1"), delegated, session("child-1")],
+            next_cursor: Some("cursor-2".into()),
+            total_count: Some(2),
+        });
+        assert_eq!(
+            state
+                .session_summary_by_id("parent")
+                .unwrap()
+                .children
+                .iter()
+                .map(|child| child.session_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["child-1"]
+        );
+
+        state.pending_session_child_loads.insert("parent".into());
+        state.merge_session_children(SessionChildrenPage {
+            parent_session_id: "parent".into(),
+            sessions: vec![session("child-1"), session("child-2")],
+            total_count: Some(2),
+            ..Default::default()
+        });
+        assert_eq!(
+            state
+                .session_summary_by_id("parent")
+                .unwrap()
+                .children
+                .iter()
+                .map(|child| child.session_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["child-1", "child-2"]
+        );
+    }
+
+    #[test]
+    fn catalog_remote_metadata_precedes_remembered_location() {
+        let mut remote = session("remote");
+        remote.node_id = Some("catalog-node".into());
+        remote.cwd = Some("/catalog".into());
+        let mut state = SessionsState::new();
+        state.session_groups = vec![SessionGroup {
+            sessions: vec![remote],
+            ..Default::default()
+        }];
+        state.remember_remote_session_location(
+            "remote",
+            "remembered-node",
+            Some("/remembered".into()),
+        );
+
+        assert_eq!(state.session_remote_node_id("remote"), Some("catalog-node"));
+        assert_eq!(state.session_remote_cwd("remote"), Some("/catalog".into()));
+    }
+
+    #[test]
+    fn remote_node_only_refresh_replaces_node_and_preserves_cwd() {
+        let mut state = SessionsState::new();
+        state.remember_remote_session_location("remote", "node-1", Some("/repo".into()));
+        state.remember_remote_session_location("remote", "node-2", Some("  ".into()));
+        assert_eq!(state.session_remote_node_id("remote"), Some("node-2"));
+        assert_eq!(state.session_remote_cwd("remote"), Some("/repo".into()));
+    }
+}

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -715,6 +715,7 @@ fn build_chat_header_spans(app: &App) -> (Vec<Span<'static>>, Vec<Span<'static>>
         _ => "no model".into(),
     };
     let sid = app
+        .sessions
         .session_id
         .as_deref()
         .map(|s| if s.len() > 8 { &s[..8] } else { s })
@@ -785,7 +786,7 @@ fn build_chat_header_spans(app: &App) -> (Vec<Span<'static>>, Vec<Span<'static>>
         }
     }
 
-    let other_active_session_count = app.other_active_session_count();
+    let other_active_session_count = app.sessions.other_active_session_count();
     if other_active_session_count > 0 {
         right_spans.push(Span::styled(
             format!(" {ICON_MULTI_SESSION} {other_active_session_count} "),
@@ -817,8 +818,8 @@ fn build_chat_header_spans(app: &App) -> (Vec<Span<'static>>, Vec<Span<'static>>
         ));
     }
     left_spans.push(Span::styled(
-        format!(" {} ", app.agent_mode),
-        Theme::mode_badge(&app.agent_mode),
+        format!(" {} ", app.sessions.agent_mode),
+        Theme::mode_badge(&app.sessions.agent_mode),
     ));
     if app.parent_session_id.is_some() {
         left_spans.push(Span::styled(" \u{2b11} child ", Theme::status_accent()));
@@ -1081,7 +1082,7 @@ fn draw_input_panel(
             Theme::input_border_thinking()
         }
         _ if app.elicitation.is_some() => Theme::input_border_thinking(), // accent while waiting
-        _ => Theme::mode_border(&app.agent_mode),
+        _ => Theme::mode_border(&app.sessions.agent_mode),
     };
     let border_line =
         Paragraph::new(INPUT_OVERLINE.repeat(border_area.width as usize)).style(border_style);
@@ -1122,7 +1123,7 @@ fn draw_input_panel(
             format!("  answer above {ARROW_UP} "),
             Theme::input_thinking(),
         ),
-        _ => ("> ".into(), Theme::mode_border(&app.agent_mode)),
+        _ => ("> ".into(), Theme::mode_border(&app.sessions.agent_mode)),
     };
     let input_style = Theme::input();
     let hide_input_contents = app.should_hide_input_contents();
@@ -2036,8 +2037,8 @@ mod tests {
     #[test]
     fn chat_header_shows_current_and_distinct_new_profile_labels() {
         let mut app = App::new();
-        app.session_id = Some("session-1".into());
-        app.agent_id = Some("agent-1".into());
+        app.sessions.session_id = Some("session-1".into());
+        app.sessions.agent_id = Some("agent-1".into());
         app.profiles.profiles = vec![
             crate::domain::profile::ProfileInfo {
                 id: "current".into(),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -774,11 +774,11 @@ mod tests {
     fn draw_chat_shows_multi_session_badge_for_other_recent_sessions() {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.session_id = Some("session-a".into());
-        app.agent_mode = "build".into();
+        app.sessions.session_id = Some("session-a".into());
+        app.sessions.agent_mode = "build".into();
         app.models.current_provider = Some("anthropic".into());
         app.models.current_model = Some("claude-sonnet".into());
-        app.session_activity.insert(
+        app.sessions.session_activity.insert(
             "session-a".into(),
             SessionActivity {
                 last_event_at: Instant::now(),
@@ -793,7 +793,7 @@ mod tests {
             .collect::<String>();
         assert!(!rendered.contains(ICON_MULTI_SESSION));
 
-        app.session_activity.insert(
+        app.sessions.session_activity.insert(
             "session-b".into(),
             SessionActivity {
                 last_event_at: Instant::now(),
@@ -808,7 +808,7 @@ mod tests {
         assert!(rendered.contains(&format!("{ICON_MULTI_SESSION} 1")));
         assert!(!rendered.contains(&format!("{ICON_MULTI_SESSION} 2")));
 
-        app.session_activity.insert(
+        app.sessions.session_activity.insert(
             "session-c".into(),
             SessionActivity {
                 last_event_at: Instant::now(),
@@ -822,7 +822,7 @@ mod tests {
             .collect::<String>();
         assert!(rendered.contains(&format!("{ICON_MULTI_SESSION} 2")));
 
-        app.session_activity.insert(
+        app.sessions.session_activity.insert(
             "session-c".into(),
             SessionActivity {
                 last_event_at: Instant::now() - Duration::from_secs(6),
@@ -842,8 +842,8 @@ mod tests {
     fn draw_chat_shows_delegate_badge_when_entries_exist() {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.session_id = Some("s1".into());
-        app.agent_mode = "build".into();
+        app.sessions.session_id = Some("s1".into());
+        app.sessions.agent_mode = "build".into();
         app.models.current_provider = Some("anthropic".into());
         app.models.current_model = Some("claude-sonnet".into());
 
@@ -903,8 +903,8 @@ mod tests {
     fn draw_chat_shows_delegate_awaiting_input_badge() {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.session_id = Some("s1".into());
-        app.agent_mode = "build".into();
+        app.sessions.session_id = Some("s1".into());
+        app.sessions.agent_mode = "build".into();
         app.models.current_provider = Some("anthropic".into());
         app.models.current_model = Some("claude-sonnet".into());
         app.delegate_entries = vec![DelegateEntry {
@@ -946,8 +946,8 @@ mod tests {
 
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.session_id = Some("s1".into());
-        app.agent_mode = "build".into();
+        app.sessions.session_id = Some("s1".into());
+        app.sessions.agent_mode = "build".into();
         app.models.current_provider = Some("anthropic".into());
         app.models.current_model = Some("claude-sonnet".into());
         app.delegate_entries = vec![DelegateEntry {
@@ -977,8 +977,8 @@ mod tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.navigation.popup = Popup::SessionSelect;
-        app.session_popup_tab = 1;
-        app.session_id = Some("parent".into());
+        app.sessions.session_popup_tab = 1;
+        app.sessions.session_id = Some("parent".into());
         app.delegate_entries = vec![
             DelegateEntry {
                 delegation_id: "del-1".into(),
@@ -1040,7 +1040,7 @@ mod tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.navigation.popup = Popup::SessionSelect;
-        app.session_popup_tab = 1;
+        app.sessions.session_popup_tab = 1;
         app.delegate_cursor = 1;
         app.delegate_entries = vec![DelegateEntry {
             delegation_id: "del-1".into(),
@@ -1088,7 +1088,7 @@ mod tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.navigation.popup = Popup::SessionSelect;
-        app.session_popup_tab = 1;
+        app.sessions.session_popup_tab = 1;
         app.delegate_entries = vec![
             DelegateEntry {
                 delegation_id: "del-1".into(),
@@ -1155,7 +1155,7 @@ mod tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.navigation.popup = Popup::SessionSelect;
-        app.session_popup_tab = 1;
+        app.sessions.session_popup_tab = 1;
         app.delegate_entries = vec![DelegateEntry {
             delegation_id: "del-1".into(),
             child_session_id: None,
@@ -1197,7 +1197,7 @@ mod tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.navigation.popup = Popup::SessionSelect;
-        app.session_popup_tab = 1;
+        app.sessions.session_popup_tab = 1;
         app.delegate_cursor = 0; // keep first row selected; failed row remains unselected
         app.delegate_entries = vec![
             DelegateEntry {
@@ -1245,7 +1245,7 @@ mod tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.navigation.popup = Popup::SessionSelect;
-        app.session_popup_tab = 1;
+        app.sessions.session_popup_tab = 1;
         app.delegate_cursor = 1;
         app.delegate_entries = vec![
             DelegateEntry {
@@ -1331,8 +1331,8 @@ mod tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.navigation.popup = Popup::SessionSelect;
-        app.session_popup_tab = 1;
-        app.session_id = Some("parent".into());
+        app.sessions.session_popup_tab = 1;
+        app.sessions.session_id = Some("parent".into());
         app.delegate_entries = vec![
             DelegateEntry {
                 delegation_id: "del-1".into(),
@@ -1387,7 +1387,7 @@ mod tests {
 
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.agent_mode = "build".into();
+        app.sessions.agent_mode = "build".into();
         app.messages.push(ChatEntry::ToolCall {
             tool_call_id: None,
             name: "delegate".into(),
@@ -1522,7 +1522,7 @@ mod tests {
     fn delegate_tool_call_shows_awaiting_input_marker() {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.agent_mode = "build".into();
+        app.sessions.agent_mode = "build".into();
         app.messages.push(ChatEntry::ToolCall {
             tool_call_id: None,
             name: "delegate".into(),
@@ -1566,7 +1566,7 @@ mod tests {
     fn draw_chat_preserves_hard_line_breaks_in_input() {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.agent_mode = "build".into();
+        app.sessions.agent_mode = "build".into();
         app.input = "alpha\nbeta".into();
         app.input_cursor = app.input.len();
 
@@ -1588,7 +1588,7 @@ mod tests {
     fn draw_chat_places_cursor_on_next_row_after_newline() {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.agent_mode = "build".into();
+        app.sessions.agent_mode = "build".into();
         app.input = "alpha\nbeta".into();
         app.input_cursor = "alpha\n".len();
 
@@ -1634,7 +1634,7 @@ mod tests {
     fn draw_chat_does_not_panic_with_empty_elicitation_fields() {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.agent_mode = "build".into();
+        app.sessions.agent_mode = "build".into();
         app.elicitation = Some(ElicitationState::new_for_test(vec![]));
         app.elicitation_ui = Some(ElicitationUiState::default());
 
@@ -1645,7 +1645,7 @@ mod tests {
     fn draw_chat_custom_elicitation_wraps_and_expands_with_prefix() {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.agent_mode = "build".into();
+        app.sessions.agent_mode = "build".into();
         let mut state = ElicitationState::new_for_test(vec![ElicitationField {
             name: "choice".into(),
             title: "Choice".into(),
@@ -1747,7 +1747,7 @@ mod tests {
     fn draw_delegate_view_shows_elicitation_popup_and_input_hint() {
         let mut app = App::new();
         app.navigation.screen = Screen::Delegate;
-        app.agent_mode = "build".into();
+        app.sessions.agent_mode = "build".into();
         app.messages.push(ChatEntry::Assistant {
             content: "Delegate context".into(),
             thinking: None,
@@ -1801,7 +1801,7 @@ mod tests {
     fn draw_delegate_view_without_elicitation_remains_read_only() {
         let mut app = App::new();
         app.navigation.screen = Screen::Delegate;
-        app.agent_mode = "build".into();
+        app.sessions.agent_mode = "build".into();
         app.messages.push(ChatEntry::Assistant {
             content: "Read-only child output".into(),
             thinking: None,
@@ -1829,8 +1829,8 @@ mod tests {
     fn draw_session_popup_shows_active_marker_for_current_session() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_id = Some("s2".into());
-        app.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
+        app.sessions.session_id = Some("s2".into());
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
 
         let backend = ratatui::backend::TestBackend::new(80, 20);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
@@ -1850,8 +1850,8 @@ mod tests {
     fn draw_session_popup_highlights_active_session_id() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_id = Some("s2".into());
-        app.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
+        app.sessions.session_id = Some("s2".into());
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
 
         let backend = ratatui::backend::TestBackend::new(80, 20);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
@@ -1870,9 +1870,9 @@ mod tests {
     fn draw_session_popup_shows_fork_count_marker() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(Some("/a"), &["s1"])];
-        app.session_groups[0].sessions[0].fork_count = 3;
-        app.session_cursor = 1;
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
+        app.sessions.session_groups[0].sessions[0].fork_count = 3;
+        app.sessions.session_cursor = 1;
 
         let backend = ratatui::backend::TestBackend::new(80, 20);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
@@ -1898,11 +1898,11 @@ mod tests {
     fn draw_session_popup_truncates_long_titles_with_unicode_ellipsis() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.session_groups = vec![make_group(Some("/a"), &["session-12345678"])];
-        app.session_groups[0].sessions[0].title =
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["session-12345678"])];
+        app.sessions.session_groups[0].sessions[0].title =
             Some("This is a very long session title that should truncate in the popup".into());
-        app.session_groups[0].sessions[0].updated_at = Some("2026-03-20T14:30:00Z".into());
-        app.session_cursor = 1;
+        app.sessions.session_groups[0].sessions[0].updated_at = Some("2026-03-20T14:30:00Z".into());
+        app.sessions.session_cursor = 1;
 
         let backend = ratatui::backend::TestBackend::new(60, 20);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
@@ -2032,7 +2032,7 @@ mod tests {
     fn draw_model_popup_groups_models_by_provider() {
         let mut app = App::new();
         app.navigation.popup = Popup::ModelSelect;
-        app.agent_mode = "build".into();
+        app.sessions.agent_mode = "build".into();
         app.models.model_popup_agent_tab = 0;
         app.models.current_provider = Some("anthropic".into());
         app.models.current_model = Some("claude-sonnet".into());
@@ -2110,7 +2110,7 @@ mod tests {
     fn draw_model_popup_live_marker_uses_status_accent_on_session_tab() {
         let mut app = App::new();
         app.navigation.popup = Popup::ModelSelect;
-        app.agent_mode = "build".into();
+        app.sessions.agent_mode = "build".into();
         app.models.model_popup_agent_tab = 0;
         app.models.current_provider = Some("anthropic".into());
         app.models.current_model = Some("claude-sonnet".into());
@@ -2159,7 +2159,7 @@ mod tests {
     fn draw_model_popup_marks_only_remote_live_row_when_duplicates() {
         let mut app = App::new();
         app.navigation.popup = Popup::ModelSelect;
-        app.agent_mode = "build".into();
+        app.sessions.agent_mode = "build".into();
         app.models.model_popup_agent_tab = 0;
         app.models.current_provider = Some("codex".into());
         app.models.current_model = Some("gpt-5".into());
@@ -2343,7 +2343,7 @@ mod tests {
     fn draw_model_popup_shows_current_mode_model_on_short_terminal() {
         let mut app = App::new();
         app.navigation.popup = Popup::ModelSelect;
-        app.agent_mode = "build".into();
+        app.sessions.agent_mode = "build".into();
         app.models.models = (0..12)
             .map(|i| ModelEntry {
                 id: format!("anthropic/model-{i}"),
@@ -2477,9 +2477,9 @@ mod tests {
     fn draw_new_session_popup_shows_compact_default_cwd_hint() {
         let mut app = App::new();
         app.navigation.popup = Popup::NewSession;
-        app.new_session_path = "/launch".into();
-        app.new_session_cursor = app.new_session_path.len();
-        app.new_session_completion = Some(crate::app::PathCompletionState {
+        app.sessions.new_session_path = "/launch".into();
+        app.sessions.new_session_cursor = app.sessions.new_session_path.len();
+        app.sessions.new_session_completion = Some(crate::session_state::PathCompletionState {
             query: "/launch".into(),
             selected_index: 0,
             results: vec![crate::app::FileIndexEntryLite {
@@ -2859,7 +2859,7 @@ mod tests {
     #[test]
     fn late_failed_tool_end_updates_cached_tool_card_without_appending_badge() {
         let mut app = App::new();
-        app.session_id = Some("test-session".into());
+        app.sessions.session_id = Some("test-session".into());
         live_update(
             &mut app,
             "test-session",
@@ -2896,7 +2896,7 @@ mod tests {
     #[test]
     fn warm_shell_tool_card_rebuilds_with_output_tail_after_native_end_update() {
         let mut app = App::new();
-        app.session_id = Some("test-session".into());
+        app.sessions.session_id = Some("test-session".into());
         live_update(
             &mut app,
             "test-session",
@@ -2949,7 +2949,7 @@ mod tests {
     #[test]
     fn warm_edit_tool_card_rebuilds_with_start_line_after_native_end_update() {
         let mut app = App::new();
-        app.session_id = Some("test-session".into());
+        app.sessions.session_id = Some("test-session".into());
         live_update(
             &mut app,
             "test-session",
@@ -3004,7 +3004,7 @@ mod tests {
     #[test]
     fn failed_tool_end_before_start_reconciles_badge_without_stale_bottom_entry() {
         let mut app = App::new();
-        app.session_id = Some("test-session".into());
+        app.sessions.session_id = Some("test-session".into());
         for update in [
             assistant_update("older assistant", "assistant-old"),
             failed_tool_end("tool-out-of-order", "shell"),
@@ -3162,7 +3162,7 @@ mod tests {
     #[test]
     fn child_session_group_replays_elicitation_as_durable_card() {
         let mut app = App::new();
-        app.session_groups = vec![SessionGroup {
+        app.sessions.session_groups = vec![SessionGroup {
             cwd: None,
             sessions: vec![SessionSummary {
                 session_id: "child-1".into(),
@@ -3953,7 +3953,7 @@ mod tests {
 
     // ── start-page session list row builder ───────────────────────────────────
 
-    use crate::app::StartPageItem;
+    use crate::session_state::StartPageItem;
 
     fn make_group(cwd: Option<&str>, ids: &[&str]) -> SessionGroup {
         SessionGroup {
@@ -3997,7 +3997,7 @@ mod tests {
     #[test]
     fn start_page_rows_single_expanded_group() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
         let rows = build_start_page_rows(&app, 80);
         assert_eq!(rows.len(), 3);
         assert!(matches!(rows[0].item, StartPageItem::GroupHeader { .. }));
@@ -4009,8 +4009,8 @@ mod tests {
     #[test]
     fn start_page_rows_collapsed_group_shows_only_header() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
-        app.collapsed_groups.insert("/a".to_string());
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
+        app.sessions.collapsed_groups.insert("/a".to_string());
         let rows = build_start_page_rows(&app, 80);
         assert_eq!(rows.len(), 1);
         assert!(matches!(
@@ -4026,8 +4026,8 @@ mod tests {
     #[test]
     fn start_page_rows_selected_flag_matches_cursor() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
-        app.session_cursor = 1; // points at first session row (index 1)
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
+        app.sessions.session_cursor = 1; // points at first session row (index 1)
         let rows = build_start_page_rows(&app, 80);
         assert!(!rows[0].selected); // header not selected
         assert!(rows[1].selected); // first session selected
@@ -4038,7 +4038,7 @@ mod tests {
     #[test]
     fn start_page_rows_header_contains_cwd() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/home/user/proj"), &["s1"])];
+        app.sessions.session_groups = vec![make_group(Some("/home/user/proj"), &["s1"])];
         let rows = build_start_page_rows(&app, 80);
         // The header line should contain the cwd somewhere in its text
         let header_text = rows[0]
@@ -4056,8 +4056,8 @@ mod tests {
     #[test]
     fn start_page_rows_header_uses_loaded_total_count() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/home/user/proj"), &["s1", "s2"])];
-        app.session_groups[0].total_count = Some(5);
+        app.sessions.session_groups = vec![make_group(Some("/home/user/proj"), &["s1", "s2"])];
+        app.sessions.session_groups[0].total_count = Some(5);
         let rows = build_start_page_rows(&app, 80);
         let header_text = row_text(&rows[0]);
 
@@ -4067,8 +4067,8 @@ mod tests {
     #[test]
     fn start_page_rows_header_uses_loaded_count_when_total_unknown() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/home/user/proj"), &["s1", "s2"])];
-        app.session_groups[0].total_count = None;
+        app.sessions.session_groups = vec![make_group(Some("/home/user/proj"), &["s1", "s2"])];
+        app.sessions.session_groups[0].total_count = None;
         let rows = build_start_page_rows(&app, 80);
         let header_text = row_text(&rows[0]);
 
@@ -4080,7 +4080,7 @@ mod tests {
     #[test]
     fn start_page_rows_session_contains_id() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["abcdef12"])];
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["abcdef12"])];
         let rows = build_start_page_rows(&app, 80);
         let session_text = rows[1]
             .line
@@ -4097,8 +4097,8 @@ mod tests {
     #[test]
     fn start_page_rows_session_shows_fork_count_marker() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["abcdef12"])];
-        app.session_groups[0].sessions[0].fork_count = 3;
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["abcdef12"])];
+        app.sessions.session_groups[0].sessions[0].fork_count = 3;
 
         let rows = build_start_page_rows(&app, 80);
         let session_text = row_text(&rows[1]);
@@ -4128,7 +4128,7 @@ mod tests {
     #[test]
     fn start_page_rows_session_hides_zero_fork_count_marker() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["abcdef12"])];
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["abcdef12"])];
 
         let rows = build_start_page_rows(&app, 80);
         let session_text = row_text(&rows[1]);
@@ -4143,8 +4143,8 @@ mod tests {
     #[test]
     fn start_page_rows_collapsed_indicator_present() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["s1"])];
-        app.collapsed_groups.insert("/a".to_string());
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
+        app.sessions.collapsed_groups.insert("/a".to_string());
         let rows = build_start_page_rows(&app, 80);
         let text = rows[0]
             .line
@@ -4162,7 +4162,7 @@ mod tests {
     #[test]
     fn start_page_rows_expanded_indicator_present() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["s1"])];
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
         // not collapsed
         let rows = build_start_page_rows(&app, 80);
         let text = rows[0]
@@ -4180,7 +4180,7 @@ mod tests {
     #[test]
     fn start_page_show_more_row_uses_show_all_label_not_load_more() {
         let mut app = App::new();
-        app.session_groups = vec![make_group(Some("/a"), &["s1", "s2", "s3", "s4"])];
+        app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2", "s3", "s4"])];
         let rows = build_start_page_rows(&app, 80);
         let text = row_text(rows.last().expect("missing show more row"));
 

--- a/src/ui/popups.rs
+++ b/src/ui/popups.rs
@@ -7,7 +7,7 @@ use ratatui::{
 };
 use unicode_width::UnicodeWidthStr;
 
-use crate::app::{App, session_group_count_text};
+use crate::app::App;
 use crate::auth_state::AuthPanel;
 use crate::diagnostics::LogLevel;
 use crate::domain::activity::DelegateStats;
@@ -15,6 +15,7 @@ use crate::domain::auth::{OAuthFlowKind, OAuthStatus};
 use crate::domain::model::ModelEntry;
 use crate::domain::profile::ProfileInfo;
 use crate::models_state::ModelPopupItem;
+use crate::session_state::session_group_count_text;
 use crate::theme::Theme;
 
 use super::chat::{CHECK_CHECKED, CHECK_FAILED, SpinnerKind, spinner};
@@ -403,7 +404,7 @@ pub(super) fn draw_session_popup(f: &mut Frame, app: &mut App) {
     let tab_labels = ["sessions", "delegates"];
     let mut tab_spans = Vec::new();
     for (i, label) in tab_labels.iter().enumerate() {
-        let is_active = i == app.session_popup_tab;
+        let is_active = i == app.sessions.session_popup_tab;
         let style = if is_active {
             Theme::popup_title().add_modifier(Modifier::UNDERLINED)
         } else {
@@ -419,7 +420,7 @@ pub(super) fn draw_session_popup(f: &mut Frame, app: &mut App) {
         chunks[0],
     );
 
-    if app.session_popup_tab == 0 {
+    if app.sessions.session_popup_tab == 0 {
         draw_session_tab_content(f, app, &chunks);
     } else {
         draw_delegate_tab_content(f, app, &chunks);
@@ -427,12 +428,15 @@ pub(super) fn draw_session_popup(f: &mut Frame, app: &mut App) {
 }
 
 fn draw_session_tab_content(f: &mut Frame, app: &mut App, chunks: &std::rc::Rc<[Rect]>) {
-    use crate::app::PopupItem;
+    use crate::session_state::PopupItem;
 
     // filter
     let avail = chunks[1].width.saturating_sub(2) as usize;
-    let (session_filter_display, session_filter_cur) =
-        scroll_input(&app.session_filter, app.session_filter.len(), avail);
+    let (session_filter_display, session_filter_cur) = scroll_input(
+        &app.sessions.session_filter,
+        app.sessions.session_filter.len(),
+        avail,
+    );
     let filter_line = Line::from(vec![
         Span::styled("> ", Theme::popup_title()),
         Span::styled(session_filter_display, Theme::popup_bg()),
@@ -444,16 +448,16 @@ fn draw_session_tab_content(f: &mut Frame, app: &mut App, chunks: &std::rc::Rc<[
     f.set_cursor_position((chunks[1].x + 2 + session_filter_cur as u16, chunks[1].y));
 
     // grouped session list
-    let popup_items = app.visible_popup_items();
+    let popup_items = app.sessions.visible_popup_items();
     let list_w = chunks[3].width as usize;
     let visible_rows = chunks[3].height as usize;
-    app.session_popup_visible_rows = visible_rows;
+    app.sessions.session_popup_visible_rows = visible_rows;
 
     let items: Vec<ListItem> = popup_items
         .iter()
         .enumerate()
         .map(|(i, item)| {
-            let selected = i == app.session_cursor;
+            let selected = i == app.sessions.session_cursor;
             match item {
                 PopupItem::GroupHeader {
                     cwd,
@@ -485,7 +489,7 @@ fn draw_session_tab_content(f: &mut Frame, app: &mut App, chunks: &std::rc::Rc<[
                     path,
                     depth,
                 } => {
-                    let Some(s) = app.session_by_path(*group_idx, path) else {
+                    let Some(s) = app.sessions.session_by_path(*group_idx, path) else {
                         return ListItem::new(Line::from(""));
                     };
                     let id_short: String = s.session_id.chars().take(8).collect();
@@ -496,7 +500,8 @@ fn draw_session_tab_content(f: &mut Frame, app: &mut App, chunks: &std::rc::Rc<[
                         .unwrap_or_default();
                     let title = s.title.as_deref().unwrap_or("(untitled)");
 
-                    let is_active = app.session_id.as_deref() == Some(s.session_id.as_str());
+                    let is_active =
+                        app.sessions.session_id.as_deref() == Some(s.session_id.as_str());
                     let is_parent = app.parent_session_id.as_deref() == Some(s.session_id.as_str());
                     let marker_part = if is_active {
                         " ● "
@@ -507,8 +512,12 @@ fn draw_session_tab_content(f: &mut Frame, app: &mut App, chunks: &std::rc::Rc<[
                     };
                     let indent = "  ".repeat(*depth);
                     let id_part = format!(" {indent}{id_short} ");
-                    let fork_marker = if app.expandable_root_session(*group_idx, path) {
-                        let indicator = if app.expanded_session_children.contains(&s.session_id) {
+                    let fork_marker = if app.sessions.expandable_root_session(*group_idx, path) {
+                        let indicator = if app
+                            .sessions
+                            .expanded_session_children
+                            .contains(&s.session_id)
+                        {
                             COLLAPSE_OPEN
                         } else {
                             COLLAPSE_CLOSED
@@ -585,11 +594,12 @@ fn draw_session_tab_content(f: &mut Frame, app: &mut App, chunks: &std::rc::Rc<[
 
     let list = List::new(items).block(Block::default().style(Theme::popup_bg()));
     let offset = app
+        .sessions
         .session_cursor
         .saturating_sub(visible_rows.saturating_sub(1));
     let mut state = ListState::default()
         .with_offset(offset)
-        .with_selected(Some(app.session_cursor));
+        .with_selected(Some(app.sessions.session_cursor));
     f.render_stateful_widget(list, chunks[3], &mut state);
 
     // hint
@@ -727,7 +737,8 @@ fn draw_delegate_tab_content(f: &mut Frame, app: &mut App, chunks: &std::rc::Rc<
                     entry.objective.clone()
                 };
 
-                let is_current = entry.child_session_id.as_deref() == app.session_id.as_deref();
+                let is_current =
+                    entry.child_session_id.as_deref() == app.sessions.session_id.as_deref();
                 let duration = entry
                     .started_at
                     .map(|start| {
@@ -1239,6 +1250,7 @@ pub(super) fn draw_profile_popup(f: &mut Frame, app: &App) {
 pub(super) fn draw_new_session_popup(f: &mut Frame, app: &App) {
     let area = f.area();
     let show_completion = app
+        .sessions
         .new_session_completion
         .as_ref()
         .map(|completion| !completion.results.is_empty())
@@ -1289,8 +1301,11 @@ pub(super) fn draw_new_session_popup(f: &mut Frame, app: &App) {
         chunks[1],
     );
     let avail = chunks[2].width.saturating_sub(2) as usize;
-    let (path_display, path_cur) =
-        scroll_input(&app.new_session_path, app.new_session_cursor, avail);
+    let (path_display, path_cur) = scroll_input(
+        &app.sessions.new_session_path,
+        app.sessions.new_session_cursor,
+        avail,
+    );
     let input_line = Line::from(vec![
         Span::styled("> ", Theme::popup_title()),
         Span::styled(path_display, Theme::popup_bg()),
@@ -1301,7 +1316,7 @@ pub(super) fn draw_new_session_popup(f: &mut Frame, app: &App) {
     );
     f.set_cursor_position((chunks[2].x + 2 + path_cur as u16, chunks[2].y));
 
-    if let Some(completion) = &app.new_session_completion
+    if let Some(completion) = &app.sessions.new_session_completion
         && !completion.results.is_empty()
     {
         let items: Vec<ListItem> = completion
@@ -3063,7 +3078,7 @@ mod tests {
             profile("other", "Other"),
         ];
         app.profiles.active_profile_id = Some("active".into());
-        app.session_id = Some("session".into());
+        app.sessions.session_id = Some("session".into());
         app.profiles
             .bind_session_profile("session".into(), "active".into());
         app.profiles.profile_filter = "selected".into();
@@ -3088,7 +3103,7 @@ mod tests {
         let mut app = App::new();
         app.profiles.profiles = vec![profile("active", "Active"), profile("current", "Current")];
         app.profiles.active_profile_id = Some("active".into());
-        app.session_id = Some("session".into());
+        app.sessions.session_id = Some("session".into());
         app.profiles
             .bind_session_profile("session".into(), "current".into());
 

--- a/src/ui/start.rs
+++ b/src/ui/start.rs
@@ -5,7 +5,8 @@ use ratatui::{
     widgets::{Block, Paragraph},
 };
 
-use crate::app::{App, session_group_count_text};
+use crate::app::App;
+use crate::session_state::{StartPageItem, session_group_count_text};
 use crate::theme::Theme;
 
 use super::{ELLIPSIS, draw_header, mesh_header_span, relative_time};
@@ -20,7 +21,7 @@ pub(super) const COLLAPSE_CLOSED: &str = "\u{25B8}"; // ▸ collapsed group
 /// Returned by [`build_start_page_rows`] and consumed by [`draw_start`].
 pub(crate) struct StartPageRow {
     /// The logical item this row represents.
-    pub(crate) item: crate::app::StartPageItem,
+    pub(crate) item: StartPageItem,
     /// Pre-rendered line (spans already styled).
     pub(crate) line: Line<'static>,
     /// True when `session_cursor` points at this row.
@@ -32,11 +33,11 @@ pub(crate) struct StartPageRow {
 /// Pure function — does not touch the frame. Accepts `area_width` for
 /// truncating long paths/titles.
 pub(crate) fn build_start_page_rows(app: &App, area_width: usize) -> Vec<StartPageRow> {
-    let items = app.visible_start_items();
+    let items = app.sessions.visible_start_items();
     let mut rows = Vec::with_capacity(items.len());
 
     for (idx, item) in items.iter().enumerate() {
-        let selected = idx == app.session_cursor;
+        let selected = idx == app.sessions.session_cursor;
 
         let (header_style, dim_style) = if selected {
             (Theme::selected(), Theme::selected())
@@ -50,7 +51,7 @@ pub(crate) fn build_start_page_rows(app: &App, area_width: usize) -> Vec<StartPa
         };
 
         let line: Line<'static> = match &item {
-            crate::app::StartPageItem::GroupHeader {
+            StartPageItem::GroupHeader {
                 cwd,
                 session_count,
                 session_total,
@@ -72,12 +73,12 @@ pub(crate) fn build_start_page_rows(app: &App, area_width: usize) -> Vec<StartPa
                 ])
             }
 
-            crate::app::StartPageItem::Session {
+            StartPageItem::Session {
                 group_idx,
                 path,
                 depth,
             } => {
-                let Some(session) = app.session_by_path(*group_idx, path) else {
+                let Some(session) = app.sessions.session_by_path(*group_idx, path) else {
                     continue;
                 };
                 let id_short: String = session.session_id.chars().take(8).collect();
@@ -88,8 +89,12 @@ pub(crate) fn build_start_page_rows(app: &App, area_width: usize) -> Vec<StartPa
                     .map(relative_time)
                     .unwrap_or_default();
 
-                let fork_marker = if app.expandable_root_session(*group_idx, path) {
-                    let indicator = if app.expanded_session_children.contains(&session.session_id) {
+                let fork_marker = if app.sessions.expandable_root_session(*group_idx, path) {
+                    let indicator = if app
+                        .sessions
+                        .expanded_session_children
+                        .contains(&session.session_id)
+                    {
                         COLLAPSE_OPEN
                     } else {
                         COLLAPSE_CLOSED
@@ -130,7 +135,7 @@ pub(crate) fn build_start_page_rows(app: &App, area_width: usize) -> Vec<StartPa
 
             // Per-group overflow row. The start page always opens the popup;
             // only the popup performs paginated load-more requests.
-            crate::app::StartPageItem::ShowMore { .. } => {
+            StartPageItem::ShowMore { .. } => {
                 let label = format!("   {ELLIPSIS} show all");
                 Line::from(vec![Span::styled(label, dim_style)])
             }
@@ -366,7 +371,7 @@ pub(super) fn draw_start(f: &mut Frame, app: &mut App) {
     };
     let filter_line = Line::from(vec![
         Span::styled(" > ", Theme::start_header()),
-        Span::styled(app.session_filter.clone(), Theme::fg()),
+        Span::styled(app.sessions.session_filter.clone(), Theme::fg()),
     ]);
     f.render_widget(
         Paragraph::new(filter_line).style(Theme::base()),
@@ -374,7 +379,7 @@ pub(super) fn draw_start(f: &mut Frame, app: &mut App) {
     );
     // Show cursor at the end of the typed filter text
     f.set_cursor_position((
-        filter_area.x + 3 + app.session_filter.chars().count() as u16,
+        filter_area.x + 3 + app.sessions.session_filter.chars().count() as u16,
         filter_area.y,
     ));
 
@@ -383,7 +388,7 @@ pub(super) fn draw_start(f: &mut Frame, app: &mut App) {
 
     if rows.is_empty() {
         // Empty state
-        let msg = if app.session_filter.is_empty() {
+        let msg = if app.sessions.session_filter.is_empty() {
             "No sessions yet.  C-x n to start a new one."
         } else {
             "No sessions match the filter."
@@ -406,19 +411,20 @@ pub(super) fn draw_start(f: &mut Frame, app: &mut App) {
         let total_rows = rows.len();
 
         // Clamp scroll so cursor is in view.
-        if app.session_cursor >= app.start_page_scroll + visible_rows {
-            app.start_page_scroll = app.session_cursor + 1 - visible_rows;
+        if app.sessions.session_cursor >= app.sessions.start_page_scroll + visible_rows {
+            app.sessions.start_page_scroll = app.sessions.session_cursor + 1 - visible_rows;
         }
-        if app.session_cursor < app.start_page_scroll {
-            app.start_page_scroll = app.session_cursor;
+        if app.sessions.session_cursor < app.sessions.start_page_scroll {
+            app.sessions.start_page_scroll = app.sessions.session_cursor;
         }
-        app.start_page_scroll = app
+        app.sessions.start_page_scroll = app
+            .sessions
             .start_page_scroll
             .min(total_rows.saturating_sub(visible_rows));
 
         for (display_row, row) in rows
             .iter()
-            .skip(app.start_page_scroll)
+            .skip(app.sessions.start_page_scroll)
             .take(visible_rows)
             .enumerate()
         {
@@ -455,7 +461,7 @@ pub(super) fn draw_start(f: &mut Frame, app: &mut App) {
         height: 1,
     };
 
-    let button_focused = app.session_cursor == rows.len();
+    let button_focused = app.sessions.session_cursor == rows.len();
 
     // Build text spans: glitch only when focused, always bold
     let text_spans: Vec<Span<'static>> = if button_focused {


### PR DESCRIPTION
## what changed

- add one private `SessionsState` owner with exactly 23 browser, discovery, viewport, identity/mode, new-session, activity, and remembered remote-location fields
- replace the 23 flat `App` fields with one `pub(crate) sessions: SessionsState`, reducing direct `App` fields from 89 to 67
- move session item/completion types, constants, matching, pagination, child merge, collapse, cursor/filter, mode, completion, activity, and remote-location behavior into the owner
- retain command construction, ACP lifecycle coordination, profile binding, filesystem/path normalization, connectivity, routing, rendering, mesh attach, and reconnect behavior at existing boundaries
- keep `launch_cwd` and `delegate_popup_visible_rows` flat; preserve the focused `reset_active_session_view` lifecycle boundary

## scope and metrics

- exact base: `3a7a599ff0fb04def35f2ba1591d3623dc5e9ba0`
- source commit: `dcc88cbc2be93550c394f8e8bd6dab2ec910c2be`
- exact 13-file allowlist: `src/session_state.rs`, `src/lib.rs`, `src/app.rs`, `src/session.rs`, `src/acp_state.rs`, `src/handlers.rs`, `src/mesh.rs`, `src/runtime/mod.rs`, `src/runtime/event_loop.rs`, `src/ui/start.rs`, `src/ui/popups.rs`, `src/ui/chat.rs`, `src/ui/mod.rs`
- diff: 13 files, 2,228 insertions, 1,709 deletions
- resulting source: 51 Rust files, 44,505 physical LOC, 67 direct `App` fields, five `App` impl files, 23 `SessionsState` fields, 848 test declarations

## validation

- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --all-targets --all-features`
- `cargo test --all-targets --all-features` (848 passed, 0 failed/ignored)
- focused owner tests (14 passed) and session-focused tests (202 passed)
- `git diff --check`

## boundary proof

- exactly one private `mod session_state;`, one `App::sessions`, and 23 owner fields
- zero old flat declarations/direct accesses and zero old `crate::app::{StartPageItem, PopupItem, PathCompletionState}` paths
- no forbidden owner imports beyond the explicitly allowed `FileIndexEntryLite` dependency
- `launch_cwd` and `delegate_popup_visible_rows` are each declared once on `App` and absent from the owner
- exactly four existing `phase 11 compatibility forward` tags remain
- no source outside the approved 13-file allowlist changed

## residuals

- no manual TUI smoke claim
- phase 4, broad roadmap acceptance, connection/chat/composer/delegates/render extraction, and phase 11 cleanup remain pending
- integration is not claimed until a separately approved merge and equivalence verification
