### PR TITLE
refactor: extract connection state

### DIFF
--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -2662,7 +2662,7 @@ mod tests {
     fn native_remote_attach_uses_remote_cwd_and_detached_refreshes_sessions() {
         let mut app = App::new();
         app.sessions.agent_id = Some("agent-1".into());
-        app.launch_cwd = Some("/launch".into());
+        app.connection.launch_cwd = Some("/launch".into());
         app.sessions.remember_remote_session_location(
             "remote-1",
             "node-1",

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, Instant};
 
 use crate::auth_state::AuthState;
 use crate::command::Command;
+use crate::connection_state::{ConnState, ConnectionState};
 use crate::diagnostics::{AppLogEntry, DiagnosticsState, LogLevel};
 use crate::domain::activity::{
     ActivityState, DelegateChildState, DelegateEntry, DelegateStats, PendingDelegateToolCall,
@@ -217,13 +218,6 @@ pub struct SlashCompletionState {
     pub results: Vec<&'static crate::slash::SlashCommandDef>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ConnState {
-    Connecting,
-    Connected,
-    Disconnected,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConnectionEvent {
     Connecting { attempt: u32, delay_ms: u64 },
@@ -240,9 +234,6 @@ pub struct App {
     pub(crate) sessions: SessionsState,
     /// Last rendered visible row count for the delegates tab in the popup.
     pub delegate_popup_visible_rows: usize,
-
-    // active session startup context
-    pub launch_cwd: Option<String>,
 
     // chat
     pub messages: Vec<ChatEntry>,
@@ -309,13 +300,8 @@ pub struct App {
     // mesh / remote (from ACP extensions)
     pub(crate) mesh: MeshState,
 
-    // connection
-    pub conn: ConnState,
-    pub reconnect_attempt: u32,
-    pub reconnect_delay_ms: Option<u64>,
-
-    // server lifecycle (managed by server_manager::supervisor)
-    pub server_state: crate::server_manager::ServerState,
+    // connection and server lifecycle
+    pub(crate) connection: ConnectionState,
 
     // syntax highlighting
     pub hl: Highlighter,
@@ -395,7 +381,6 @@ impl App {
             navigation: NavigationState::new(),
             sessions: SessionsState::new(),
             delegate_popup_visible_rows: 0,
-            launch_cwd: None,
             messages: Vec::new(),
             pending_prompt_seq: 0,
             input: String::new(),
@@ -436,10 +421,7 @@ impl App {
             session_stats: SessionStatsLite::default(),
             pending_cancel_confirm_until: None,
             mesh: MeshState::new(),
-            conn: ConnState::Connecting,
-            reconnect_attempt: 0,
-            reconnect_delay_ms: None,
-            server_state: crate::server_manager::ServerState::default(),
+            connection: ConnectionState::new(),
             hl: Highlighter::new(),
             card_cache: CardCache::new(),
             auth: AuthState::new(),
@@ -772,7 +754,7 @@ impl App {
             );
         } else if let Some(activity_status) = self.activity_status_text() {
             self.set_status(LogLevel::Debug, "activity", activity_status);
-        } else if self.conn == ConnState::Connected {
+        } else if self.connection.conn == ConnState::Connected {
             self.set_status(LogLevel::Debug, "activity", "ready");
         }
     }
@@ -846,9 +828,7 @@ impl App {
         self.clear_cancel_confirm();
         match event {
             ConnectionEvent::Connecting { attempt, delay_ms } => {
-                self.conn = ConnState::Connecting;
-                self.reconnect_attempt = attempt;
-                self.reconnect_delay_ms = Some(delay_ms);
+                self.connection.apply_connecting(attempt, delay_ms);
                 let secs = delay_ms as f64 / 1000.0;
                 self.set_status(
                     LogLevel::Warn,
@@ -857,9 +837,7 @@ impl App {
                 );
             }
             ConnectionEvent::Connected => {
-                self.conn = ConnState::Connected;
-                self.reconnect_attempt = 0;
-                self.reconnect_delay_ms = None;
+                self.connection.apply_connected();
                 self.set_status(
                     LogLevel::Info,
                     "connection",
@@ -871,8 +849,7 @@ impl App {
                 );
             }
             ConnectionEvent::Disconnected { reason } => {
-                self.conn = ConnState::Disconnected;
-                self.reconnect_delay_ms = None;
+                self.connection.apply_disconnected();
                 self.sessions.session_discovery_in_progress = false;
                 self.sessions.pending_session_group_loads.clear();
                 self.set_status(
@@ -1297,7 +1274,7 @@ mod reasoning_effort_tests {
     #[test]
     fn resolve_new_session_default_cwd_prefers_active_session_cwd_then_group_then_launch() {
         let mut app = App::new();
-        app.launch_cwd = Some("/launch".into());
+        app.connection.launch_cwd = Some("/launch".into());
         app.sessions.session_id = Some("session-a".into());
         app.sessions.session_groups = vec![SessionGroup {
             cwd: Some("/group".into()),
@@ -1335,7 +1312,7 @@ mod reasoning_effort_tests {
     #[test]
     fn open_new_session_popup_prefills_path_and_cursor() {
         let mut app = App::new();
-        app.launch_cwd = Some("/launch".into());
+        app.connection.launch_cwd = Some("/launch".into());
 
         app.open_new_session_popup();
 
@@ -1347,7 +1324,7 @@ mod reasoning_effort_tests {
     #[test]
     fn normalize_new_session_path_uses_launch_cwd_for_relative_paths() {
         let mut app = App::new();
-        app.launch_cwd = Some("/launch/base".into());
+        app.connection.launch_cwd = Some("/launch/base".into());
 
         assert_eq!(
             app.normalize_new_session_path("proj/subdir").as_deref(),
@@ -1406,7 +1383,7 @@ mod reasoning_effort_tests {
         std::fs::write(dir.join("project-file.txt"), "x").unwrap();
 
         let mut app = App::new();
-        app.launch_cwd = Some(dir.to_string_lossy().into_owned());
+        app.connection.launch_cwd = Some(dir.to_string_lossy().into_owned());
         let results = app.rank_path_completion_matches("project");
 
         assert!(results.iter().all(|entry| entry.is_dir));
@@ -1752,6 +1729,7 @@ mod session_mode_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::connection_state::ServerState;
     use crate::domain::chat::OUTCOME_BULLET;
 
     fn make_turn(message_id: &str) -> UndoableTurn {
@@ -2037,12 +2015,12 @@ mod tests {
     #[test]
     fn refresh_transient_status_preserves_connection_and_operation_precedence() {
         let mut app = App::new();
-        app.conn = ConnState::Disconnected;
+        app.connection.conn = ConnState::Disconnected;
         app.set_status(LogLevel::Warn, "connection", "connection lost - retrying");
         app.refresh_transient_status();
         assert_eq!(app.diagnostics.status, "connection lost - retrying");
 
-        app.conn = ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.activity = ActivityState::Thinking;
         app.refresh_transient_status();
         assert_eq!(app.diagnostics.status, "thinking...");
@@ -2283,15 +2261,19 @@ mod tests {
     }
 
     #[test]
-    fn connection_events_update_status_and_retry_metadata() {
+    fn connecting_event_updates_status_retry_metadata_and_clears_cancel_confirmation() {
         let mut app = App::new();
+        app.arm_cancel_confirm();
+
         app.handle_connection_event(ConnectionEvent::Connecting {
             attempt: 3,
             delay_ms: 2000,
         });
-        assert_eq!(app.conn, ConnState::Connecting);
-        assert_eq!(app.reconnect_attempt, 3);
-        assert_eq!(app.reconnect_delay_ms, Some(2000));
+
+        assert_eq!(app.connection.conn, ConnState::Connecting);
+        assert_eq!(app.connection.reconnect_attempt, 3);
+        assert_eq!(app.connection.reconnect_delay_ms, Some(2000));
+        assert!(app.pending_cancel_confirm_until.is_none());
         assert_eq!(
             app.diagnostics.status,
             "waiting for server - retry 3 in 2.0s"
@@ -2299,25 +2281,73 @@ mod tests {
         assert!(
             matches!(app.diagnostics.logs.last(), Some(entry) if entry.target == "connection" && entry.level == LogLevel::Warn)
         );
+    }
+
+    #[test]
+    fn connected_event_selects_connected_or_reconnected_and_resets_retry_metadata() {
+        let mut app = App::new();
+        app.connection.reconnect_attempt = 3;
+        app.connection.reconnect_delay_ms = Some(2000);
+
+        app.handle_connection_event(ConnectionEvent::Connected);
+        assert_eq!(app.connection.conn, ConnState::Connected);
+        assert_eq!(app.connection.reconnect_attempt, 0);
+        assert_eq!(app.connection.reconnect_delay_ms, None);
+        assert_eq!(app.diagnostics.status, "connected");
+
+        app.sessions.session_id = Some("session-1".into());
+        app.connection.reconnect_attempt = 2;
+        app.connection.reconnect_delay_ms = Some(1000);
+        app.handle_connection_event(ConnectionEvent::Connected);
+        assert_eq!(app.connection.conn, ConnState::Connected);
+        assert_eq!(app.connection.reconnect_attempt, 0);
+        assert_eq!(app.connection.reconnect_delay_ms, None);
+        assert_eq!(app.diagnostics.status, "reconnected");
+        assert!(
+            matches!(app.diagnostics.logs.last(), Some(entry) if entry.level == LogLevel::Info && entry.message == "reconnected")
+        );
+    }
+
+    #[test]
+    fn disconnected_event_clears_only_transient_session_discovery_and_delay_state() {
+        let mut app = App::new();
+        app.connection.launch_cwd = Some("/workspace".into());
+        app.connection.reconnect_attempt = 4;
+        app.connection.reconnect_delay_ms = Some(4000);
+        app.connection.server_state = ServerState::Running;
+        app.sessions.session_id = Some("session-1".into());
+        app.sessions.session_discovery_in_progress = true;
+        app.sessions
+            .pending_session_group_loads
+            .insert(Some("/workspace".into()));
+        app.sessions
+            .pending_session_child_loads
+            .insert("session-1".into());
+        app.input = "retained prompt".into();
+        app.arm_cancel_confirm();
 
         app.handle_connection_event(ConnectionEvent::Disconnected {
             reason: "socket closed".into(),
         });
-        assert_eq!(app.conn, ConnState::Disconnected);
-        assert_eq!(app.reconnect_delay_ms, None);
+
+        assert_eq!(app.connection.conn, ConnState::Disconnected);
+        assert_eq!(app.connection.reconnect_attempt, 4);
+        assert_eq!(app.connection.reconnect_delay_ms, None);
+        assert_eq!(app.connection.launch_cwd.as_deref(), Some("/workspace"));
+        assert_eq!(app.connection.server_state, ServerState::Running);
+        assert_eq!(app.sessions.session_id.as_deref(), Some("session-1"));
+        assert!(!app.sessions.session_discovery_in_progress);
+        assert!(app.sessions.pending_session_group_loads.is_empty());
+        assert!(
+            app.sessions
+                .pending_session_child_loads
+                .contains("session-1")
+        );
+        assert_eq!(app.input, "retained prompt");
+        assert!(app.pending_cancel_confirm_until.is_none());
         assert_eq!(app.diagnostics.status, "connection lost - socket closed");
         assert!(
             matches!(app.diagnostics.logs.last(), Some(entry) if entry.message == "connection lost - socket closed")
-        );
-
-        app.sessions.session_id = Some("session-1".into());
-        app.handle_connection_event(ConnectionEvent::Connected);
-        assert_eq!(app.conn, ConnState::Connected);
-        assert_eq!(app.reconnect_attempt, 0);
-        assert_eq!(app.reconnect_delay_ms, None);
-        assert_eq!(app.diagnostics.status, "reconnected");
-        assert!(
-            matches!(app.diagnostics.logs.last(), Some(entry) if entry.level == LogLevel::Info && entry.message == "reconnected")
         );
     }
 

--- a/src/connection_state.rs
+++ b/src/connection_state.rs
@@ -1,0 +1,177 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConnState {
+    Connecting,
+    Connected,
+    Disconnected,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) enum ServerState {
+    #[default]
+    Disabled,
+    BinaryNotFound,
+    Starting,
+    Running,
+    StartFailed {
+        error: String,
+    },
+    Restarting {
+        reason: String,
+    },
+}
+
+pub(crate) struct ConnectionState {
+    pub(crate) launch_cwd: Option<String>,
+    pub(crate) conn: ConnState,
+    pub(crate) reconnect_attempt: u32,
+    pub(crate) reconnect_delay_ms: Option<u64>,
+    pub(crate) server_state: ServerState,
+}
+
+impl ConnectionState {
+    pub(crate) fn new() -> Self {
+        Self {
+            launch_cwd: None,
+            conn: ConnState::Connecting,
+            reconnect_attempt: 0,
+            reconnect_delay_ms: None,
+            server_state: ServerState::Disabled,
+        }
+    }
+
+    pub(crate) fn apply_connecting(&mut self, attempt: u32, delay_ms: u64) {
+        self.conn = ConnState::Connecting;
+        self.reconnect_attempt = attempt;
+        self.reconnect_delay_ms = Some(delay_ms);
+    }
+
+    pub(crate) fn apply_connected(&mut self) {
+        self.conn = ConnState::Connected;
+        self.reconnect_attempt = 0;
+        self.reconnect_delay_ms = None;
+    }
+
+    pub(crate) fn apply_disconnected(&mut self) {
+        self.conn = ConnState::Disconnected;
+        self.reconnect_delay_ms = None;
+    }
+
+    pub(crate) fn apply_server_starting(&mut self) {
+        self.server_state = ServerState::Starting;
+    }
+
+    pub(crate) fn apply_server_started(&mut self) {
+        self.server_state = ServerState::Running;
+    }
+
+    pub(crate) fn apply_server_binary_not_found(&mut self) {
+        self.server_state = ServerState::BinaryNotFound;
+    }
+
+    pub(crate) fn apply_server_start_failed(&mut self, error: String) {
+        self.server_state = ServerState::StartFailed { error };
+    }
+
+    pub(crate) fn apply_server_stopped(&mut self, reason: String) {
+        self.server_state = ServerState::Restarting { reason };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seeded_state() -> ConnectionState {
+        ConnectionState {
+            launch_cwd: Some("/workspace".into()),
+            conn: ConnState::Connected,
+            reconnect_attempt: 7,
+            reconnect_delay_ms: Some(8000),
+            server_state: ServerState::Running,
+        }
+    }
+
+    #[test]
+    fn constructor_uses_exact_defaults() {
+        let state = ConnectionState::new();
+
+        assert_eq!(state.launch_cwd, None);
+        assert_eq!(state.conn, ConnState::Connecting);
+        assert_eq!(state.reconnect_attempt, 0);
+        assert_eq!(state.reconnect_delay_ms, None);
+        assert_eq!(state.server_state, ServerState::Disabled);
+    }
+
+    #[test]
+    fn connection_transitions_replace_retry_metadata_and_preserve_launch_and_server_state() {
+        let mut state = seeded_state();
+
+        state.apply_connecting(3, 2000);
+        assert_eq!(state.conn, ConnState::Connecting);
+        assert_eq!(state.reconnect_attempt, 3);
+        assert_eq!(state.reconnect_delay_ms, Some(2000));
+        assert_eq!(state.launch_cwd.as_deref(), Some("/workspace"));
+        assert_eq!(state.server_state, ServerState::Running);
+
+        state.apply_connected();
+        assert_eq!(state.conn, ConnState::Connected);
+        assert_eq!(state.reconnect_attempt, 0);
+        assert_eq!(state.reconnect_delay_ms, None);
+        assert_eq!(state.launch_cwd.as_deref(), Some("/workspace"));
+        assert_eq!(state.server_state, ServerState::Running);
+    }
+
+    #[test]
+    fn disconnected_clears_delay_and_preserves_stale_attempt_launch_and_server_state() {
+        let mut state = seeded_state();
+
+        state.apply_disconnected();
+
+        assert_eq!(state.conn, ConnState::Disconnected);
+        assert_eq!(state.reconnect_attempt, 7);
+        assert_eq!(state.reconnect_delay_ms, None);
+        assert_eq!(state.launch_cwd.as_deref(), Some("/workspace"));
+        assert_eq!(state.server_state, ServerState::Running);
+    }
+
+    #[test]
+    fn server_transitions_replace_only_server_state_and_preserve_payloads() {
+        let mut state = seeded_state();
+        let expected_connection = (
+            state.launch_cwd.clone(),
+            state.conn,
+            state.reconnect_attempt,
+            state.reconnect_delay_ms,
+        );
+
+        state.apply_server_starting();
+        assert_eq!(state.server_state, ServerState::Starting);
+        state.apply_server_started();
+        assert_eq!(state.server_state, ServerState::Running);
+        state.apply_server_binary_not_found();
+        assert_eq!(state.server_state, ServerState::BinaryNotFound);
+        state.apply_server_start_failed("invalid command".into());
+        assert_eq!(
+            state.server_state,
+            ServerState::StartFailed {
+                error: "invalid command".into()
+            }
+        );
+        state.apply_server_stopped("process exited".into());
+        assert_eq!(
+            state.server_state,
+            ServerState::Restarting {
+                reason: "process exited".into()
+            }
+        );
+        assert_eq!(
+            (
+                state.launch_cwd,
+                state.conn,
+                state.reconnect_attempt,
+                state.reconnect_delay_ms,
+            ),
+            expected_connection
+        );
+    }
+}

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,7 +1,7 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use tokio::sync::mpsc;
 
-use crate::app::{self, App};
+use crate::app::App;
 use crate::auth_state::{AuthPanel, AuthUiNotice};
 use crate::diagnostics::LogLevel;
 use crate::domain::activity::{ActivityState, SessionOp};
@@ -15,6 +15,7 @@ fn popup_page_step(visible_rows: usize) -> usize {
 }
 use crate::command::{Command, PromptBlock};
 use crate::config;
+use crate::connection_state::ConnState;
 use crate::theme;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -24,7 +25,7 @@ pub(crate) enum AppAction {
 }
 
 pub(crate) fn can_send_server_commands(app: &mut App) -> bool {
-    if app.conn == app::ConnState::Connected {
+    if app.connection.conn == ConnState::Connected {
         true
     } else {
         app.set_status(
@@ -2606,6 +2607,30 @@ mod model_popup_tests {
         KeyEvent::new(code, KeyModifiers::empty())
     }
 
+    #[test]
+    fn can_send_server_commands_accepts_only_connected_and_preserves_exact_warning() {
+        let mut app = App::new();
+
+        assert!(!can_send_server_commands(&mut app));
+        assert_eq!(
+            app.diagnostics.status,
+            "not connected - waiting to reconnect"
+        );
+
+        app.connection.conn = ConnState::Disconnected;
+        app.set_status(LogLevel::Debug, "test", "before disconnected guard");
+        assert!(!can_send_server_commands(&mut app));
+        assert_eq!(
+            app.diagnostics.status,
+            "not connected - waiting to reconnect"
+        );
+
+        app.connection.conn = ConnState::Connected;
+        app.set_status(LogLevel::Debug, "test", "retained");
+        assert!(can_send_server_commands(&mut app));
+        assert_eq!(app.diagnostics.status, "retained");
+    }
+
     fn make_model(provider: &str, model: &str) -> ModelEntry {
         ModelEntry {
             id: format!("{provider}/{model}"),
@@ -2775,7 +2800,7 @@ mod model_popup_tests {
     #[test]
     fn command_palette_open_mesh_refreshes_remote_nodes() {
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.navigation.popup = Popup::CommandPalette;
         app.navigation.command_palette_filter = "open mesh".into();
 
@@ -2820,7 +2845,7 @@ mod model_popup_tests {
     fn mesh_popup_create_remote_session_does_not_forward_local_cwd() {
         let mut app = App::new();
         app.navigation.popup = Popup::Mesh;
-        app.launch_cwd = Some("/local/launch".into());
+        app.connection.launch_cwd = Some("/local/launch".into());
         app.mesh.mesh_nodes = vec![crate::domain::mesh::RemoteNodeInfo {
             id: "node-1".into(),
             label: "framework".into(),
@@ -2842,7 +2867,7 @@ mod model_popup_tests {
     #[test]
     fn command_palette_create_mesh_invite_opens_prefilled_invite_popup() {
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.navigation.popup = Popup::CommandPalette;
         app.navigation.command_palette_filter = "mesh invite".into();
 
@@ -2957,7 +2982,7 @@ mod model_popup_tests {
     #[test]
     fn command_palette_profile_lists_profiles() {
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.navigation.popup = Popup::CommandPalette;
         app.navigation.command_palette_filter = "profile".into();
         app.profiles.profiles = vec![make_profile("fast", "Fast"), make_profile("deep", "Deep")];
@@ -2977,7 +3002,7 @@ mod model_popup_tests {
     #[test]
     fn slash_profile_without_arg_opens_selector_and_lists_profiles() {
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.navigation.screen = Screen::Chat;
         app.input = "/profile".into();
         app.input_cursor = app.input.len();
@@ -2994,7 +3019,7 @@ mod model_popup_tests {
     fn slash_profile_with_arg_updates_local_new_session_profile() {
         let _guard = TestPersistenceGuard::new("slash-profile");
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.navigation.screen = Screen::Chat;
         app.profiles.profiles = vec![make_profile("fast", "Fast")];
         app.profiles.active_profile_id = Some("old".into());
@@ -3019,7 +3044,7 @@ mod model_popup_tests {
     fn profile_popup_enter_updates_local_new_session_profile() {
         let _guard = TestPersistenceGuard::new("profile-popup-enter");
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.navigation.popup = Popup::ProfileSelect;
         app.profiles.profiles = vec![make_profile("fast", "Fast"), make_profile("deep", "Deep")];
         app.profiles.profile_cursor = 1;
@@ -3042,7 +3067,7 @@ mod model_popup_tests {
     fn profile_selection_with_bound_session_skips_agent_refresh() {
         let _guard = TestPersistenceGuard::new("profile-bound-session");
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.navigation.popup = Popup::ProfileSelect;
         app.sessions.session_id = Some("session".into());
         app.profiles
@@ -3060,7 +3085,7 @@ mod model_popup_tests {
     #[test]
     fn new_session_uses_locally_selected_profile() {
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.navigation.popup = Popup::NewSession;
         app.sessions.new_session_path = "/repo".into();
         app.sessions.new_session_cursor = app.sessions.new_session_path.len();
@@ -3322,7 +3347,7 @@ mod model_popup_tests {
     #[test]
     fn opening_model_popup_starts_on_session_tab() {
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.navigation.screen = Screen::Chat;
         app.sessions.agent_mode = "review".into();
         app.models.current_provider = Some("openai".into());
@@ -3343,7 +3368,7 @@ mod model_popup_tests {
     #[test]
     fn slash_model_starts_on_session_tab() {
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.navigation.screen = Screen::Chat;
         app.sessions.agent_mode = "review".into();
         app.models.current_provider = Some("openai".into());
@@ -3368,7 +3393,7 @@ mod model_popup_tests {
     fn review_slash_command_enters_review_and_tab_returns_to_previous_mode() {
         let _guard = TestPersistenceGuard::new("review-cycle");
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.navigation.screen = Screen::Chat;
         app.sessions.agent_mode = "plan".into();
         app.input = "/review".into();
@@ -3435,7 +3460,7 @@ mod model_popup_tests {
     #[test]
     fn review_slash_command_is_noop_when_already_in_review() {
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.navigation.screen = Screen::Chat;
         app.sessions.agent_mode = "review".into();
         app.sessions.mode_before_review = Some("plan".into());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod app;
 mod auth_state;
 mod command;
 mod config;
+mod connection_state;
 mod diagnostics;
 mod domain;
 mod handlers;

--- a/src/runtime/endpoint.rs
+++ b/src/runtime/endpoint.rs
@@ -2,7 +2,7 @@ use std::ffi::OsString;
 
 use clap::Parser;
 
-use crate::{acp_client::AcpEndpoint, config, server_manager};
+use crate::{acp_client::AcpEndpoint, config, connection_state::ServerState, server_manager};
 
 pub(super) const DEFAULT_ACP_WS_HOST: &str = "127.0.0.1";
 const DEFAULT_ACP_WS_PORT: &str = "3030";
@@ -34,7 +34,7 @@ pub(super) struct Cli {
 pub(super) enum EndpointSelection {
     Endpoint {
         endpoint: AcpEndpoint,
-        state: server_manager::ServerState,
+        state: ServerState,
         discovered_ws: Option<String>,
         missing_binary_fallback: bool,
     },
@@ -92,7 +92,7 @@ pub(super) fn select_acp_endpoint(
     {
         return EndpointSelection::Endpoint {
             endpoint: AcpEndpoint::WebSocket { url },
-            state: server_manager::ServerState::Starting,
+            state: ServerState::Starting,
             discovered_ws: None,
             missing_binary_fallback: false,
         };
@@ -103,7 +103,7 @@ pub(super) fn select_acp_endpoint(
             endpoint: AcpEndpoint::Stdio {
                 argv: server_manager::build_acp_argv(OsString::from(binary_path), cfg.acp_args()),
             },
-            state: server_manager::ServerState::Starting,
+            state: ServerState::Starting,
             discovered_ws: None,
             missing_binary_fallback: false,
         };
@@ -112,7 +112,7 @@ pub(super) fn select_acp_endpoint(
     if let Some(url) = cfg.acp.websocket_url.as_deref().map(normalize_acp_ws_url) {
         return EndpointSelection::Endpoint {
             endpoint: AcpEndpoint::WebSocket { url },
-            state: server_manager::ServerState::Starting,
+            state: ServerState::Starting,
             discovered_ws: None,
             missing_binary_fallback: false,
         };
@@ -124,7 +124,7 @@ pub(super) fn select_acp_endpoint(
             endpoint: AcpEndpoint::WebSocket {
                 url: default_acp_ws_url(),
             },
-            state: server_manager::ServerState::Starting,
+            state: ServerState::Starting,
             discovered_ws: None,
             missing_binary_fallback: false,
         };
@@ -140,7 +140,7 @@ pub(super) fn select_acp_endpoint(
             endpoint: AcpEndpoint::WebSocket {
                 url: default_ws_url.clone(),
             },
-            state: server_manager::ServerState::Starting,
+            state: ServerState::Starting,
             discovered_ws: Some(default_ws_url),
             missing_binary_fallback: false,
         };
@@ -152,7 +152,7 @@ pub(super) fn select_acp_endpoint(
             endpoint: AcpEndpoint::WebSocket {
                 url: default_ws_url,
             },
-            state: server_manager::ServerState::Starting,
+            state: ServerState::Starting,
             discovered_ws: None,
             missing_binary_fallback: true,
         },
@@ -160,7 +160,7 @@ pub(super) fn select_acp_endpoint(
             endpoint: AcpEndpoint::Stdio {
                 argv: server_manager::build_acp_argv(binary, cfg.acp_args()),
             },
-            state: server_manager::ServerState::Starting,
+            state: ServerState::Starting,
             discovered_ws: None,
             missing_binary_fallback: false,
         },
@@ -177,7 +177,7 @@ pub(super) fn detect_launch_cwd() -> Option<String> {
 mod tests {
     use clap::{CommandFactory, Parser};
 
-    use crate::{acp_client::AcpEndpoint, config, server_manager::ServerState};
+    use crate::{acp_client::AcpEndpoint, config, connection_state::ServerState};
 
     use super::{
         Cli, DEFAULT_ACP_WS_HOST, EndpointSelection, normalize_acp_ws_url, select_acp_endpoint,

--- a/src/runtime/event_loop.rs
+++ b/src/runtime/event_loop.rs
@@ -5,11 +5,12 @@ use futures::StreamExt;
 use tokio::sync::mpsc;
 
 use crate::{
-    app::{self, App},
+    app::App,
     command::Command,
+    connection_state::ConnState,
     diagnostics::LogLevel,
     handlers::{AppAction, handle_key, handle_mouse},
-    server_manager::{self, ServerEvent, ServerState},
+    server_manager::{self, ServerEvent},
     ui,
 };
 
@@ -57,6 +58,45 @@ fn reconnect_session_commands(app: &mut App) -> Vec<Command> {
     .into()
 }
 
+fn handle_server_event(app: &mut App, event: ServerEvent) {
+    match event {
+        ServerEvent::Starting => {
+            app.connection.apply_server_starting();
+            if app.connection.conn != ConnState::Connected {
+                app.set_status(LogLevel::Info, "acp", "starting qmtcode ACP agent...");
+            }
+        }
+        ServerEvent::Started => {
+            app.connection.apply_server_started();
+            if app.connection.conn != ConnState::Connected {
+                app.set_status(LogLevel::Info, "acp", "qmtcode ACP agent started");
+            }
+        }
+        ServerEvent::BinaryNotFound => {
+            app.connection.apply_server_binary_not_found();
+            if app.connection.conn != ConnState::Connected {
+                app.set_status(
+                    LogLevel::Warn,
+                    "acp",
+                    "qmtcode not found; install it or set acp.binary_path in ~/.qmt/qmtui.toml",
+                );
+            }
+        }
+        ServerEvent::StartFailed { error } => {
+            app.connection.apply_server_start_failed(error.clone());
+            app.set_status(LogLevel::Error, "acp", format!("ACP start failed: {error}"));
+        }
+        ServerEvent::Stopped { reason } => {
+            app.connection.apply_server_stopped(reason.clone());
+            app.set_status(
+                LogLevel::Warn,
+                "acp",
+                format!("ACP agent stopped ({reason})"),
+            );
+        }
+    }
+}
+
 pub(super) async fn run_loop(
     terminal: &mut AppTerminal,
     app: &mut App,
@@ -77,16 +117,18 @@ pub(super) async fn run_loop(
             Some(event) = conn_rx.recv() => {
                 match event {
                     ConnectionManagerEvent::State(state) => {
-                        let was_connected = app.conn == app::ConnState::Connected;
+                        let was_connected = app.connection.conn == ConnState::Connected;
                         app.handle_connection_event(state);
-                        if app.conn == app::ConnState::Connected {
+                        if app.connection.conn == ConnState::Connected {
                             cmd_tx.send(Command::Init)?;
                             cmd_tx.send(Command::list_sessions_browse())?;
                             cmd_tx.send(Command::ListAllModels { refresh: false })?;
                             for command in reconnect_session_commands(app) {
                                 cmd_tx.send(command)?;
                             }
-                        } else if was_connected && app.conn == app::ConnState::Disconnected {
+                        } else if was_connected
+                            && app.connection.conn == ConnState::Disconnected
+                        {
                             app.set_status(
                                 LogLevel::Warn,
                                 "connection",
@@ -102,46 +144,7 @@ pub(super) async fn run_loop(
                 }
             }
             Some(sup_event) = sup_rx.recv() => {
-                match sup_event {
-                    ServerEvent::Starting => {
-                        app.server_state = ServerState::Starting;
-                        if app.conn != app::ConnState::Connected {
-                            app.set_status(LogLevel::Info, "acp", "starting qmtcode ACP agent...");
-                        }
-                    }
-                    ServerEvent::Started => {
-                        app.server_state = ServerState::Running;
-                        if app.conn != app::ConnState::Connected {
-                            app.set_status(LogLevel::Info, "acp", "qmtcode ACP agent started");
-                        }
-                    }
-                    ServerEvent::BinaryNotFound => {
-                        app.server_state = ServerState::BinaryNotFound;
-                        if app.conn != app::ConnState::Connected {
-                            app.set_status(
-                                LogLevel::Warn,
-                                "acp",
-                                "qmtcode not found; install it or set acp.binary_path in ~/.qmt/qmtui.toml",
-                            );
-                        }
-                    }
-                    ServerEvent::StartFailed { error } => {
-                        app.server_state = ServerState::StartFailed { error: error.clone() };
-                        app.set_status(
-                            LogLevel::Error,
-                            "acp",
-                            format!("ACP start failed: {error}"),
-                        );
-                    }
-                    ServerEvent::Stopped { reason } => {
-                        app.server_state = ServerState::Restarting { reason: reason.clone() };
-                        app.set_status(
-                            LogLevel::Warn,
-                            "acp",
-                            format!("ACP agent stopped ({reason})"),
-                        );
-                    }
-                }
+                handle_server_event(app, sup_event);
             }
             Some(event_result) = term_events.next() => {
                 match event_result {
@@ -192,9 +195,11 @@ mod tests {
 
     use tokio::sync::mpsc;
 
-    use super::{reconnect_session_commands, send_command, tick_from_elapsed};
+    use super::{handle_server_event, reconnect_session_commands, send_command, tick_from_elapsed};
     use crate::app::App;
     use crate::command::Command;
+    use crate::connection_state::{ConnState, ServerState};
+    use crate::server_manager::ServerEvent;
 
     #[test]
     fn send_command_sends_each_command_once_without_implicit_subscribe() {
@@ -260,7 +265,7 @@ mod tests {
         let mut app = App::new();
         app.sessions.session_id = Some("local-1".into());
         app.sessions.agent_id = Some("agent-1".into());
-        app.launch_cwd = Some("/local/repo".into());
+        app.connection.launch_cwd = Some("/local/repo".into());
 
         assert_eq!(
             reconnect_session_commands(&mut app),
@@ -280,6 +285,80 @@ mod tests {
     #[test]
     fn reconnect_without_active_session_does_nothing() {
         assert!(reconnect_session_commands(&mut App::new()).is_empty());
+    }
+
+    #[test]
+    fn server_lifecycle_events_report_exact_statuses_while_disconnected() {
+        let mut app = App::new();
+        app.connection.conn = ConnState::Disconnected;
+
+        handle_server_event(&mut app, ServerEvent::Starting);
+        assert_eq!(app.connection.server_state, ServerState::Starting);
+        assert_eq!(app.diagnostics.status, "starting qmtcode ACP agent...");
+
+        handle_server_event(&mut app, ServerEvent::Started);
+        assert_eq!(app.connection.server_state, ServerState::Running);
+        assert_eq!(app.diagnostics.status, "qmtcode ACP agent started");
+
+        handle_server_event(&mut app, ServerEvent::BinaryNotFound);
+        assert_eq!(app.connection.server_state, ServerState::BinaryNotFound);
+        assert_eq!(
+            app.diagnostics.status,
+            "qmtcode not found; install it or set acp.binary_path in ~/.qmt/qmtui.toml"
+        );
+    }
+
+    #[test]
+    fn server_statuses_are_suppressed_while_connected_but_state_still_updates() {
+        let mut app = App::new();
+        app.connection.conn = ConnState::Connected;
+        app.set_status(crate::diagnostics::LogLevel::Debug, "test", "retained");
+
+        handle_server_event(&mut app, ServerEvent::Starting);
+        assert_eq!(app.connection.server_state, ServerState::Starting);
+        assert_eq!(app.diagnostics.status, "retained");
+
+        handle_server_event(&mut app, ServerEvent::Started);
+        assert_eq!(app.connection.server_state, ServerState::Running);
+        assert_eq!(app.diagnostics.status, "retained");
+
+        handle_server_event(&mut app, ServerEvent::BinaryNotFound);
+        assert_eq!(app.connection.server_state, ServerState::BinaryNotFound);
+        assert_eq!(app.diagnostics.status, "retained");
+    }
+
+    #[test]
+    fn server_failures_always_report_exact_status_and_payload() {
+        let mut app = App::new();
+        app.connection.conn = ConnState::Connected;
+
+        handle_server_event(
+            &mut app,
+            ServerEvent::StartFailed {
+                error: "invalid command".into(),
+            },
+        );
+        assert_eq!(
+            app.connection.server_state,
+            ServerState::StartFailed {
+                error: "invalid command".into()
+            }
+        );
+        assert_eq!(app.diagnostics.status, "ACP start failed: invalid command");
+
+        handle_server_event(
+            &mut app,
+            ServerEvent::Stopped {
+                reason: "process exited".into(),
+            },
+        );
+        assert_eq!(
+            app.connection.server_state,
+            ServerState::Restarting {
+                reason: "process exited".into()
+            }
+        );
+        assert_eq!(app.diagnostics.status, "ACP agent stopped (process exited)");
     }
 
     #[test]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -12,6 +12,7 @@ use crate::{
     app::{self, App},
     command::Command,
     config,
+    connection_state::ServerState,
     diagnostics::LogLevel,
     domain::model::DelegateModelPreference,
     navigation_state::Screen,
@@ -27,7 +28,7 @@ use event_loop::run_loop;
 use tokio::sync::mpsc;
 
 #[cfg(test)]
-use crate::navigation_state::Popup;
+use crate::{connection_state::ConnState, navigation_state::Popup};
 
 #[derive(Debug)]
 pub(crate) enum ConnectionManagerEvent {
@@ -84,7 +85,7 @@ mod tests {
 
     fn make_app_with_elicitation(state: ElicitationState) -> App {
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.sessions.session_id = Some("sess-1".into());
         app.messages.push(ChatEntry::Elicitation {
             elicitation_id: state.elicitation_id.clone(),
@@ -655,7 +656,7 @@ mod external_editor_tests {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.activity = ActivityState::RunningTool {
             name: "read_tool".into(),
         };
@@ -692,7 +693,7 @@ mod external_editor_tests {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.input = "  first line\nsecond line\n  ".into();
         app.input_cursor = app.input.len();
 
@@ -720,7 +721,7 @@ mod external_editor_tests {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.input = " \n  ".into();
         app.input_cursor = app.input.len();
 
@@ -882,7 +883,7 @@ mod external_editor_tests {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.sessions.session_id = Some("s1".into());
         app.sessions.agent_mode = "build".into();
         app.input = "/mode".into();
@@ -911,7 +912,7 @@ mod external_editor_tests {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.sessions.session_id = Some("s1".into());
         app.sessions.agent_mode = "build".into();
         app.input = "/mode plan".into();
@@ -936,7 +937,7 @@ mod external_editor_tests {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.sessions.session_id = Some("s1".into());
         app.sessions.agent_mode = "build".into();
         app.input = "/mode build".into();
@@ -958,7 +959,7 @@ mod external_editor_tests {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.sessions.session_id = Some("s1".into());
         app.input = "/mode xyz".into();
         app.input_cursor = "/mode xyz".len();
@@ -980,7 +981,7 @@ mod external_editor_tests {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.sessions.session_id = Some("s1".into());
         app.input = "/thinking high".into();
         app.input_cursor = "/thinking high".len();
@@ -1006,7 +1007,7 @@ mod external_editor_tests {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.sessions.session_id = Some("s1".into());
         app.models.reasoning_effort = Some("max".into());
         app.input = "/thinking auto".into();
@@ -1033,7 +1034,7 @@ mod external_editor_tests {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.sessions.session_id = Some("s1".into());
         app.input = "/thinking med".into();
         app.input_cursor = "/thinking med".len();
@@ -1113,7 +1114,7 @@ mod external_editor_tests {
     fn app_with_forkable_messages() -> App {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.messages = vec![
             ChatEntry::User {
                 text: "alpha prompt".into(),
@@ -1250,7 +1251,7 @@ mod external_editor_tests {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.open_fork_turn_popup();
 
         handle_fork_turn_popup_key(
@@ -1269,7 +1270,7 @@ mod external_editor_tests {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.sessions.session_id = Some("s1".into());
         app.input = "/model sonnet".into();
         app.input_cursor = "/model sonnet".len();
@@ -1291,7 +1292,7 @@ mod external_editor_tests {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.sessions.session_id = Some("s1".into());
         app.input = "/model".into();
         app.input_cursor = "/model".len();
@@ -1346,7 +1347,7 @@ mod external_editor_tests {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.activity = ActivityState::SessionOp(SessionOp::Undo);
         app.input = "draft".into();
         app.input_cursor = app.input.len();
@@ -1390,7 +1391,7 @@ mod external_editor_tests {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.activity = ActivityState::RunningTool {
             name: "read_tool".into(),
         };
@@ -1482,7 +1483,7 @@ pub async fn run() -> anyhow::Result<()> {
     let (conn_tx, mut conn_rx) = mpsc::unbounded_channel::<ConnectionManagerEvent>();
 
     let mut app = App::new();
-    app.launch_cwd = detect_launch_cwd();
+    app.connection.launch_cwd = detect_launch_cwd();
     app.profiles.active_profile_id = cfg.profile.id.clone();
     app.show_thinking = cfg.show_thinking.unwrap_or(true);
     app.models.delegate_model_preferences = cfg.profile_delegate_models.clone();
@@ -1575,9 +1576,9 @@ pub async fn run() -> anyhow::Result<()> {
         } => (Some(endpoint), state),
         EndpointSelection::BinaryNotFound => {
             let _ = sup_event_tx.send(server_manager::ServerEvent::BinaryNotFound);
-            (None, server_manager::ServerState::BinaryNotFound)
+            (None, ServerState::BinaryNotFound)
         }
-        EndpointSelection::Disabled => (None, server_manager::ServerState::Disabled),
+        EndpointSelection::Disabled => (None, ServerState::Disabled),
     };
 
     if let Some(endpoint) = endpoint {
@@ -1587,13 +1588,13 @@ pub async fn run() -> anyhow::Result<()> {
             cmd_rx,
             conn_tx,
             sup_event_tx.clone(),
-            app.launch_cwd.clone(),
+            app.connection.launch_cwd.clone(),
         ));
     }
 
     let mut terminal = terminal::enter()?;
 
-    app.server_state = initial_server_state;
+    app.connection.server_state = initial_server_state;
     let result = run_loop(
         &mut terminal,
         &mut app,
@@ -1735,7 +1736,7 @@ mod sessions_key_tests {
     #[test]
     fn enter_on_session_emits_one_load_and_one_subscribe() {
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.sessions.agent_id = Some("agent-1".into());
         app.sessions.session_groups = vec![make_group(Some("/a"), &["abc12345"])];
         app.sessions.session_cursor = 1;
@@ -2531,8 +2532,8 @@ mod session_popup_key_tests {
     fn popup_ctrl_n_opens_new_session_popup() {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
-        app.conn = crate::app::ConnState::Connected;
-        app.launch_cwd = Some("/launch".into());
+        app.connection.conn = ConnState::Connected;
+        app.connection.launch_cwd = Some("/launch".into());
 
         let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
         handle_session_popup_key(
@@ -2574,8 +2575,8 @@ mod session_popup_key_tests {
     #[test]
     fn global_ctrl_x_n_opens_new_session_popup() {
         let mut app = App::new();
-        app.conn = crate::app::ConnState::Connected;
-        app.launch_cwd = Some("/launch".into());
+        app.connection.conn = ConnState::Connected;
+        app.connection.launch_cwd = Some("/launch".into());
         let (tx, mut rx) = mpsc::unbounded_channel();
 
         handle_key(
@@ -2599,7 +2600,7 @@ mod session_popup_key_tests {
     #[test]
     fn global_ctrl_x_l_opens_session_popup() {
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         let (tx, _rx) = mpsc::unbounded_channel();
 
         handle_key(
@@ -2681,9 +2682,9 @@ mod session_popup_key_tests {
     #[test]
     fn new_session_popup_enter_with_empty_path_uses_launch_cwd() {
         let mut app = App::new();
-        app.conn = crate::app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.navigation.popup = Popup::NewSession;
-        app.launch_cwd = Some("/launch".into());
+        app.connection.launch_cwd = Some("/launch".into());
         app.sessions.new_session_path.clear();
         app.sessions.new_session_cursor = 0;
 
@@ -2708,9 +2709,9 @@ mod session_popup_key_tests {
     #[test]
     fn new_session_popup_enter_normalizes_relative_path_to_absolute() {
         let mut app = App::new();
-        app.conn = crate::app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.navigation.popup = Popup::NewSession;
-        app.launch_cwd = Some("/launch".into());
+        app.connection.launch_cwd = Some("/launch".into());
         app.sessions.new_session_path = "proj/subdir".into();
         app.sessions.new_session_cursor = app.sessions.new_session_path.len();
 
@@ -2759,7 +2760,7 @@ mod session_popup_key_tests {
     #[test]
     fn handle_key_routes_tab_to_new_session_popup_before_global_mode_switch() {
         let mut app = App::new();
-        app.conn = crate::app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.navigation.popup = Popup::NewSession;
         app.sessions.agent_mode = "build".into();
         app.sessions.new_session_completion = Some(crate::session_state::PathCompletionState {
@@ -3064,7 +3065,7 @@ mod chord_reasoning_effort_tests {
         let _guard = PersistenceGuard::new("main-test");
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         assert_eq!(app.models.reasoning_effort, None);
 
         handle_key(&mut app, ctrl_t(), &tx).unwrap();
@@ -3085,7 +3086,7 @@ mod chord_reasoning_effort_tests {
         let _guard = PersistenceGuard::new("main-test");
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.models.reasoning_effort = Some("max".into());
 
         handle_key(&mut app, ctrl_t(), &tx).unwrap();
@@ -3106,7 +3107,7 @@ mod chord_reasoning_effort_tests {
         let _guard = PersistenceGuard::new("main-test");
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         handle_key(&mut app, ctrl_t(), &tx).unwrap();
         // status should reflect the new level
         assert!(
@@ -3165,7 +3166,7 @@ mod reasoning_effort_integration_tests {
         let _guard = PersistenceGuard::new("main-test");
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
 
         handle_key(
             &mut app,
@@ -3187,7 +3188,7 @@ mod reasoning_effort_integration_tests {
         let _guard = PersistenceGuard::new("main-test");
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.sessions.session_id = Some("s1".into());
         app.sessions.agent_mode = "build".into();
         app.models.current_provider = Some("anthropic".into());
@@ -3220,7 +3221,7 @@ mod reasoning_effort_integration_tests {
         let _guard = PersistenceGuard::new("main-test");
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.sessions.session_id = Some("s1".into());
         app.sessions.agent_mode = "build".into();
         app.models.current_provider = Some("anthropic".into());
@@ -3252,7 +3253,7 @@ mod reasoning_effort_integration_tests {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.sessions.agent_mode = "plan".into();
         app.models.model_popup_agent_tab = 0;
         app.models.current_provider = Some("anthropic".into());
@@ -3288,7 +3289,7 @@ mod reasoning_effort_integration_tests {
         let _guard = PersistenceGuard::new("main-test");
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.sessions.session_id = Some("s1".into());
         app.navigation.popup = Popup::ModelSelect;
         app.sessions.agent_mode = "build".into();
@@ -3330,7 +3331,7 @@ mod reasoning_effort_integration_tests {
         let _guard = PersistenceGuard::new("main-test");
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.sessions.session_id = Some("s1".into());
         app.navigation.popup = Popup::ModelSelect;
         app.sessions.agent_mode = "build".into();
@@ -3444,7 +3445,7 @@ mod auth_tests {
 
     fn make_app_with_providers(providers: Vec<AuthProviderEntry>) -> App {
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
         app.auth.providers = providers;
         app.navigation.popup = Popup::ProviderAuth;
         app
@@ -4159,7 +4160,7 @@ mod auth_tests {
     fn chord_a_opens_auth_popup_and_sends_list() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let mut app = App::new();
-        app.conn = app::ConnState::Connected;
+        app.connection.conn = ConnState::Connected;
 
         // Activate chord mode
         let ctrl_x = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL);

--- a/src/server_manager.rs
+++ b/src/server_manager.rs
@@ -22,22 +22,6 @@ pub enum ServerEvent {
     Stopped { reason: String },
 }
 
-/// Local ACP process state stored on [`crate::app::App`].
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub enum ServerState {
-    #[default]
-    Disabled,
-    BinaryNotFound,
-    Starting,
-    Running,
-    StartFailed {
-        error: String,
-    },
-    Restarting {
-        reason: String,
-    },
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BinaryDiscovery {
     pub binary: Option<OsString>,

--- a/src/session.rs
+++ b/src/session.rs
@@ -64,7 +64,8 @@ impl App {
             }
         }
 
-        self.launch_cwd
+        self.connection
+            .launch_cwd
             .as_ref()
             .filter(|cwd| !cwd.trim().is_empty())
             .cloned()
@@ -90,7 +91,8 @@ impl App {
     }
 
     pub fn new_session_base_dir(&self) -> PathBuf {
-        self.launch_cwd
+        self.connection
+            .launch_cwd
             .as_ref()
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from("."))

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -36,7 +36,8 @@ use ratatui::{
 
 use unicode_width::UnicodeWidthChar;
 
-use crate::app::{App, ConnState};
+use crate::app::App;
+use crate::connection_state::ConnState;
 use crate::navigation_state::{Popup, Screen};
 use crate::theme::Theme;
 
@@ -415,7 +416,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
 }
 
 fn conn_indicator(app: &App) -> Span<'static> {
-    let (sym, color) = match app.conn {
+    let (sym, color) = match app.connection.conn {
         ConnState::Connected => (CONN_ONLINE, Theme::ok()),
         ConnState::Connecting => (CONN_OFFLINE, Theme::warn()),
         ConnState::Disconnected => (CONN_ONLINE, Theme::err()),
@@ -492,6 +493,23 @@ mod tests {
     use ratatui::widgets::ListItem;
     use serial_test::serial;
     use std::time::{Duration, Instant};
+
+    #[test]
+    fn connection_indicator_preserves_three_state_symbols_and_colors() {
+        let mut app = App::new();
+
+        for (state, symbol, color) in [
+            (ConnState::Connecting, CONN_OFFLINE, Theme::warn()),
+            (ConnState::Connected, CONN_ONLINE, Theme::ok()),
+            (ConnState::Disconnected, CONN_ONLINE, Theme::err()),
+        ] {
+            app.connection.conn = state;
+            let indicator = conn_indicator(&app);
+            assert_eq!(indicator.content.as_ref(), format!("{symbol} "));
+            assert_eq!(indicator.style.fg, Some(color));
+            assert_eq!(indicator.style.bg, Some(Theme::bg_dim()));
+        }
+    }
 
     fn tool_call(name: &str) -> ChatEntry {
         ChatEntry::ToolCall {


### PR DESCRIPTION
## change

- extract the five application-owned connection fields into private `ConnectionState`
- move `ConnState` and `ServerState` into the owner while keeping `ConnectionEvent`, `ServerEvent`, runtime retry policy, transport, channels, endpoint selection, and process supervision at their existing boundaries
- preserve connection/server event ordering, exact status strings, reconnect commands, launch-cwd precedence, command guards, and the three-state indicator
- add focused owner, app coordinator, server-event, handler, and ui tests

## exact base and scope

- base commit: `b8237b6959c44ad3f5d8486107c595add7dd326b`
- base parent: `3a7a599ff0fb04def35f2ba1591d3623dc5e9ba0`
- base tree: `c6ce4018b275f14e5eee0fb54d92ad8ed04c9f4d`
- source commit: `d8ad276`
- target: `refactor/components`
- changed exactly the 11 approved source files: `src/connection_state.rs`, `src/lib.rs`, `src/app.rs`, `src/server_manager.rs`, `src/runtime/endpoint.rs`, `src/runtime/mod.rs`, `src/runtime/event_loop.rs`, `src/handlers.rs`, `src/session.rs`, `src/acp_state.rs`, and `src/ui/mod.rs`
- diff: 508 insertions, 191 deletions

## validation

- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --all-targets --all-features`
- `cargo test --all-targets --all-features` — 859 passed, 0 failed (base: 848)
- `git diff --check`
- focused owner, app connection-event, command-guard, server-event suppression/status, endpoint, reconnect/launch-cwd, and ui indicator tests passed

## boundary proof

- one private `mod connection_state;`; no export or re-export
- one `App.connection: ConnectionState`; owner has exactly five fields; `App` has 63 direct fields
- one definition each of `ConnectionState`, `ConnState`, and `ServerState`
- no flat `App` declarations or accesses for the extracted fields; no getter/facade/alias/`Deref`/second owner
- `ConnectionEvent` remains in `app`; `ServerEvent` remains in `server_manager`; `ConnectionManagerEvent` and `ServerChannelMsg` remain in runtime
- runtime backoff remains in `runtime/connection.rs`; ACP runtime launch cwd remains in `acp_client.rs`
- 52 Rust files, 44,822 Rust lines, five `App` implementation files, and four `phase 11 compatibility forward` tags
- `AGENTS.md`, `CLAUDE.md`, `REFACTOR.md`, roadmap/history, runtime retry, transport, config, protocol, and domain files are absent from the source commit

integration into `refactor/components` is still pending review and merge.
