### PR TITLE
refactor: extract chat state owner

### DIFF
--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -10,7 +10,6 @@ use crate::domain::activity::{
     ActivityState, DelegateChildState, DelegateStatus, DelegationState, DelegationUpdate,
 };
 use crate::domain::auth::{AuthProviderEntry, OAuthFlow, OAuthResult};
-use crate::domain::chat::ChatEntry;
 use crate::domain::elicitation::ElicitationState;
 use crate::domain::mesh::{
     MeshInviteCreatedInfo, MeshNodesInfo, MeshStatusInfo, RemoteSessionAttachInfo,
@@ -19,7 +18,7 @@ use crate::domain::mesh::{
 use crate::domain::model::ModelEntry;
 use crate::domain::profile::{AgentInfo, ProfileInfo};
 use crate::domain::session::{
-    ForkResult, RedoResult, SessionListPage, UndoResult, UndoStackSnapshot, UndoableTurn,
+    ForkResult, RedoResult, SessionListPage, UndoResult, UndoStackSnapshot,
 };
 use crate::domain::tool::ToolDetail;
 use crate::navigation_state::{Popup, Screen};
@@ -271,7 +270,7 @@ impl crate::app::App {
                 self.models
                     .replace_live_selection(provider, model, provider_node_id);
                 if let Some(limit) = context_limit {
-                    self.context_limit = limit;
+                    self.chat.context_limit = limit;
                 }
                 vec![]
             }
@@ -346,11 +345,13 @@ impl crate::app::App {
                 vec![]
             }
             AcpAppEvent::UndoStack(undo_stack) => {
-                self.undo_state = self.build_undo_state_from_server_stack(&undo_stack, None, None);
+                self.chat.undo_state =
+                    self.chat
+                        .build_undo_state_from_server_stack(&undo_stack, None, None);
                 vec![]
             }
             AcpAppEvent::UndoResult(result) => {
-                self.activity = ActivityState::Idle;
+                self.chat.activity = ActivityState::Idle;
                 match result {
                     UndoResult::Applied {
                         target_message_id,
@@ -360,14 +361,14 @@ impl crate::app::App {
                     } => {
                         let message_id_for_files =
                             target_message_id.or_else(|| stack.message_ids.last().cloned());
-                        self.undo_state = self.build_undo_state_from_server_stack(
+                        self.chat.undo_state = self.chat.build_undo_state_from_server_stack(
                             &stack,
                             message_id_for_files.as_deref(),
                             Some(&reverted_files),
                         );
-                        self.recent_prompt_text = None;
-                        self.streaming_content.clear();
-                        self.streaming_content_message_id = None;
+                        self.chat.recent_prompt_text = None;
+                        self.chat.streaming_content.clear();
+                        self.chat.streaming_content_message_id = None;
                         self.streaming_cache.invalidate();
                         self.set_status(LogLevel::Info, "session", "undone - reloading session");
                         if let Some(ref sid) = self.sessions.session_id {
@@ -386,7 +387,7 @@ impl crate::app::App {
                     } => {
                         let preferred =
                             target_message_id.or_else(|| stack.message_ids.last().cloned());
-                        self.undo_state = self.build_undo_state_from_server_stack(
+                        self.chat.undo_state = self.chat.build_undo_state_from_server_stack(
                             &stack,
                             preferred.as_deref(),
                             None,
@@ -401,11 +402,12 @@ impl crate::app::App {
                 vec![]
             }
             AcpAppEvent::RedoResult(result) => {
-                self.activity = ActivityState::Idle;
+                self.chat.activity = ActivityState::Idle;
                 match result {
                     RedoResult::Applied { message: _, stack } => {
-                        self.undo_state =
-                            self.build_undo_state_from_server_stack(&stack, None, None);
+                        self.chat.undo_state = self
+                            .chat
+                            .build_undo_state_from_server_stack(&stack, None, None);
                         self.set_status(LogLevel::Info, "session", "redone - reloading session");
                         if let Some(ref sid) = self.sessions.session_id {
                             return Command::load_session_commands(
@@ -417,8 +419,9 @@ impl crate::app::App {
                         }
                     }
                     RedoResult::Rejected { message, stack } => {
-                        self.undo_state =
-                            self.build_undo_state_from_server_stack(&stack, None, None);
+                        self.chat.undo_state = self
+                            .chat
+                            .build_undo_state_from_server_stack(&stack, None, None);
                         self.set_status(
                             LogLevel::Warn,
                             "session",
@@ -429,7 +432,7 @@ impl crate::app::App {
                 vec![]
             }
             AcpAppEvent::ForkResult(result) => {
-                self.pending_fork_message_id = None;
+                self.chat.pending_fork_message_id = None;
                 match result {
                     ForkResult::Succeeded {
                         source_session_id: _,
@@ -528,22 +531,14 @@ impl crate::app::App {
                 vec![]
             }
             AcpAppEvent::Error { message } => {
-                self.end_llm_request_span(None);
+                self.chat.end_llm_request_span(None);
                 self.push_acp_error(&message);
                 self.set_status(LogLevel::Error, "acp", format!("error: {message}"));
                 vec![]
             }
             AcpAppEvent::PromptFailed { local_id, message } => {
-                self.end_llm_request_span(None);
-                self.messages.retain(|entry| {
-                    !matches!(
-                        entry,
-                        ChatEntry::User {
-                            message_id: Some(message_id),
-                            ..
-                        } if message_id == &local_id
-                    )
-                });
+                self.chat.end_llm_request_span(None);
+                self.chat.rollback_pending_prompt(&local_id);
                 self.card_cache.invalidate();
                 self.push_acp_error(&message);
                 self.set_status(LogLevel::Error, "acp", format!("error: {message}"));
@@ -651,7 +646,7 @@ impl crate::app::App {
         session_id: String,
         profile_id: Option<String>,
     ) -> Vec<Command> {
-        self.activity = ActivityState::Idle;
+        self.chat.activity = ActivityState::Idle;
         let discovered_parent = self
             .sessions
             .session_parent_id(&session_id)
@@ -683,30 +678,14 @@ impl crate::app::App {
     }
 
     fn reset_active_session_view(&mut self) {
-        self.messages.clear();
-        self.pending_prompt_seq = 0;
-        self.streaming_content.clear();
-        self.streaming_content_message_id = None;
-        self.streaming_thinking.clear();
-        self.streaming_thinking_message_id = None;
+        self.chat.reset_for_session_switch();
         self.invalidate_streaming_caches();
         self.card_cache.invalidate();
-        self.scroll_offset = 0;
-        self.undo_state = None;
-        self.undoable_turns.clear();
-        self.recent_prompt_text = None;
-        self.suppress_turn_output = false;
         if self.delegates.parent_session_id.is_none() {
             self.delegates.clear_for_root_session();
         }
         self.composer.reset_for_session_switch();
-        self.last_compaction_token_estimate = None;
-        self.elicitation = None;
-        self.elicitation_ui = None;
-        self.clear_cancel_confirm();
         self.sessions.mode_before_review = None;
-        self.cumulative_cost = None;
-        self.session_stats = crate::domain::activity::SessionStatsLite::default();
     }
 
     fn upsert_provisional_delegate(
@@ -855,14 +834,9 @@ impl crate::app::App {
 
         match update {
             AcpSessionUpdate::TurnStarted => {
-                self.clear_cancel_confirm();
-                if !is_replay {
-                    self.begin_llm_request_span(None);
-                }
-                self.activity = ActivityState::Thinking;
-                self.streaming_content.clear();
-                self.streaming_content_message_id = None;
-                self.invalidate_streaming_caches();
+                self.chat.begin_turn(is_replay);
+                self.streaming_cache.invalidate();
+                self.streaming_thinking_cache.invalidate();
                 self.set_status(LogLevel::Debug, "activity", "thinking...");
             }
             AcpSessionUpdate::UserMessage {
@@ -873,56 +847,28 @@ impl crate::app::App {
                 content,
                 message_id,
             } => {
-                if self.is_turn_active() {
-                    self.activity = ActivityState::Streaming;
+                let transition = self.chat.append_streaming_content(&content, message_id);
+                if transition.finalized_previous {
+                    self.streaming_cache.invalidate();
+                    self.streaming_thinking_cache.invalidate();
+                    self.card_cache.invalidate();
                 }
-                let active_message_id = self
-                    .streaming_content_message_id
-                    .as_deref()
-                    .or(self.streaming_thinking_message_id.as_deref());
-                if message_id.as_deref().is_some_and(|incoming| {
-                    active_message_id.is_some_and(|active| active != incoming)
-                }) {
-                    self.finalize_streaming_segment();
-                }
-                if self.streaming_content.is_empty()
-                    || (self.streaming_content_message_id.is_none() && message_id.is_some())
-                {
-                    self.streaming_content_message_id = message_id;
-                }
-                self.streaming_content.push_str(&content);
             }
             AcpSessionUpdate::AssistantThinkingDelta {
                 content,
                 message_id,
             } => {
-                // `Finished` clears non-durable streaming thinking, so only an unterminated
-                // replay can be present here for a second identical application.
-                if is_replay
-                    && message_id.as_deref().is_some_and(|incoming| {
-                        self.messages.iter().any(|entry| {
-                            matches!(entry, ChatEntry::Thinking { message_id: Some(existing), .. } if existing == incoming)
-                        }) || (self.streaming_thinking_message_id.as_deref() == Some(incoming)
-                            && self.streaming_thinking == content)
-                    })
-                {
+                let transition = self
+                    .chat
+                    .append_streaming_thinking(&content, message_id, is_replay);
+                if transition.ignored_duplicate {
                     return;
                 }
-                let active_message_id = self
-                    .streaming_content_message_id
-                    .as_deref()
-                    .or(self.streaming_thinking_message_id.as_deref());
-                if message_id.as_deref().is_some_and(|incoming| {
-                    active_message_id.is_some_and(|active| active != incoming)
-                }) {
-                    self.finalize_streaming_segment();
+                if transition.finalized_previous {
+                    self.streaming_cache.invalidate();
+                    self.streaming_thinking_cache.invalidate();
+                    self.card_cache.invalidate();
                 }
-                if self.streaming_thinking.is_empty()
-                    || (self.streaming_thinking_message_id.is_none() && message_id.is_some())
-                {
-                    self.streaming_thinking_message_id = message_id;
-                }
-                self.streaming_thinking.push_str(&content);
             }
             AcpSessionUpdate::AssistantMessage {
                 content,
@@ -934,10 +880,10 @@ impl crate::app::App {
                 name,
                 arguments,
             } => {
-                if self.suppress_turn_output {
+                if self.chat.suppress_turn_output {
                     return;
                 }
-                self.activity = ActivityState::RunningTool { name: name.clone() };
+                self.chat.activity = ActivityState::RunningTool { name: name.clone() };
                 self.set_status(LogLevel::Debug, "tool", format!("tool: {name}"));
                 self.finalize_streaming_segment();
                 if name == "delegate" {
@@ -947,35 +893,21 @@ impl crate::app::App {
                     let cwd = self.current_session_cwd();
                     let detail =
                         tool_detail::parse_tool_detail(&name, arguments.as_ref(), cwd.as_deref());
-                    if tool_detail::reconcile_tool_call_start(
-                        &mut self.messages,
+                    if self.chat.reconcile_tool_call_start(
                         tool_call_id.as_deref(),
                         &name,
                         detail.clone(),
                     ) {
-                        self.streaming_thinking.clear();
-                        self.streaming_thinking_message_id = None;
+                        self.chat.clear_streaming_thinking();
                         self.streaming_thinking_cache.invalidate();
                         self.card_cache.invalidate();
                         return;
                     }
-                    self.session_stats.total_tool_calls =
-                        self.session_stats.total_tool_calls.saturating_add(1);
-                    if !self.streaming_thinking.is_empty() {
-                        let thinking = std::mem::take(&mut self.streaming_thinking);
-                        let thinking_message_id = self.streaming_thinking_message_id.take();
-                        self.messages.push(ChatEntry::Thinking {
-                            content: thinking,
-                            message_id: thinking_message_id,
-                        });
+                    self.chat.record_tool_call();
+                    if self.chat.push_streaming_thinking_entry() {
                         self.streaming_thinking_cache.invalidate();
                     }
-                    self.messages.push(ChatEntry::ToolCall {
-                        tool_call_id,
-                        name,
-                        is_error: false,
-                        detail,
-                    });
+                    self.chat.push_tool_call(tool_call_id, name, false, detail);
                 }
             }
             AcpSessionUpdate::ToolCallEnd {
@@ -987,25 +919,24 @@ impl crate::app::App {
                 let mut updated = false;
                 if let Some(result) = result.as_deref() {
                     updated = tool_detail::update_tool_detail(
-                        &mut self.messages,
+                        &mut self.chat.messages,
                         tool_call_id.as_deref(),
                         result,
                     );
                 }
                 if is_error {
-                    if tool_detail::mark_tool_call_failed(
-                        &mut self.messages,
-                        tool_call_id.as_deref(),
-                        &name,
-                    ) {
+                    if self
+                        .chat
+                        .mark_tool_call_failed(tool_call_id.as_deref(), &name)
+                    {
                         updated = true;
                     } else {
-                        self.messages.push(ChatEntry::ToolCall {
+                        self.chat.push_tool_call(
                             tool_call_id,
-                            name: format!("{name} (failed)"),
-                            is_error: true,
-                            detail: result.map(ToolDetail::Summary).unwrap_or(ToolDetail::None),
-                        });
+                            format!("{name} (failed)"),
+                            true,
+                            result.map(ToolDetail::Summary).unwrap_or(ToolDetail::None),
+                        );
                         updated = true;
                     }
                 }
@@ -1018,15 +949,7 @@ impl crate::app::App {
                 size,
                 cost_usd,
             } => {
-                if used > 0 {
-                    self.session_stats.latest_context_tokens = Some(used);
-                }
-                if size > 0 {
-                    self.context_limit = size;
-                }
-                if let Some(cost_usd) = cost_usd {
-                    self.cumulative_cost = Some(cost_usd);
-                }
+                self.chat.apply_usage(used, size, cost_usd);
                 let pct = if used > 0 && size > 0 {
                     format!(" ({}%)", (used as f64 / size as f64 * 100.0) as u32)
                 } else {
@@ -1043,8 +966,8 @@ impl crate::app::App {
             }
             AcpSessionUpdate::TimingUpdate { duration_secs } => {
                 if duration_secs > 0 {
-                    self.session_stats.active_llm_duration +=
-                        std::time::Duration::from_secs(duration_secs);
+                    self.chat
+                        .add_active_llm_duration(std::time::Duration::from_secs(duration_secs));
                     self.push_log(
                         LogLevel::Info,
                         "usage",
@@ -1069,25 +992,15 @@ impl crate::app::App {
                 );
             }
             AcpSessionUpdate::Cancelled => {
-                if !is_replay {
-                    self.end_llm_request_span(None);
-                }
-                self.activity = ActivityState::Idle;
-                self.streaming_content.clear();
-                self.streaming_content_message_id = None;
-                self.invalidate_streaming_caches();
+                self.chat.cancel_turn(is_replay);
+                self.streaming_cache.invalidate();
+                self.streaming_thinking_cache.invalidate();
                 self.set_status(LogLevel::Warn, "activity", "cancelled");
             }
             AcpSessionUpdate::Finished { finish_reason } => {
-                if !is_replay {
-                    self.end_llm_request_span(None);
-                }
-                self.activity = ActivityState::Idle;
-                self.streaming_content.clear();
-                self.streaming_content_message_id = None;
-                self.streaming_thinking.clear();
-                self.streaming_thinking_message_id = None;
-                self.invalidate_streaming_caches();
+                self.chat.finish_turn(is_replay);
+                self.streaming_cache.invalidate();
+                self.streaming_thinking_cache.invalidate();
                 self.set_status(
                     LogLevel::Debug,
                     "activity",
@@ -1104,103 +1017,24 @@ impl crate::app::App {
         is_replay: bool,
     ) {
         let text = acp_content_to_string(&content);
-        if text.is_empty() {
-            return;
-        }
-        if let Some(message_id) = message_id.as_deref()
-            && self.messages.iter().any(|entry| {
-                matches!(entry, ChatEntry::User { message_id: Some(mid), .. } if mid == message_id)
-            })
-        {
-            self.recent_prompt_text = Some(text);
-            self.suppress_turn_output = false;
-            return;
-        }
-        // QueryMT currently echoes prompts without the client's local ID. Correlating
-        // PromptRequest._meta with UserMessageChunk._meta would make this identity-based;
-        // until then, normalized text is the interoperable fallback for generic ACP agents.
-        if !is_replay
-            && let Some(entry) = self.messages.iter_mut().find(|entry| {
-                matches!(
-                    entry,
-                    ChatEntry::User {
-                        text: pending_text,
-                        message_id: Some(pending_id),
-                    } if pending_id.starts_with("local:pending:")
-                        && pending_text.trim() == text.trim()
-                )
-            })
-        {
-            if let ChatEntry::User {
-                text: pending_text,
-                message_id: pending_id,
-            } = entry
-            {
-                *pending_text = text.clone();
-                *pending_id = message_id.clone();
-            }
-            self.recent_prompt_text = Some(text.clone());
-            self.suppress_turn_output = false;
-            if let Some(message_id) = message_id {
-                self.push_undoable_user_turn(message_id, text);
-            }
+        let transition = self.chat.push_user_message(text, message_id, is_replay);
+        if matches!(
+            transition,
+            crate::chat_state::UserMessageTransition::Reconciled
+        ) {
             self.card_cache.invalidate();
-            return;
-        }
-        if !is_replay && (self.undo_state.is_some() || self.suppress_turn_output) {
-            return;
-        }
-        self.suppress_turn_output = false;
-        self.messages.push(ChatEntry::User {
-            text: text.clone(),
-            message_id: message_id.clone(),
-        });
-        self.recent_prompt_text = Some(text.clone());
-        if let Some(message_id) = message_id {
-            self.push_undoable_user_turn(message_id, text);
         }
     }
 
     fn finalize_streaming_segment(&mut self) {
-        if self.streaming_content.is_empty() && self.streaming_thinking.is_empty() {
-            return;
+        if self.chat.finalize_streaming_segment() {
+            self.invalidate_streaming_caches();
+            self.card_cache.invalidate();
         }
-        let content = std::mem::take(&mut self.streaming_content);
-        let content_message_id = self.streaming_content_message_id.take();
-        let thinking = (!self.streaming_thinking.is_empty())
-            .then(|| std::mem::take(&mut self.streaming_thinking));
-        let thinking_message_id = self.streaming_thinking_message_id.take();
-        self.invalidate_streaming_caches();
-
-        if content.is_empty() {
-            if let Some(thinking) = thinking {
-                self.messages.push(ChatEntry::Thinking {
-                    content: thinking,
-                    message_id: thinking_message_id,
-                });
-            }
-        } else {
-            self.messages.push(ChatEntry::Assistant {
-                content,
-                thinking,
-                message_id: content_message_id.or(thinking_message_id),
-            });
-        }
-        self.card_cache.invalidate();
     }
 
     fn push_undoable_user_turn(&mut self, message_id: String, text: String) {
-        if !self
-            .undoable_turns
-            .iter()
-            .any(|turn| turn.message_id == message_id)
-        {
-            self.undoable_turns.push(UndoableTurn {
-                turn_id: message_id.clone(),
-                message_id,
-                text,
-            });
-        }
+        self.chat.push_undoable_user_turn(message_id, text);
     }
 
     fn push_acp_assistant_message(
@@ -1209,97 +1043,18 @@ impl crate::app::App {
         thinking: Option<String>,
         message_id: Option<String>,
     ) {
-        let explicit_thinking = thinking.filter(|text| !text.is_empty());
-        let streaming_thinking_message_id = self.streaming_thinking_message_id.clone();
-        let thinking_message_id = message_id.clone().or(streaming_thinking_message_id);
-        self.streaming_content.clear();
-        self.streaming_content_message_id = None;
         self.streaming_cache.invalidate();
-        if self.is_turn_active() {
-            self.activity = ActivityState::Thinking;
-        }
-        if content.is_empty() && explicit_thinking.is_none() && self.streaming_thinking.is_empty() {
-            self.streaming_thinking_message_id = None;
-            self.streaming_thinking_cache.invalidate();
-            return;
-        }
-        self.recent_prompt_text = None;
-        if self.suppress_turn_output {
-            self.streaming_thinking.clear();
-            self.streaming_thinking_message_id = None;
-            self.streaming_thinking_cache.invalidate();
-            return;
-        }
-
-        if let Some(message_id) = message_id.as_deref() {
-            if self.messages.iter().any(|entry| {
-                matches!(entry, ChatEntry::Assistant { message_id: Some(mid), .. } if mid == message_id)
-            }) {
-                self.streaming_thinking.clear();
-                self.streaming_thinking_message_id = None;
-                self.streaming_thinking_cache.invalidate();
-                return;
-            }
-
-            if let Some(idx) = self.messages.iter().position(|entry| {
-                matches!(entry, ChatEntry::Thinking { message_id: Some(mid), .. } if mid == message_id)
-            }) {
-                if content.is_empty() {
-                    self.streaming_thinking.clear();
-                    self.streaming_thinking_message_id = None;
-                    self.streaming_thinking_cache.invalidate();
-                    return;
-                }
-                let existing_thinking = match &self.messages[idx] {
-                    ChatEntry::Thinking { content, .. } => content.clone(),
-                    _ => String::new(),
-                };
-                let streaming_thinking = (!self.streaming_thinking.is_empty())
-                    .then(|| std::mem::take(&mut self.streaming_thinking));
-                let thinking_text = explicit_thinking
-                    .or_else(|| (!existing_thinking.is_empty()).then_some(existing_thinking))
-                    .or(streaming_thinking);
-                self.streaming_thinking_message_id = None;
-                self.streaming_thinking_cache.invalidate();
-                self.messages[idx] = ChatEntry::Assistant {
-                    content,
-                    thinking: thinking_text,
-                    message_id: Some(message_id.to_string()),
-                };
-                self.card_cache.invalidate();
-                return;
-            }
-        }
-
-        let streaming_thinking = (!self.streaming_thinking.is_empty())
-            .then(|| std::mem::take(&mut self.streaming_thinking));
-        let thinking_text = explicit_thinking.or(streaming_thinking);
-        self.streaming_thinking_message_id = None;
+        let replaced = self
+            .chat
+            .push_assistant_message(content, thinking, message_id);
         self.streaming_thinking_cache.invalidate();
-        if content.is_empty() {
-            if let Some(thinking) = thinking_text {
-                self.messages.push(ChatEntry::Thinking {
-                    content: thinking,
-                    message_id: thinking_message_id,
-                });
-            }
-        } else {
-            self.messages.push(ChatEntry::Assistant {
-                content,
-                thinking: thinking_text,
-                message_id,
-            });
+        if replaced {
+            self.card_cache.invalidate();
         }
     }
 
     fn push_acp_error(&mut self, message: &str) {
-        if !self
-            .messages
-            .iter()
-            .any(|entry| matches!(entry, ChatEntry::Error(existing) if existing == message))
-        {
-            self.messages.push(ChatEntry::Error(message.to_string()));
-        }
+        self.chat.push_error(message);
     }
 
     fn handle_acp_elicitation_requested(
@@ -1311,61 +1066,45 @@ impl crate::app::App {
         allow_custom: bool,
         is_replay: bool,
     ) {
-        // An elicitation ID is the durable identity across live delivery and replay.
-        // Keep an existing card (and any recorded outcome) rather than reopening it.
-        if self.messages.iter().any(|entry| {
-            matches!(
-                entry,
-                ChatEntry::Elicitation {
-                    elicitation_id: existing_id,
-                    ..
-                } if existing_id == elicitation_id
-            )
-        }) {
+        let fields = ElicitationState::parse_schema(requested_schema);
+        let supported = !fields.is_empty();
+        let active = (supported && !is_replay).then(|| ElicitationState {
+            elicitation_id: elicitation_id.to_string(),
+            message: message.to_string(),
+            source: source.to_string(),
+            fields,
+            selected: std::collections::HashMap::new(),
+            text_input: String::new(),
+            custom_input: String::new(),
+            allow_custom,
+        });
+        let outcome = (!supported).then(|| "unsupported schema - cannot answer in TUI".into());
+        let transition = self.chat.push_elicitation(
+            active,
+            elicitation_id.to_string(),
+            message.to_string(),
+            source.to_string(),
+            outcome,
+        );
+        if !transition.inserted {
             return;
         }
-
-        self.finalize_streaming_segment();
-        let fields = ElicitationState::parse_schema(requested_schema);
-        if fields.is_empty() {
-            let outcome = "unsupported schema - cannot answer in TUI";
-            self.messages.push(ChatEntry::Elicitation {
-                elicitation_id: elicitation_id.to_string(),
-                message: message.to_string(),
-                source: source.to_string(),
-                outcome: Some(outcome.into()),
-            });
-            self.scroll_offset = 0;
-            self.set_status(
-                LogLevel::Warn,
-                "elicitation",
-                "question skipped - unsupported schema",
-            );
-        } else {
-            if !is_replay {
-                self.elicitation = Some(ElicitationState {
-                    elicitation_id: elicitation_id.to_string(),
-                    message: message.to_string(),
-                    source: source.to_string(),
-                    fields,
-                    selected: std::collections::HashMap::new(),
-                    text_input: String::new(),
-                    custom_input: String::new(),
-                    allow_custom,
-                });
-                self.elicitation_ui = Some(crate::ui::ElicitationUiState::default());
-            }
-            self.messages.push(ChatEntry::Elicitation {
-                elicitation_id: elicitation_id.to_string(),
-                message: message.to_string(),
-                source: source.to_string(),
-                outcome: None,
-            });
-            self.scroll_offset = 0;
+        if transition.finalized_streaming {
+            self.streaming_cache.invalidate();
+            self.streaming_thinking_cache.invalidate();
+            self.card_cache.invalidate();
+        }
+        if supported {
             self.set_status(
                 LogLevel::Info,
                 "elicitation",
                 "question - answer in the panel above input",
+            );
+        } else {
+            self.set_status(
+                LogLevel::Warn,
+                "elicitation",
+                "question skipped - unsupported schema",
             );
         }
     }
@@ -1809,14 +1548,17 @@ fn acp_content_to_string(value: &Value) -> String {
 mod tests {
     use super::*;
     use crate::app::App;
+    use crate::chat_state::ElicitationUiState;
     use crate::composer_state::{FileIndexEntryLite, MentionState};
     use crate::domain::activity::{
         DelegateEntry, DelegateStats, PendingDelegateToolCall, SessionOp,
     };
+    use crate::domain::chat::ChatEntry;
     use crate::domain::mesh::{RemoteNodeInfo, RemoteSessionInfo};
     use crate::domain::model::DelegateModelPreference;
     use crate::domain::session::{
         SessionGroup, SessionListPage, SessionSummary, UndoFrame, UndoFrameStatus, UndoState,
+        UndoableTurn,
     };
 
     const TEST_SESSION_ID: &str = "session-1";
@@ -1900,7 +1642,7 @@ mod tests {
         expected_message_id: &str,
     ) {
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [ChatEntry::Assistant { content, thinking, message_id: Some(message_id) }]
                 if content == expected_content
                     && thinking.as_deref() == expected_thinking
@@ -1909,7 +1651,7 @@ mod tests {
     }
 
     fn push_thinking_entry(app: &mut App, content: &str) {
-        app.messages.push(ChatEntry::Thinking {
+        app.chat.messages.push(ChatEntry::Thinking {
             content: content.into(),
             message_id: Some(TEST_ASSISTANT_ID.into()),
         });
@@ -2300,16 +2042,16 @@ mod tests {
     #[test]
     fn delegation_completion_does_not_interrupt_parent_streaming() {
         let mut app = app_with_active_session();
-        app.streaming_content = "partial".into();
-        app.activity = ActivityState::Streaming;
+        app.chat.streaming_content = "partial".into();
+        app.chat.activity = ActivityState::Streaming;
 
         app.handle_acp_event(AcpAppEvent::DelegationUpdate(delegation_update(
             DelegationState::Completed,
             120,
         )));
 
-        assert_eq!(app.streaming_content, "partial");
-        assert_eq!(app.activity, ActivityState::Streaming);
+        assert_eq!(app.chat.streaming_content, "partial");
+        assert_eq!(app.chat.activity, ActivityState::Streaming);
     }
 
     #[test]
@@ -2848,8 +2590,8 @@ mod tests {
     #[test]
     fn native_session_created_resets_view_and_subscribes() {
         let mut app = App::new();
-        app.messages.push(ChatEntry::Error("stale".into()));
-        app.streaming_content = "stale stream".into();
+        app.chat.messages.push(ChatEntry::Error("stale".into()));
+        app.chat.streaming_content = "stale stream".into();
         app.delegates.parent_session_id = Some("old-parent".into());
         app.delegates.pending_parent_session_id = Some("staged-parent".into());
         app.delegates.delegate_entries.push(DelegateEntry {
@@ -2864,7 +2606,7 @@ mod tests {
             ended_at: None,
             child_state: DelegateChildState::None,
         });
-        app.scroll_offset = 3;
+        app.chat.scroll_offset = 3;
         app.composer.input = "/mo".into();
         app.composer.input_cursor = 3;
         app.composer.input_scroll = 2;
@@ -2884,13 +2626,13 @@ mod tests {
             selected_index: 0,
             results: Vec::new(),
         });
-        app.undo_state = Some(UndoState {
+        app.chat.undo_state = Some(UndoState {
             stack: Vec::new(),
             frontier_message_id: Some("undo-1".into()),
         });
-        app.elicitation = Some(ElicitationState::new_for_test(Vec::new()));
-        app.elicitation_ui = Some(crate::ui::ElicitationUiState::default());
-        app.session_stats.total_tool_calls = 1;
+        app.chat.elicitation = Some(ElicitationState::new_for_test(Vec::new()));
+        app.chat.elicitation_ui = Some(ElicitationUiState::default());
+        app.chat.session_stats.total_tool_calls = 1;
         app.mesh.mesh_nodes = vec![RemoteNodeInfo {
             id: "node-1".into(),
             label: "framework".into(),
@@ -2912,9 +2654,9 @@ mod tests {
         assert_eq!(app.delegates.parent_session_id, None);
         assert_eq!(app.delegates.pending_parent_session_id, None);
         assert!(app.delegates.delegate_entries.is_empty());
-        assert!(app.messages.is_empty());
-        assert!(app.streaming_content.is_empty());
-        assert_eq!(app.scroll_offset, 0);
+        assert!(app.chat.messages.is_empty());
+        assert!(app.chat.streaming_content.is_empty());
+        assert_eq!(app.chat.scroll_offset, 0);
         assert_eq!(app.composer.input, "/mo");
         assert_eq!(app.composer.input_cursor, 3);
         assert_eq!(app.composer.input_scroll, 2);
@@ -2926,9 +2668,9 @@ mod tests {
         assert_eq!(app.composer.file_index_error, None);
         assert!(app.composer.mention_state.is_none());
         assert!(app.composer.slash_state.is_some());
-        assert!(app.undo_state.is_none());
-        assert!(app.elicitation.is_none());
-        assert_eq!(app.session_stats.total_tool_calls, 0);
+        assert!(app.chat.undo_state.is_none());
+        assert!(app.chat.elicitation.is_none());
+        assert_eq!(app.chat.session_stats.total_tool_calls, 0);
         assert_eq!(app.mesh.mesh_node_count, Some(1));
         assert_eq!(app.mesh.selected_mesh_node_id(), Some("node-1"));
         assert_eq!(app.mesh.mesh_invite_name, "preserved");
@@ -2968,20 +2710,20 @@ mod tests {
             sessions: vec![parent],
             ..Default::default()
         }];
-        app.messages.push(ChatEntry::Error("stale".into()));
-        app.streaming_content = "stale stream".into();
-        app.streaming_content_message_id = Some("stream-1".into());
-        app.streaming_thinking = "stale thinking".into();
-        app.streaming_thinking_message_id = Some("thinking-1".into());
-        app.scroll_offset = 4;
-        app.undo_state = Some(UndoState {
+        app.chat.messages.push(ChatEntry::Error("stale".into()));
+        app.chat.streaming_content = "stale stream".into();
+        app.chat.streaming_content_message_id = Some("stream-1".into());
+        app.chat.streaming_thinking = "stale thinking".into();
+        app.chat.streaming_thinking_message_id = Some("thinking-1".into());
+        app.chat.scroll_offset = 4;
+        app.chat.undo_state = Some(UndoState {
             stack: Vec::new(),
             frontier_message_id: Some("undo-1".into()),
         });
-        app.recent_prompt_text = Some("stale prompt".into());
-        app.elicitation = Some(ElicitationState::new_for_test(Vec::new()));
-        app.elicitation_ui = Some(crate::ui::ElicitationUiState::default());
-        app.session_stats.total_tool_calls = 2;
+        app.chat.recent_prompt_text = Some("stale prompt".into());
+        app.chat.elicitation = Some(ElicitationState::new_for_test(Vec::new()));
+        app.chat.elicitation_ui = Some(ElicitationUiState::default());
+        app.chat.session_stats.total_tool_calls = 2;
         seed_model_state(&mut app);
         app.delegates.delegate_entries.push(DelegateEntry {
             delegation_id: "delegate-1".into(),
@@ -3004,17 +2746,17 @@ mod tests {
 
         assert_eq!(app.delegates.parent_session_id.as_deref(), Some("parent"));
         assert_eq!(app.navigation.screen, Screen::Delegate);
-        assert!(app.messages.is_empty());
-        assert!(app.streaming_content.is_empty());
-        assert_eq!(app.streaming_content_message_id, None);
-        assert!(app.streaming_thinking.is_empty());
-        assert_eq!(app.streaming_thinking_message_id, None);
-        assert_eq!(app.scroll_offset, 0);
-        assert!(app.undo_state.is_none());
-        assert!(app.undoable_turns.is_empty());
-        assert!(app.recent_prompt_text.is_none());
-        assert!(app.elicitation.is_none());
-        assert_eq!(app.session_stats.total_tool_calls, 0);
+        assert!(app.chat.messages.is_empty());
+        assert!(app.chat.streaming_content.is_empty());
+        assert_eq!(app.chat.streaming_content_message_id, None);
+        assert!(app.chat.streaming_thinking.is_empty());
+        assert_eq!(app.chat.streaming_thinking_message_id, None);
+        assert_eq!(app.chat.scroll_offset, 0);
+        assert!(app.chat.undo_state.is_none());
+        assert!(app.chat.undoable_turns.is_empty());
+        assert!(app.chat.recent_prompt_text.is_none());
+        assert!(app.chat.elicitation.is_none());
+        assert_eq!(app.chat.session_stats.total_tool_calls, 0);
         assert_eq!(app.delegates.delegate_entries.len(), 1);
         assert_seeded_model_state(&app);
         assert!(matches!(
@@ -3135,7 +2877,7 @@ mod tests {
     #[test]
     fn native_provider_changed_updates_selection_and_preserves_limit_when_absent() {
         let mut app = App::new();
-        app.context_limit = 4_096;
+        app.chat.context_limit = 4_096;
 
         app.handle_acp_event(AcpAppEvent::ProviderChanged {
             provider: "remote-provider".into(),
@@ -3148,7 +2890,7 @@ mod tests {
             Some("remote-provider")
         );
         assert_eq!(app.models.current_model.as_deref(), Some("model-1"));
-        assert_eq!(app.context_limit, 128_000);
+        assert_eq!(app.chat.context_limit, 128_000);
         assert_eq!(app.models.current_model_node_id.as_deref(), Some("node-1"));
 
         app.handle_acp_event(AcpAppEvent::ProviderChanged {
@@ -3162,7 +2904,7 @@ mod tests {
             Some("local-provider")
         );
         assert_eq!(app.models.current_model.as_deref(), Some("model-2"));
-        assert_eq!(app.context_limit, 128_000);
+        assert_eq!(app.chat.context_limit, 128_000);
         assert_eq!(app.models.current_model_node_id, None);
     }
 
@@ -3200,7 +2942,7 @@ mod tests {
         apply_live_update(&mut app, final_assistant_update("world", None));
 
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [
                 ChatEntry::User { text, message_id: Some(user_id) },
                 ChatEntry::Assistant { content, message_id: Some(assistant_id), .. }
@@ -3237,7 +2979,7 @@ mod tests {
         );
 
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [
                 ChatEntry::User { message_id: Some(message_id), .. },
                 ChatEntry::Elicitation { elicitation_id, .. }
@@ -3259,7 +3001,7 @@ mod tests {
         );
 
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [ChatEntry::User { text, message_id: Some(message_id) }]
                 if text == "first line\nsecond line" && message_id == "user-1"
         ));
@@ -3282,7 +3024,7 @@ mod tests {
         }
 
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [
                 ChatEntry::User { text: first_text, message_id: Some(first), .. },
                 ChatEntry::User { text: second_text, message_id: Some(second), .. }
@@ -3308,7 +3050,7 @@ mod tests {
         }
 
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [
                 ChatEntry::User { message_id: Some(first), .. },
                 ChatEntry::User { message_id: Some(second), .. }
@@ -3335,13 +3077,13 @@ mod tests {
         );
 
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [ChatEntry::Assistant { content, message_id: Some(message_id), .. }]
                 if content == "first" && message_id == "assistant-1"
         ));
-        assert_eq!(app.streaming_content, "second");
+        assert_eq!(app.chat.streaming_content, "second");
         assert_eq!(
-            app.streaming_content_message_id.as_deref(),
+            app.chat.streaming_content_message_id.as_deref(),
             Some("assistant-2")
         );
     }
@@ -3366,13 +3108,13 @@ mod tests {
         );
 
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [
                 ChatEntry::Assistant { content, message_id: Some(message_id), .. },
                 ChatEntry::ToolCall { tool_call_id: Some(tool_call_id), .. }
             ] if content == "Let me check." && message_id == "assistant-1" && tool_call_id == "tool-1"
         ));
-        assert!(app.streaming_content.is_empty());
+        assert!(app.chat.streaming_content.is_empty());
     }
 
     #[test]
@@ -3390,12 +3132,12 @@ mod tests {
             });
         }
 
-        assert_eq!(app.streaming_thinking, "inspect files");
+        assert_eq!(app.chat.streaming_thinking, "inspect files");
         assert_eq!(
-            app.streaming_thinking_message_id.as_deref(),
+            app.chat.streaming_thinking_message_id.as_deref(),
             Some("assistant-1")
         );
-        assert!(app.messages.is_empty());
+        assert!(app.chat.messages.is_empty());
     }
 
     #[test]
@@ -3412,9 +3154,9 @@ mod tests {
             });
         }
 
-        assert_eq!(app.streaming_thinking, "hello");
+        assert_eq!(app.chat.streaming_thinking, "hello");
         assert_eq!(
-            app.streaming_thinking_message_id.as_deref(),
+            app.chat.streaming_thinking_message_id.as_deref(),
             Some("assistant-1")
         );
     }
@@ -3446,7 +3188,7 @@ mod tests {
         }
 
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [
                 ChatEntry::Thinking { content, message_id: Some(message_id) },
                 ChatEntry::ToolCall { tool_call_id: Some(tool_call_id), .. },
@@ -3457,11 +3199,11 @@ mod tests {
     #[test]
     fn final_assistant_replaces_matching_thinking_without_crossing_tool() {
         let mut app = app_with_active_session();
-        app.messages.push(ChatEntry::Thinking {
+        app.chat.messages.push(ChatEntry::Thinking {
             content: "Need to inspect".into(),
             message_id: Some("assistant-1".into()),
         });
-        app.messages.push(ChatEntry::ToolCall {
+        app.chat.messages.push(ChatEntry::ToolCall {
             tool_call_id: Some("tool-1".into()),
             name: "read_tool".into(),
             is_error: false,
@@ -3478,7 +3220,7 @@ mod tests {
         );
 
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [
                 ChatEntry::Assistant { content, thinking: Some(thinking), .. },
                 ChatEntry::ToolCall { tool_call_id: Some(tool_call_id), .. }
@@ -3498,8 +3240,11 @@ mod tests {
             },
         );
 
-        assert_eq!(app.streaming_thinking, "thinking");
-        assert_eq!(app.streaming_thinking_message_id.as_deref(), Some("a1"));
+        assert_eq!(app.chat.streaming_thinking, "thinking");
+        assert_eq!(
+            app.chat.streaming_thinking_message_id.as_deref(),
+            Some("a1")
+        );
     }
 
     #[test]
@@ -3529,8 +3274,8 @@ mod tests {
             },
         );
 
-        assert!(app.streaming_content.is_empty());
-        assert!(app.streaming_thinking.is_empty());
+        assert!(app.chat.streaming_content.is_empty());
+        assert!(app.chat.streaming_thinking.is_empty());
         assert_single_assistant(
             &app,
             "final answer",
@@ -3575,7 +3320,7 @@ mod tests {
     #[test]
     fn native_duplicate_final_assistant_message_is_not_appended() {
         let mut app = app_with_active_session();
-        app.messages.push(ChatEntry::Assistant {
+        app.chat.messages.push(ChatEntry::Assistant {
             content: "first answer".into(),
             thinking: Some("first thinking".into()),
             message_id: Some(TEST_ASSISTANT_ID.into()),
@@ -3613,13 +3358,13 @@ mod tests {
         });
 
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [ChatEntry::ToolCall {
                 detail: ToolDetail::Shell { command, workdir, .. },
                 ..
             }] if command == "cargo check --examples" && workdir.as_deref() == Some("/repo")
         ));
-        assert_eq!(app.session_stats.total_tool_calls, 1);
+        assert_eq!(app.chat.session_stats.total_tool_calls, 1);
     }
 
     #[test]
@@ -3637,9 +3382,9 @@ mod tests {
             },
         });
 
-        assert_eq!(app.session_stats.latest_context_tokens, Some(2048));
-        assert_eq!(app.context_limit, 8192);
-        assert_eq!(app.cumulative_cost, Some(0.0123));
+        assert_eq!(app.chat.session_stats.latest_context_tokens, Some(2048));
+        assert_eq!(app.chat.context_limit, 8192);
+        assert_eq!(app.chat.cumulative_cost, Some(0.0123));
         assert!(matches!(
             app.diagnostics.logs.last(),
             Some(entry)
@@ -3661,7 +3406,7 @@ mod tests {
         });
 
         assert_eq!(
-            app.llm_request_elapsed(),
+            app.chat.llm_request_elapsed(),
             Some(std::time::Duration::from_secs(42))
         );
         assert!(matches!(
@@ -3684,12 +3429,13 @@ mod tests {
             update: AcpSessionUpdate::TurnStarted,
         });
 
-        assert!(app.session_stats.open_llm_request_instant.is_some());
-        app.session_stats.open_llm_request_instant = app
+        assert!(app.chat.session_stats.open_llm_request_instant.is_some());
+        app.chat.session_stats.open_llm_request_instant = app
+            .chat
             .session_stats
             .open_llm_request_instant
             .map(|started| started - std::time::Duration::from_secs(2));
-        assert!(app.llm_request_elapsed().is_some_and(|elapsed| {
+        assert!(app.chat.llm_request_elapsed().is_some_and(|elapsed| {
             elapsed >= std::time::Duration::from_secs(2)
                 && elapsed < std::time::Duration::from_secs(3)
         }));
@@ -3702,8 +3448,8 @@ mod tests {
             },
         });
 
-        assert!(app.session_stats.open_llm_request_instant.is_none());
-        assert!(app.llm_request_elapsed().is_some_and(|elapsed| {
+        assert!(app.chat.session_stats.open_llm_request_instant.is_none());
+        assert!(app.chat.llm_request_elapsed().is_some_and(|elapsed| {
             elapsed >= std::time::Duration::from_secs(2)
                 && elapsed < std::time::Duration::from_secs(3)
         }));
@@ -3720,8 +3466,8 @@ mod tests {
             update: AcpSessionUpdate::TurnStarted,
         });
 
-        assert!(app.session_stats.open_llm_request_instant.is_none());
-        assert_eq!(app.llm_request_elapsed(), None);
+        assert!(app.chat.session_stats.open_llm_request_instant.is_none());
+        assert_eq!(app.chat.llm_request_elapsed(), None);
     }
 
     #[test]
@@ -3736,12 +3482,13 @@ mod tests {
         });
 
         assert!(matches!(
-            app.messages.first(),
+            app.chat.messages.first(),
             Some(ChatEntry::User { text, message_id: Some(message_id) })
                 if text == "second" && message_id == &second
         ));
         assert_eq!(
-            app.messages
+            app.chat
+                .messages
                 .iter()
                 .filter(|entry| matches!(entry, ChatEntry::User { .. }))
                 .count(),
@@ -3759,7 +3506,8 @@ mod tests {
             is_replay: false,
             update: AcpSessionUpdate::TurnStarted,
         });
-        app.session_stats.open_llm_request_instant = app
+        app.chat.session_stats.open_llm_request_instant = app
+            .chat
             .session_stats
             .open_llm_request_instant
             .map(|started| started - std::time::Duration::from_secs(3));
@@ -3767,8 +3515,8 @@ mod tests {
             message: "prompt failed".into(),
         });
 
-        assert!(app.session_stats.open_llm_request_instant.is_none());
-        assert!(app.llm_request_elapsed().is_some_and(|elapsed| {
+        assert!(app.chat.session_stats.open_llm_request_instant.is_none());
+        assert!(app.chat.llm_request_elapsed().is_some_and(|elapsed| {
             elapsed >= std::time::Duration::from_secs(3)
                 && elapsed < std::time::Duration::from_secs(4)
         }));
@@ -3803,7 +3551,7 @@ mod tests {
         });
 
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [ChatEntry::ToolCall {
                 detail: ToolDetail::Shell { output_tail: Some(tail), .. },
                 ..
@@ -3831,7 +3579,7 @@ mod tests {
         });
 
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [ChatEntry::ToolCall {
                 detail: ToolDetail::ReadTool { path, start_line: Some(10), end_line: Some(14) },
                 ..
@@ -3844,8 +3592,8 @@ mod tests {
         let mut app = App::new();
         app.sessions.session_id = Some("session-1".into());
         app.sessions.agent_id = Some("agent-1".into());
-        app.activity = ActivityState::SessionOp(SessionOp::Undo);
-        app.undoable_turns.push(UndoableTurn {
+        app.chat.activity = ActivityState::SessionOp(SessionOp::Undo);
+        app.chat.undoable_turns.push(UndoableTurn {
             turn_id: "u1".into(),
             message_id: "u1".into(),
             text: "change".into(),
@@ -3860,11 +3608,11 @@ mod tests {
             },
         }));
 
-        assert!(matches!(app.activity, ActivityState::Idle));
+        assert!(matches!(app.chat.activity, ActivityState::Idle));
         assert_eq!(app.diagnostics.status, "undone - reloading session");
-        assert!(app.can_redo());
+        assert!(app.chat.can_redo());
         assert_eq!(
-            app.undo_state.as_ref().unwrap().stack[0].reverted_files,
+            app.chat.undo_state.as_ref().unwrap().stack[0].reverted_files,
             ["src/main.rs"]
         );
         assert!(matches!(
@@ -3883,9 +3631,9 @@ mod tests {
     fn native_undo_rejection_without_target_uses_stack_tail_without_reload() {
         let mut app = App::new();
         app.sessions.session_id = Some("session-1".into());
-        app.activity = ActivityState::SessionOp(SessionOp::Undo);
-        app.streaming_content = "keep streaming content".into();
-        app.undoable_turns = vec![
+        app.chat.activity = ActivityState::SessionOp(SessionOp::Undo);
+        app.chat.streaming_content = "keep streaming content".into();
+        app.chat.undoable_turns = vec![
             UndoableTurn {
                 turn_id: "turn-1".into(),
                 message_id: "msg-1".into(),
@@ -3897,7 +3645,7 @@ mod tests {
                 text: "second".into(),
             },
         ];
-        app.undo_state = Some(UndoState {
+        app.chat.undo_state = Some(UndoState {
             stack: vec![UndoFrame {
                 turn_id: "turn-1".into(),
                 message_id: "msg-1".into(),
@@ -3915,11 +3663,11 @@ mod tests {
             },
         }));
 
-        assert!(matches!(app.activity, ActivityState::Idle));
+        assert!(matches!(app.chat.activity, ActivityState::Idle));
         assert_eq!(app.diagnostics.status, "Undo rejected");
-        assert_eq!(app.streaming_content, "keep streaming content");
+        assert_eq!(app.chat.streaming_content, "keep streaming content");
         assert!(replies.is_empty());
-        let undo_state = app.undo_state.as_ref().expect("undo state");
+        let undo_state = app.chat.undo_state.as_ref().expect("undo state");
         assert_eq!(undo_state.frontier_message_id.as_deref(), Some("msg-2"));
         assert!(
             undo_state
@@ -3928,7 +3676,8 @@ mod tests {
                 .all(|frame| frame.reverted_files.is_empty())
         );
         assert_eq!(
-            app.current_undo_target()
+            app.chat
+                .current_undo_target()
                 .map(|turn| turn.message_id.as_str()),
             Some("msg-1")
         );
@@ -3937,7 +3686,7 @@ mod tests {
     #[test]
     fn native_undo_rejection_prefers_explicit_target() {
         let mut app = App::new();
-        app.undoable_turns = vec![
+        app.chat.undoable_turns = vec![
             UndoableTurn {
                 turn_id: "turn-1".into(),
                 message_id: "msg-1".into(),
@@ -3960,7 +3709,8 @@ mod tests {
 
         assert!(replies.is_empty());
         assert_eq!(
-            app.undo_state
+            app.chat
+                .undo_state
                 .as_ref()
                 .and_then(|state| state.frontier_message_id.as_deref()),
             Some("msg-1")
@@ -3972,7 +3722,7 @@ mod tests {
         let mut app = App::new();
         app.sessions.session_id = Some("session-1".into());
         app.sessions.agent_id = Some("agent-1".into());
-        app.activity = ActivityState::SessionOp(SessionOp::Redo);
+        app.chat.activity = ActivityState::SessionOp(SessionOp::Redo);
 
         let replies = app.handle_acp_event(AcpAppEvent::RedoResult(RedoResult::Applied {
             message: Some("redone".into()),
@@ -3981,9 +3731,9 @@ mod tests {
             },
         }));
 
-        assert!(matches!(app.activity, ActivityState::Idle));
+        assert!(matches!(app.chat.activity, ActivityState::Idle));
         assert_eq!(app.diagnostics.status, "redone - reloading session");
-        assert!(app.can_redo());
+        assert!(app.chat.can_redo());
         assert!(matches!(
             replies.as_slice(),
             [
@@ -3999,7 +3749,7 @@ mod tests {
     #[test]
     fn native_redo_result_failure_clears_pending_state_and_logs_warning() {
         let mut app = App::new();
-        app.activity = ActivityState::SessionOp(SessionOp::Redo);
+        app.chat.activity = ActivityState::SessionOp(SessionOp::Redo);
 
         let replies = app.handle_acp_event(AcpAppEvent::RedoResult(RedoResult::Rejected {
             message: Some("Nothing to redo".into()),
@@ -4008,9 +3758,9 @@ mod tests {
             },
         }));
 
-        assert!(matches!(app.activity, ActivityState::Idle));
+        assert!(matches!(app.chat.activity, ActivityState::Idle));
         assert_eq!(app.diagnostics.status, "Nothing to redo");
-        assert!(app.can_redo());
+        assert!(app.chat.can_redo());
         assert!(replies.is_empty());
         assert!(matches!(
             app.diagnostics.logs.last(),
@@ -4023,7 +3773,7 @@ mod tests {
         let mut app = App::new();
         app.sessions.agent_id = Some("agent-1".into());
         app.navigation.popup = Popup::ForkTurnSelect;
-        app.pending_fork_message_id = Some("msg-1".into());
+        app.chat.pending_fork_message_id = Some("msg-1".into());
 
         let replies = app.handle_acp_event(AcpAppEvent::ForkResult(ForkResult::Succeeded {
             source_session_id: Some("source-1".into()),
@@ -4031,7 +3781,7 @@ mod tests {
             message: None,
         }));
 
-        assert_eq!(app.pending_fork_message_id, None);
+        assert_eq!(app.chat.pending_fork_message_id, None);
         assert_eq!(app.navigation.popup, Popup::None);
         assert_eq!(app.diagnostics.status, "forked - loading session");
         assert_eq!(replies.len(), 2);
@@ -4048,7 +3798,7 @@ mod tests {
     fn native_fork_result_success_without_id_warns_and_keeps_popup() {
         let mut app = App::new();
         app.navigation.popup = Popup::ForkTurnSelect;
-        app.pending_fork_message_id = Some("msg-1".into());
+        app.chat.pending_fork_message_id = Some("msg-1".into());
 
         let replies = app.handle_acp_event(AcpAppEvent::ForkResult(ForkResult::Succeeded {
             source_session_id: Some("source-1".into()),
@@ -4057,7 +3807,7 @@ mod tests {
         }));
 
         assert!(replies.is_empty());
-        assert_eq!(app.pending_fork_message_id, None);
+        assert_eq!(app.chat.pending_fork_message_id, None);
         assert_eq!(app.navigation.popup, Popup::ForkTurnSelect);
         assert_eq!(app.diagnostics.status, "fork succeeded without session id");
     }
@@ -4066,7 +3816,7 @@ mod tests {
     fn native_fork_result_failure_clears_pending_and_keeps_popup() {
         let mut app = App::new();
         app.navigation.popup = Popup::ForkTurnSelect;
-        app.pending_fork_message_id = Some("msg-1".into());
+        app.chat.pending_fork_message_id = Some("msg-1".into());
 
         let replies = app.handle_acp_event(AcpAppEvent::ForkResult(ForkResult::Failed {
             source_session_id: Some("source-1".into()),
@@ -4074,7 +3824,7 @@ mod tests {
         }));
 
         assert!(replies.is_empty());
-        assert_eq!(app.pending_fork_message_id, None);
+        assert_eq!(app.chat.pending_fork_message_id, None);
         assert_eq!(app.navigation.popup, Popup::ForkTurnSelect);
         assert_eq!(app.diagnostics.status, "fork failed");
     }
@@ -4087,7 +3837,7 @@ mod tests {
             message_ids: vec!["u1".into()],
         }));
 
-        assert!(app.can_redo());
+        assert!(app.chat.can_redo());
     }
 
     #[test]
@@ -4105,7 +3855,7 @@ mod tests {
             },
         });
 
-        assert!(app.messages.is_empty());
+        assert!(app.chat.messages.is_empty());
         assert!(app.sessions.session_activity.contains_key("other"));
     }
 
@@ -4131,7 +3881,7 @@ mod tests {
 
         assert!(replies.is_empty());
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [
                 ChatEntry::User { text, message_id: Some(user_id) },
                 ChatEntry::Assistant { content, message_id: Some(assistant_id), .. }
@@ -4178,7 +3928,7 @@ mod tests {
         });
 
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [
                 ChatEntry::User { .. },
                 ChatEntry::Assistant { content: before, .. },
@@ -4213,7 +3963,7 @@ mod tests {
         });
 
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [ChatEntry::Assistant { content, thinking: Some(thinking), message_id: Some(message_id) }]
                 if content == "final" && thinking == "final thinking" && message_id == "a1"
         ));
@@ -4251,7 +4001,7 @@ mod tests {
         });
 
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [
                 ChatEntry::Assistant { content: first, message_id: Some(first_id), .. },
                 ChatEntry::ToolCall { .. },
@@ -4272,7 +4022,7 @@ mod tests {
         apply_live_update(&mut app, update);
 
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [ChatEntry::User { text, message_id: Some(message_id) }]
                 if text == "hello" && message_id == "u1"
         ));
@@ -4291,7 +4041,7 @@ mod tests {
         apply_live_update(&mut app, update);
 
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [ChatEntry::Thinking { content, message_id: Some(message_id) }]
                 if content == "checking" && message_id == "a1"
         ));
@@ -4308,7 +4058,7 @@ mod tests {
         app.handle_acp_event(event);
 
         assert!(
-            matches!(app.messages.as_slice(), [ChatEntry::Error(message)] if message == "connection lost")
+            matches!(app.chat.messages.as_slice(), [ChatEntry::Error(message)] if message == "connection lost")
         );
     }
 
@@ -4327,7 +4077,7 @@ mod tests {
         );
 
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [ChatEntry::ToolCall { tool_call_id: Some(tool_call_id), name, is_error: true, detail: ToolDetail::Shell { command, .. } }]
                 if tool_call_id == "tool-1" && name == "shell" && command == "echo late"
         ));
@@ -4342,7 +4092,7 @@ mod tests {
         apply_live_update(&mut app, failed_tool_end("tool-2", "shell"));
 
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [
                 ChatEntry::ToolCall { tool_call_id: Some(first), name: first_name, is_error: true, .. },
                 ChatEntry::ToolCall { tool_call_id: Some(second), name: second_name, is_error: true, .. },
@@ -4371,13 +4121,14 @@ mod tests {
         );
 
         assert_eq!(
-            app.elicitation
+            app.chat
+                .elicitation
                 .as_ref()
                 .map(|state| state.elicitation_id.as_str()),
             Some("elic-1")
         );
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [ChatEntry::Elicitation { elicitation_id, message, outcome: None, .. }]
                 if elicitation_id == "elic-1" && message == "Choose a target"
         ));
@@ -4402,9 +4153,9 @@ mod tests {
             }],
         });
 
-        assert!(app.elicitation.is_none());
+        assert!(app.chat.elicitation.is_none());
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [ChatEntry::Elicitation { elicitation_id, message, outcome: None, .. }]
                 if elicitation_id == "elic-1" && message == "Choose a target"
         ));
@@ -4437,9 +4188,9 @@ mod tests {
             updates,
         });
 
-        assert!(app.elicitation.is_none());
+        assert!(app.chat.elicitation.is_none());
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [ChatEntry::Elicitation { elicitation_id, outcome: Some(outcome), .. }]
                 if elicitation_id == "elic-1" && outcome == "staging"
         ));
@@ -4467,13 +4218,14 @@ mod tests {
         });
 
         assert_eq!(
-            app.elicitation
+            app.chat
+                .elicitation
                 .as_ref()
                 .map(|state| state.elicitation_id.as_str()),
             Some("elic-live")
         );
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [
                 ChatEntry::Elicitation { elicitation_id: first, .. },
                 ChatEntry::Elicitation { elicitation_id: second, .. },
@@ -4500,7 +4252,7 @@ mod tests {
         }
 
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [ChatEntry::Elicitation { elicitation_id, outcome: Some(outcome), .. }]
                 if elicitation_id == "elic-unsupported"
                     && outcome == "unsupported schema - cannot answer in TUI"
@@ -4530,7 +4282,7 @@ mod tests {
         }
 
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [
                 ChatEntry::User { message_id: Some(user_id), .. },
                 ChatEntry::Assistant { message_id: Some(assistant_id), .. },

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,21 +1,13 @@
 use std::collections::HashSet;
-use std::time::{Duration, Instant};
 
 use crate::auth_state::AuthState;
+use crate::chat_state::ChatState;
 use crate::command::Command;
 use crate::composer_state::ComposerState;
 use crate::connection_state::{ConnState, ConnectionState};
 use crate::delegates_state::DelegatesState;
 use crate::diagnostics::{AppLogEntry, DiagnosticsState, LogLevel};
-use crate::domain::activity::{
-    ActivityState, DelegateChildState, DelegateStats, SessionOp, SessionStatsLite,
-};
-use crate::domain::chat::{ChatEntry, format_outcome_labels};
-use crate::domain::elicitation::ElicitationState;
-use crate::domain::session::{
-    ForkBoundaryKind, ForkTurnItem, UndoFrame, UndoFrameStatus, UndoStackSnapshot, UndoState,
-    UndoableTurn,
-};
+use crate::domain::activity::{DelegateChildState, DelegateStats};
 use crate::highlight::Highlighter;
 use crate::markdown::CardBlock;
 use crate::mesh_state::MeshState;
@@ -24,7 +16,7 @@ use crate::navigation_state::{NavigationState, Popup};
 use crate::profiles_state::ProfilesState;
 use crate::protocol::audit::EventKind;
 use crate::session_state::SessionsState;
-use crate::ui::{CardCache, ElicitationUiState};
+use crate::ui::CardCache;
 
 /// Cache for rendered streaming markdown to avoid re-parsing every frame.
 /// Invalidated when `streaming_content` grows or is cleared.
@@ -168,43 +160,12 @@ pub(crate) fn update_delegate_child_state(state: &mut DelegateChildState, kind: 
     }
 }
 
-pub(crate) fn backfill_elicitation_outcomes(messages: &mut [ChatEntry], result_str: &str) {
-    let Ok(val) = serde_json::from_str::<serde_json::Value>(result_str) else {
-        return;
-    };
-    let Some(answers) = val.get("answers").and_then(|a| a.as_array()) else {
-        return;
-    };
-
-    let mut answer_iter = answers.iter();
-    for entry in messages.iter_mut() {
-        let ChatEntry::Elicitation { outcome, .. } = entry else {
-            continue;
-        };
-        if outcome.as_deref() != Some("responded") {
-            continue;
-        }
-        let Some(answer_entry) = answer_iter.next() else {
-            break;
-        };
-        let labels = answer_entry
-            .get("answers")
-            .and_then(|a| a.as_array())
-            .map(|answers| answers.iter().filter_map(|answer| answer.as_str()))
-            .into_iter()
-            .flatten();
-        *outcome = Some(format_outcome_labels(labels));
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConnectionEvent {
     Connecting { attempt: u32, delay_ms: u64 },
     Connected,
     Disconnected { reason: String },
 }
-
-const CANCEL_CONFIRM_TIMEOUT: Duration = Duration::from_millis(1000);
 
 pub struct App {
     pub(crate) navigation: NavigationState,
@@ -214,33 +175,14 @@ pub struct App {
     pub(crate) delegates: DelegatesState,
 
     // chat
-    pub messages: Vec<ChatEntry>,
-    /// Monotonic identifier source for locally rendered prompts awaiting ACP echo.
-    pub pending_prompt_seq: u64,
+    pub(crate) chat: ChatState,
     pub(crate) composer: ComposerState,
-    pub fork_filter: String,
-    pub fork_cursor: usize,
-    pub pending_fork_message_id: Option<String>,
-    pub scroll_offset: u16,
     /// Total content height (in rows) from the last render frame.
-    /// Used to compensate `scroll_offset` when content grows while the user
+    /// Used to compensate chat scroll when content grows while the user
     /// is scrolled up, so the viewport stays at the same absolute position.
     pub prev_total_height: u16,
-    pub activity: ActivityState,
-    pub streaming_content: String,
-    pub streaming_content_message_id: Option<String>,
     pub streaming_cache: StreamingCache,
-    pub streaming_thinking: String,
-    pub streaming_thinking_message_id: Option<String>,
     pub streaming_thinking_cache: StreamingCache,
-    pub last_compaction_token_estimate: Option<u32>,
-    /// Active elicitation request waiting for user response.
-    pub elicitation: Option<ElicitationState>,
-    /// Editor, cursor, and layout state for the active elicitation panel.
-    pub elicitation_ui: Option<ElicitationUiState>,
-
-    // thinking display
-    pub show_thinking: bool,
 
     // profile info
     pub(crate) profiles: ProfilesState,
@@ -250,20 +192,6 @@ pub struct App {
 
     // in-memory logs popup and status line
     pub(crate) diagnostics: DiagnosticsState,
-
-    // Undo/redo state mirrors the web UI semantics: a server-authoritative stack
-    // of reverted turns plus a frontier that marks the current branch point.
-    pub undo_state: Option<UndoState>,
-    pub undoable_turns: Vec<UndoableTurn>,
-    /// Tracks the latest prompt text so the follow-up `user_message_stored`
-    /// event can behave like a backfill instead of a duplicate row.
-    pub recent_prompt_text: Option<String>,
-
-    // session stats
-    pub cumulative_cost: Option<f64>,
-    pub context_limit: u64,
-    pub session_stats: SessionStatsLite,
-    pub pending_cancel_confirm_until: Option<Instant>,
 
     // mesh / remote (from ACP extensions)
     pub(crate) mesh: MeshState,
@@ -280,20 +208,8 @@ pub struct App {
     // auth popup state
     pub(crate) auth: AuthState,
 
-    /// While a reverted frontier turn is being suppressed, ignore any
-    /// follow-up assistant/tool/cancelled events until a new prompt arrives.
-    pub suppress_turn_output: bool,
-
     pub tick: u64,
     pub should_quit: bool,
-}
-
-fn move_wrapping_cursor(cursor: usize, len: usize, delta: isize) -> usize {
-    if len == 0 {
-        0
-    } else {
-        (cursor as isize + delta).rem_euclid(len as isize) as usize
-    }
 }
 
 impl App {
@@ -328,41 +244,19 @@ impl App {
             navigation: NavigationState::new(),
             sessions: SessionsState::new(),
             delegates: DelegatesState::new(),
-            messages: Vec::new(),
-            pending_prompt_seq: 0,
+            chat: ChatState::new(),
             composer: ComposerState::new(),
-            fork_filter: String::new(),
-            fork_cursor: 0,
-            pending_fork_message_id: None,
-            scroll_offset: 0,
             prev_total_height: 0,
-            activity: ActivityState::Idle,
-            streaming_content: String::new(),
-            streaming_content_message_id: None,
             streaming_cache: StreamingCache::new(),
-            streaming_thinking: String::new(),
-            streaming_thinking_message_id: None,
             streaming_thinking_cache: StreamingCache::new(),
-            last_compaction_token_estimate: None,
-            elicitation: None,
-            elicitation_ui: None,
-            show_thinking: true,
             profiles: ProfilesState::new(),
             models: ModelsState::new(),
             diagnostics: DiagnosticsState::new(),
-            undo_state: None,
-            undoable_turns: Vec::new(),
-            recent_prompt_text: None,
-            cumulative_cost: None,
-            context_limit: 0,
-            session_stats: SessionStatsLite::default(),
-            pending_cancel_confirm_until: None,
             mesh: MeshState::new(),
             connection: ConnectionState::new(),
             hl: Highlighter::new(),
             card_cache: CardCache::new(),
             auth: AuthState::new(),
-            suppress_turn_output: false,
             tick: 0,
             should_quit: false,
         }
@@ -372,7 +266,7 @@ impl App {
         self.composer.input_cursor = 0;
         self.composer.input_scroll = 0;
         self.composer.input_preferred_col = None;
-        self.scroll_offset = 0;
+        self.chat.scroll_offset = 0;
         self.composer.mention_state = None;
         self.composer.slash_state = None;
         std::mem::take(&mut self.composer.input)
@@ -385,8 +279,7 @@ impl App {
     /// are discarded.
     pub fn invalidate_streaming_caches(&mut self) {
         self.streaming_cache.invalidate();
-        self.streaming_thinking.clear();
-        self.streaming_thinking_message_id = None;
+        self.chat.clear_streaming_thinking();
         self.streaming_thinking_cache.invalidate();
     }
 
@@ -471,29 +364,9 @@ impl App {
         self.diagnostics.cycle_log_level_filter();
     }
 
-    pub fn cancel_confirm_active(&self) -> bool {
-        self.pending_cancel_confirm_until
-            .map(|deadline| Instant::now() <= deadline)
-            .unwrap_or(false)
-    }
-
     pub fn arm_cancel_confirm(&mut self) {
-        self.pending_cancel_confirm_until = Some(Instant::now() + CANCEL_CONFIRM_TIMEOUT);
+        self.chat.arm_cancel_confirm();
         self.set_status(LogLevel::Warn, "input", "press Esc again to stop");
-    }
-
-    pub fn clear_cancel_confirm(&mut self) {
-        self.pending_cancel_confirm_until = None;
-    }
-
-    pub fn is_turn_active(&self) -> bool {
-        matches!(
-            self.activity,
-            ActivityState::Thinking
-                | ActivityState::Streaming
-                | ActivityState::RunningTool { .. }
-                | ActivityState::Compacting { .. }
-        )
     }
 
     /// Adjust `scroll_offset` to compensate for content growth so the
@@ -503,190 +376,34 @@ impl App {
     /// Call from the renderer after computing the new `total_height`.
     pub fn compensate_scroll_for_growth(&mut self, total_height: u16) {
         let growth = total_height.saturating_sub(self.prev_total_height);
-        if self.scroll_offset > 0 && growth > 0 {
-            self.scroll_offset = self.scroll_offset.saturating_add(growth);
+        if self.chat.scroll_offset > 0 && growth > 0 {
+            self.chat.scroll_offset = self.chat.scroll_offset.saturating_add(growth);
         }
         self.prev_total_height = total_height;
     }
 
-    pub fn has_cancellable_activity(&self) -> bool {
-        self.is_turn_active()
-    }
-
-    pub fn has_pending_session_op(&self) -> bool {
-        matches!(self.activity, ActivityState::SessionOp(_))
-    }
-
-    pub fn forkable_turns(&self) -> Vec<ForkTurnItem> {
-        let mut turns = Vec::new();
-        let mut current_user: Option<(Option<String>, String)> = None;
-        let mut current_assistant: Option<(String, String)> = None;
-
-        for entry in &self.messages {
-            match entry {
-                ChatEntry::User { text, message_id } => {
-                    if let Some((user_id, user_text)) = current_user.take()
-                        && let Some(item) = Self::fork_turn_item(
-                            turns.len() + 1,
-                            user_id,
-                            user_text,
-                            current_assistant.take(),
-                        )
-                    {
-                        turns.push(item);
-                    }
-                    current_user = Some((message_id.clone(), text.clone()));
-                    current_assistant = None;
-                }
-                ChatEntry::Assistant {
-                    content,
-                    message_id,
-                    ..
-                } => {
-                    if let Some(id) = message_id.clone() {
-                        current_assistant = Some((id, content.clone()));
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        if let Some((user_id, user_text)) = current_user.take()
-            && let Some(item) = Self::fork_turn_item(
-                turns.len() + 1,
-                user_id,
-                user_text,
-                current_assistant.take(),
-            )
-        {
-            turns.push(item);
-        }
-
-        turns
-    }
-
-    fn fork_turn_item(
-        turn_index: usize,
-        user_id: Option<String>,
-        user_text: String,
-        assistant: Option<(String, String)>,
-    ) -> Option<ForkTurnItem> {
-        let (message_id, boundary_kind, assistant_preview) = match assistant {
-            Some((assistant_id, assistant_text)) => (
-                Some(assistant_id),
-                ForkBoundaryKind::Assistant,
-                assistant_text,
-            ),
-            None => (user_id, ForkBoundaryKind::User, String::new()),
-        };
-
-        let message_id = message_id.filter(|message_id| !message_id.is_empty())?;
-
-        Some(ForkTurnItem {
-            turn_index,
-            message_id,
-            boundary_kind,
-            user_preview: user_text,
-            assistant_preview,
-        })
-    }
-
-    pub fn filtered_fork_turns(&self) -> Vec<ForkTurnItem> {
-        let query = self.fork_filter.trim().to_lowercase();
-        self.forkable_turns()
-            .into_iter()
-            .filter(|turn| {
-                query.is_empty()
-                    || turn.user_preview.to_lowercase().contains(&query)
-                    || turn.assistant_preview.to_lowercase().contains(&query)
-            })
-            .collect()
-    }
-
-    pub fn visible_fork_turns(&self) -> Vec<ForkTurnItem> {
-        self.filtered_fork_turns().into_iter().rev().collect()
-    }
-
-    pub fn latest_fork_boundary(&self) -> Option<ForkTurnItem> {
-        if self.is_turn_active() {
-            None
-        } else {
-            self.forkable_turns().into_iter().last()
-        }
-    }
-
     pub fn open_fork_turn_popup(&mut self) {
         self.navigation.popup = Popup::ForkTurnSelect;
-        self.fork_filter.clear();
-        self.fork_cursor = 0;
-    }
-
-    pub fn move_fork_cursor(&mut self, delta: isize) {
-        self.fork_cursor =
-            move_wrapping_cursor(self.fork_cursor, self.visible_fork_turns().len(), delta);
-    }
-
-    pub fn fork_filter_insert(&mut self, c: char) {
-        self.fork_filter.push(c);
-        self.fork_cursor = 0;
-    }
-
-    pub fn fork_filter_backspace(&mut self) {
-        self.fork_filter.pop();
-        self.fork_cursor = 0;
-    }
-
-    pub fn selected_fork_turn(&self) -> Option<ForkTurnItem> {
-        self.visible_fork_turns().get(self.fork_cursor).cloned()
+        self.chat.reset_fork_selector();
     }
 
     pub fn push_pending_prompt(&mut self, text: String) -> String {
-        self.pending_prompt_seq = self.pending_prompt_seq.saturating_add(1);
-        let local_id = format!("local:pending:{}", self.pending_prompt_seq);
-        self.messages.push(ChatEntry::User {
-            text,
-            message_id: Some(local_id.clone()),
-        });
+        let local_id = self.chat.push_pending_prompt(text);
         self.card_cache.invalidate();
-        self.scroll_offset = 0;
         local_id
     }
 
-    pub fn input_blocked_by_activity(&self) -> bool {
-        self.elicitation.is_some()
-            || self.has_pending_session_op()
-            || self.pending_cancel_confirm_until.is_some()
-    }
-
-    pub fn should_hide_input_contents(&self) -> bool {
-        self.input_blocked_by_activity()
-    }
-
-    pub fn activity_status_text(&self) -> Option<String> {
-        match &self.activity {
-            ActivityState::Idle => None,
-            ActivityState::Thinking => Some("thinking...".into()),
-            ActivityState::Streaming => Some("streaming...".into()),
-            ActivityState::RunningTool { name } => Some(format!("tool: {name}")),
-            ActivityState::Compacting { token_estimate } => {
-                Some(format!("compacting context (~{token_estimate} tokens)"))
-            }
-            ActivityState::SessionOp(SessionOp::Undo) => Some("undoing...".into()),
-            ActivityState::SessionOp(SessionOp::Redo) => Some("redoing...".into()),
-        }
-    }
-
     pub fn refresh_transient_status(&mut self) {
-        if self.pending_cancel_confirm_until.is_some() {
+        if self.chat.pending_cancel_confirm_until.is_some() {
             return;
         }
-        if self.elicitation.is_some() {
+        if self.chat.elicitation.is_some() {
             self.set_status(
                 LogLevel::Debug,
                 "elicitation",
                 "question - answer in the panel above input",
             );
-        } else if let Some(activity_status) = self.activity_status_text() {
+        } else if let Some(activity_status) = self.chat.activity_status_text() {
             self.set_status(LogLevel::Debug, "activity", activity_status);
         } else if self.connection.conn == ConnState::Connected {
             self.set_status(LogLevel::Debug, "activity", "ready");
@@ -694,72 +411,30 @@ impl App {
     }
 
     pub fn clear_expired_cancel_confirm(&mut self) {
-        if self.pending_cancel_confirm_until.is_some() && !self.cancel_confirm_active() {
-            self.clear_cancel_confirm();
+        if self.chat.clear_expired_cancel_confirm() {
             self.refresh_transient_status();
         }
     }
 
-    pub fn begin_llm_request_span(&mut self, timestamp: Option<i64>) {
-        if self.session_stats.open_llm_request_ts.is_none() {
-            self.session_stats.open_llm_request_ts = timestamp;
-            self.session_stats.open_llm_request_instant = Some(Instant::now());
-        }
-    }
-
-    pub fn end_llm_request_span(&mut self, timestamp: Option<i64>) {
-        let duration = match (self.session_stats.open_llm_request_ts, timestamp) {
-            (Some(started), Some(ended)) if ended >= started => {
-                Some(Duration::from_secs((ended - started) as u64))
-            }
-            _ => self
-                .session_stats
-                .open_llm_request_instant
-                .map(|started| started.elapsed()),
-        };
-        if let Some(duration) = duration {
-            self.session_stats.active_llm_duration += duration;
-        }
-        self.session_stats.open_llm_request_ts = None;
-        self.session_stats.open_llm_request_instant = None;
-    }
-
     pub fn apply_event_stats(&mut self, kind: &EventKind, timestamp: Option<i64>) {
         match kind {
-            EventKind::ToolCallStart { .. } => {
-                self.session_stats.total_tool_calls =
-                    self.session_stats.total_tool_calls.saturating_add(1);
-            }
-            EventKind::LlmRequestStart { .. } => {
-                self.begin_llm_request_span(timestamp);
-            }
+            EventKind::ToolCallStart { .. } => self.chat.record_tool_call(),
+            EventKind::LlmRequestStart { .. } => self.chat.begin_llm_request_span(timestamp),
             EventKind::LlmRequestEnd { context_tokens, .. } => {
-                self.end_llm_request_span(timestamp);
-                if let Some(ctx) = context_tokens {
-                    self.session_stats.latest_context_tokens = Some(*ctx);
+                self.chat.end_llm_request_span(timestamp);
+                if let Some(context_tokens) = context_tokens {
+                    self.chat.record_context_tokens(*context_tokens);
                 }
             }
             EventKind::Cancelled | EventKind::Error { .. } => {
-                self.end_llm_request_span(timestamp);
+                self.chat.end_llm_request_span(timestamp);
             }
             _ => {}
         }
     }
 
-    pub fn llm_request_elapsed(&self) -> Option<Duration> {
-        let mut elapsed = self.session_stats.active_llm_duration;
-        if let Some(started) = self.session_stats.open_llm_request_instant {
-            elapsed += started.elapsed();
-        }
-        if elapsed.is_zero() {
-            None
-        } else {
-            Some(elapsed)
-        }
-    }
-
     pub fn handle_connection_event(&mut self, event: ConnectionEvent) {
-        self.clear_cancel_confirm();
+        self.chat.clear_cancel_confirm();
         match event {
             ConnectionEvent::Connecting { attempt, delay_ms } => {
                 self.connection.apply_connecting(attempt, delay_ms);
@@ -795,161 +470,9 @@ impl App {
         }
     }
 
-    pub fn has_pending_undo(&self) -> bool {
-        self.undo_state
-            .as_ref()
-            .map(|state| {
-                state
-                    .stack
-                    .iter()
-                    .any(|frame| frame.status == UndoFrameStatus::Pending)
-            })
-            .unwrap_or(false)
-    }
-
-    pub fn pending_session_label(&self) -> Option<&'static str> {
-        match self.activity {
-            ActivityState::SessionOp(SessionOp::Undo) => Some("undoing"),
-            ActivityState::SessionOp(SessionOp::Redo) => Some("redoing"),
-            _ => None,
-        }
-    }
-
-    pub fn current_undo_target(&self) -> Option<&UndoableTurn> {
-        let frontier_message_id = self
-            .undo_state
-            .as_ref()
-            .and_then(|state| state.frontier_message_id.as_deref());
-
-        let mut start_index = self.undoable_turns.len();
-        if let Some(frontier_message_id) = frontier_message_id
-            && let Some(frontier_index) = self
-                .undoable_turns
-                .iter()
-                .position(|turn| turn.message_id == frontier_message_id)
-        {
-            start_index = frontier_index;
-        }
-
-        self.undoable_turns[..start_index]
-            .iter()
-            .rev()
-            .find(|turn| !turn.message_id.is_empty())
-    }
-
-    pub fn can_redo(&self) -> bool {
-        self.undo_state
-            .as_ref()
-            .map(|state| !state.stack.is_empty())
-            .unwrap_or(false)
-    }
-
-    pub fn push_pending_undo(&mut self, turn: &UndoableTurn) {
-        let mut stack = self
-            .undo_state
-            .as_ref()
-            .map(|state| state.stack.clone())
-            .unwrap_or_default();
-        stack.push(UndoFrame {
-            turn_id: turn.turn_id.clone(),
-            message_id: turn.message_id.clone(),
-            status: UndoFrameStatus::Pending,
-            reverted_files: Vec::new(),
-        });
-        self.undo_state = Some(UndoState {
-            stack,
-            frontier_message_id: Some(turn.message_id.clone()),
-        });
-    }
-
-    pub fn build_undo_state_from_server_stack(
-        &self,
-        undo_stack: &UndoStackSnapshot,
-        preferred_frontier_message_id: Option<&str>,
-        reverted_files: Option<&[String]>,
-    ) -> Option<UndoState> {
-        if undo_stack.message_ids.is_empty() {
-            return None;
-        }
-
-        let previous_state = self.undo_state.as_ref();
-        let mut previous_by_message_id = std::collections::HashMap::new();
-        if let Some(previous_state) = previous_state {
-            for frame in &previous_state.stack {
-                previous_by_message_id.insert(frame.message_id.clone(), frame.clone());
-            }
-        }
-
-        let stack: Vec<UndoFrame> = undo_stack
-            .message_ids
-            .iter()
-            .map(|message_id| {
-                let previous = previous_by_message_id.get(message_id);
-                let reverted_files = if preferred_frontier_message_id == Some(message_id.as_str()) {
-                    reverted_files
-                        .map(|files| files.to_vec())
-                        .or_else(|| previous.map(|frame| frame.reverted_files.clone()))
-                        .unwrap_or_default()
-                } else {
-                    previous
-                        .map(|frame| frame.reverted_files.clone())
-                        .unwrap_or_default()
-                };
-                let turn_id = previous
-                    .map(|frame| frame.turn_id.clone())
-                    .or_else(|| {
-                        self.undoable_turns
-                            .iter()
-                            .find(|turn| turn.message_id == *message_id)
-                            .map(|turn| turn.turn_id.clone())
-                    })
-                    .unwrap_or_else(|| message_id.clone());
-                UndoFrame {
-                    turn_id,
-                    message_id: message_id.clone(),
-                    status: UndoFrameStatus::Confirmed,
-                    reverted_files,
-                }
-            })
-            .collect();
-
-        let has_message = |message_id: Option<&str>| {
-            message_id
-                .map(|message_id| stack.iter().any(|frame| frame.message_id == message_id))
-                .unwrap_or(false)
-        };
-
-        let frontier_message_id = if has_message(preferred_frontier_message_id) {
-            preferred_frontier_message_id.map(ToOwned::to_owned)
-        } else if has_message(previous_state.and_then(|state| state.frontier_message_id.as_deref()))
-        {
-            previous_state.and_then(|state| state.frontier_message_id.clone())
-        } else {
-            stack.last().map(|frame| frame.message_id.clone())
-        };
-
-        Some(UndoState {
-            stack,
-            frontier_message_id,
-        })
-    }
-
     /// Mark the pending elicitation chat card with an outcome and clear the active state.
     pub fn resolve_elicitation(&mut self, elicitation_id: &str, outcome: &str) {
-        for entry in &mut self.messages {
-            if let ChatEntry::Elicitation {
-                elicitation_id: eid,
-                outcome: out,
-                ..
-            } = entry
-                && eid == elicitation_id
-            {
-                *out = Some(outcome.to_string());
-                break;
-            }
-        }
-        self.elicitation = None;
-        self.elicitation_ui = None;
+        self.chat.resolve_elicitation(elicitation_id, outcome);
         self.card_cache.invalidate();
         self.refresh_transient_status();
     }
@@ -1003,6 +526,8 @@ impl App {
 
 #[cfg(test)]
 mod reasoning_effort_tests {
+    use std::time::{Duration, Instant};
+
     use super::*;
     use crate::domain::activity::SessionActivity;
     use crate::domain::session::{SessionGroup, SessionSummary};
@@ -1663,9 +1188,15 @@ mod session_mode_tests {
 
 #[cfg(test)]
 mod tests {
+    use std::time::{Duration, Instant};
+
     use super::*;
     use crate::connection_state::ServerState;
-    use crate::domain::chat::OUTCOME_BULLET;
+    use crate::domain::activity::{ActivityState, SessionOp};
+    use crate::domain::chat::{ChatEntry, OUTCOME_BULLET};
+    use crate::domain::session::{
+        ForkBoundaryKind, UndoFrame, UndoFrameStatus, UndoStackSnapshot, UndoState, UndoableTurn,
+    };
 
     fn make_turn(message_id: &str) -> UndoableTurn {
         UndoableTurn {
@@ -1684,7 +1215,7 @@ mod tests {
     #[test]
     fn fork_boundary_derivation_uses_last_assistant_then_user_fallback() {
         let mut app = App::new();
-        app.messages = vec![
+        app.chat.messages = vec![
             ChatEntry::User {
                 text: "first prompt".into(),
                 message_id: Some("user-1".into()),
@@ -1705,7 +1236,7 @@ mod tests {
             },
         ];
 
-        let turns = app.forkable_turns();
+        let turns = app.chat.forkable_turns();
         assert_eq!(turns.len(), 2);
         assert_eq!(turns[0].message_id, "asst-1b");
         assert_eq!(turns[0].boundary_kind, ForkBoundaryKind::Assistant);
@@ -1716,7 +1247,7 @@ mod tests {
     #[test]
     fn fork_boundary_derivation_includes_turn_when_only_assistant_has_message_id() {
         let mut app = App::new();
-        app.messages = vec![
+        app.chat.messages = vec![
             ChatEntry::User {
                 text: "first prompt".into(),
                 message_id: None,
@@ -1746,7 +1277,7 @@ mod tests {
             },
         ];
 
-        let turns = app.forkable_turns();
+        let turns = app.chat.forkable_turns();
         assert_eq!(turns.len(), 2);
 
         assert_eq!(turns[0].turn_index, 1);
@@ -1765,7 +1296,7 @@ mod tests {
     #[test]
     fn latest_fork_boundary_selects_latest_eligible_turn() {
         let mut app = App::new();
-        app.messages = vec![
+        app.chat.messages = vec![
             ChatEntry::User {
                 text: "old".into(),
                 message_id: Some("user-old".into()),
@@ -1786,26 +1317,30 @@ mod tests {
             },
         ];
 
-        let latest = app.latest_fork_boundary().expect("latest fork boundary");
+        let latest = app
+            .chat
+            .latest_fork_boundary()
+            .expect("latest fork boundary");
         assert_eq!(latest.message_id, "asst-new");
         assert_eq!(latest.boundary_kind, ForkBoundaryKind::Assistant);
 
-        app.activity = ActivityState::Streaming;
-        assert!(app.latest_fork_boundary().is_none());
+        app.chat.activity = ActivityState::Streaming;
+        assert!(app.chat.latest_fork_boundary().is_none());
     }
 
     #[test]
     fn current_undo_target_moves_left_of_frontier() {
         let mut app = App::new();
-        app.undoable_turns = vec![make_turn("msg-1"), make_turn("msg-2"), make_turn("msg-3")];
+        app.chat.undoable_turns = vec![make_turn("msg-1"), make_turn("msg-2"), make_turn("msg-3")];
 
         assert_eq!(
-            app.current_undo_target()
+            app.chat
+                .current_undo_target()
                 .map(|turn| turn.message_id.as_str()),
             Some("msg-3")
         );
 
-        app.undo_state = Some(UndoState {
+        app.chat.undo_state = Some(UndoState {
             stack: vec![UndoFrame {
                 turn_id: "turn-msg-3".into(),
                 message_id: "msg-3".into(),
@@ -1816,7 +1351,8 @@ mod tests {
         });
 
         assert_eq!(
-            app.current_undo_target()
+            app.chat
+                .current_undo_target()
                 .map(|turn| turn.message_id.as_str()),
             Some("msg-2")
         );
@@ -1825,8 +1361,8 @@ mod tests {
     #[test]
     fn build_undo_state_confirms_frames_and_preserves_frontier() {
         let mut app = App::new();
-        app.undoable_turns = vec![make_turn("msg-1"), make_turn("msg-2")];
-        app.undo_state = Some(UndoState {
+        app.chat.undoable_turns = vec![make_turn("msg-1"), make_turn("msg-2")];
+        app.chat.undo_state = Some(UndoState {
             stack: vec![UndoFrame {
                 turn_id: "turn-msg-1".into(),
                 message_id: "msg-1".into(),
@@ -1837,6 +1373,7 @@ mod tests {
         });
 
         let next = app
+            .chat
             .build_undo_state_from_server_stack(
                 &make_stack(&["msg-1", "msg-2"]),
                 Some("msg-2"),
@@ -1858,7 +1395,7 @@ mod tests {
     #[test]
     fn build_undo_state_preserves_order_previous_turn_and_unknown_fallback() {
         let mut app = App::new();
-        app.undo_state = Some(UndoState {
+        app.chat.undo_state = Some(UndoState {
             stack: vec![UndoFrame {
                 turn_id: "previous-turn".into(),
                 message_id: "msg-1".into(),
@@ -1869,6 +1406,7 @@ mod tests {
         });
 
         let state = app
+            .chat
             .build_undo_state_from_server_stack(&make_stack(&["msg-1", "unknown"]), None, None)
             .expect("undo state");
 
@@ -1884,7 +1422,8 @@ mod tests {
     fn build_undo_state_returns_none_for_empty_stack() {
         let app = App::new();
         assert_eq!(
-            app.build_undo_state_from_server_stack(&UndoStackSnapshot::default(), None, None),
+            app.chat
+                .build_undo_state_from_server_stack(&UndoStackSnapshot::default(), None, None),
             None
         );
     }
@@ -1893,21 +1432,23 @@ mod tests {
     fn pending_guard_tracks_pending_frames() {
         let mut app = App::new();
         let turn = make_turn("msg-1");
-        app.push_pending_undo(&turn);
+        app.chat.push_pending_undo(&turn);
 
-        assert!(app.has_pending_undo());
+        assert!(app.chat.has_pending_undo());
         assert_eq!(
-            app.undo_state
+            app.chat
+                .undo_state
                 .as_ref()
                 .and_then(|state| state.frontier_message_id.as_deref()),
             Some("msg-1")
         );
         assert_eq!(
-            app.undo_state.as_ref().map(|state| state.stack.len()),
+            app.chat.undo_state.as_ref().map(|state| state.stack.len()),
             Some(1)
         );
         assert_eq!(
-            app.undo_state
+            app.chat
+                .undo_state
                 .as_ref()
                 .map(|state| state.stack[0].status.clone()),
             Some(UndoFrameStatus::Pending)
@@ -1917,30 +1458,30 @@ mod tests {
     #[test]
     fn pending_session_label_stays_reserved_for_undo_and_redo() {
         let mut app = App::new();
-        app.activity = ActivityState::Compacting {
+        app.chat.activity = ActivityState::Compacting {
             token_estimate: 9_000,
         };
-        assert_eq!(app.pending_session_label(), None);
+        assert_eq!(app.chat.pending_session_label(), None);
 
-        app.activity = ActivityState::SessionOp(SessionOp::Undo);
-        assert_eq!(app.pending_session_label(), Some("undoing"));
+        app.chat.activity = ActivityState::SessionOp(SessionOp::Undo);
+        assert_eq!(app.chat.pending_session_label(), Some("undoing"));
     }
 
     #[test]
     fn cancel_confirm_arms_expires_and_restores_status() {
         let mut app = App::new();
-        app.activity = ActivityState::Thinking;
+        app.chat.activity = ActivityState::Thinking;
 
         app.arm_cancel_confirm();
-        assert!(app.cancel_confirm_active());
+        assert!(app.chat.cancel_confirm_active());
         assert_eq!(app.diagnostics.status, "press Esc again to stop");
         assert!(
             matches!(app.diagnostics.logs.last(), Some(entry) if entry.message == "press Esc again to stop")
         );
 
-        app.pending_cancel_confirm_until = Some(Instant::now() - Duration::from_millis(1));
+        app.chat.pending_cancel_confirm_until = Some(Instant::now() - Duration::from_millis(1));
         app.clear_expired_cancel_confirm();
-        assert!(!app.cancel_confirm_active());
+        assert!(!app.chat.cancel_confirm_active());
         assert_eq!(app.diagnostics.status, "thinking...");
         assert!(
             matches!(app.diagnostics.logs.last(), Some(entry) if entry.message == "thinking...")
@@ -1956,17 +1497,17 @@ mod tests {
         assert_eq!(app.diagnostics.status, "connection lost - retrying");
 
         app.connection.conn = ConnState::Connected;
-        app.activity = ActivityState::Thinking;
+        app.chat.activity = ActivityState::Thinking;
         app.refresh_transient_status();
         assert_eq!(app.diagnostics.status, "thinking...");
 
-        app.activity = ActivityState::Compacting {
+        app.chat.activity = ActivityState::Compacting {
             token_estimate: 2048,
         };
         app.refresh_transient_status();
         assert_eq!(app.diagnostics.status, "compacting context (~2048 tokens)");
 
-        app.activity = ActivityState::SessionOp(SessionOp::Redo);
+        app.chat.activity = ActivityState::SessionOp(SessionOp::Redo);
         app.refresh_transient_status();
         assert_eq!(app.diagnostics.status, "redoing...");
     }
@@ -2007,9 +1548,12 @@ mod tests {
             Some(160),
         );
 
-        assert_eq!(app.session_stats.latest_context_tokens, Some(2048));
-        assert_eq!(app.session_stats.total_tool_calls, 1);
-        assert_eq!(app.llm_request_elapsed(), Some(Duration::from_secs(40)));
+        assert_eq!(app.chat.session_stats.latest_context_tokens, Some(2048));
+        assert_eq!(app.chat.session_stats.total_tool_calls, 1);
+        assert_eq!(
+            app.chat.llm_request_elapsed(),
+            Some(Duration::from_secs(40))
+        );
     }
 
     #[test]
@@ -2022,47 +1566,50 @@ mod tests {
             Some(200),
         );
         app.apply_event_stats(&EventKind::Cancelled, Some(215));
-        assert_eq!(app.llm_request_elapsed(), Some(Duration::from_secs(15)));
-        assert_eq!(app.session_stats.open_llm_request_ts, None);
-        assert_eq!(app.session_stats.open_llm_request_instant, None);
+        assert_eq!(
+            app.chat.llm_request_elapsed(),
+            Some(Duration::from_secs(15))
+        );
+        assert_eq!(app.chat.session_stats.open_llm_request_ts, None);
+        assert_eq!(app.chat.session_stats.open_llm_request_instant, None);
     }
 
     #[test]
     fn activity_helpers_report_turn_and_session_state() {
         let mut app = App::new();
-        assert!(!app.is_turn_active());
-        assert!(!app.has_pending_session_op());
-        assert!(!app.input_blocked_by_activity());
-        assert!(!app.should_hide_input_contents());
-        assert_eq!(app.pending_session_label(), None);
+        assert!(!app.chat.is_turn_active());
+        assert!(!app.chat.has_pending_session_op());
+        assert!(!app.chat.input_blocked_by_activity());
+        assert!(!app.chat.should_hide_input_contents());
+        assert_eq!(app.chat.pending_session_label(), None);
 
-        app.activity = ActivityState::SessionOp(SessionOp::Undo);
-        assert!(!app.is_turn_active());
-        assert!(app.has_pending_session_op());
-        assert!(app.input_blocked_by_activity());
-        assert!(app.should_hide_input_contents());
-        assert_eq!(app.pending_session_label(), Some("undoing"));
+        app.chat.activity = ActivityState::SessionOp(SessionOp::Undo);
+        assert!(!app.chat.is_turn_active());
+        assert!(app.chat.has_pending_session_op());
+        assert!(app.chat.input_blocked_by_activity());
+        assert!(app.chat.should_hide_input_contents());
+        assert_eq!(app.chat.pending_session_label(), Some("undoing"));
 
-        app.activity = ActivityState::SessionOp(SessionOp::Redo);
-        assert!(!app.is_turn_active());
-        assert!(app.has_pending_session_op());
-        assert!(app.input_blocked_by_activity());
-        assert!(app.should_hide_input_contents());
-        assert_eq!(app.pending_session_label(), Some("redoing"));
+        app.chat.activity = ActivityState::SessionOp(SessionOp::Redo);
+        assert!(!app.chat.is_turn_active());
+        assert!(app.chat.has_pending_session_op());
+        assert!(app.chat.input_blocked_by_activity());
+        assert!(app.chat.should_hide_input_contents());
+        assert_eq!(app.chat.pending_session_label(), Some("redoing"));
 
-        app.activity = ActivityState::RunningTool {
+        app.chat.activity = ActivityState::RunningTool {
             name: "read_tool".into(),
         };
-        assert!(app.is_turn_active());
-        assert!(app.has_cancellable_activity());
-        assert!(!app.has_pending_session_op());
-        assert!(!app.input_blocked_by_activity());
-        assert!(!app.should_hide_input_contents());
-        assert_eq!(app.pending_session_label(), None);
+        assert!(app.chat.is_turn_active());
+        assert!(app.chat.has_cancellable_activity());
+        assert!(!app.chat.has_pending_session_op());
+        assert!(!app.chat.input_blocked_by_activity());
+        assert!(!app.chat.should_hide_input_contents());
+        assert_eq!(app.chat.pending_session_label(), None);
 
         app.arm_cancel_confirm();
-        assert!(app.input_blocked_by_activity());
-        assert!(app.should_hide_input_contents());
+        assert!(app.chat.input_blocked_by_activity());
+        assert!(app.chat.should_hide_input_contents());
     }
 
     #[test]
@@ -2078,7 +1625,7 @@ mod tests {
         assert_eq!(app.connection.conn, ConnState::Connecting);
         assert_eq!(app.connection.reconnect_attempt, 3);
         assert_eq!(app.connection.reconnect_delay_ms, Some(2000));
-        assert!(app.pending_cancel_confirm_until.is_none());
+        assert!(app.chat.pending_cancel_confirm_until.is_none());
         assert_eq!(
             app.diagnostics.status,
             "waiting for server - retry 3 in 2.0s"
@@ -2149,7 +1696,7 @@ mod tests {
                 .contains("session-1")
         );
         assert_eq!(app.composer.input, "retained prompt");
-        assert!(app.pending_cancel_confirm_until.is_none());
+        assert!(app.chat.pending_cancel_confirm_until.is_none());
         assert_eq!(app.diagnostics.status, "connection lost - socket closed");
         assert!(
             matches!(app.diagnostics.logs.last(), Some(entry) if entry.message == "connection lost - socket closed")
@@ -2169,7 +1716,10 @@ mod tests {
             outcome: Some("responded".into()),
         }];
         let result = r#"{"answers":[{"question":"Pick one","answers":["Beta"]}]}"#;
-        backfill_elicitation_outcomes(&mut messages, result);
+        let mut chat = ChatState::new();
+        chat.messages = messages;
+        chat.backfill_elicitation_outcomes(result);
+        messages = chat.messages;
         assert!(matches!(&messages[0],
             ChatEntry::Elicitation { outcome: Some(o), .. } if *o == format!("{OUTCOME_BULLET}Beta")
         ));
@@ -2184,7 +1734,10 @@ mod tests {
             outcome: Some("responded".into()),
         }];
         let result = r#"{"answers":[{"question":"Pick many","answers":["X","Z"]}]}"#;
-        backfill_elicitation_outcomes(&mut messages, result);
+        let mut chat = ChatState::new();
+        chat.messages = messages;
+        chat.backfill_elicitation_outcomes(result);
+        messages = chat.messages;
         assert!(matches!(&messages[0],
             ChatEntry::Elicitation { outcome: Some(o), .. } if *o == format!("{OUTCOME_BULLET}X\n{OUTCOME_BULLET}Z")
         ));
@@ -2207,7 +1760,10 @@ mod tests {
             },
         ];
         let result = r#"{"answers":[{"question":"Q1","answers":["Alpha"]},{"question":"Q2","answers":["Yes"]}]}"#;
-        backfill_elicitation_outcomes(&mut messages, result);
+        let mut chat = ChatState::new();
+        chat.messages = messages;
+        chat.backfill_elicitation_outcomes(result);
+        messages = chat.messages;
         assert!(matches!(&messages[0],
             ChatEntry::Elicitation { outcome: Some(o), .. } if *o == format!("{OUTCOME_BULLET}Alpha")
         ));
@@ -2233,7 +1789,10 @@ mod tests {
             },
         ];
         let result = r#"{"answers":[{"question":"Q2","answers":["Beta"]}]}"#;
-        backfill_elicitation_outcomes(&mut messages, result);
+        let mut chat = ChatState::new();
+        chat.messages = messages;
+        chat.backfill_elicitation_outcomes(result);
+        messages = chat.messages;
         // First card unchanged
         assert!(matches!(&messages[0],
             ChatEntry::Elicitation { outcome: Some(o), .. } if *o == format!("{OUTCOME_BULLET}AlreadySet")

--- a/src/chat_state.rs
+++ b/src/chat_state.rs
@@ -1,0 +1,1446 @@
+use std::time::{Duration, Instant};
+
+use crate::composer_state::build_input_visual_layout;
+use crate::domain::activity::{ActivityState, SessionOp, SessionStatsLite};
+use crate::domain::chat::{ChatEntry, format_outcome_labels};
+use crate::domain::elicitation::ElicitationState;
+use crate::domain::session::{
+    ForkBoundaryKind, ForkTurnItem, UndoFrame, UndoFrameStatus, UndoStackSnapshot, UndoState,
+    UndoableTurn,
+};
+use crate::domain::tool::ToolDetail;
+
+const CANCEL_CONFIRM_TIMEOUT: Duration = Duration::from_millis(1000);
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ElicitationUiState {
+    pub(crate) field_cursor: usize,
+    pub(crate) option_cursor: usize,
+    pub(crate) text_cursor: usize,
+    pub(crate) custom_active: bool,
+    pub(crate) custom_cursor: usize,
+    pub(crate) custom_line_width: usize,
+    pub(crate) custom_scroll: u16,
+}
+
+impl ElicitationUiState {
+    pub(crate) fn current_field_index(&self, field_count: usize) -> Option<usize> {
+        (field_count > 0).then(|| self.field_cursor.min(field_count - 1))
+    }
+
+    pub(crate) fn custom_insert(&mut self, input: &mut String, character: char) {
+        input.insert(self.custom_cursor, character);
+        self.custom_cursor += character.len_utf8();
+    }
+
+    pub(crate) fn custom_backspace(&mut self, input: &mut String) {
+        if self.custom_cursor == 0 {
+            return;
+        }
+        let previous = input[..self.custom_cursor]
+            .char_indices()
+            .last()
+            .map(|(index, _)| index)
+            .unwrap_or(0);
+        input.drain(previous..self.custom_cursor);
+        self.custom_cursor = previous;
+    }
+
+    pub(crate) fn custom_delete(&mut self, input: &mut String) {
+        if self.custom_cursor >= input.len() {
+            return;
+        }
+        let next = input[self.custom_cursor..]
+            .char_indices()
+            .nth(1)
+            .map(|(index, _)| self.custom_cursor + index)
+            .unwrap_or(input.len());
+        input.drain(self.custom_cursor..next);
+    }
+
+    pub(crate) fn custom_left(&mut self, input: &str) {
+        if self.custom_cursor > 0 {
+            self.custom_cursor = input[..self.custom_cursor]
+                .char_indices()
+                .last()
+                .map(|(index, _)| index)
+                .unwrap_or(0);
+        }
+    }
+
+    pub(crate) fn custom_right(&mut self, input: &str) {
+        if self.custom_cursor < input.len() {
+            self.custom_cursor = input[self.custom_cursor..]
+                .char_indices()
+                .nth(1)
+                .map(|(index, _)| self.custom_cursor + index)
+                .unwrap_or(input.len());
+        }
+    }
+
+    pub(crate) fn custom_home(&mut self, input: &str) {
+        self.custom_cursor = input[..self.custom_cursor]
+            .rfind('\n')
+            .map(|index| index + 1)
+            .unwrap_or(0);
+    }
+
+    pub(crate) fn custom_end(&mut self, input: &str) {
+        self.custom_cursor = input[self.custom_cursor..]
+            .find('\n')
+            .map(|index| self.custom_cursor + index)
+            .unwrap_or(input.len());
+    }
+
+    pub(crate) fn custom_move_visual(&mut self, input: &str, delta: i32) {
+        let layout =
+            build_input_visual_layout(input, self.custom_cursor, self.custom_line_width.max(1), 2);
+        let row = (layout.cursor_row as i32 + delta)
+            .clamp(0, layout.total_rows().saturating_sub(1) as i32) as usize;
+        self.custom_cursor = layout.cursor_offset_for_row_col(row, layout.cursor_text_col);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UserMessageTransition {
+    Ignored,
+    Duplicate,
+    Reconciled,
+    Appended,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct StreamingDeltaTransition {
+    pub(crate) finalized_previous: bool,
+    pub(crate) ignored_duplicate: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct ElicitationTransition {
+    pub(crate) inserted: bool,
+    pub(crate) finalized_streaming: bool,
+}
+
+pub(crate) struct ChatState {
+    pub(crate) messages: Vec<ChatEntry>,
+    pub(crate) pending_prompt_seq: u64,
+    pub(crate) fork_filter: String,
+    pub(crate) fork_cursor: usize,
+    pub(crate) pending_fork_message_id: Option<String>,
+    pub(crate) scroll_offset: u16,
+    pub(crate) activity: ActivityState,
+    pub(crate) streaming_content: String,
+    pub(crate) streaming_content_message_id: Option<String>,
+    pub(crate) streaming_thinking: String,
+    pub(crate) streaming_thinking_message_id: Option<String>,
+    pub(crate) last_compaction_token_estimate: Option<u32>,
+    pub(crate) elicitation: Option<ElicitationState>,
+    pub(crate) elicitation_ui: Option<ElicitationUiState>,
+    pub(crate) show_thinking: bool,
+    pub(crate) undo_state: Option<UndoState>,
+    pub(crate) undoable_turns: Vec<UndoableTurn>,
+    pub(crate) recent_prompt_text: Option<String>,
+    pub(crate) cumulative_cost: Option<f64>,
+    pub(crate) context_limit: u64,
+    pub(crate) session_stats: SessionStatsLite,
+    pub(crate) pending_cancel_confirm_until: Option<Instant>,
+    pub(crate) suppress_turn_output: bool,
+}
+
+impl ChatState {
+    pub(crate) fn new() -> Self {
+        Self {
+            messages: Vec::new(),
+            pending_prompt_seq: 0,
+            fork_filter: String::new(),
+            fork_cursor: 0,
+            pending_fork_message_id: None,
+            scroll_offset: 0,
+            activity: ActivityState::Idle,
+            streaming_content: String::new(),
+            streaming_content_message_id: None,
+            streaming_thinking: String::new(),
+            streaming_thinking_message_id: None,
+            last_compaction_token_estimate: None,
+            elicitation: None,
+            elicitation_ui: None,
+            show_thinking: true,
+            undo_state: None,
+            undoable_turns: Vec::new(),
+            recent_prompt_text: None,
+            cumulative_cost: None,
+            context_limit: 0,
+            session_stats: SessionStatsLite::default(),
+            pending_cancel_confirm_until: None,
+            suppress_turn_output: false,
+        }
+    }
+
+    pub(crate) fn reset_for_session_switch(&mut self) {
+        self.messages.clear();
+        self.pending_prompt_seq = 0;
+        self.streaming_content.clear();
+        self.streaming_content_message_id = None;
+        self.streaming_thinking.clear();
+        self.streaming_thinking_message_id = None;
+        self.scroll_offset = 0;
+        self.undo_state = None;
+        self.undoable_turns.clear();
+        self.recent_prompt_text = None;
+        self.suppress_turn_output = false;
+        self.last_compaction_token_estimate = None;
+        self.elicitation = None;
+        self.elicitation_ui = None;
+        self.pending_cancel_confirm_until = None;
+        self.cumulative_cost = None;
+        self.session_stats = SessionStatsLite::default();
+    }
+
+    pub(crate) fn cancel_confirm_active(&self) -> bool {
+        self.cancel_confirm_active_at(Instant::now())
+    }
+
+    fn cancel_confirm_active_at(&self, now: Instant) -> bool {
+        self.pending_cancel_confirm_until
+            .map(|deadline| now <= deadline)
+            .unwrap_or(false)
+    }
+
+    pub(crate) fn arm_cancel_confirm(&mut self) {
+        self.pending_cancel_confirm_until = Some(Instant::now() + CANCEL_CONFIRM_TIMEOUT);
+    }
+
+    pub(crate) fn clear_cancel_confirm(&mut self) {
+        self.pending_cancel_confirm_until = None;
+    }
+
+    pub(crate) fn clear_expired_cancel_confirm(&mut self) -> bool {
+        if self.pending_cancel_confirm_until.is_some() && !self.cancel_confirm_active() {
+            self.clear_cancel_confirm();
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn is_turn_active(&self) -> bool {
+        matches!(
+            self.activity,
+            ActivityState::Thinking
+                | ActivityState::Streaming
+                | ActivityState::RunningTool { .. }
+                | ActivityState::Compacting { .. }
+        )
+    }
+
+    pub(crate) fn has_cancellable_activity(&self) -> bool {
+        self.is_turn_active()
+    }
+
+    pub(crate) fn has_pending_session_op(&self) -> bool {
+        matches!(self.activity, ActivityState::SessionOp(_))
+    }
+
+    pub(crate) fn input_blocked_by_activity(&self) -> bool {
+        self.elicitation.is_some()
+            || self.has_pending_session_op()
+            || self.pending_cancel_confirm_until.is_some()
+    }
+
+    pub(crate) fn should_hide_input_contents(&self) -> bool {
+        self.input_blocked_by_activity()
+    }
+
+    pub(crate) fn activity_status_text(&self) -> Option<String> {
+        match &self.activity {
+            ActivityState::Idle => None,
+            ActivityState::Thinking => Some("thinking...".into()),
+            ActivityState::Streaming => Some("streaming...".into()),
+            ActivityState::RunningTool { name } => Some(format!("tool: {name}")),
+            ActivityState::Compacting { token_estimate } => {
+                Some(format!("compacting context (~{token_estimate} tokens)"))
+            }
+            ActivityState::SessionOp(SessionOp::Undo) => Some("undoing...".into()),
+            ActivityState::SessionOp(SessionOp::Redo) => Some("redoing...".into()),
+        }
+    }
+
+    pub(crate) fn pending_session_label(&self) -> Option<&'static str> {
+        match self.activity {
+            ActivityState::SessionOp(SessionOp::Undo) => Some("undoing"),
+            ActivityState::SessionOp(SessionOp::Redo) => Some("redoing"),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn forkable_turns(&self) -> Vec<ForkTurnItem> {
+        let mut turns = Vec::new();
+        let mut current_user: Option<(Option<String>, String)> = None;
+        let mut current_assistant: Option<(String, String)> = None;
+
+        for entry in &self.messages {
+            match entry {
+                ChatEntry::User { text, message_id } => {
+                    if let Some((user_id, user_text)) = current_user.take()
+                        && let Some(item) = Self::fork_turn_item(
+                            turns.len() + 1,
+                            user_id,
+                            user_text,
+                            current_assistant.take(),
+                        )
+                    {
+                        turns.push(item);
+                    }
+                    current_user = Some((message_id.clone(), text.clone()));
+                    current_assistant = None;
+                }
+                ChatEntry::Assistant {
+                    content,
+                    message_id,
+                    ..
+                } => {
+                    if let Some(id) = message_id.clone() {
+                        current_assistant = Some((id, content.clone()));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if let Some((user_id, user_text)) = current_user.take()
+            && let Some(item) = Self::fork_turn_item(
+                turns.len() + 1,
+                user_id,
+                user_text,
+                current_assistant.take(),
+            )
+        {
+            turns.push(item);
+        }
+
+        turns
+    }
+
+    fn fork_turn_item(
+        turn_index: usize,
+        user_id: Option<String>,
+        user_text: String,
+        assistant: Option<(String, String)>,
+    ) -> Option<ForkTurnItem> {
+        let (message_id, boundary_kind, assistant_preview) = match assistant {
+            Some((assistant_id, assistant_text)) => (
+                Some(assistant_id),
+                ForkBoundaryKind::Assistant,
+                assistant_text,
+            ),
+            None => (user_id, ForkBoundaryKind::User, String::new()),
+        };
+
+        let message_id = message_id.filter(|message_id| !message_id.is_empty())?;
+        Some(ForkTurnItem {
+            turn_index,
+            message_id,
+            boundary_kind,
+            user_preview: user_text,
+            assistant_preview,
+        })
+    }
+
+    pub(crate) fn filtered_fork_turns(&self) -> Vec<ForkTurnItem> {
+        let query = self.fork_filter.trim().to_lowercase();
+        self.forkable_turns()
+            .into_iter()
+            .filter(|turn| {
+                query.is_empty()
+                    || turn.user_preview.to_lowercase().contains(&query)
+                    || turn.assistant_preview.to_lowercase().contains(&query)
+            })
+            .collect()
+    }
+
+    pub(crate) fn visible_fork_turns(&self) -> Vec<ForkTurnItem> {
+        self.filtered_fork_turns().into_iter().rev().collect()
+    }
+
+    pub(crate) fn latest_fork_boundary(&self) -> Option<ForkTurnItem> {
+        if self.is_turn_active() {
+            None
+        } else {
+            self.forkable_turns().into_iter().last()
+        }
+    }
+
+    pub(crate) fn reset_fork_selector(&mut self) {
+        self.fork_filter.clear();
+        self.fork_cursor = 0;
+    }
+
+    pub(crate) fn move_fork_cursor(&mut self, delta: isize) {
+        self.fork_cursor =
+            move_wrapping_cursor(self.fork_cursor, self.visible_fork_turns().len(), delta);
+    }
+
+    pub(crate) fn fork_filter_insert(&mut self, character: char) {
+        self.fork_filter.push(character);
+        self.fork_cursor = 0;
+    }
+
+    pub(crate) fn fork_filter_backspace(&mut self) {
+        self.fork_filter.pop();
+        self.fork_cursor = 0;
+    }
+
+    pub(crate) fn selected_fork_turn(&self) -> Option<ForkTurnItem> {
+        self.visible_fork_turns().get(self.fork_cursor).cloned()
+    }
+
+    pub(crate) fn push_pending_prompt(&mut self, text: String) -> String {
+        self.pending_prompt_seq = self.pending_prompt_seq.saturating_add(1);
+        let local_id = format!("local:pending:{}", self.pending_prompt_seq);
+        self.messages.push(ChatEntry::User {
+            text,
+            message_id: Some(local_id.clone()),
+        });
+        self.scroll_offset = 0;
+        local_id
+    }
+
+    pub(crate) fn rollback_pending_prompt(&mut self, local_id: &str) -> bool {
+        let old_len = self.messages.len();
+        self.messages.retain(|entry| {
+            !matches!(
+                entry,
+                ChatEntry::User {
+                    message_id: Some(message_id),
+                    ..
+                } if message_id == local_id
+            )
+        });
+        old_len != self.messages.len()
+    }
+
+    pub(crate) fn begin_llm_request_span(&mut self, timestamp: Option<i64>) {
+        if self.session_stats.open_llm_request_ts.is_none() {
+            self.session_stats.open_llm_request_ts = timestamp;
+            self.session_stats.open_llm_request_instant = Some(Instant::now());
+        }
+    }
+
+    pub(crate) fn end_llm_request_span(&mut self, timestamp: Option<i64>) {
+        let duration = match (self.session_stats.open_llm_request_ts, timestamp) {
+            (Some(started), Some(ended)) if ended >= started => {
+                Some(Duration::from_secs((ended - started) as u64))
+            }
+            _ => self
+                .session_stats
+                .open_llm_request_instant
+                .map(|started| started.elapsed()),
+        };
+        if let Some(duration) = duration {
+            self.session_stats.active_llm_duration += duration;
+        }
+        self.session_stats.open_llm_request_ts = None;
+        self.session_stats.open_llm_request_instant = None;
+    }
+
+    pub(crate) fn record_tool_call(&mut self) {
+        self.session_stats.total_tool_calls = self.session_stats.total_tool_calls.saturating_add(1);
+    }
+
+    pub(crate) fn record_context_tokens(&mut self, context_tokens: u64) {
+        self.session_stats.latest_context_tokens = Some(context_tokens);
+    }
+
+    pub(crate) fn apply_usage(&mut self, used: u64, size: u64, cost_usd: Option<f64>) {
+        if used > 0 {
+            self.record_context_tokens(used);
+        }
+        if size > 0 {
+            self.context_limit = size;
+        }
+        if let Some(cost_usd) = cost_usd {
+            self.cumulative_cost = Some(cost_usd);
+        }
+    }
+
+    pub(crate) fn add_active_llm_duration(&mut self, duration: Duration) {
+        self.session_stats.active_llm_duration += duration;
+    }
+
+    pub(crate) fn llm_request_elapsed(&self) -> Option<Duration> {
+        let mut elapsed = self.session_stats.active_llm_duration;
+        if let Some(started) = self.session_stats.open_llm_request_instant {
+            elapsed += started.elapsed();
+        }
+        (!elapsed.is_zero()).then_some(elapsed)
+    }
+
+    pub(crate) fn has_pending_undo(&self) -> bool {
+        self.undo_state
+            .as_ref()
+            .map(|state| {
+                state
+                    .stack
+                    .iter()
+                    .any(|frame| frame.status == UndoFrameStatus::Pending)
+            })
+            .unwrap_or(false)
+    }
+
+    pub(crate) fn current_undo_target(&self) -> Option<&UndoableTurn> {
+        let frontier_message_id = self
+            .undo_state
+            .as_ref()
+            .and_then(|state| state.frontier_message_id.as_deref());
+
+        let mut start_index = self.undoable_turns.len();
+        if let Some(frontier_message_id) = frontier_message_id
+            && let Some(frontier_index) = self
+                .undoable_turns
+                .iter()
+                .position(|turn| turn.message_id == frontier_message_id)
+        {
+            start_index = frontier_index;
+        }
+
+        self.undoable_turns[..start_index]
+            .iter()
+            .rev()
+            .find(|turn| !turn.message_id.is_empty())
+    }
+
+    pub(crate) fn can_redo(&self) -> bool {
+        self.undo_state
+            .as_ref()
+            .map(|state| !state.stack.is_empty())
+            .unwrap_or(false)
+    }
+
+    pub(crate) fn push_pending_undo(&mut self, turn: &UndoableTurn) {
+        let mut stack = self
+            .undo_state
+            .as_ref()
+            .map(|state| state.stack.clone())
+            .unwrap_or_default();
+        stack.push(UndoFrame {
+            turn_id: turn.turn_id.clone(),
+            message_id: turn.message_id.clone(),
+            status: UndoFrameStatus::Pending,
+            reverted_files: Vec::new(),
+        });
+        self.undo_state = Some(UndoState {
+            stack,
+            frontier_message_id: Some(turn.message_id.clone()),
+        });
+    }
+
+    pub(crate) fn build_undo_state_from_server_stack(
+        &self,
+        undo_stack: &UndoStackSnapshot,
+        preferred_frontier_message_id: Option<&str>,
+        reverted_files: Option<&[String]>,
+    ) -> Option<UndoState> {
+        if undo_stack.message_ids.is_empty() {
+            return None;
+        }
+
+        let previous_state = self.undo_state.as_ref();
+        let mut previous_by_message_id = std::collections::HashMap::new();
+        if let Some(previous_state) = previous_state {
+            for frame in &previous_state.stack {
+                previous_by_message_id.insert(frame.message_id.clone(), frame.clone());
+            }
+        }
+
+        let stack: Vec<UndoFrame> = undo_stack
+            .message_ids
+            .iter()
+            .map(|message_id| {
+                let previous = previous_by_message_id.get(message_id);
+                let reverted_files = if preferred_frontier_message_id == Some(message_id.as_str()) {
+                    reverted_files
+                        .map(|files| files.to_vec())
+                        .or_else(|| previous.map(|frame| frame.reverted_files.clone()))
+                        .unwrap_or_default()
+                } else {
+                    previous
+                        .map(|frame| frame.reverted_files.clone())
+                        .unwrap_or_default()
+                };
+                let turn_id = previous
+                    .map(|frame| frame.turn_id.clone())
+                    .or_else(|| {
+                        self.undoable_turns
+                            .iter()
+                            .find(|turn| turn.message_id == *message_id)
+                            .map(|turn| turn.turn_id.clone())
+                    })
+                    .unwrap_or_else(|| message_id.clone());
+                UndoFrame {
+                    turn_id,
+                    message_id: message_id.clone(),
+                    status: UndoFrameStatus::Confirmed,
+                    reverted_files,
+                }
+            })
+            .collect();
+
+        let has_message = |message_id: Option<&str>| {
+            message_id
+                .map(|message_id| stack.iter().any(|frame| frame.message_id == message_id))
+                .unwrap_or(false)
+        };
+
+        let frontier_message_id = if has_message(preferred_frontier_message_id) {
+            preferred_frontier_message_id.map(ToOwned::to_owned)
+        } else if has_message(previous_state.and_then(|state| state.frontier_message_id.as_deref()))
+        {
+            previous_state.and_then(|state| state.frontier_message_id.clone())
+        } else {
+            stack.last().map(|frame| frame.message_id.clone())
+        };
+
+        Some(UndoState {
+            stack,
+            frontier_message_id,
+        })
+    }
+
+    pub(crate) fn push_undoable_user_turn(&mut self, message_id: String, text: String) {
+        if !self
+            .undoable_turns
+            .iter()
+            .any(|turn| turn.message_id == message_id)
+        {
+            self.undoable_turns.push(UndoableTurn {
+                turn_id: message_id.clone(),
+                message_id,
+                text,
+            });
+        }
+    }
+
+    pub(crate) fn begin_turn(&mut self, is_replay: bool) {
+        self.clear_cancel_confirm();
+        if !is_replay {
+            self.begin_llm_request_span(None);
+        }
+        self.activity = ActivityState::Thinking;
+        self.streaming_content.clear();
+        self.streaming_content_message_id = None;
+        self.clear_streaming_thinking();
+    }
+
+    pub(crate) fn append_streaming_content(
+        &mut self,
+        content: &str,
+        message_id: Option<String>,
+    ) -> StreamingDeltaTransition {
+        if self.is_turn_active() {
+            self.activity = ActivityState::Streaming;
+        }
+        let active_message_id = self
+            .streaming_content_message_id
+            .as_deref()
+            .or(self.streaming_thinking_message_id.as_deref());
+        let finalized_previous = message_id
+            .as_deref()
+            .is_some_and(|incoming| active_message_id.is_some_and(|active| active != incoming))
+            && self.finalize_streaming_segment();
+        if self.streaming_content.is_empty()
+            || (self.streaming_content_message_id.is_none() && message_id.is_some())
+        {
+            self.streaming_content_message_id = message_id;
+        }
+        self.streaming_content.push_str(content);
+        StreamingDeltaTransition {
+            finalized_previous,
+            ignored_duplicate: false,
+        }
+    }
+
+    pub(crate) fn append_streaming_thinking(
+        &mut self,
+        content: &str,
+        message_id: Option<String>,
+        is_replay: bool,
+    ) -> StreamingDeltaTransition {
+        if is_replay
+            && message_id.as_deref().is_some_and(|incoming| {
+                self.messages.iter().any(|entry| {
+                    matches!(entry, ChatEntry::Thinking { message_id: Some(existing), .. } if existing == incoming)
+                }) || (self.streaming_thinking_message_id.as_deref() == Some(incoming)
+                    && self.streaming_thinking == content)
+            })
+        {
+            return StreamingDeltaTransition {
+                finalized_previous: false,
+                ignored_duplicate: true,
+            };
+        }
+
+        let active_message_id = self
+            .streaming_content_message_id
+            .as_deref()
+            .or(self.streaming_thinking_message_id.as_deref());
+        let finalized_previous = message_id
+            .as_deref()
+            .is_some_and(|incoming| active_message_id.is_some_and(|active| active != incoming))
+            && self.finalize_streaming_segment();
+        if self.streaming_thinking.is_empty()
+            || (self.streaming_thinking_message_id.is_none() && message_id.is_some())
+        {
+            self.streaming_thinking_message_id = message_id;
+        }
+        self.streaming_thinking.push_str(content);
+        StreamingDeltaTransition {
+            finalized_previous,
+            ignored_duplicate: false,
+        }
+    }
+
+    pub(crate) fn finalize_streaming_segment(&mut self) -> bool {
+        if self.streaming_content.is_empty() && self.streaming_thinking.is_empty() {
+            return false;
+        }
+        let content = std::mem::take(&mut self.streaming_content);
+        let content_message_id = self.streaming_content_message_id.take();
+        let thinking = (!self.streaming_thinking.is_empty())
+            .then(|| std::mem::take(&mut self.streaming_thinking));
+        let thinking_message_id = self.streaming_thinking_message_id.take();
+
+        if content.is_empty() {
+            if let Some(thinking) = thinking {
+                self.messages.push(ChatEntry::Thinking {
+                    content: thinking,
+                    message_id: thinking_message_id,
+                });
+            }
+        } else {
+            self.messages.push(ChatEntry::Assistant {
+                content,
+                thinking,
+                message_id: content_message_id.or(thinking_message_id),
+            });
+        }
+        true
+    }
+
+    pub(crate) fn clear_streaming_thinking(&mut self) {
+        self.streaming_thinking.clear();
+        self.streaming_thinking_message_id = None;
+    }
+
+    pub(crate) fn push_streaming_thinking_entry(&mut self) -> bool {
+        if self.streaming_thinking.is_empty() {
+            return false;
+        }
+        self.messages.push(ChatEntry::Thinking {
+            content: std::mem::take(&mut self.streaming_thinking),
+            message_id: self.streaming_thinking_message_id.take(),
+        });
+        true
+    }
+
+    pub(crate) fn cancel_turn(&mut self, is_replay: bool) {
+        if !is_replay {
+            self.end_llm_request_span(None);
+        }
+        self.activity = ActivityState::Idle;
+        self.streaming_content.clear();
+        self.streaming_content_message_id = None;
+        self.clear_streaming_thinking();
+    }
+
+    pub(crate) fn finish_turn(&mut self, is_replay: bool) {
+        self.cancel_turn(is_replay);
+    }
+
+    pub(crate) fn push_user_message(
+        &mut self,
+        text: String,
+        message_id: Option<String>,
+        is_replay: bool,
+    ) -> UserMessageTransition {
+        if text.is_empty() {
+            return UserMessageTransition::Ignored;
+        }
+        if let Some(message_id) = message_id.as_deref()
+            && self.messages.iter().any(|entry| {
+                matches!(entry, ChatEntry::User { message_id: Some(mid), .. } if mid == message_id)
+            })
+        {
+            self.recent_prompt_text = Some(text);
+            self.suppress_turn_output = false;
+            return UserMessageTransition::Duplicate;
+        }
+        if !is_replay
+            && let Some(entry) = self.messages.iter_mut().find(|entry| {
+                matches!(
+                    entry,
+                    ChatEntry::User {
+                        text: pending_text,
+                        message_id: Some(pending_id),
+                    } if pending_id.starts_with("local:pending:")
+                        && pending_text.trim() == text.trim()
+                )
+            })
+        {
+            if let ChatEntry::User {
+                text: pending_text,
+                message_id: pending_id,
+            } = entry
+            {
+                *pending_text = text.clone();
+                *pending_id = message_id.clone();
+            }
+            self.recent_prompt_text = Some(text.clone());
+            self.suppress_turn_output = false;
+            if let Some(message_id) = message_id {
+                self.push_undoable_user_turn(message_id, text);
+            }
+            return UserMessageTransition::Reconciled;
+        }
+        if !is_replay && (self.undo_state.is_some() || self.suppress_turn_output) {
+            return UserMessageTransition::Ignored;
+        }
+        self.suppress_turn_output = false;
+        self.messages.push(ChatEntry::User {
+            text: text.clone(),
+            message_id: message_id.clone(),
+        });
+        self.recent_prompt_text = Some(text.clone());
+        if let Some(message_id) = message_id {
+            self.push_undoable_user_turn(message_id, text);
+        }
+        UserMessageTransition::Appended
+    }
+
+    pub(crate) fn push_assistant_message(
+        &mut self,
+        content: String,
+        thinking: Option<String>,
+        message_id: Option<String>,
+    ) -> bool {
+        let explicit_thinking = thinking.filter(|text| !text.is_empty());
+        let thinking_message_id = message_id
+            .clone()
+            .or_else(|| self.streaming_thinking_message_id.clone());
+        self.streaming_content.clear();
+        self.streaming_content_message_id = None;
+        if self.is_turn_active() {
+            self.activity = ActivityState::Thinking;
+        }
+        if content.is_empty() && explicit_thinking.is_none() && self.streaming_thinking.is_empty() {
+            self.streaming_thinking_message_id = None;
+            return false;
+        }
+        self.recent_prompt_text = None;
+        if self.suppress_turn_output {
+            self.clear_streaming_thinking();
+            return false;
+        }
+
+        if let Some(message_id) = message_id.as_deref() {
+            if self.messages.iter().any(|entry| {
+                matches!(entry, ChatEntry::Assistant { message_id: Some(mid), .. } if mid == message_id)
+            }) {
+                self.clear_streaming_thinking();
+                return false;
+            }
+
+            if let Some(index) = self.messages.iter().position(|entry| {
+                matches!(entry, ChatEntry::Thinking { message_id: Some(mid), .. } if mid == message_id)
+            }) {
+                if content.is_empty() {
+                    self.clear_streaming_thinking();
+                    return false;
+                }
+                let existing_thinking = match &self.messages[index] {
+                    ChatEntry::Thinking { content, .. } => content.clone(),
+                    _ => String::new(),
+                };
+                let streaming_thinking = (!self.streaming_thinking.is_empty())
+                    .then(|| std::mem::take(&mut self.streaming_thinking));
+                let thinking_text = explicit_thinking
+                    .or_else(|| (!existing_thinking.is_empty()).then_some(existing_thinking))
+                    .or(streaming_thinking);
+                self.streaming_thinking_message_id = None;
+                self.messages[index] = ChatEntry::Assistant {
+                    content,
+                    thinking: thinking_text,
+                    message_id: Some(message_id.to_string()),
+                };
+                return true;
+            }
+        }
+
+        let streaming_thinking = (!self.streaming_thinking.is_empty())
+            .then(|| std::mem::take(&mut self.streaming_thinking));
+        let thinking_text = explicit_thinking.or(streaming_thinking);
+        self.streaming_thinking_message_id = None;
+        if content.is_empty() {
+            if let Some(thinking) = thinking_text {
+                self.messages.push(ChatEntry::Thinking {
+                    content: thinking,
+                    message_id: thinking_message_id,
+                });
+            }
+        } else {
+            self.messages.push(ChatEntry::Assistant {
+                content,
+                thinking: thinking_text,
+                message_id,
+            });
+        }
+        false
+    }
+
+    pub(crate) fn reconcile_tool_call_start(
+        &mut self,
+        tool_call_id: Option<&str>,
+        tool_name: &str,
+        detail: ToolDetail,
+    ) -> bool {
+        let Some(tool_call_id) = tool_call_id else {
+            return false;
+        };
+        let fallback_name = format!("{tool_name} (failed)");
+        for entry in self.messages.iter_mut().rev() {
+            if let ChatEntry::ToolCall {
+                tool_call_id: Some(existing),
+                name,
+                detail: existing_detail,
+                ..
+            } = entry
+            {
+                if existing != tool_call_id {
+                    continue;
+                }
+                let is_failed_fallback = name == &fallback_name;
+                if is_failed_fallback {
+                    *name = tool_name.to_string();
+                }
+                if (is_failed_fallback || matches!(existing_detail, ToolDetail::None))
+                    && !matches!(detail, ToolDetail::None)
+                {
+                    *existing_detail = detail;
+                }
+                return true;
+            }
+        }
+        false
+    }
+
+    pub(crate) fn mark_tool_call_failed(
+        &mut self,
+        tool_call_id: Option<&str>,
+        tool_name: &str,
+    ) -> bool {
+        let Some(tool_call_id) = tool_call_id else {
+            return false;
+        };
+        let fallback_name = format!("{tool_name} (failed)");
+        for entry in self.messages.iter_mut().rev() {
+            if let ChatEntry::ToolCall {
+                tool_call_id: Some(existing),
+                name,
+                is_error,
+                ..
+            } = entry
+                && existing == tool_call_id
+                && (name == tool_name || name == &fallback_name)
+            {
+                *is_error = true;
+                return true;
+            }
+        }
+        false
+    }
+
+    pub(crate) fn push_tool_call(
+        &mut self,
+        tool_call_id: Option<String>,
+        name: String,
+        is_error: bool,
+        detail: ToolDetail,
+    ) {
+        self.messages.push(ChatEntry::ToolCall {
+            tool_call_id,
+            name,
+            is_error,
+            detail,
+        });
+    }
+
+    pub(crate) fn push_error(&mut self, message: &str) -> bool {
+        if self
+            .messages
+            .iter()
+            .any(|entry| matches!(entry, ChatEntry::Error(existing) if existing == message))
+        {
+            false
+        } else {
+            self.messages.push(ChatEntry::Error(message.to_string()));
+            true
+        }
+    }
+
+    pub(crate) fn push_elicitation(
+        &mut self,
+        active: Option<ElicitationState>,
+        elicitation_id: String,
+        message: String,
+        source: String,
+        outcome: Option<String>,
+    ) -> ElicitationTransition {
+        if self.messages.iter().any(|entry| {
+            matches!(
+                entry,
+                ChatEntry::Elicitation {
+                    elicitation_id: existing_id,
+                    ..
+                } if existing_id == &elicitation_id
+            )
+        }) {
+            return ElicitationTransition::default();
+        }
+
+        let finalized_streaming = self.finalize_streaming_segment();
+        if let Some(active) = active {
+            self.elicitation = Some(active);
+            self.elicitation_ui = Some(ElicitationUiState::default());
+        }
+        self.messages.push(ChatEntry::Elicitation {
+            elicitation_id,
+            message,
+            source,
+            outcome,
+        });
+        self.scroll_offset = 0;
+        ElicitationTransition {
+            inserted: true,
+            finalized_streaming,
+        }
+    }
+
+    pub(crate) fn resolve_elicitation(&mut self, elicitation_id: &str, outcome: &str) -> bool {
+        let mut resolved = false;
+        for entry in &mut self.messages {
+            if let ChatEntry::Elicitation {
+                elicitation_id: existing_id,
+                outcome: existing_outcome,
+                ..
+            } = entry
+                && existing_id == elicitation_id
+            {
+                *existing_outcome = Some(outcome.to_string());
+                resolved = true;
+                break;
+            }
+        }
+        self.elicitation = None;
+        self.elicitation_ui = None;
+        resolved
+    }
+
+    pub(crate) fn backfill_elicitation_outcomes(&mut self, result_str: &str) {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(result_str) else {
+            return;
+        };
+        let Some(answers) = value.get("answers").and_then(|answers| answers.as_array()) else {
+            return;
+        };
+
+        let mut answer_iter = answers.iter();
+        for entry in &mut self.messages {
+            let ChatEntry::Elicitation { outcome, .. } = entry else {
+                continue;
+            };
+            if outcome.as_deref() != Some("responded") {
+                continue;
+            }
+            let Some(answer_entry) = answer_iter.next() else {
+                break;
+            };
+            let labels = answer_entry
+                .get("answers")
+                .and_then(|answers| answers.as_array())
+                .map(|answers| answers.iter().filter_map(|answer| answer.as_str()))
+                .into_iter()
+                .flatten();
+            *outcome = Some(format_outcome_labels(labels));
+        }
+    }
+}
+
+fn move_wrapping_cursor(cursor: usize, len: usize, delta: isize) -> usize {
+    if len == 0 {
+        0
+    } else {
+        (cursor as isize + delta).rem_euclid(len as isize) as usize
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::chat::OUTCOME_BULLET;
+    use crate::domain::tool::ToolDetail;
+
+    fn user(text: &str, message_id: Option<&str>) -> ChatEntry {
+        ChatEntry::User {
+            text: text.into(),
+            message_id: message_id.map(str::to_string),
+        }
+    }
+
+    fn assistant(content: &str, message_id: Option<&str>) -> ChatEntry {
+        ChatEntry::Assistant {
+            content: content.into(),
+            thinking: None,
+            message_id: message_id.map(str::to_string),
+        }
+    }
+
+    fn turn(message_id: &str) -> UndoableTurn {
+        UndoableTurn {
+            turn_id: format!("turn-{message_id}"),
+            message_id: message_id.into(),
+            text: format!("prompt {message_id}"),
+        }
+    }
+
+    #[test]
+    fn constructor_uses_exact_twenty_three_defaults() {
+        let chat = ChatState::new();
+        assert!(chat.messages.is_empty());
+        assert_eq!(chat.pending_prompt_seq, 0);
+        assert!(chat.fork_filter.is_empty());
+        assert_eq!(chat.fork_cursor, 0);
+        assert!(chat.pending_fork_message_id.is_none());
+        assert_eq!(chat.scroll_offset, 0);
+        assert_eq!(chat.activity, ActivityState::Idle);
+        assert!(chat.streaming_content.is_empty());
+        assert!(chat.streaming_content_message_id.is_none());
+        assert!(chat.streaming_thinking.is_empty());
+        assert!(chat.streaming_thinking_message_id.is_none());
+        assert!(chat.last_compaction_token_estimate.is_none());
+        assert!(chat.elicitation.is_none());
+        assert!(chat.elicitation_ui.is_none());
+        assert!(chat.show_thinking);
+        assert!(chat.undo_state.is_none());
+        assert!(chat.undoable_turns.is_empty());
+        assert!(chat.recent_prompt_text.is_none());
+        assert!(chat.cumulative_cost.is_none());
+        assert_eq!(chat.context_limit, 0);
+        assert_eq!(chat.session_stats, SessionStatsLite::default());
+        assert!(chat.pending_cancel_confirm_until.is_none());
+        assert!(!chat.suppress_turn_output);
+    }
+
+    #[test]
+    fn session_switch_reset_clears_exact_scope_and_preserves_survivors() {
+        let mut chat = ChatState::new();
+        chat.messages.push(ChatEntry::Error("stale".into()));
+        chat.pending_prompt_seq = 8;
+        chat.fork_filter = "keep".into();
+        chat.fork_cursor = 3;
+        chat.pending_fork_message_id = Some("keep-fork".into());
+        chat.scroll_offset = 7;
+        chat.activity = ActivityState::Streaming;
+        chat.streaming_content = "content".into();
+        chat.streaming_content_message_id = Some("content-id".into());
+        chat.streaming_thinking = "thinking".into();
+        chat.streaming_thinking_message_id = Some("thinking-id".into());
+        chat.last_compaction_token_estimate = Some(42);
+        chat.elicitation = Some(ElicitationState::new_for_test(Vec::new()));
+        chat.elicitation_ui = Some(ElicitationUiState::default());
+        chat.show_thinking = false;
+        chat.undo_state = Some(UndoState {
+            stack: Vec::new(),
+            frontier_message_id: Some("frontier".into()),
+        });
+        chat.undoable_turns.push(turn("turn"));
+        chat.recent_prompt_text = Some("prompt".into());
+        chat.cumulative_cost = Some(1.25);
+        chat.context_limit = 200_000;
+        chat.session_stats.total_tool_calls = 2;
+        chat.pending_cancel_confirm_until = Some(Instant::now());
+        chat.suppress_turn_output = true;
+
+        chat.reset_for_session_switch();
+
+        assert!(chat.messages.is_empty());
+        assert_eq!(chat.pending_prompt_seq, 0);
+        assert_eq!(chat.fork_filter, "keep");
+        assert_eq!(chat.fork_cursor, 3);
+        assert_eq!(chat.pending_fork_message_id.as_deref(), Some("keep-fork"));
+        assert_eq!(chat.scroll_offset, 0);
+        assert_eq!(chat.activity, ActivityState::Streaming);
+        assert!(chat.streaming_content.is_empty());
+        assert!(chat.streaming_content_message_id.is_none());
+        assert!(chat.streaming_thinking.is_empty());
+        assert!(chat.streaming_thinking_message_id.is_none());
+        assert!(chat.last_compaction_token_estimate.is_none());
+        assert!(chat.elicitation.is_none());
+        assert!(chat.elicitation_ui.is_none());
+        assert!(!chat.show_thinking);
+        assert!(chat.undo_state.is_none());
+        assert!(chat.undoable_turns.is_empty());
+        assert!(chat.recent_prompt_text.is_none());
+        assert!(chat.cumulative_cost.is_none());
+        assert_eq!(chat.context_limit, 200_000);
+        assert_eq!(chat.session_stats, SessionStatsLite::default());
+        assert!(chat.pending_cancel_confirm_until.is_none());
+        assert!(!chat.suppress_turn_output);
+    }
+
+    #[test]
+    fn fork_filter_order_wrap_and_selection_preserve_boundaries() {
+        let mut chat = ChatState::new();
+        chat.messages = vec![
+            user("first alpha", Some("user-1")),
+            assistant("reply one", Some("assistant-1")),
+            user("second beta", Some("user-2")),
+            user("third alpha", Some("user-3")),
+        ];
+        let turns = chat.forkable_turns();
+        assert_eq!(turns.len(), 3);
+        assert_eq!(turns[0].message_id, "assistant-1");
+        assert_eq!(turns[0].boundary_kind, ForkBoundaryKind::Assistant);
+        assert_eq!(turns[1].message_id, "user-2");
+        assert_eq!(turns[1].boundary_kind, ForkBoundaryKind::User);
+
+        chat.fork_filter_insert('a');
+        assert_eq!(chat.visible_fork_turns().len(), 3);
+        assert_eq!(chat.selected_fork_turn().unwrap().message_id, "user-3");
+        chat.move_fork_cursor(-1);
+        assert_eq!(chat.selected_fork_turn().unwrap().message_id, "assistant-1");
+        chat.move_fork_cursor(1);
+        assert_eq!(chat.selected_fork_turn().unwrap().message_id, "user-3");
+        chat.fork_filter = "beta".into();
+        chat.fork_cursor = 9;
+        chat.move_fork_cursor(1);
+        assert_eq!(chat.fork_cursor, 0);
+        assert_eq!(chat.selected_fork_turn().unwrap().message_id, "user-2");
+    }
+
+    #[test]
+    fn pending_prompt_ids_saturate_and_rollback_only_the_target() {
+        let mut chat = ChatState::new();
+        let first = chat.push_pending_prompt("first".into());
+        let second = chat.push_pending_prompt("second".into());
+        chat.messages.push(assistant("answer", Some("assistant")));
+        assert_eq!(first, "local:pending:1");
+        assert_eq!(second, "local:pending:2");
+        assert!(chat.rollback_pending_prompt(&first));
+        assert!(!chat.rollback_pending_prompt("missing"));
+        assert!(chat.messages.iter().any(
+            |entry| matches!(entry, ChatEntry::User { message_id: Some(id), .. } if id == &second)
+        ));
+        assert!(
+            chat.messages
+                .iter()
+                .any(|entry| matches!(entry, ChatEntry::Assistant { .. }))
+        );
+    }
+
+    #[test]
+    fn cancel_deadline_and_activity_status_transitions_are_local() {
+        let mut chat = ChatState::new();
+        chat.activity = ActivityState::Compacting {
+            token_estimate: 2048,
+        };
+        assert!(chat.is_turn_active());
+        assert_eq!(
+            chat.activity_status_text().as_deref(),
+            Some("compacting context (~2048 tokens)")
+        );
+        chat.arm_cancel_confirm();
+        assert!(chat.cancel_confirm_active());
+        chat.pending_cancel_confirm_until = Some(Instant::now() - Duration::from_millis(1));
+        assert!(chat.clear_expired_cancel_confirm());
+        assert!(!chat.cancel_confirm_active());
+        chat.activity = ActivityState::SessionOp(SessionOp::Undo);
+        assert!(chat.has_pending_session_op());
+        assert_eq!(chat.pending_session_label(), Some("undoing"));
+        assert!(chat.input_blocked_by_activity());
+    }
+
+    #[test]
+    fn timing_usage_cost_context_and_tool_stats_accumulate() {
+        let mut chat = ChatState::new();
+        chat.begin_llm_request_span(Some(100));
+        chat.record_tool_call();
+        chat.end_llm_request_span(Some(140));
+        chat.apply_usage(2048, 8192, Some(0.0123));
+        chat.add_active_llm_duration(Duration::from_secs(2));
+        assert_eq!(chat.llm_request_elapsed(), Some(Duration::from_secs(42)));
+        assert_eq!(chat.session_stats.latest_context_tokens, Some(2048));
+        assert_eq!(chat.session_stats.total_tool_calls, 1);
+        assert_eq!(chat.context_limit, 8192);
+        assert_eq!(chat.cumulative_cost, Some(0.0123));
+    }
+
+    #[test]
+    fn undo_frontier_pending_and_server_rebuild_preserve_order() {
+        let mut chat = ChatState::new();
+        chat.undoable_turns = vec![turn("one"), turn("two"), turn("three")];
+        assert_eq!(chat.current_undo_target().unwrap().message_id, "three");
+        let target = chat.current_undo_target().unwrap().clone();
+        chat.push_pending_undo(&target);
+        assert!(chat.has_pending_undo());
+        assert_eq!(chat.current_undo_target().unwrap().message_id, "two");
+
+        let state = chat
+            .build_undo_state_from_server_stack(
+                &UndoStackSnapshot {
+                    message_ids: vec!["three".into(), "unknown".into()],
+                },
+                Some("unknown"),
+                Some(&["src/lib.rs".into()]),
+            )
+            .unwrap();
+        assert_eq!(state.frontier_message_id.as_deref(), Some("unknown"));
+        assert_eq!(state.stack[0].turn_id, "turn-three");
+        assert_eq!(state.stack[1].turn_id, "unknown");
+        assert_eq!(state.stack[1].reverted_files, ["src/lib.rs"]);
+    }
+
+    #[test]
+    fn elicitation_resolution_and_backfill_update_durable_cards() {
+        let mut chat = ChatState::new();
+        let state = ElicitationState::new_for_test(Vec::new());
+        let transition = chat.push_elicitation(
+            Some(state),
+            "elic-1".into(),
+            "Pick".into(),
+            "question".into(),
+            None,
+        );
+        assert!(transition.inserted);
+        assert!(chat.elicitation.is_some());
+        assert!(chat.resolve_elicitation("elic-1", "responded"));
+        assert!(chat.elicitation.is_none());
+        chat.backfill_elicitation_outcomes(
+            r#"{"answers":[{"question":"Pick","answers":["Alpha","Beta"]}]}"#,
+        );
+        assert!(matches!(
+            &chat.messages[0],
+            ChatEntry::Elicitation { outcome: Some(outcome), .. }
+                if outcome == &format!("{OUTCOME_BULLET}Alpha\n{OUTCOME_BULLET}Beta")
+        ));
+    }
+
+    #[test]
+    fn elicitation_live_replay_duplicate_identity_is_idempotent() {
+        let mut chat = ChatState::new();
+        let replay = chat.push_elicitation(
+            None,
+            "elic-1".into(),
+            "Question".into(),
+            "source".into(),
+            None,
+        );
+        assert!(replay.inserted);
+        assert!(chat.elicitation.is_none());
+        let duplicate = chat.push_elicitation(
+            Some(ElicitationState::new_for_test(Vec::new())),
+            "elic-1".into(),
+            "Question".into(),
+            "source".into(),
+            None,
+        );
+        assert_eq!(duplicate, ElicitationTransition::default());
+        assert_eq!(chat.messages.len(), 1);
+        assert!(chat.elicitation.is_none());
+    }
+
+    #[test]
+    fn streaming_content_and_thinking_keep_message_id_boundaries() {
+        let mut chat = ChatState::new();
+        chat.activity = ActivityState::Thinking;
+        chat.append_streaming_thinking("plan", Some("one".into()), false);
+        chat.append_streaming_content("answer", Some("one".into()));
+        let transition = chat.append_streaming_content("second", Some("two".into()));
+        assert!(transition.finalized_previous);
+        assert!(matches!(
+            chat.messages.as_slice(),
+            [ChatEntry::Assistant { content, thinking: Some(thinking), message_id: Some(id) }]
+                if content == "answer" && thinking == "plan" && id == "one"
+        ));
+        assert_eq!(chat.streaming_content, "second");
+        assert_eq!(chat.streaming_content_message_id.as_deref(), Some("two"));
+    }
+
+    #[test]
+    fn duplicate_replay_messages_and_final_assistants_are_suppressed() {
+        let mut chat = ChatState::new();
+        assert_eq!(
+            chat.push_user_message("prompt".into(), Some("user-1".into()), true),
+            UserMessageTransition::Appended
+        );
+        assert_eq!(
+            chat.push_user_message("prompt".into(), Some("user-1".into()), true),
+            UserMessageTransition::Duplicate
+        );
+        chat.push_assistant_message("answer".into(), None, Some("assistant-1".into()));
+        chat.push_assistant_message("answer".into(), None, Some("assistant-1".into()));
+        assert_eq!(chat.messages.len(), 2);
+    }
+
+    #[test]
+    fn tool_boundary_preserves_streamed_thinking_before_tool_entry() {
+        let mut chat = ChatState::new();
+        chat.streaming_thinking = "inspect".into();
+        chat.streaming_thinking_message_id = Some("assistant-1".into());
+        assert!(chat.push_streaming_thinking_entry());
+        chat.record_tool_call();
+        chat.messages.push(ChatEntry::ToolCall {
+            tool_call_id: Some("call-1".into()),
+            name: "read_tool".into(),
+            is_error: false,
+            detail: ToolDetail::None,
+        });
+        assert!(matches!(
+            chat.messages.as_slice(),
+            [ChatEntry::Thinking { message_id: Some(id), .. }, ChatEntry::ToolCall { tool_call_id: Some(call_id), .. }]
+                if id == "assistant-1" && call_id == "call-1"
+        ));
+        assert_eq!(chat.session_stats.total_tool_calls, 1);
+    }
+
+    #[test]
+    fn optimistic_prompt_reconciliation_is_submission_ordered() {
+        let mut chat = ChatState::new();
+        let first = chat.push_pending_prompt("repeat".into());
+        let second = chat.push_pending_prompt("repeat".into());
+        assert_eq!(
+            chat.push_user_message("repeat".into(), Some("server-1".into()), false),
+            UserMessageTransition::Reconciled
+        );
+        assert!(matches!(
+            &chat.messages[0],
+            ChatEntry::User { message_id: Some(id), .. } if id == "server-1"
+        ));
+        assert!(matches!(
+            &chat.messages[1],
+            ChatEntry::User { message_id: Some(id), .. } if id == &second
+        ));
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn elicitation_editor_reuses_composer_visual_layout() {
+        let mut ui = ElicitationUiState {
+            custom_cursor: 4,
+            custom_line_width: 4,
+            ..Default::default()
+        };
+        ui.custom_move_visual("abcdef", -1);
+        assert_eq!(ui.custom_cursor, 2);
+        ui.custom_move_visual("abcdef", 1);
+        assert_eq!(ui.custom_cursor, 4);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -155,7 +155,7 @@ impl TuiConfig {
     pub fn with_app_settings(&self, app: &crate::app::App) -> Self {
         let mut merged = self.clone();
         merged.theme = Some(crate::theme::Theme::current_id().to_string());
-        merged.show_thinking = Some(app.show_thinking);
+        merged.show_thinking = Some(app.chat.show_thinking);
         merged.profile_delegate_models = app.models.delegate_model_preferences.clone();
         merged.profile.id = app.profiles.active_profile_id.clone();
         if let Some(profile_id) = app.profiles.active_profile_id.as_deref()
@@ -347,7 +347,7 @@ mod tests {
     #[test]
     fn with_app_settings_preserves_acp_settings() {
         let mut app = App::new();
-        app.show_thinking = false;
+        app.chat.show_thinking = false;
 
         let existing = TuiConfig {
             theme: Some("base16-ocean".into()),

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -6,7 +6,7 @@ use crate::auth_state::{AuthPanel, AuthUiNotice};
 use crate::diagnostics::LogLevel;
 use crate::domain::activity::{ActivityState, SessionOp};
 use crate::domain::auth::{OAuthFlowKind, OAuthStatus};
-use crate::domain::chat::{ChatEntry, format_outcome_labels};
+use crate::domain::chat::format_outcome_labels;
 use crate::domain::model::ModelEntry;
 use crate::navigation_state::{CommandPaletteAction, Popup, Screen};
 
@@ -60,7 +60,10 @@ pub(crate) fn handle_elicitation_key(
 ) -> anyhow::Result<()> {
     use crate::domain::elicitation::ElicitationFieldKind;
 
-    let (Some(state), Some(ui)) = (app.elicitation.as_mut(), app.elicitation_ui.as_mut()) else {
+    let (Some(state), Some(ui)) = (
+        app.chat.elicitation.as_mut(),
+        app.chat.elicitation_ui.as_mut(),
+    ) else {
         return Ok(());
     };
     let Some(field_index) = ui.current_field_index(state.fields.len()) else {
@@ -490,8 +493,8 @@ pub(crate) fn handle_key(
     key: KeyEvent,
     cmd_tx: &mpsc::UnboundedSender<Command>,
 ) -> anyhow::Result<AppAction> {
-    if key.code != KeyCode::Esc && app.pending_cancel_confirm_until.is_some() {
-        app.clear_cancel_confirm();
+    if key.code != KeyCode::Esc && app.chat.pending_cancel_confirm_until.is_some() {
+        app.chat.clear_cancel_confirm();
         app.refresh_transient_status();
     }
 
@@ -534,7 +537,7 @@ pub(crate) fn handle_key(
     }
 
     // elicitation popup takes full control of input when active
-    if app.elicitation.is_some() {
+    if app.chat.elicitation.is_some() {
         handle_elicitation_key(app, key, cmd_tx)?;
         return Ok(AppAction::None);
     }
@@ -667,10 +670,10 @@ pub(crate) fn handle_key(
 pub(crate) fn handle_mouse(app: &mut App, mouse: MouseEvent) {
     match (mouse.kind, &app.navigation.screen, &app.navigation.popup) {
         (MouseEventKind::ScrollUp, Screen::Chat | Screen::Delegate, Popup::None) => {
-            app.scroll_offset = app.scroll_offset.saturating_add(3);
+            app.chat.scroll_offset = app.chat.scroll_offset.saturating_add(3);
         }
         (MouseEventKind::ScrollDown, Screen::Chat | Screen::Delegate, Popup::None) => {
-            app.scroll_offset = app.scroll_offset.saturating_sub(3);
+            app.chat.scroll_offset = app.chat.scroll_offset.saturating_sub(3);
         }
         _ => {}
     }
@@ -766,20 +769,20 @@ pub(crate) fn handle_chord(
             if !can_send_server_commands(app) {
                 return Ok(());
             }
-            if app.is_turn_active() {
+            if app.chat.is_turn_active() {
                 app.set_status(
                     LogLevel::Warn,
                     "session",
                     "cannot undo while agent is active",
                 );
-            } else if app.has_pending_session_op() || app.has_pending_undo() {
+            } else if app.chat.has_pending_session_op() || app.chat.has_pending_undo() {
                 app.set_status(LogLevel::Warn, "session", "undo already pending");
-            } else if let Some(turn) = app.current_undo_target().cloned() {
+            } else if let Some(turn) = app.chat.current_undo_target().cloned() {
                 if app.composer.input.trim().is_empty() && !turn.text.is_empty() {
                     app.composer.replace_input(turn.text.clone());
                 }
-                app.push_pending_undo(&turn);
-                app.activity = ActivityState::SessionOp(SessionOp::Undo);
+                app.chat.push_pending_undo(&turn);
+                app.chat.activity = ActivityState::SessionOp(SessionOp::Undo);
                 app.set_status(LogLevel::Info, "session", "undoing...");
                 cmd_tx.send(Command::Undo {
                     message_id: turn.message_id,
@@ -792,16 +795,16 @@ pub(crate) fn handle_chord(
             if !can_send_server_commands(app) {
                 return Ok(());
             }
-            if app.is_turn_active() {
+            if app.chat.is_turn_active() {
                 app.set_status(
                     LogLevel::Warn,
                     "session",
                     "cannot redo while agent is active",
                 );
-            } else if app.has_pending_session_op() || app.has_pending_undo() {
+            } else if app.chat.has_pending_session_op() || app.chat.has_pending_undo() {
                 app.set_status(LogLevel::Warn, "session", "undo already pending");
-            } else if app.can_redo() {
-                app.activity = ActivityState::SessionOp(SessionOp::Redo);
+            } else if app.chat.can_redo() {
+                app.chat.activity = ActivityState::SessionOp(SessionOp::Redo);
                 app.set_status(LogLevel::Info, "session", "redoing...");
                 cmd_tx.send(Command::Redo)?;
             } else {
@@ -1154,23 +1157,23 @@ fn handle_delegate_view_key(
 ) -> anyhow::Result<AppAction> {
     match key.code {
         KeyCode::Up => {
-            app.scroll_offset = app.scroll_offset.saturating_add(1);
+            app.chat.scroll_offset = app.chat.scroll_offset.saturating_add(1);
         }
         KeyCode::Down => {
-            app.scroll_offset = app.scroll_offset.saturating_sub(1);
+            app.chat.scroll_offset = app.chat.scroll_offset.saturating_sub(1);
         }
         KeyCode::PageUp => {
-            app.scroll_offset = app.scroll_offset.saturating_add(10);
+            app.chat.scroll_offset = app.chat.scroll_offset.saturating_add(10);
         }
         KeyCode::PageDown => {
-            app.scroll_offset = app.scroll_offset.saturating_sub(10);
+            app.chat.scroll_offset = app.chat.scroll_offset.saturating_sub(10);
         }
         KeyCode::Home => {
             // Scroll to top: set a large offset (draw_messages clamps it).
-            app.scroll_offset = u16::MAX;
+            app.chat.scroll_offset = u16::MAX;
         }
         KeyCode::End => {
-            app.scroll_offset = 0;
+            app.chat.scroll_offset = 0;
         }
         KeyCode::Esc => {
             // Go back to parent session.
@@ -1283,15 +1286,15 @@ fn begin_fork_session(
     message_id: String,
     cmd_tx: &mpsc::UnboundedSender<Command>,
 ) -> anyhow::Result<()> {
-    if app.pending_fork_message_id.is_some() {
+    if app.chat.pending_fork_message_id.is_some() {
         app.set_status(LogLevel::Warn, "fork", "fork already pending");
         return Ok(());
     }
-    if app.is_turn_active() {
+    if app.chat.is_turn_active() {
         app.set_status(LogLevel::Warn, "fork", "cannot fork while agent is active");
         return Ok(());
     }
-    if app.has_pending_session_op() {
+    if app.chat.has_pending_session_op() {
         app.set_status(LogLevel::Warn, "fork", "session operation already pending");
         return Ok(());
     }
@@ -1300,7 +1303,7 @@ fn begin_fork_session(
         return Ok(());
     }
 
-    app.pending_fork_message_id = Some(message_id.clone());
+    app.chat.pending_fork_message_id = Some(message_id.clone());
     app.set_status(LogLevel::Info, "fork", "forking session...");
     cmd_tx.send(Command::ForkSession { message_id })?;
     Ok(())
@@ -1313,18 +1316,18 @@ pub(crate) fn handle_fork_turn_popup_key(
 ) -> anyhow::Result<()> {
     match key.code {
         KeyCode::Esc => app.navigation.popup = Popup::None,
-        KeyCode::Up => app.move_fork_cursor(-1),
-        KeyCode::Down => app.move_fork_cursor(1),
-        KeyCode::Backspace => app.fork_filter_backspace(),
+        KeyCode::Up => app.chat.move_fork_cursor(-1),
+        KeyCode::Down => app.chat.move_fork_cursor(1),
+        KeyCode::Backspace => app.chat.fork_filter_backspace(),
         KeyCode::Enter => {
-            if let Some(turn) = app.selected_fork_turn() {
+            if let Some(turn) = app.chat.selected_fork_turn() {
                 begin_fork_session(app, turn.message_id, cmd_tx)?;
             } else {
                 app.set_status(LogLevel::Warn, "fork", "no forkable turns");
             }
         }
         KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
-            app.fork_filter_insert(c);
+            app.chat.fork_filter_insert(c);
         }
         _ => {}
     }
@@ -1532,24 +1535,24 @@ pub(crate) fn handle_chat_key(
     if app.composer.input_line_width == 0 {
         app.composer.input_line_width = 1;
     }
-    let input_blocked = app.input_blocked_by_activity();
+    let input_blocked = app.chat.input_blocked_by_activity();
     match key.code {
         KeyCode::Esc => {
             // Dismiss whichever completion popup is open first.
             if app.composer.mention_state.is_some() || app.composer.slash_state.is_some() {
                 app.composer.mention_state = None;
                 app.composer.slash_state = None;
-                app.clear_cancel_confirm();
-            } else if app.has_cancellable_activity() {
-                if app.cancel_confirm_active() {
-                    app.clear_cancel_confirm();
+                app.chat.clear_cancel_confirm();
+            } else if app.chat.has_cancellable_activity() {
+                if app.chat.cancel_confirm_active() {
+                    app.chat.clear_cancel_confirm();
                     app.set_status(LogLevel::Warn, "activity", "stopping...");
                     cmd_tx.send(Command::CancelSession)?;
                 } else {
                     app.arm_cancel_confirm();
                 }
             } else {
-                app.clear_cancel_confirm();
+                app.chat.clear_cancel_confirm();
             }
         }
         KeyCode::Enter => {
@@ -1597,15 +1600,7 @@ pub(crate) fn handle_chat_key(
                     prompt,
                     local_id: local_id.clone(),
                 }) {
-                    app.messages.retain(|entry| {
-                        !matches!(
-                            entry,
-                            ChatEntry::User {
-                                message_id: Some(message_id),
-                                ..
-                            } if message_id == &local_id
-                        )
-                    });
+                    app.chat.rollback_pending_prompt(&local_id);
                     app.card_cache.invalidate();
                     return Err(error.into());
                 }
@@ -1652,10 +1647,10 @@ pub(crate) fn handle_chat_key(
             }
         }
         KeyCode::PageUp => {
-            app.scroll_offset = app.scroll_offset.saturating_add(10);
+            app.chat.scroll_offset = app.chat.scroll_offset.saturating_add(10);
         }
         KeyCode::PageDown => {
-            app.scroll_offset = app.scroll_offset.saturating_sub(10);
+            app.chat.scroll_offset = app.chat.scroll_offset.saturating_sub(10);
         }
         KeyCode::Backspace if !input_blocked => {
             app.composer.input_backspace();
@@ -1674,9 +1669,9 @@ pub(crate) fn handle_chat_key(
         }
         KeyCode::End => {
             if input_blocked {
-                app.scroll_offset = 0;
+                app.chat.scroll_offset = 0;
             } else if app.composer.input.is_empty() {
-                app.scroll_offset = 0; // snap to bottom
+                app.chat.scroll_offset = 0; // snap to bottom
             } else {
                 app.composer.input_end();
             }
@@ -1937,13 +1932,13 @@ fn try_execute_slash_command(
             if !can_send_server_commands(app) {
                 return Ok(SlashResult::Handled);
             }
-            if app.pending_fork_message_id.is_some() {
+            if app.chat.pending_fork_message_id.is_some() {
                 app.set_status(LogLevel::Warn, "fork", "fork already pending");
-            } else if app.has_pending_session_op() {
+            } else if app.chat.has_pending_session_op() {
                 app.set_status(LogLevel::Warn, "fork", "session operation already pending");
-            } else if app.is_turn_active() {
+            } else if app.chat.is_turn_active() {
                 app.set_status(LogLevel::Warn, "fork", "cannot fork while agent is active");
-            } else if let Some(turn) = app.latest_fork_boundary() {
+            } else if let Some(turn) = app.chat.latest_fork_boundary() {
                 begin_fork_session(app, turn.message_id, cmd_tx)?;
             } else {
                 app.set_status(LogLevel::Warn, "fork", "no forkable turns");
@@ -1956,20 +1951,20 @@ fn try_execute_slash_command(
             if !can_send_server_commands(app) {
                 return Ok(SlashResult::Handled);
             }
-            if app.is_turn_active() {
+            if app.chat.is_turn_active() {
                 app.set_status(
                     LogLevel::Warn,
                     "session",
                     "cannot undo while agent is active",
                 );
-            } else if app.has_pending_session_op() || app.has_pending_undo() {
+            } else if app.chat.has_pending_session_op() || app.chat.has_pending_undo() {
                 app.set_status(LogLevel::Warn, "session", "undo already pending");
-            } else if let Some(turn) = app.current_undo_target().cloned() {
+            } else if let Some(turn) = app.chat.current_undo_target().cloned() {
                 if app.composer.input.trim().is_empty() && !turn.text.is_empty() {
                     app.composer.replace_input(turn.text.clone());
                 }
-                app.push_pending_undo(&turn);
-                app.activity = ActivityState::SessionOp(SessionOp::Undo);
+                app.chat.push_pending_undo(&turn);
+                app.chat.activity = ActivityState::SessionOp(SessionOp::Undo);
                 app.set_status(LogLevel::Info, "session", "undoing...");
                 cmd_tx.send(Command::Undo {
                     message_id: turn.message_id,
@@ -1983,16 +1978,16 @@ fn try_execute_slash_command(
             if !can_send_server_commands(app) {
                 return Ok(SlashResult::Handled);
             }
-            if app.is_turn_active() {
+            if app.chat.is_turn_active() {
                 app.set_status(
                     LogLevel::Warn,
                     "session",
                     "cannot redo while agent is active",
                 );
-            } else if app.has_pending_session_op() || app.has_pending_undo() {
+            } else if app.chat.has_pending_session_op() || app.chat.has_pending_undo() {
                 app.set_status(LogLevel::Warn, "session", "redo already pending");
-            } else if app.can_redo() {
-                app.activity = ActivityState::SessionOp(SessionOp::Redo);
+            } else if app.chat.can_redo() {
+                app.chat.activity = ActivityState::SessionOp(SessionOp::Redo);
                 app.set_status(LogLevel::Info, "session", "redoing...");
                 cmd_tx.send(Command::Redo)?;
             } else {
@@ -2005,8 +2000,8 @@ fn try_execute_slash_command(
         }
         "cancel" => {
             app.take_input();
-            if app.has_cancellable_activity() {
-                app.clear_cancel_confirm();
+            if app.chat.has_cancellable_activity() {
+                app.chat.clear_cancel_confirm();
                 app.set_status(LogLevel::Warn, "activity", "stopping...");
                 cmd_tx.send(Command::CancelSession)?;
             } else {
@@ -2573,6 +2568,7 @@ mod model_popup_tests {
     use crate::app::App;
     use crate::command::PromptBlock;
     use crate::config::TestPersistenceGuard;
+    use crate::domain::chat::ChatEntry;
     use crate::domain::model::ModelEntry;
     use crate::domain::profile::{AgentInfo, ProfileInfo};
     use crate::domain::session::{SessionGroup, SessionSummary};
@@ -2607,7 +2603,7 @@ mod model_popup_tests {
         handle_chat_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
 
         assert!(app.composer.input.is_empty());
-        let local_id = match app.messages.as_slice() {
+        let local_id = match app.chat.messages.as_slice() {
             [
                 ChatEntry::User {
                     text,
@@ -2630,7 +2626,7 @@ mod model_popup_tests {
         drop(rx);
         let mut app = App::new();
         app.connection.conn = ConnState::Connected;
-        app.messages.push(ChatEntry::Assistant {
+        app.chat.messages.push(ChatEntry::Assistant {
             content: "keep".into(),
             thinking: None,
             message_id: Some("assistant-1".into()),
@@ -2641,7 +2637,7 @@ mod model_popup_tests {
 
         assert!(app.composer.input.is_empty());
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [ChatEntry::Assistant { content, .. }] if content == "keep"
         ));
     }
@@ -2657,7 +2653,7 @@ mod model_popup_tests {
         app.composer.input = "/mo".into();
         app.composer.input_cursor = 3;
         app.composer.refresh_slash_state();
-        app.scroll_offset = 7;
+        app.chat.scroll_offset = 7;
 
         assert_eq!(app.take_input(), "/mo");
         assert_eq!(app.composer.input_cursor, 0);
@@ -2665,7 +2661,7 @@ mod model_popup_tests {
         assert_eq!(app.composer.input_preferred_col, None);
         assert!(app.composer.mention_state.is_none());
         assert!(app.composer.slash_state.is_none());
-        assert_eq!(app.scroll_offset, 0);
+        assert_eq!(app.chat.scroll_offset, 0);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod acp_client;
 mod acp_state;
 mod app;
 mod auth_state;
+mod chat_state;
 mod command;
 mod composer_state;
 mod config;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -87,14 +87,14 @@ mod tests {
         let mut app = App::new();
         app.connection.conn = ConnState::Connected;
         app.sessions.session_id = Some("sess-1".into());
-        app.messages.push(ChatEntry::Elicitation {
+        app.chat.messages.push(ChatEntry::Elicitation {
             elicitation_id: state.elicitation_id.clone(),
             message: state.message.clone(),
             source: state.source.clone(),
             outcome: None,
         });
-        app.elicitation = Some(state);
-        app.elicitation_ui = Some(crate::ui::ElicitationUiState::default());
+        app.chat.elicitation = Some(state);
+        app.chat.elicitation_ui = Some(crate::chat_state::ElicitationUiState::default());
         app
     }
 
@@ -115,7 +115,7 @@ mod tests {
         let mut app = make_app_with_elicitation(make_elicitation_single_select());
         let (tx, _rx) = mpsc::unbounded_channel();
         handle_elicitation_key(&mut app, key(KeyCode::Down), &tx).unwrap();
-        assert_eq!(app.elicitation_ui.as_ref().unwrap().option_cursor, 1);
+        assert_eq!(app.chat.elicitation_ui.as_ref().unwrap().option_cursor, 1);
     }
 
     #[test]
@@ -123,7 +123,7 @@ mod tests {
         let mut app = make_app_with_elicitation(make_elicitation_single_select());
         let (tx, _rx) = mpsc::unbounded_channel();
         handle_elicitation_key(&mut app, key(KeyCode::Up), &tx).unwrap();
-        assert_eq!(app.elicitation_ui.as_ref().unwrap().option_cursor, 0);
+        assert_eq!(app.chat.elicitation_ui.as_ref().unwrap().option_cursor, 0);
     }
 
     #[test]
@@ -135,7 +135,7 @@ mod tests {
         handle_elicitation_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
 
         // Elicitation should be cleared
-        assert!(app.elicitation.is_none());
+        assert!(app.chat.elicitation.is_none());
 
         // Accept response sent
         let msg = rx.try_recv().expect("message sent");
@@ -145,7 +145,7 @@ mod tests {
         ));
 
         // Chat card updated with the selected label
-        assert!(app.messages.iter().any(|m| matches!(m,
+        assert!(app.chat.messages.iter().any(|m| matches!(m,
             ChatEntry::Elicitation { outcome: Some(o), .. } if *o == format!("{OUTCOME_BULLET}Beta")
         )));
     }
@@ -159,7 +159,8 @@ mod tests {
         handle_elicitation_key(&mut app, key(KeyCode::Down), &tx).unwrap();
         handle_elicitation_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
         assert!(
-            app.elicitation_ui
+            app.chat
+                .elicitation_ui
                 .as_ref()
                 .is_some_and(|ui| ui.custom_active)
         );
@@ -178,7 +179,7 @@ mod tests {
         }
         handle_elicitation_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
 
-        assert!(app.elicitation.is_none());
+        assert!(app.chat.elicitation.is_none());
         assert!(matches!(rx.try_recv().expect("message sent"),
             Command::ElicitationResponse { action, content: Some(ref c), .. }
             if action == "accept" && c["choice"] == "custom\nanswer"
@@ -196,14 +197,15 @@ mod tests {
         handle_elicitation_key(&mut app, key(KeyCode::Esc), &tx).unwrap();
 
         assert!(
-            app.elicitation_ui
+            app.chat
+                .elicitation_ui
                 .as_ref()
                 .is_some_and(|ui| !ui.custom_active)
         );
         assert!(rx.try_recv().is_err());
 
         handle_elicitation_key(&mut app, key(KeyCode::Esc), &tx).unwrap();
-        assert!(app.elicitation.is_none());
+        assert!(app.chat.elicitation.is_none());
         assert!(matches!(rx.try_recv().expect("decline sent"),
             Command::ElicitationResponse { action, .. } if action == "decline"
         ));
@@ -220,7 +222,7 @@ mod tests {
         handle_elicitation_key(&mut app, key(KeyCode::Char(' ')), &tx).unwrap();
         handle_elicitation_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
 
-        assert!(app.elicitation.is_some());
+        assert!(app.chat.elicitation.is_some());
         assert!(rx.try_recv().is_err());
     }
 
@@ -230,12 +232,12 @@ mod tests {
         let (tx, mut rx) = mpsc::unbounded_channel();
         handle_elicitation_key(&mut app, key(KeyCode::Esc), &tx).unwrap();
 
-        assert!(app.elicitation.is_none());
+        assert!(app.chat.elicitation.is_none());
         let msg = rx.try_recv().expect("message sent");
         assert!(matches!(msg,
             Command::ElicitationResponse { action, .. } if action == "decline"
         ));
-        assert!(app.messages.iter().any(|m| matches!(m,
+        assert!(app.chat.messages.iter().any(|m| matches!(m,
             ChatEntry::Elicitation { outcome: Some(o), .. } if o == "declined"
         )));
     }
@@ -250,17 +252,17 @@ mod tests {
                 required: true,
                 kind: ElicitationFieldKind::TextInput,
             }]));
-        app.elicitation.as_mut().unwrap().text_input = "Alice".into();
+        app.chat.elicitation.as_mut().unwrap().text_input = "Alice".into();
         let (tx, mut rx) = mpsc::unbounded_channel();
         handle_elicitation_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
 
-        assert!(app.elicitation.is_none());
+        assert!(app.chat.elicitation.is_none());
         let msg = rx.try_recv().expect("message sent");
         assert!(matches!(msg,
             Command::ElicitationResponse { action, content: Some(ref c), .. }
             if action == "accept" && c["name"] == "Alice"
         ));
-        assert!(app.messages.iter().any(|m| matches!(m,
+        assert!(app.chat.messages.iter().any(|m| matches!(m,
             ChatEntry::Elicitation { outcome: Some(o), .. } if o == "Alice"
         )));
     }
@@ -278,7 +280,7 @@ mod tests {
         let (tx, _rx) = mpsc::unbounded_channel();
         handle_elicitation_key(&mut app, key(KeyCode::Char('H')), &tx).unwrap();
         handle_elicitation_key(&mut app, key(KeyCode::Char('i')), &tx).unwrap();
-        assert_eq!(app.elicitation.as_ref().unwrap().text_input, "Hi");
+        assert_eq!(app.chat.elicitation.as_ref().unwrap().text_input, "Hi");
     }
 
     #[test]
@@ -291,11 +293,11 @@ mod tests {
                 required: false,
                 kind: ElicitationFieldKind::TextInput,
             }]));
-        app.elicitation.as_mut().unwrap().text_input = "Hi".into();
-        app.elicitation_ui.as_mut().unwrap().text_cursor = 2;
+        app.chat.elicitation.as_mut().unwrap().text_input = "Hi".into();
+        app.chat.elicitation_ui.as_mut().unwrap().text_cursor = 2;
         let (tx, _rx) = mpsc::unbounded_channel();
         handle_elicitation_key(&mut app, key(KeyCode::Backspace), &tx).unwrap();
-        assert_eq!(app.elicitation.as_ref().unwrap().text_input, "H");
+        assert_eq!(app.chat.elicitation.as_ref().unwrap().text_input, "H");
     }
 
     #[test]
@@ -305,10 +307,11 @@ mod tests {
 
         handle_elicitation_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
 
-        assert!(app.elicitation.is_some(), "popup should remain open");
+        assert!(app.chat.elicitation.is_some(), "popup should remain open");
         assert!(rx.try_recv().is_err(), "no response should be sent");
         assert!(
-            app.messages
+            app.chat
+                .messages
                 .iter()
                 .any(|m| matches!(m, ChatEntry::Elicitation { outcome: None, .. }))
         );
@@ -321,7 +324,8 @@ mod tests {
 
         handle_elicitation_key(&mut app, key(KeyCode::Char(' ')), &tx).unwrap();
         assert_eq!(
-            app.elicitation
+            app.chat
+                .elicitation
                 .as_ref()
                 .and_then(|state| state.selected.get("confirm")),
             Some(&serde_json::json!(true))
@@ -329,13 +333,13 @@ mod tests {
 
         handle_elicitation_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
 
-        assert!(app.elicitation.is_none());
+        assert!(app.chat.elicitation.is_none());
         let msg = rx.try_recv().expect("message sent");
         assert!(matches!(msg,
             Command::ElicitationResponse { action, content: Some(ref c), .. }
             if action == "accept" && c["confirm"] == true
         ));
-        assert!(app.messages.iter().any(|m| matches!(m,
+        assert!(app.chat.messages.iter().any(|m| matches!(m,
             ChatEntry::Elicitation { outcome: Some(o), .. } if o == "Yes"
         )));
     }
@@ -348,7 +352,8 @@ mod tests {
         handle_elicitation_key(&mut app, key(KeyCode::Char(' ')), &tx).unwrap();
         handle_elicitation_key(&mut app, key(KeyCode::Char(' ')), &tx).unwrap();
         assert_eq!(
-            app.elicitation
+            app.chat
+                .elicitation
                 .as_ref()
                 .and_then(|state| state.selected.get("confirm")),
             Some(&serde_json::json!(false))
@@ -356,13 +361,13 @@ mod tests {
 
         handle_elicitation_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
 
-        assert!(app.elicitation.is_none());
+        assert!(app.chat.elicitation.is_none());
         let msg = rx.try_recv().expect("message sent");
         assert!(matches!(msg,
             Command::ElicitationResponse { action, content: Some(ref c), .. }
             if action == "accept" && c["confirm"] == false
         ));
-        assert!(app.messages.iter().any(|m| matches!(m,
+        assert!(app.chat.messages.iter().any(|m| matches!(m,
             ChatEntry::Elicitation { outcome: Some(o), .. } if o == "No"
         )));
     }
@@ -378,7 +383,7 @@ mod tests {
         handle_elicitation_key(&mut app, key(KeyCode::Backspace), &tx).unwrap();
         handle_elicitation_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
 
-        assert!(app.elicitation.is_some());
+        assert!(app.chat.elicitation.is_some());
         assert!(rx.try_recv().is_err(), "no response should be sent");
     }
 
@@ -390,11 +395,11 @@ mod tests {
         Theme::begin_frame();
 
         let mut app = App::new();
-        app.messages.push(ChatEntry::User {
+        app.chat.messages.push(ChatEntry::User {
             text: "hello".into(),
             message_id: None,
         });
-        app.messages.push(ChatEntry::ToolCall {
+        app.chat.messages.push(ChatEntry::ToolCall {
             tool_call_id: None,
             name: "edit".into(),
             is_error: false,
@@ -435,7 +440,7 @@ mod tests {
         assert!(app.streaming_thinking_cache.get(3).is_some());
         assert_eq!(
             app.card_cache.processed_messages,
-            app.messages.len(),
+            app.chat.messages.len(),
             "card_cache should be populated"
         );
 
@@ -459,7 +464,7 @@ mod tests {
             "streaming_thinking_cache should be invalidated"
         );
         assert!(matches!(
-            &app.messages[1],
+            &app.chat.messages[1],
             ChatEntry::ToolCall {
                 detail: ToolDetail::Edit { old, new, .. },
                 ..
@@ -513,7 +518,7 @@ mod external_editor_tests {
         app.composer.input = "abcdef".into();
         app.composer.input_cursor = 4;
         app.composer.input_line_width = 4;
-        app.scroll_offset = 7;
+        app.chat.scroll_offset = 7;
 
         handle_chat_key(
             &mut app,
@@ -522,7 +527,7 @@ mod external_editor_tests {
         )
         .unwrap();
         assert_eq!(app.composer.input_cursor, 2);
-        assert_eq!(app.scroll_offset, 7);
+        assert_eq!(app.chat.scroll_offset, 7);
 
         handle_chat_key(
             &mut app,
@@ -531,7 +536,7 @@ mod external_editor_tests {
         )
         .unwrap();
         assert_eq!(app.composer.input_cursor, 4);
-        assert_eq!(app.scroll_offset, 7);
+        assert_eq!(app.chat.scroll_offset, 7);
     }
 
     #[test]
@@ -539,7 +544,7 @@ mod external_editor_tests {
         let (tx, _rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.scroll_offset = 3;
+        app.chat.scroll_offset = 3;
 
         handle_chat_key(
             &mut app,
@@ -547,7 +552,7 @@ mod external_editor_tests {
             &tx,
         )
         .unwrap();
-        assert_eq!(app.scroll_offset, 13);
+        assert_eq!(app.chat.scroll_offset, 13);
 
         handle_chat_key(
             &mut app,
@@ -555,7 +560,7 @@ mod external_editor_tests {
             &tx,
         )
         .unwrap();
-        assert_eq!(app.scroll_offset, 3);
+        assert_eq!(app.chat.scroll_offset, 3);
     }
 
     #[test]
@@ -657,7 +662,7 @@ mod external_editor_tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.connection.conn = ConnState::Connected;
-        app.activity = ActivityState::RunningTool {
+        app.chat.activity = ActivityState::RunningTool {
             name: "read_tool".into(),
         };
 
@@ -682,7 +687,7 @@ mod external_editor_tests {
         ));
         assert!(app.composer.input.is_empty());
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [ChatEntry::User { text, message_id: Some(message_id) }]
                 if text == "n" && message_id.starts_with("local:pending:")
         ));
@@ -711,7 +716,7 @@ mod external_editor_tests {
                     if text == "first line\nsecond line")
         ));
         assert!(matches!(
-            app.messages.as_slice(),
+            app.chat.messages.as_slice(),
             [ChatEntry::User { text, .. }] if text == "first line\nsecond line"
         ));
     }
@@ -733,7 +738,7 @@ mod external_editor_tests {
         .unwrap();
 
         assert!(rx.try_recv().is_err());
-        assert!(app.messages.is_empty());
+        assert!(app.chat.messages.is_empty());
         assert!(app.composer.input.is_empty());
     }
 
@@ -1118,7 +1123,7 @@ mod external_editor_tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.connection.conn = ConnState::Connected;
-        app.messages = vec![
+        app.chat.messages = vec![
             ChatEntry::User {
                 text: "alpha prompt".into(),
                 message_id: Some("user-1".into()),
@@ -1154,7 +1159,7 @@ mod external_editor_tests {
             rx.try_recv().expect("ForkSession sent"),
             Command::ForkSession { message_id } if message_id == "user-2"
         ));
-        assert_eq!(app.pending_fork_message_id.as_deref(), Some("user-2"));
+        assert_eq!(app.chat.pending_fork_message_id.as_deref(), Some("user-2"));
     }
 
     #[test]
@@ -1167,9 +1172,9 @@ mod external_editor_tests {
         handle_key(&mut app, plain_key('b'), &tx).unwrap();
 
         assert_eq!(app.navigation.popup, Popup::ForkTurnSelect);
-        assert_eq!(app.fork_filter, "b");
+        assert_eq!(app.chat.fork_filter, "b");
         assert!(app.composer.input.is_empty());
-        assert_eq!(app.filtered_fork_turns().len(), 1);
+        assert_eq!(app.chat.filtered_fork_turns().len(), 1);
     }
 
     #[test]
@@ -1203,7 +1208,7 @@ mod external_editor_tests {
         .unwrap();
 
         assert!(rx.try_recv().is_err());
-        assert!(app.pending_fork_message_id.is_none());
+        assert!(app.chat.pending_fork_message_id.is_none());
         assert!(app.diagnostics.status.contains("only available in chat"));
         assert!(matches!(app.diagnostics.logs.last(), Some(entry) if entry.target == "fork"));
     }
@@ -1213,7 +1218,7 @@ mod external_editor_tests {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = app_with_forkable_messages();
         app.open_fork_turn_popup();
-        app.fork_filter = "alpha".into();
+        app.chat.fork_filter = "alpha".into();
 
         handle_fork_turn_popup_key(
             &mut app,
@@ -1226,7 +1231,7 @@ mod external_editor_tests {
             rx.try_recv().expect("ForkSession sent"),
             Command::ForkSession { message_id } if message_id == "asst-1"
         ));
-        assert_eq!(app.pending_fork_message_id.as_deref(), Some("asst-1"));
+        assert_eq!(app.chat.pending_fork_message_id.as_deref(), Some("asst-1"));
     }
 
     #[test]
@@ -1246,7 +1251,7 @@ mod external_editor_tests {
             rx.try_recv().expect("ForkSession sent"),
             Command::ForkSession { message_id } if message_id == "user-2"
         ));
-        assert_eq!(app.pending_fork_message_id.as_deref(), Some("user-2"));
+        assert_eq!(app.chat.pending_fork_message_id.as_deref(), Some("user-2"));
     }
 
     #[test]
@@ -1316,7 +1321,7 @@ mod external_editor_tests {
         let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.activity = ActivityState::RunningTool {
+        app.chat.activity = ActivityState::RunningTool {
             name: "read_tool".into(),
         };
 
@@ -1326,7 +1331,7 @@ mod external_editor_tests {
             &tx,
         )
         .unwrap();
-        assert!(app.cancel_confirm_active());
+        assert!(app.chat.cancel_confirm_active());
 
         handle_chat_key(
             &mut app,
@@ -1351,7 +1356,7 @@ mod external_editor_tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.connection.conn = ConnState::Connected;
-        app.activity = ActivityState::SessionOp(SessionOp::Undo);
+        app.chat.activity = ActivityState::SessionOp(SessionOp::Undo);
         app.composer.input = "draft".into();
         app.composer.input_cursor = app.composer.input.len();
 
@@ -1395,7 +1400,7 @@ mod external_editor_tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.connection.conn = ConnState::Connected;
-        app.activity = ActivityState::RunningTool {
+        app.chat.activity = ActivityState::RunningTool {
             name: "read_tool".into(),
         };
         app.composer.input = "draft".into();
@@ -1407,8 +1412,8 @@ mod external_editor_tests {
             &tx,
         )
         .unwrap();
-        assert!(app.cancel_confirm_active());
-        assert!(app.input_blocked_by_activity());
+        assert!(app.chat.cancel_confirm_active());
+        assert!(app.chat.input_blocked_by_activity());
 
         handle_chat_key(
             &mut app,
@@ -1488,7 +1493,7 @@ pub async fn run() -> anyhow::Result<()> {
     let mut app = App::new();
     app.connection.launch_cwd = detect_launch_cwd();
     app.profiles.active_profile_id = cfg.profile.id.clone();
-    app.show_thinking = cfg.show_thinking.unwrap_or(true);
+    app.chat.show_thinking = cfg.show_thinking.unwrap_or(true);
     app.models.delegate_model_preferences = cfg.profile_delegate_models.clone();
     if let Some(profile_id) = cfg.profile.id.as_deref() {
         let legacy_preferences = app

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -252,12 +252,12 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
     let cache = &app.card_cache;
 
     // Auto-invalidate if messages shrank (clear/retain)
-    if app.messages.len() < cache.processed_messages {
+    if app.chat.messages.len() < cache.processed_messages {
         app.card_cache.invalidate();
     }
 
     // Cache hit — nothing new
-    if app.messages.len() == app.card_cache.processed_messages {
+    if app.chat.messages.len() == app.card_cache.processed_messages {
         return &app.card_cache.cards;
     }
 
@@ -273,9 +273,9 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
         // entries are transparent and should not split a tool batch.
         let mut idx = app.card_cache.processed_messages;
         while idx > 0 {
-            match app.messages.get(idx - 1) {
+            match app.chat.messages.get(idx - 1) {
                 Some(ChatEntry::ToolCall { .. }) => idx -= 1,
-                Some(ChatEntry::Thinking { .. }) if !app.show_thinking => idx -= 1,
+                Some(ChatEntry::Thinking { .. }) if !app.chat.show_thinking => idx -= 1,
                 _ => break,
             }
         }
@@ -318,12 +318,12 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                 })
                 .or_else(|| app.delegates.delegate_entries.get(sequential_idx))
         };
-    let mut delegate_idx = app.messages[..start_idx]
+    let mut delegate_idx = app.chat.messages[..start_idx]
         .iter()
         .filter(|entry| matches!(entry, ChatEntry::ToolCall { name, .. } if name == "delegate"))
         .count();
 
-    for entry in &app.messages[start_idx..] {
+    for entry in &app.chat.messages[start_idx..] {
         match entry {
             ChatEntry::User { text, .. } => {
                 flush_tools(&mut pending_tools, &mut app.card_cache.cards);
@@ -335,7 +335,7 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
             } => {
                 flush_tools(&mut pending_tools, &mut app.card_cache.cards);
                 let mut blocks = Vec::new();
-                if app.show_thinking
+                if app.chat.show_thinking
                     && let Some(thinking_text) = thinking
                 {
                     let mut rendered =
@@ -353,7 +353,7 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                     .push(Card::new(CardKind::Assistant, blocks));
             }
             ChatEntry::Thinking { content, .. } => {
-                if app.show_thinking {
+                if app.chat.show_thinking {
                     flush_tools(&mut pending_tools, &mut app.card_cache.cards);
                     let mut blocks = markdown::render(content, Theme::thinking_text(), &app.hl);
                     markdown::prepend_span_to_first_text(
@@ -667,7 +667,7 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
     }
 
     flush_tools(&mut pending_tools, &mut app.card_cache.cards);
-    app.card_cache.processed_messages = app.messages.len();
+    app.card_cache.processed_messages = app.chat.messages.len();
 
     &app.card_cache.cards
 }
@@ -725,32 +725,32 @@ fn build_chat_header_spans(app: &App) -> (Vec<Span<'static>>, Vec<Span<'static>>
 
     let mut right_spans: Vec<Span<'static>> = Vec::new();
 
-    if let Some(dur) = app.llm_request_elapsed() {
+    if let Some(dur) = app.chat.llm_request_elapsed() {
         right_spans.push(Span::styled(
             format!(" {} ", format_status_duration(dur)),
             Theme::status(),
         ));
     }
 
-    if let Some(context_tokens) = app.session_stats.latest_context_tokens
+    if let Some(context_tokens) = app.chat.session_stats.latest_context_tokens
         && context_tokens > 0
-        && app.context_limit > 0
+        && app.chat.context_limit > 0
     {
-        let pct = (context_tokens as f64 / app.context_limit as f64 * 100.0) as u32;
+        let pct = (context_tokens as f64 / app.chat.context_limit as f64 * 100.0) as u32;
         right_spans.push(Span::styled(
             format!(" {ICON_CONTEXT} {pct}% "),
             Theme::status(),
         ));
     }
 
-    if app.session_stats.total_tool_calls > 0 {
+    if app.chat.session_stats.total_tool_calls > 0 {
         right_spans.push(Span::styled(
-            format!(" {ICON_TOOLS} {} ", app.session_stats.total_tool_calls),
+            format!(" {ICON_TOOLS} {} ", app.chat.session_stats.total_tool_calls),
             Theme::status(),
         ));
     }
 
-    if let Some(cost) = app.cumulative_cost
+    if let Some(cost) = app.chat.cumulative_cost
         && cost > 0.0
     {
         right_spans.push(Span::styled(
@@ -1013,7 +1013,7 @@ fn elicitation_option_text(label: &str, description: Option<&str>) -> String {
 fn elicitation_option_rows(app: &App, width: u16) -> u16 {
     use crate::domain::elicitation::ElicitationFieldKind;
 
-    let (Some(state), Some(ui)) = (&app.elicitation, &app.elicitation_ui) else {
+    let (Some(state), Some(ui)) = (&app.chat.elicitation, &app.chat.elicitation_ui) else {
         return 0;
     };
     let schema_rows = match ui
@@ -1046,7 +1046,7 @@ fn elicitation_option_rows(app: &App, width: u16) -> u16 {
 }
 
 fn elicitation_popup_height(app: &App, area: Rect) -> u16 {
-    if let (Some(state), Some(ui)) = (&app.elicitation, &app.elicitation_ui) {
+    if let (Some(state), Some(ui)) = (&app.chat.elicitation, &app.chat.elicitation_ui) {
         let message_width = area.width.saturating_sub(4).max(1);
         let message_rows = wrapped_text_rows(&state.message, message_width);
         let option_width = area.width.saturating_sub(6).max(1);
@@ -1075,15 +1075,15 @@ fn draw_input_panel(
     input_layout: InputVisualLayout,
 ) {
     // input border line reflects active session state
-    let border_style = match &app.activity {
+    let border_style = match &app.chat.activity {
         ActivityState::SessionOp(SessionOp::Undo) => Theme::input_border_undo(),
         ActivityState::SessionOp(SessionOp::Redo) => Theme::input_border_redo(),
-        _ if app.cancel_confirm_active() => Theme::input_border_cancel_confirm(),
+        _ if app.chat.cancel_confirm_active() => Theme::input_border_cancel_confirm(),
         ActivityState::Compacting { .. } => Theme::input_border_compacting(),
         ActivityState::Thinking | ActivityState::Streaming | ActivityState::RunningTool { .. } => {
             Theme::input_border_thinking()
         }
-        _ if app.elicitation.is_some() => Theme::input_border_thinking(), // accent while waiting
+        _ if app.chat.elicitation.is_some() => Theme::input_border_thinking(), // accent while waiting
         _ => Theme::mode_border(&app.sessions.agent_mode),
     };
     let border_line =
@@ -1098,7 +1098,7 @@ fn draw_input_panel(
     app.composer.input_line_width = (inner.width as usize).max(1);
     f.render_widget(input_bg, input_area);
 
-    let (label_text, label_style) = match &app.activity {
+    let (label_text, label_style) = match &app.chat.activity {
         ActivityState::SessionOp(SessionOp::Undo) => (
             format!("{} undoing ", spinner(SpinnerKind::Braille, app.tick)),
             Theme::input_undo(),
@@ -1107,7 +1107,7 @@ fn draw_input_panel(
             format!("{} redoing ", spinner(SpinnerKind::Braille, app.tick)),
             Theme::input_redo(),
         ),
-        _ if app.cancel_confirm_active() => (
+        _ if app.chat.cancel_confirm_active() => (
             format!(
                 "{} Esc again to stop ",
                 spinner(SpinnerKind::Braille, app.tick)
@@ -1121,14 +1121,14 @@ fn draw_input_panel(
             format!("{} ", spinner(SpinnerKind::Braille, app.tick)),
             Theme::input_thinking(),
         ),
-        _ if app.elicitation.is_some() => (
+        _ if app.chat.elicitation.is_some() => (
             format!("  answer above {ARROW_UP} "),
             Theme::input_thinking(),
         ),
         _ => ("> ".into(), Theme::mode_border(&app.sessions.agent_mode)),
     };
     let input_style = Theme::input();
-    let hide_input_contents = app.should_hide_input_contents();
+    let hide_input_contents = app.chat.should_hide_input_contents();
 
     if hide_input_contents {
         app.composer.input_scroll = 0;
@@ -1186,7 +1186,10 @@ fn draw_elicitation_popup(f: &mut Frame, app: &mut App, area: Rect) {
     if area.height == 0 || area.width == 0 {
         return;
     }
-    let (Some(state), Some(ui)) = (app.elicitation.as_mut(), app.elicitation_ui.as_mut()) else {
+    let (Some(state), Some(ui)) = (
+        app.chat.elicitation.as_mut(),
+        app.chat.elicitation_ui.as_mut(),
+    ) else {
         return;
     };
 
@@ -1572,7 +1575,7 @@ fn draw_mention_panel(f: &mut Frame, app: &App, area: Rect) {
 
 /// Build the transient streaming/thinking card (not cached, rebuilt every frame).
 fn build_streaming_card(app: &mut App) -> Option<Card> {
-    let activity_text = match &app.activity {
+    let activity_text = match &app.chat.activity {
         ActivityState::RunningTool { name } => {
             format!("{} tool: {name}", spinner(SpinnerKind::Braille, app.tick))
         }
@@ -1585,20 +1588,23 @@ fn build_streaming_card(app: &mut App) -> Option<Card> {
         _ => format!("{} thinking", spinner(SpinnerKind::Braille, app.tick)),
     };
 
-    let has_thinking = app.show_thinking && !app.streaming_thinking.is_empty();
-    let has_content = !app.streaming_content.is_empty();
+    let has_thinking = app.chat.show_thinking && !app.chat.streaming_thinking.is_empty();
+    let has_content = !app.chat.streaming_content.is_empty();
 
     if has_thinking || has_content {
         let mut blocks = Vec::new();
 
         if has_thinking {
-            let thinking_len = app.streaming_thinking.len();
+            let thinking_len = app.chat.streaming_thinking.len();
             let mut thinking_blocks =
                 if let Some(cached) = app.streaming_thinking_cache.get(thinking_len) {
                     cached.to_vec()
                 } else {
-                    let rendered =
-                        markdown::render(&app.streaming_thinking, Theme::thinking_text(), &app.hl);
+                    let rendered = markdown::render(
+                        &app.chat.streaming_thinking,
+                        Theme::thinking_text(),
+                        &app.hl,
+                    );
                     app.streaming_thinking_cache
                         .store(thinking_len, rendered.clone());
                     rendered
@@ -1614,12 +1620,15 @@ fn build_streaming_card(app: &mut App) -> Option<Card> {
         }
 
         if has_content {
-            let content_len = app.streaming_content.len();
+            let content_len = app.chat.streaming_content.len();
             let content_blocks = if let Some(cached) = app.streaming_cache.get(content_len) {
                 cached.to_vec()
             } else {
-                let rendered =
-                    markdown::render(&app.streaming_content, Theme::assistant_text(), &app.hl);
+                let rendered = markdown::render(
+                    &app.chat.streaming_content,
+                    Theme::assistant_text(),
+                    &app.hl,
+                );
                 app.streaming_cache.store(content_len, rendered.clone());
                 rendered
             };
@@ -1631,7 +1640,7 @@ fn build_streaming_card(app: &mut App) -> Option<Card> {
             Theme::thinking(),
         ))));
         Some(Card::new(CardKind::Streaming, blocks))
-    } else if app.is_turn_active() {
+    } else if app.chat.is_turn_active() {
         Some(Card::new(
             CardKind::Thinking,
             vec![crate::markdown::CardBlock::Text(Line::from(Span::styled(
@@ -1997,9 +2006,9 @@ fn draw_messages(f: &mut Frame, app: &mut App, area: Rect) {
     // max scroll = how far we can scroll from the bottom
     let max_scroll = total_height.saturating_sub(area.height);
     // clamp so we never scroll past the top
-    app.scroll_offset = app.scroll_offset.min(max_scroll);
+    app.chat.scroll_offset = app.chat.scroll_offset.min(max_scroll);
     // scroll_offset 0 = pinned to bottom, higher = scrolled up
-    let scroll = max_scroll.saturating_sub(app.scroll_offset);
+    let scroll = max_scroll.saturating_sub(app.chat.scroll_offset);
 
     let all_cards: Vec<&Card> = app
         .card_cache

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -35,99 +35,9 @@ use ratatui::{
 };
 
 use crate::app::App;
-use crate::composer_state::build_input_visual_layout;
 use crate::connection_state::ConnState;
 use crate::navigation_state::{Popup, Screen};
 use crate::theme::Theme;
-
-#[derive(Debug, Clone, Default)]
-pub(crate) struct ElicitationUiState {
-    pub(crate) field_cursor: usize,
-    pub(crate) option_cursor: usize,
-    pub(crate) text_cursor: usize,
-    pub(crate) custom_active: bool,
-    pub(crate) custom_cursor: usize,
-    pub(crate) custom_line_width: usize,
-    pub(crate) custom_scroll: u16,
-}
-
-impl ElicitationUiState {
-    pub(crate) fn current_field_index(&self, field_count: usize) -> Option<usize> {
-        (field_count > 0).then(|| self.field_cursor.min(field_count - 1))
-    }
-
-    pub(crate) fn custom_insert(&mut self, input: &mut String, character: char) {
-        input.insert(self.custom_cursor, character);
-        self.custom_cursor += character.len_utf8();
-    }
-
-    pub(crate) fn custom_backspace(&mut self, input: &mut String) {
-        if self.custom_cursor == 0 {
-            return;
-        }
-        let previous = input[..self.custom_cursor]
-            .char_indices()
-            .last()
-            .map(|(index, _)| index)
-            .unwrap_or(0);
-        input.drain(previous..self.custom_cursor);
-        self.custom_cursor = previous;
-    }
-
-    pub(crate) fn custom_delete(&mut self, input: &mut String) {
-        if self.custom_cursor >= input.len() {
-            return;
-        }
-        let next = input[self.custom_cursor..]
-            .char_indices()
-            .nth(1)
-            .map(|(index, _)| self.custom_cursor + index)
-            .unwrap_or(input.len());
-        input.drain(self.custom_cursor..next);
-    }
-
-    pub(crate) fn custom_left(&mut self, input: &str) {
-        if self.custom_cursor > 0 {
-            self.custom_cursor = input[..self.custom_cursor]
-                .char_indices()
-                .last()
-                .map(|(index, _)| index)
-                .unwrap_or(0);
-        }
-    }
-
-    pub(crate) fn custom_right(&mut self, input: &str) {
-        if self.custom_cursor < input.len() {
-            self.custom_cursor = input[self.custom_cursor..]
-                .char_indices()
-                .nth(1)
-                .map(|(index, _)| self.custom_cursor + index)
-                .unwrap_or(input.len());
-        }
-    }
-
-    pub(crate) fn custom_home(&mut self, input: &str) {
-        self.custom_cursor = input[..self.custom_cursor]
-            .rfind('\n')
-            .map(|index| index + 1)
-            .unwrap_or(0);
-    }
-
-    pub(crate) fn custom_end(&mut self, input: &str) {
-        self.custom_cursor = input[self.custom_cursor..]
-            .find('\n')
-            .map(|index| self.custom_cursor + index)
-            .unwrap_or(input.len());
-    }
-
-    pub(crate) fn custom_move_visual(&mut self, input: &str, delta: i32) {
-        let layout =
-            build_input_visual_layout(input, self.custom_cursor, self.custom_line_width.max(1), 2);
-        let row = (layout.cursor_row as i32 + delta)
-            .clamp(0, layout.total_rows().saturating_sub(1) as i32) as usize;
-        self.custom_cursor = layout.cursor_offset_for_row_col(row, layout.cursor_text_col);
-    }
-}
 
 // ── Symbols shared across sub-modules ──────────────────────────────────────────
 pub(super) const COLOR_SWATCH: &str = "\u{25A0}"; // ■ black square  – theme palette colour preview
@@ -321,6 +231,7 @@ mod tests {
     use crate::acp_state::{AcpAppEvent, AcpSessionUpdate};
     use crate::app::App;
     use crate::auth_state::{AuthPanel, AuthUiNotice};
+    use crate::chat_state::ElicitationUiState;
     use crate::diagnostics::LogLevel;
     use crate::domain::activity::{
         DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus, SessionActivity,
@@ -550,7 +461,7 @@ mod tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.navigation.popup = Popup::ForkTurnSelect;
-        app.messages = vec![
+        app.chat.messages = vec![
             ChatEntry::User {
                 text: "alpha prompt".into(),
                 message_id: Some("user-1".into()),
@@ -1233,7 +1144,7 @@ mod tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.sessions.agent_mode = "build".into();
-        app.messages.push(ChatEntry::ToolCall {
+        app.chat.messages.push(ChatEntry::ToolCall {
             tool_call_id: None,
             name: "delegate".into(),
             is_error: false,
@@ -1273,7 +1184,7 @@ mod tests {
         use crate::theme::Theme;
 
         let mut app = App::new();
-        app.messages.push(ChatEntry::ToolCall {
+        app.chat.messages.push(ChatEntry::ToolCall {
             tool_call_id: None,
             name: "index".into(),
             is_error: false,
@@ -1301,7 +1212,7 @@ mod tests {
         use crate::theme::Theme;
 
         let mut app = App::new();
-        app.messages.push(ChatEntry::ToolCall {
+        app.chat.messages.push(ChatEntry::ToolCall {
             tool_call_id: None,
             name: "search_text".into(),
             is_error: false,
@@ -1331,7 +1242,7 @@ mod tests {
         use crate::theme::Theme;
 
         let mut app = App::new();
-        app.messages.push(ChatEntry::ToolCall {
+        app.chat.messages.push(ChatEntry::ToolCall {
             tool_call_id: None,
             name: "read_tool".into(),
             is_error: false,
@@ -1368,7 +1279,7 @@ mod tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.sessions.agent_mode = "build".into();
-        app.messages.push(ChatEntry::ToolCall {
+        app.chat.messages.push(ChatEntry::ToolCall {
             tool_call_id: None,
             name: "delegate".into(),
             is_error: false,
@@ -1480,8 +1391,8 @@ mod tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.sessions.agent_mode = "build".into();
-        app.elicitation = Some(ElicitationState::new_for_test(vec![]));
-        app.elicitation_ui = Some(ElicitationUiState::default());
+        app.chat.elicitation = Some(ElicitationState::new_for_test(vec![]));
+        app.chat.elicitation_ui = Some(ElicitationUiState::default());
 
         let _buffer = render_chat_buffer(&mut app, 80, 12);
     }
@@ -1511,8 +1422,8 @@ mod tests {
             custom_cursor: state.custom_input.len(),
             ..Default::default()
         };
-        app.elicitation = Some(state);
-        app.elicitation_ui = Some(ui);
+        app.chat.elicitation = Some(state);
+        app.chat.elicitation_ui = Some(ui);
 
         let buffer = render_chat_buffer(&mut app, 40, 21);
         let rendered = buffer
@@ -1545,8 +1456,8 @@ mod tests {
             },
         }]);
         state.message = "When designing a new system-level tool, which approach best describes how you balance rapid prototyping and maintainability?".into();
-        app.elicitation = Some(state);
-        app.elicitation_ui = Some(ElicitationUiState::default());
+        app.chat.elicitation = Some(state);
+        app.chat.elicitation_ui = Some(ElicitationUiState::default());
 
         let buffer = render_chat_buffer(&mut app, 50, 21);
         let first =
@@ -1563,7 +1474,7 @@ mod tests {
     fn draw_chat_wraps_long_elicitation_answers() {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.elicitation = Some(ElicitationState::new_for_test(vec![ElicitationField {
+        app.chat.elicitation = Some(ElicitationState::new_for_test(vec![ElicitationField {
             name: "choice".into(),
             title: "Choice".into(),
             description: None,
@@ -1576,7 +1487,7 @@ mod tests {
                 }],
             },
         }]));
-        app.elicitation_ui = Some(ElicitationUiState::default());
+        app.chat.elicitation_ui = Some(ElicitationUiState::default());
 
         let buffer = render_chat_buffer(&mut app, 50, 21);
         let first = find_buffer_text(&buffer, "Keep the validated").expect("missing answer row");
@@ -1593,12 +1504,12 @@ mod tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Delegate;
         app.sessions.agent_mode = "build".into();
-        app.messages.push(ChatEntry::Assistant {
+        app.chat.messages.push(ChatEntry::Assistant {
             content: "Delegate context".into(),
             thinking: None,
             message_id: None,
         });
-        app.elicitation = Some(ElicitationState::new_for_test(vec![ElicitationField {
+        app.chat.elicitation = Some(ElicitationState::new_for_test(vec![ElicitationField {
             name: "choice".into(),
             title: "Choice".into(),
             description: None,
@@ -1618,7 +1529,7 @@ mod tests {
                 ],
             },
         }]));
-        app.elicitation_ui = Some(ElicitationUiState::default());
+        app.chat.elicitation_ui = Some(ElicitationUiState::default());
 
         let buffer = render_delegate_buffer(&mut app, 100, 17);
         let rendered = buffer_text(&buffer);
@@ -1647,7 +1558,7 @@ mod tests {
         let mut app = App::new();
         app.navigation.screen = Screen::Delegate;
         app.sessions.agent_mode = "build".into();
-        app.messages.push(ChatEntry::Assistant {
+        app.chat.messages.push(ChatEntry::Assistant {
             content: "Read-only child output".into(),
             thinking: None,
             message_id: None,
@@ -2356,7 +2267,7 @@ mod tests {
     #[test]
     fn delegate_row_fixture_marks_parent_awaiting_input() {
         let mut app = App::new();
-        app.messages.push(delegate_tool_call(
+        app.chat.messages.push(delegate_tool_call(
             "tool-delegate-1",
             "coder",
             "Fix live bug",
@@ -2428,7 +2339,7 @@ mod tests {
     #[test]
     fn message_cards_single_user() {
         let mut app = App::new();
-        app.messages.push(ChatEntry::User {
+        app.chat.messages.push(ChatEntry::User {
             text: "hello".into(),
             message_id: None,
         });
@@ -2441,7 +2352,7 @@ mod tests {
     #[test]
     fn message_cards_user_supports_markdown_rendering() {
         let mut app = App::new();
-        app.messages.push(ChatEntry::User {
+        app.chat.messages.push(ChatEntry::User {
             text: "- item\n\n`code`".into(),
             message_id: None,
         });
@@ -2468,7 +2379,7 @@ mod tests {
     #[test]
     fn message_cards_incremental_append() {
         let mut app = App::new();
-        app.messages.push(ChatEntry::User {
+        app.chat.messages.push(ChatEntry::User {
             text: "hello".into(),
             message_id: None,
         });
@@ -2477,7 +2388,7 @@ mod tests {
             assert_eq!(cards.len(), 1);
         }
 
-        app.messages.push(ChatEntry::Assistant {
+        app.chat.messages.push(ChatEntry::Assistant {
             content: "world".into(),
             thinking: None,
             message_id: None,
@@ -2493,7 +2404,7 @@ mod tests {
     #[test]
     fn message_cards_cache_hit_no_change() {
         let mut app = App::new();
-        app.messages.push(ChatEntry::User {
+        app.chat.messages.push(ChatEntry::User {
             text: "hello".into(),
             message_id: None,
         });
@@ -2509,7 +2420,8 @@ mod tests {
     #[test]
     fn delegate_row_updates_after_child_state_change_without_message_append() {
         let mut app = App::new();
-        app.messages
+        app.chat
+            .messages
             .push(delegate_tool_call("tool-1", "coder", "Fix cache bug"));
         app.delegates.delegate_entries.push(DelegateEntry {
             delegation_id: "del-1".into(),
@@ -2526,7 +2438,7 @@ mod tests {
 
         let lines = rendered_card_lines(&mut app);
         assert!(!lines.iter().any(|line| line.contains("awaiting input")));
-        assert_eq!(app.card_cache.processed_messages, app.messages.len());
+        assert_eq!(app.card_cache.processed_messages, app.chat.messages.len());
 
         app.delegates.delegate_entries[0].child_state = DelegateChildState::PendingElicitation {
             elicitation_id: "elic-1".into(),
@@ -2538,7 +2450,7 @@ mod tests {
         let lines = rendered_card_lines(&mut app);
 
         assert_eq!(
-            app.messages.len(),
+            app.chat.messages.len(),
             1,
             "delegate state changed without appending messages"
         );
@@ -2551,15 +2463,17 @@ mod tests {
     #[test]
     fn delegate_row_awaiting_marker_uses_tool_call_identity_not_sequence() {
         let mut app = App::new();
-        app.messages.push(ChatEntry::User {
+        app.chat.messages.push(ChatEntry::User {
             text: "first".into(),
             message_id: None,
         });
         build_message_cards(&mut app);
-        app.messages
+        app.chat
+            .messages
             .push(delegate_tool_call("tool-a", "coder", "First task"));
         build_message_cards(&mut app);
-        app.messages
+        app.chat
+            .messages
             .push(delegate_tool_call("tool-b", "coder", "Second task"));
         app.delegates.delegate_entries = vec![
             DelegateEntry {
@@ -2617,8 +2531,8 @@ mod tests {
     #[test]
     fn message_cards_tool_batch() {
         let mut app = App::new();
-        app.messages.push(tool_call("read"));
-        app.messages.push(tool_call("write"));
+        app.chat.messages.push(tool_call("read"));
+        app.chat.messages.push(tool_call("write"));
 
         let cards = build_message_cards(&mut app);
         // Two consecutive tools → one tool card
@@ -2630,7 +2544,7 @@ mod tests {
     #[test]
     fn message_cards_tool_batch_grows_incrementally() {
         let mut app = App::new();
-        app.messages.push(tool_call("read"));
+        app.chat.messages.push(tool_call("read"));
         {
             let cards = build_message_cards(&mut app);
             assert_eq!(cards.len(), 1);
@@ -2638,7 +2552,7 @@ mod tests {
         }
 
         // Add another tool — should merge into same batch
-        app.messages.push(tool_call("write"));
+        app.chat.messages.push(tool_call("write"));
         {
             let cards = build_message_cards(&mut app);
             assert_eq!(cards.len(), 1); // still 1 card
@@ -2649,10 +2563,10 @@ mod tests {
     #[test]
     fn message_cards_tool_then_user_finalizes_batch() {
         let mut app = App::new();
-        app.messages.push(tool_call("read"));
+        app.chat.messages.push(tool_call("read"));
         build_message_cards(&mut app);
 
-        app.messages.push(ChatEntry::User {
+        app.chat.messages.push(ChatEntry::User {
             text: "next".into(),
             message_id: None,
         });
@@ -2665,14 +2579,14 @@ mod tests {
     #[test]
     fn message_cards_invalidated_on_clear() {
         let mut app = App::new();
-        app.messages.push(ChatEntry::User {
+        app.chat.messages.push(ChatEntry::User {
             text: "hello".into(),
             message_id: None,
         });
         build_message_cards(&mut app);
         assert_eq!(app.card_cache.processed_messages, 1);
 
-        app.messages.clear();
+        app.chat.messages.clear();
         app.card_cache.invalidate();
         let cards = build_message_cards(&mut app);
         assert!(cards.is_empty());
@@ -2682,11 +2596,11 @@ mod tests {
     #[test]
     fn message_cards_auto_invalidates_on_shrink() {
         let mut app = App::new();
-        app.messages.push(ChatEntry::User {
+        app.chat.messages.push(ChatEntry::User {
             text: "hello".into(),
             message_id: None,
         });
-        app.messages.push(ChatEntry::Assistant {
+        app.chat.messages.push(ChatEntry::Assistant {
             content: "world".into(),
             thinking: None,
             message_id: None,
@@ -2695,7 +2609,9 @@ mod tests {
         assert_eq!(app.card_cache.processed_messages, 2);
 
         // Simulate retain() shrinking messages (like compaction does)
-        app.messages.retain(|e| matches!(e, ChatEntry::User { .. }));
+        app.chat
+            .messages
+            .retain(|e| matches!(e, ChatEntry::User { .. }));
         let cards = build_message_cards(&mut app);
         assert_eq!(cards.len(), 1);
         assert_eq!(cards[0].kind, CardKind::User);
@@ -2723,9 +2639,9 @@ mod tests {
 
         live_update(&mut app, "test-session", failed_tool_end("tool-1", "shell"));
 
-        assert_eq!(app.messages.len(), 2);
+        assert_eq!(app.chat.messages.len(), 2);
         assert!(matches!(
-            app.messages[0],
+            app.chat.messages[0],
             ChatEntry::ToolCall { is_error: true, .. }
         ));
         assert_eq!(
@@ -2735,7 +2651,7 @@ mod tests {
         let lines = rendered_card_lines(&mut app);
         assert!(lines.iter().any(|line| line.contains("x shell")));
         assert!(!lines.iter().any(|line| line.contains("shell (failed)")));
-        assert!(matches!(app.messages[1], ChatEntry::Assistant { .. }));
+        assert!(matches!(app.chat.messages[1], ChatEntry::Assistant { .. }));
     }
 
     #[test]
@@ -2755,7 +2671,7 @@ mod tests {
         let warm_lines = rendered_card_lines(&mut app);
         assert!(warm_lines.iter().any(|line| line.contains("$ cargo test")));
         assert!(!warm_lines.iter().any(|line| line.contains("tail sentinel")));
-        assert_eq!(app.card_cache.processed_messages, app.messages.len());
+        assert_eq!(app.card_cache.processed_messages, app.chat.messages.len());
 
         live_update(
             &mut app,
@@ -2769,7 +2685,7 @@ mod tests {
         );
 
         assert_eq!(
-            app.messages.len(),
+            app.chat.messages.len(),
             1,
             "tool detail update should be in place"
         );
@@ -2815,7 +2731,7 @@ mod tests {
                 .iter()
                 .any(|line| line.contains("  1 ") && line.contains("- before"))
         );
-        assert_eq!(app.card_cache.processed_messages, app.messages.len());
+        assert_eq!(app.card_cache.processed_messages, app.chat.messages.len());
 
         live_update(
             &mut app,
@@ -2829,7 +2745,7 @@ mod tests {
         );
 
         assert_eq!(
-            app.messages.len(),
+            app.chat.messages.len(),
             1,
             "tool detail update should be in place"
         );
@@ -2886,23 +2802,23 @@ mod tests {
         let mut app = App::new();
 
         // Build incrementally
-        app.messages.push(ChatEntry::User {
+        app.chat.messages.push(ChatEntry::User {
             text: "q1".into(),
             message_id: None,
         });
         build_message_cards(&mut app);
 
-        app.messages.push(ChatEntry::Assistant {
+        app.chat.messages.push(ChatEntry::Assistant {
             content: "a1".into(),
             thinking: None,
             message_id: None,
         });
         build_message_cards(&mut app);
 
-        app.messages.push(tool_call("edit"));
+        app.chat.messages.push(tool_call("edit"));
         build_message_cards(&mut app);
 
-        app.messages.push(ChatEntry::User {
+        app.chat.messages.push(ChatEntry::User {
             text: "q2".into(),
             message_id: None,
         });
@@ -2924,11 +2840,11 @@ mod tests {
     #[test]
     fn session_load_invalidates_card_cache_before_native_replay() {
         let mut app = App::new();
-        app.messages.push(ChatEntry::User {
+        app.chat.messages.push(ChatEntry::User {
             text: "parent prompt".into(),
             message_id: None,
         });
-        app.messages.push(ChatEntry::Assistant {
+        app.chat.messages.push(ChatEntry::Assistant {
             content: "parent reply".into(),
             thinking: None,
             message_id: None,
@@ -2937,7 +2853,7 @@ mod tests {
         assert_eq!(app.card_cache.processed_messages, 2);
 
         load_session(&mut app, "delegate-session", "agent-2");
-        assert!(app.messages.is_empty());
+        assert!(app.chat.messages.is_empty());
         assert_eq!(app.card_cache.processed_messages, 0);
         assert!(app.card_cache.cards.is_empty());
 
@@ -2949,7 +2865,7 @@ mod tests {
                 assistant_update("delegate reply", "delegate-assistant"),
             ],
         );
-        assert_eq!(app.messages.len(), 2);
+        assert_eq!(app.chat.messages.len(), 2);
     }
 
     #[test]
@@ -2969,9 +2885,9 @@ mod tests {
         );
 
         // Native replay creates a durable card but intentionally does not restore active state.
-        assert!(app.elicitation.is_none());
+        assert!(app.chat.elicitation.is_none());
         assert!(
-            matches!(app.messages.as_slice(), [ChatEntry::Elicitation { elicitation_id, outcome: None, .. }] if elicitation_id == "elic-1")
+            matches!(app.chat.messages.as_slice(), [ChatEntry::Elicitation { elicitation_id, outcome: None, .. }] if elicitation_id == "elic-1")
         );
         let rendered = buffer_text(&render_delegate_buffer(&mut app, 100, 16));
         assert!(rendered.contains("Need approval"));
@@ -2981,7 +2897,7 @@ mod tests {
     fn replayed_elicitation_preserves_existing_response_card() {
         let mut app = App::new();
         load_session(&mut app, "child-1", "coder");
-        app.messages.push(ChatEntry::Elicitation {
+        app.chat.messages.push(ChatEntry::Elicitation {
             elicitation_id: "elic-1".into(),
             message: "Need approval".into(),
             source: "builtin:question".into(),
@@ -2998,9 +2914,9 @@ mod tests {
                 allow_custom: true,
             }],
         );
-        assert!(app.elicitation.is_none());
+        assert!(app.chat.elicitation.is_none());
         assert!(
-            matches!(app.messages.as_slice(), [ChatEntry::Elicitation { outcome: Some(outcome), .. }] if outcome == "responded")
+            matches!(app.chat.messages.as_slice(), [ChatEntry::Elicitation { outcome: Some(outcome), .. }] if outcome == "responded")
         );
     }
 
@@ -3030,9 +2946,9 @@ mod tests {
             }],
         );
         assert_eq!(app.delegates.parent_session_id.as_deref(), Some("parent"));
-        assert!(app.elicitation.is_none());
+        assert!(app.chat.elicitation.is_none());
         assert!(
-            matches!(app.messages.as_slice(), [ChatEntry::Elicitation { elicitation_id, outcome: None, .. }] if elicitation_id == "elic-1")
+            matches!(app.chat.messages.as_slice(), [ChatEntry::Elicitation { elicitation_id, outcome: None, .. }] if elicitation_id == "elic-1")
         );
     }
 
@@ -3049,8 +2965,8 @@ mod tests {
             kind: ElicitationFieldKind::TextInput,
         }]);
         state.message = "Need approval".into();
-        app.elicitation = Some(state);
-        app.elicitation_ui = Some(ElicitationUiState::default());
+        app.chat.elicitation = Some(state);
+        app.chat.elicitation_ui = Some(ElicitationUiState::default());
         let rendered = buffer_text(&render_delegate_buffer(&mut app, 100, 16));
         assert!(rendered.contains("Question"));
         assert!(rendered.contains("Need approval"));
@@ -3072,9 +2988,9 @@ mod tests {
                 allow_custom: false,
             }],
         );
-        assert!(app.elicitation.is_none());
+        assert!(app.chat.elicitation.is_none());
         assert!(
-            matches!(app.messages.as_slice(), [ChatEntry::Elicitation { elicitation_id, outcome: Some(outcome), .. }] if elicitation_id == "elic-1" && outcome == "unsupported schema - cannot answer in TUI")
+            matches!(app.chat.messages.as_slice(), [ChatEntry::Elicitation { elicitation_id, outcome: Some(outcome), .. }] if elicitation_id == "elic-1" && outcome == "unsupported schema - cannot answer in TUI")
         );
     }
 
@@ -3137,12 +3053,12 @@ mod tests {
     #[test]
     fn message_cards_compact_tool_after_assistant() {
         let mut app = App::new();
-        app.messages.push(ChatEntry::Assistant {
+        app.chat.messages.push(ChatEntry::Assistant {
             content: "thinking...".into(),
             thinking: None,
             message_id: None,
         });
-        app.messages.push(tool_call("read"));
+        app.chat.messages.push(tool_call("read"));
 
         let cards = build_message_cards(&mut app);
         assert_eq!(cards.len(), 2);
@@ -3154,11 +3070,11 @@ mod tests {
     #[test]
     fn message_cards_non_compact_tool_after_user() {
         let mut app = App::new();
-        app.messages.push(ChatEntry::User {
+        app.chat.messages.push(ChatEntry::User {
             text: "do it".into(),
             message_id: None,
         });
-        app.messages.push(tool_call("read"));
+        app.chat.messages.push(tool_call("read"));
 
         let cards = build_message_cards(&mut app);
         assert_eq!(cards.len(), 2);
@@ -3172,7 +3088,7 @@ mod tests {
         let mut app = App::new();
         let old = "aaa\nbbb\n";
         let new = "aaa\nccc\n";
-        app.messages.push(ChatEntry::ToolCall {
+        app.chat.messages.push(ChatEntry::ToolCall {
             tool_call_id: None,
             name: "edit".into(),
             is_error: false,
@@ -3198,7 +3114,7 @@ mod tests {
     fn message_cards_write_tool_includes_content_lines() {
         let mut app = App::new();
         let content = "fn main() {}\n";
-        app.messages.push(ChatEntry::ToolCall {
+        app.chat.messages.push(ChatEntry::ToolCall {
             tool_call_id: None,
             name: "write_file".into(),
             is_error: false,
@@ -3231,7 +3147,7 @@ mod tests {
                 start_line: Some(20),
             },
         ];
-        app.messages.push(ChatEntry::ToolCall {
+        app.chat.messages.push(ChatEntry::ToolCall {
             tool_call_id: None,
             name: "multiedit".into(),
             is_error: false,
@@ -3291,7 +3207,7 @@ mod tests {
             new: "fn build_message_cards() {\n    new();\n}\n".into(),
             start_line: Some(211),
         }];
-        app.messages.push(ChatEntry::ToolCall {
+        app.chat.messages.push(ChatEntry::ToolCall {
             tool_call_id: None,
             name: "replace_symbol".into(),
             is_error: false,
@@ -3357,7 +3273,7 @@ mod tests {
             ],
             hidden_line_count: 12,
         };
-        app.messages.push(ChatEntry::ToolCall {
+        app.chat.messages.push(ChatEntry::ToolCall {
             tool_call_id: None,
             name: "shell".into(),
             is_error: false,
@@ -4050,7 +3966,7 @@ mod tests {
     #[test]
     fn message_card_with_thinking_includes_bullet_header() {
         let mut app = App::new();
-        app.messages.push(ChatEntry::Assistant {
+        app.chat.messages.push(ChatEntry::Assistant {
             content: "answer".into(),
             thinking: Some("reasoning".into()),
             message_id: None,
@@ -4070,7 +3986,7 @@ mod tests {
     #[test]
     fn message_card_without_thinking_has_no_bullet() {
         let mut app = App::new();
-        app.messages.push(ChatEntry::Assistant {
+        app.chat.messages.push(ChatEntry::Assistant {
             content: "answer".into(),
             thinking: None,
             message_id: None,
@@ -4093,8 +4009,8 @@ mod tests {
     #[test]
     fn message_card_thinking_hidden_when_show_thinking_false() {
         let mut app = App::new();
-        app.show_thinking = false;
-        app.messages.push(ChatEntry::Assistant {
+        app.chat.show_thinking = false;
+        app.chat.messages.push(ChatEntry::Assistant {
             content: "answer".into(),
             thinking: Some("reasoning".into()),
             message_id: None,
@@ -4114,16 +4030,16 @@ mod tests {
     #[test]
     fn hidden_thinking_entry_between_tools_keeps_incremental_tool_batching() {
         let mut app = App::new();
-        app.show_thinking = false;
+        app.chat.show_thinking = false;
 
-        app.messages.push(tool_call("glob"));
+        app.chat.messages.push(tool_call("glob"));
         build_message_cards(&mut app);
-        app.messages.push(ChatEntry::Thinking {
+        app.chat.messages.push(ChatEntry::Thinking {
             content: "hidden reasoning".into(),
             message_id: Some("think-1".into()),
         });
         build_message_cards(&mut app);
-        app.messages.push(tool_call("read_tool"));
+        app.chat.messages.push(tool_call("read_tool"));
 
         let incremental_kinds: Vec<_> = {
             let cards = build_message_cards(&mut app);

--- a/src/ui/popups.rs
+++ b/src/ui/popups.rs
@@ -1399,7 +1399,8 @@ pub(super) fn draw_fork_turn_popup(f: &mut Frame, app: &App) {
     );
 
     let avail = chunks[1].width.saturating_sub(2) as usize;
-    let (filter_display, filter_cur) = scroll_input(&app.fork_filter, app.fork_filter.len(), avail);
+    let (filter_display, filter_cur) =
+        scroll_input(&app.chat.fork_filter, app.chat.fork_filter.len(), avail);
     let input_line = Line::from(vec![
         Span::styled("/ ", Theme::popup_title()),
         Span::styled(filter_display, Theme::popup_bg()),
@@ -1410,7 +1411,7 @@ pub(super) fn draw_fork_turn_popup(f: &mut Frame, app: &App) {
     );
     f.set_cursor_position((chunks[1].x + 2 + filter_cur as u16, chunks[1].y));
 
-    let turns = app.visible_fork_turns();
+    let turns = app.chat.visible_fork_turns();
     if turns.is_empty() {
         f.render_widget(
             Paragraph::new(Span::styled("No forkable turns", Theme::status()))
@@ -1420,7 +1421,7 @@ pub(super) fn draw_fork_turn_popup(f: &mut Frame, app: &App) {
     } else {
         let row_width = chunks[2].width as usize;
         let preview_budget = row_width.saturating_sub(8) / 2;
-        let selected_idx = app.fork_cursor.min(turns.len().saturating_sub(1));
+        let selected_idx = app.chat.fork_cursor.min(turns.len().saturating_sub(1));
         let selected = Some(selected_idx);
         let dim_style = Theme::status().add_modifier(Modifier::DIM);
         let selected_style = Theme::selected();


### PR DESCRIPTION
## change
- extract the exact 23 chat fields into private `ChatState`
- move `ElicitationUiState` and chat-local transitions into the owner
- preserve acp, handler, config, runtime, and ratatui coordination at their existing boundaries
- add focused owner coverage for defaults, reset, fork, prompt, cancel, timing, undo, elicitation, streaming, replay, and tool reconciliation

## validation
- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --all-targets --all-features`
- `cargo test --all-targets --all-features` (886 passed, 0 failed, 0 ignored)
- `git diff --check`

## boundary
- exact base: `81e231e7d99f0ccc8fd73c20bb2d81956d4d3677`
- exact 10-file allowlist
- one private `mod chat_state;` and one `pub(crate) chat: ChatState`
- 23 owner fields; app reduced from 40 to 18 direct fields
- no render state, phase 5, protocol, transport, persistence schema, or cache architecture changes
- four phase 11 compatibility forward tags retained

integration, manual tui smoke, renderstate, and phase 5 remain pending.