### PR TITLE
refactor: centralize application effects

### DIFF
--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use serde_json::Value;
 
 use crate::acp_client::DelegateModelOverrideInfo;
+use crate::application::Effect;
 use crate::command::{Command, SessionListRequest};
 use crate::delegates_state::DelegateLifecycleUpdate;
 use crate::diagnostics::LogLevel;
@@ -181,7 +182,10 @@ pub(crate) enum AcpAppEvent {
 }
 
 impl crate::app::App {
-    pub(crate) fn handle_acp_event(&mut self, event: AcpAppEvent) -> Vec<Command> {
+    pub(crate) fn handle_acp_event(&mut self, event: AcpAppEvent) -> Vec<Effect> {
+        fn effects(commands: Vec<Command>) -> Vec<Effect> {
+            commands.into_iter().map(Effect::Command).collect()
+        }
         match event {
             AcpAppEvent::Initialized {
                 agent_id,
@@ -228,7 +232,7 @@ impl crate::app::App {
             AcpAppEvent::Profiles {
                 profiles,
                 active_profile_id,
-            } => self.apply_profile_catalog(profiles, active_profile_id),
+            } => effects(self.apply_profile_catalog(profiles, active_profile_id)),
             AcpAppEvent::ProfileAgents { profile_id, agents } => {
                 if self.desired_agents_profile_id() == Some(profile_id.as_str()) {
                     self.models.replace_profile_agents(profile_id, agents);
@@ -238,7 +242,9 @@ impl crate::app::App {
                             self.models.agents_profile_id.as_deref(),
                         )
                     {
-                        return self.delegate_model_commands_for_session(session_id, profile_id);
+                        return effects(
+                            self.delegate_model_commands_for_session(session_id, profile_id),
+                        );
                     }
                 }
                 vec![]
@@ -290,7 +296,7 @@ impl crate::app::App {
                 self.apply_mesh_status(status);
                 vec![]
             }
-            AcpAppEvent::MeshNodes(nodes) => self.apply_mesh_nodes(nodes),
+            AcpAppEvent::MeshNodes(nodes) => effects(self.apply_mesh_nodes(nodes)),
             AcpAppEvent::MeshInviteCreated(invite) => {
                 self.apply_mesh_invite_created(invite);
                 vec![]
@@ -300,10 +306,10 @@ impl crate::app::App {
                 vec![]
             }
             AcpAppEvent::RemoteSessionAttached(attached) => {
-                self.apply_remote_session_attached(attached)
+                effects(self.apply_remote_session_attached(attached))
             }
             AcpAppEvent::SessionList { request, page } => {
-                self.apply_acp_session_list(request, page)
+                effects(self.apply_acp_session_list(request, page))
             }
             AcpAppEvent::SessionListFailed { request, message } => {
                 self.apply_acp_session_list_failure(&request);
@@ -315,12 +321,12 @@ impl crate::app::App {
                 agent_id,
                 session_id,
                 profile_id,
-            } => self.apply_acp_session_created(agent_id, session_id, profile_id),
+            } => effects(self.apply_acp_session_created(agent_id, session_id, profile_id)),
             AcpAppEvent::SessionLoaded {
                 agent_id,
                 session_id,
                 profile_id,
-            } => self.apply_acp_session_loaded(agent_id, session_id, profile_id),
+            } => effects(self.apply_acp_session_loaded(agent_id, session_id, profile_id)),
             AcpAppEvent::SessionUpdate {
                 session_id,
                 update,
@@ -372,12 +378,14 @@ impl crate::app::App {
                         self.render.invalidate_content_cache();
                         self.set_status(LogLevel::Info, "session", "undone - reloading session");
                         if let Some(ref sid) = self.sessions.session_id {
-                            return Command::load_session_commands(
-                                sid.clone(),
-                                self.current_session_cwd(),
-                                self.sessions.agent_id.clone(),
-                            )
-                            .into();
+                            return effects(
+                                Command::load_session_commands(
+                                    sid.clone(),
+                                    self.current_session_cwd(),
+                                    self.sessions.agent_id.clone(),
+                                )
+                                .into(),
+                            );
                         }
                     }
                     UndoResult::Rejected {
@@ -410,12 +418,14 @@ impl crate::app::App {
                             .build_undo_state_from_server_stack(&stack, None, None);
                         self.set_status(LogLevel::Info, "session", "redone - reloading session");
                         if let Some(ref sid) = self.sessions.session_id {
-                            return Command::load_session_commands(
-                                sid.clone(),
-                                self.current_session_cwd(),
-                                self.sessions.agent_id.clone(),
-                            )
-                            .into();
+                            return effects(
+                                Command::load_session_commands(
+                                    sid.clone(),
+                                    self.current_session_cwd(),
+                                    self.sessions.agent_id.clone(),
+                                )
+                                .into(),
+                            );
                         }
                     }
                     RedoResult::Rejected { message, stack } => {
@@ -441,12 +451,14 @@ impl crate::app::App {
                     } => {
                         self.navigation.popup = Popup::None;
                         self.set_status(LogLevel::Info, "fork", "forked - loading session");
-                        return Command::load_session_commands(
-                            forked_session_id,
-                            self.current_session_cwd(),
-                            self.sessions.agent_id.clone(),
-                        )
-                        .into();
+                        return effects(
+                            Command::load_session_commands(
+                                forked_session_id,
+                                self.current_session_cwd(),
+                                self.sessions.agent_id.clone(),
+                            )
+                            .into(),
+                        );
                     }
                     ForkResult::Succeeded {
                         source_session_id: _,
@@ -524,7 +536,7 @@ impl crate::app::App {
                 self.push_log(level, "auth", &result.message);
                 let applied_success = self.auth.apply_oauth_result(result);
                 debug_assert_eq!(applied_success, is_success);
-                vec![Command::ListAuthProviders]
+                vec![Effect::Command(Command::ListAuthProviders)]
             }
             AcpAppEvent::InfoLog { target, message } => {
                 self.push_log(LogLevel::Info, target, message);
@@ -1552,6 +1564,16 @@ fn acp_content_to_string(value: &Value) -> String {
 mod tests {
     use super::*;
     use crate::app::App;
+
+    fn command_refs(effects: &[Effect]) -> Vec<&Command> {
+        effects
+            .iter()
+            .filter_map(|effect| match effect {
+                Effect::Command(command) => Some(command),
+                _ => None,
+            })
+            .collect()
+    }
     use crate::chat_state::ElicitationUiState;
     use crate::composer_state::{FileIndexEntryLite, MentionState};
     use crate::domain::activity::{
@@ -1791,7 +1813,7 @@ mod tests {
         });
 
         assert!(matches!(
-            commands.as_slice(),
+            command_refs(&commands).as_slice(),
             [Command::ListProfileAgents { profile_id }] if profile_id == "fast"
         ));
     }
@@ -1825,7 +1847,7 @@ mod tests {
 
         assert_eq!(app.current_session_profile_id(), Some("fast"));
         assert!(matches!(
-            commands.as_slice(),
+            command_refs(&commands).as_slice(),
             [
                 Command::SetAgentMode { mode },
                 Command::ListProfileAgents { profile_id },
@@ -1849,7 +1871,7 @@ mod tests {
 
         assert!(app.current_session_profile_id().is_none());
         assert!(matches!(
-            commands.as_slice(),
+            command_refs(&commands).as_slice(),
             [Command::SetAgentMode { mode }] if mode == "build"
         ));
     }
@@ -2136,7 +2158,7 @@ mod tests {
         });
 
         assert!(matches!(
-            commands.as_slice(),
+            command_refs(&commands).as_slice(),
             [Command::SetDelegateModel {
                 session_id,
                 agent_id,
@@ -2200,7 +2222,7 @@ mod tests {
             "stale-session"
         );
         assert!(matches!(
-            replies.as_slice(),
+            command_refs(&replies).as_slice(),
             [Command::ListRemoteSessions { node_id, offset: 0, limit: 50 }]
                 if node_id == "node-1"
         ));
@@ -2309,7 +2331,7 @@ mod tests {
             Some("node-1")
         );
         assert!(matches!(
-            replies.as_slice(),
+            command_refs(&replies).as_slice(),
             [
                 Command::LoadSession { session_id: load_id, cwd: None },
                 Command::SubscribeSession { session_id: subscribe_id, agent_id },
@@ -2340,7 +2362,7 @@ mod tests {
             },
         ));
         assert!(matches!(
-            attached.as_slice(),
+            command_refs(&attached).as_slice(),
             [
                 Command::LoadSession { session_id, cwd: Some(cwd) },
                 Command::SubscribeSession { session_id: subscribed_id, agent_id },
@@ -2364,14 +2386,14 @@ mod tests {
             Some("node-2")
         );
         assert_eq!(app.sessions.session_remote_cwd("remote-2"), None);
-        assert_eq!(
-            detached,
-            vec![Command::ListRemoteSessions {
-                node_id: "node-2".into(),
+        assert!(matches!(
+            detached.as_slice(),
+            [Effect::Command(Command::ListRemoteSessions {
+                node_id,
                 offset: 0,
                 limit: 50,
-            }]
-        );
+            })] if node_id == "node-2"
+        ));
     }
 
     #[test]
@@ -2426,18 +2448,18 @@ mod tests {
         assert_eq!(app.sessions.session_groups[0].next_cursor, None);
         assert!(replies.iter().any(|reply| matches!(
             reply,
-            Command::ListSessions {
+            Effect::Command(Command::ListSessions {
                 request: SessionListRequest::WorkspaceFirstPage { cwd },
                 cursor: None,
                 ..
-            } if cwd == "/repo"
+            }) if cwd == "/repo"
         )));
         assert!(replies.iter().any(|reply| matches!(
             reply,
-            Command::ListSessions {
+            Effect::Command(Command::ListSessions {
                 request: SessionListRequest::Discovery,
                 cursor: Some(cursor),
-            } if cursor == "opaque-root-2"
+            }) if cursor == "opaque-root-2"
         )));
     }
 
@@ -2508,10 +2530,10 @@ mod tests {
         );
         assert!(replies.iter().any(|reply| matches!(
             reply,
-            Command::ListSessions {
+            Effect::Command(Command::ListSessions {
                 request: SessionListRequest::WorkspaceFirstPage { cwd },
                 ..
-            } if cwd == "/later"
+            }) if cwd == "/later"
         )));
     }
 
@@ -2680,7 +2702,7 @@ mod tests {
         assert_eq!(app.mesh.mesh_invite_name, "preserved");
         assert_seeded_model_state(&app);
         assert!(matches!(
-            replies.as_slice(),
+            command_refs(&replies).as_slice(),
             [
                 Command::SubscribeSession { session_id, agent_id },
                 Command::ListProfileAgents { profile_id },
@@ -2764,7 +2786,7 @@ mod tests {
         assert_eq!(app.delegates.delegate_entries.len(), 1);
         assert_seeded_model_state(&app);
         assert!(matches!(
-            replies.as_slice(),
+            command_refs(&replies).as_slice(),
             [Command::SetAgentMode { mode }] if mode == "plan"
         ));
     }
@@ -3620,7 +3642,7 @@ mod tests {
             ["src/main.rs"]
         );
         assert!(matches!(
-            replies.as_slice(),
+            command_refs(&replies).as_slice(),
             [
                 Command::LoadSession { session_id: load_id, cwd },
                 Command::SubscribeSession { session_id: subscribe_id, agent_id },
@@ -3739,7 +3761,7 @@ mod tests {
         assert_eq!(app.diagnostics.status, "redone - reloading session");
         assert!(app.chat.can_redo());
         assert!(matches!(
-            replies.as_slice(),
+            command_refs(&replies).as_slice(),
             [
                 Command::LoadSession { session_id: load_id, cwd },
                 Command::SubscribeSession { session_id: subscribe_id, agent_id },
@@ -3790,7 +3812,7 @@ mod tests {
         assert_eq!(app.diagnostics.status, "forked - loading session");
         assert_eq!(replies.len(), 2);
         assert!(matches!(
-            replies.as_slice(),
+            command_refs(&replies).as_slice(),
             [
                 Command::LoadSession { session_id: load_id, .. },
                 Command::SubscribeSession { session_id: subscribe_id, agent_id }

--- a/src/application.rs
+++ b/src/application.rs
@@ -7,6 +7,7 @@ use crate::{
     command::Command,
     connection_state::ConnState,
     diagnostics::LogLevel,
+    domain::chat::ChatEntry,
     handlers,
     server_manager::ServerEvent,
 };
@@ -30,6 +31,10 @@ pub(crate) enum RuntimeEvent {
     ExternalEditorFinished {
         outcome: ExternalEditorOutcome,
     },
+    ElicitationResponseSent {
+        elicitation_id: String,
+        outcome: String,
+    },
     CommandFailed {
         command: Command,
         message: String,
@@ -52,6 +57,10 @@ pub(crate) enum ExternalEditorOutcome {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Effect {
     Command(Command),
+    CommandThen {
+        command: Command,
+        on_sent: RuntimeEvent,
+    },
     PersistConfig,
     CopyToClipboard {
         target: ClipboardTarget,
@@ -235,6 +244,34 @@ fn handle_runtime_event(app: &mut App, event: RuntimeEvent) -> Vec<Effect> {
             }
             vec![Effect::Terminal(TerminalAction::Redraw)]
         }
+        RuntimeEvent::ElicitationResponseSent {
+            elicitation_id,
+            outcome,
+        } => {
+            let is_active = app
+                .chat
+                .elicitation
+                .as_ref()
+                .is_some_and(|state| state.elicitation_id == elicitation_id);
+            if is_active {
+                app.resolve_elicitation(&elicitation_id, &outcome);
+            } else if let Some(ChatEntry::Elicitation {
+                outcome: card_outcome,
+                ..
+            }) = app.chat.messages.iter_mut().find(|entry| {
+                matches!(
+                    entry,
+                    ChatEntry::Elicitation {
+                        elicitation_id: existing_id,
+                        ..
+                    } if existing_id == &elicitation_id
+                )
+            }) {
+                *card_outcome = Some(outcome);
+                app.render.invalidate_card_cache();
+            }
+            Vec::new()
+        }
         RuntimeEvent::CommandFailed { command, message } => {
             if let Command::Prompt { local_id, .. } = command {
                 app.chat.rollback_pending_prompt(&local_id);
@@ -254,10 +291,12 @@ mod tests {
 
     use super::*;
     use crate::{
+        chat_state::ElicitationUiState,
         connection_state::ServerState,
         domain::{
             auth::{OAuthFlow, OAuthFlowKind},
             chat::ChatEntry,
+            elicitation::ElicitationState,
             mesh::MeshInviteCreatedInfo,
             profile::ProfileInfo,
             session::{SessionGroup, SessionSummary},
@@ -265,14 +304,20 @@ mod tests {
         navigation_state::Screen,
     };
 
-    fn commands(effects: &[Effect]) -> Vec<&Command> {
-        effects
-            .iter()
-            .filter_map(|effect| match effect {
-                Effect::Command(command) => Some(command),
-                _ => None,
-            })
-            .collect()
+    fn add_elicitation(app: &mut App, elicitation_id: &str, active: bool) {
+        app.chat.messages.push(ChatEntry::Elicitation {
+            elicitation_id: elicitation_id.into(),
+            message: format!("Question {elicitation_id}"),
+            source: "builtin:question".into(),
+            outcome: None,
+        });
+        if active {
+            let mut state = ElicitationState::new_for_test(Vec::new());
+            state.elicitation_id = elicitation_id.into();
+            state.message = format!("Question {elicitation_id}");
+            app.chat.elicitation = Some(state);
+            app.chat.elicitation_ui = Some(ElicitationUiState::default());
+        }
     }
 
     #[test]
@@ -347,19 +392,19 @@ mod tests {
         let effects = update(&mut app, AppEvent::Connection(ConnectionEvent::Connected));
 
         assert_eq!(
-            commands(&effects),
+            effects,
             vec![
-                &Command::Init,
-                &Command::list_sessions_browse(),
-                &Command::ListAllModels { refresh: false },
-                &Command::LoadSession {
+                Effect::Command(Command::Init),
+                Effect::Command(Command::list_sessions_browse()),
+                Effect::Command(Command::ListAllModels { refresh: false }),
+                Effect::Command(Command::LoadSession {
                     session_id: "session-1".into(),
                     cwd: Some("/repo".into()),
-                },
-                &Command::SubscribeSession {
+                }),
+                Effect::Command(Command::SubscribeSession {
                     session_id: "session-1".into(),
                     agent_id: Some("agent-1".into()),
-                },
+                }),
             ]
         );
     }
@@ -376,15 +421,18 @@ mod tests {
 
         let effects = update(&mut app, AppEvent::Connection(ConnectionEvent::Connected));
 
-        assert!(matches!(
-            commands(&effects).as_slice(),
-            [
-                Command::Init,
-                Command::ListSessions { .. },
-                Command::ListAllModels { refresh: false },
-                Command::AttachRemoteSession { node_id, session_id },
-            ] if node_id == "node-1" && session_id == "remote-1"
-        ));
+        assert_eq!(
+            effects,
+            vec![
+                Effect::Command(Command::Init),
+                Effect::Command(Command::list_sessions_browse()),
+                Effect::Command(Command::ListAllModels { refresh: false }),
+                Effect::Command(Command::AttachRemoteSession {
+                    node_id: "node-1".into(),
+                    session_id: "remote-1".into(),
+                }),
+            ]
+        );
     }
 
     #[test]
@@ -403,11 +451,11 @@ mod tests {
         let effects = update(&mut app, AppEvent::Connection(ConnectionEvent::Connected));
 
         assert_eq!(
-            commands(&effects),
+            effects,
             vec![
-                &Command::Init,
-                &Command::list_sessions_browse(),
-                &Command::ListAllModels { refresh: false },
+                Effect::Command(Command::Init),
+                Effect::Command(Command::list_sessions_browse()),
+                Effect::Command(Command::ListAllModels { refresh: false }),
             ]
         );
         assert_eq!(
@@ -675,6 +723,97 @@ mod tests {
             "external editor failed: editor exited"
         );
         assert_eq!(effects, vec![Effect::Terminal(TerminalAction::Redraw)]);
+    }
+
+    #[test]
+    fn elicitation_response_ack_resolves_the_matching_active_card() {
+        let mut app = App::new();
+        add_elicitation(&mut app, "elic-1", true);
+
+        let effects = update(
+            &mut app,
+            AppEvent::Runtime(RuntimeEvent::ElicitationResponseSent {
+                elicitation_id: "elic-1".into(),
+                outcome: "accepted".into(),
+            }),
+        );
+
+        assert!(effects.is_empty());
+        assert!(app.chat.elicitation.is_none());
+        assert!(app.chat.elicitation_ui.is_none());
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::Elicitation { elicitation_id, outcome: Some(outcome), .. }]
+                if elicitation_id == "elic-1" && outcome == "accepted"
+        ));
+    }
+
+    #[test]
+    fn elicitation_command_failure_leaves_active_card_pending() {
+        let mut app = App::new();
+        add_elicitation(&mut app, "elic-1", true);
+
+        let effects = update(
+            &mut app,
+            AppEvent::Runtime(RuntimeEvent::CommandFailed {
+                command: Command::ElicitationResponse {
+                    elicitation_id: "elic-1".into(),
+                    action: "decline".into(),
+                    content: None,
+                },
+                message: "channel closed".into(),
+            }),
+        );
+
+        assert!(effects.is_empty());
+        assert_eq!(
+            app.chat
+                .elicitation
+                .as_ref()
+                .map(|state| state.elicitation_id.as_str()),
+            Some("elic-1")
+        );
+        assert!(app.chat.elicitation_ui.is_some());
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::Elicitation { elicitation_id, outcome: None, .. }]
+                if elicitation_id == "elic-1"
+        ));
+        assert_eq!(app.diagnostics.status, "channel closed");
+    }
+
+    #[test]
+    fn stale_elicitation_ack_backfills_old_card_without_clearing_newer_active() {
+        let mut app = App::new();
+        add_elicitation(&mut app, "elic-old", false);
+        add_elicitation(&mut app, "elic-new", true);
+        app.render.card_cache.processed_messages = 2;
+
+        let effects = update(
+            &mut app,
+            AppEvent::Runtime(RuntimeEvent::ElicitationResponseSent {
+                elicitation_id: "elic-old".into(),
+                outcome: "accepted".into(),
+            }),
+        );
+
+        assert!(effects.is_empty());
+        assert_eq!(
+            app.chat
+                .elicitation
+                .as_ref()
+                .map(|state| state.elicitation_id.as_str()),
+            Some("elic-new")
+        );
+        assert!(app.chat.elicitation_ui.is_some());
+        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [
+                ChatEntry::Elicitation { elicitation_id: old_id, outcome: Some(outcome), .. },
+                ChatEntry::Elicitation { elicitation_id: new_id, outcome: None, .. },
+            ] if old_id == "elic-old" && outcome == "accepted" && new_id == "elic-new"
+        ));
     }
 
     #[test]

--- a/src/application.rs
+++ b/src/application.rs
@@ -57,9 +57,11 @@ pub(crate) enum ExternalEditorOutcome {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Effect {
     Command(Command),
-    CommandThen {
-        command: Command,
-        on_sent: RuntimeEvent,
+    ElicitationResponse {
+        elicitation_id: String,
+        action: String,
+        content: Option<serde_json::Value>,
+        outcome: String,
     },
     PersistConfig,
     CopyToClipboard {

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,0 +1,708 @@
+use crossterm::event::{KeyEvent, MouseEvent};
+
+use crate::{
+    acp_state::AcpAppEvent,
+    app::{App, ConnectionEvent},
+    auth_state::AuthUiNotice,
+    command::Command,
+    connection_state::ConnState,
+    diagnostics::LogLevel,
+    handlers,
+    server_manager::ServerEvent,
+};
+
+pub(crate) enum AppEvent {
+    Key(KeyEvent),
+    Mouse(MouseEvent),
+    Acp(AcpAppEvent),
+    Connection(ConnectionEvent),
+    Supervisor(ServerEvent),
+    Tick,
+    Runtime(RuntimeEvent),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RuntimeEvent {
+    ClipboardFinished {
+        target: ClipboardTarget,
+        success: bool,
+    },
+    ExternalEditorFinished {
+        outcome: ExternalEditorOutcome,
+    },
+    CommandFailed {
+        command: Command,
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ClipboardTarget {
+    Auth { provider: String },
+    MeshInvite,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ExternalEditorOutcome {
+    Completed(String),
+    Cancelled,
+    Failed(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Effect {
+    Command(Command),
+    PersistConfig,
+    CopyToClipboard {
+        target: ClipboardTarget,
+        text: String,
+    },
+    OpenExternalEditor {
+        initial_text: String,
+    },
+    Terminal(TerminalAction),
+    Quit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TerminalAction {
+    Redraw,
+}
+
+pub(crate) fn update(app: &mut App, event: AppEvent) -> Vec<Effect> {
+    match event {
+        AppEvent::Key(key) => handlers::handle_key(app, key),
+        AppEvent::Mouse(mouse) => handlers::handle_mouse(app, mouse),
+        AppEvent::Acp(event) => app.handle_acp_event(event),
+        AppEvent::Connection(event) => handle_connection_event(app, event),
+        AppEvent::Supervisor(event) => handle_supervisor_event(app, event),
+        AppEvent::Tick => {
+            app.render
+                .replace_tick((app.diagnostics.started_at.elapsed().as_millis() / 80) as u64);
+            app.clear_expired_cancel_confirm();
+            Vec::new()
+        }
+        AppEvent::Runtime(event) => handle_runtime_event(app, event),
+    }
+}
+fn handle_connection_event(app: &mut App, event: ConnectionEvent) -> Vec<Effect> {
+    let was_connected = app.connection.conn == ConnState::Connected;
+    app.handle_connection_event(event);
+
+    if app.connection.conn == ConnState::Connected {
+        let mut effects = vec![
+            Effect::Command(Command::Init),
+            Effect::Command(Command::list_sessions_browse()),
+            Effect::Command(Command::ListAllModels { refresh: false }),
+        ];
+        effects.extend(reconnect_session_effects(app));
+        effects
+    } else {
+        if was_connected && app.connection.conn == ConnState::Disconnected {
+            app.set_status(
+                LogLevel::Warn,
+                "connection",
+                "connection lost - reconnecting...",
+            );
+        }
+        Vec::new()
+    }
+}
+
+fn reconnect_session_effects(app: &mut App) -> Vec<Effect> {
+    let Some(session_id) = app.sessions.session_id.clone() else {
+        return Vec::new();
+    };
+
+    if let Some(node_id) = app.sessions.session_remote_node_id(&session_id) {
+        return vec![Effect::Command(Command::AttachRemoteSession {
+            node_id: node_id.to_string(),
+            session_id,
+        })];
+    }
+    if app.sessions.is_remote_session_id(&session_id) {
+        app.set_status(
+            LogLevel::Warn,
+            "session",
+            "remote session is missing node id; reconnect attach skipped",
+        );
+        return Vec::new();
+    }
+
+    Command::load_session_commands(
+        session_id,
+        app.current_session_cwd(),
+        app.sessions.agent_id.clone(),
+    )
+    .into_iter()
+    .map(Effect::Command)
+    .collect()
+}
+
+fn handle_supervisor_event(app: &mut App, event: ServerEvent) -> Vec<Effect> {
+    match event {
+        ServerEvent::Starting => {
+            app.connection.apply_server_starting();
+            if app.connection.conn != ConnState::Connected {
+                app.set_status(LogLevel::Info, "acp", "starting qmtcode ACP agent...");
+            }
+        }
+        ServerEvent::Started => {
+            app.connection.apply_server_started();
+            if app.connection.conn != ConnState::Connected {
+                app.set_status(LogLevel::Info, "acp", "qmtcode ACP agent started");
+            }
+        }
+        ServerEvent::BinaryNotFound => {
+            app.connection.apply_server_binary_not_found();
+            if app.connection.conn != ConnState::Connected {
+                app.set_status(
+                    LogLevel::Warn,
+                    "acp",
+                    "qmtcode not found; install it or set acp.binary_path in ~/.qmt/qmtui.toml",
+                );
+            }
+        }
+        ServerEvent::StartFailed { error } => {
+            app.connection.apply_server_start_failed(error.clone());
+            app.set_status(LogLevel::Error, "acp", format!("ACP start failed: {error}"));
+        }
+        ServerEvent::Stopped { reason } => {
+            app.connection.apply_server_stopped(reason.clone());
+            app.set_status(
+                LogLevel::Warn,
+                "acp",
+                format!("ACP agent stopped ({reason})"),
+            );
+        }
+    }
+    Vec::new()
+}
+
+fn handle_runtime_event(app: &mut App, event: RuntimeEvent) -> Vec<Effect> {
+    match event {
+        RuntimeEvent::ClipboardFinished { target, success } => {
+            match target {
+                ClipboardTarget::Auth { provider } => {
+                    if success {
+                        app.auth.ui_notice = Some(AuthUiNotice {
+                            provider: Some(provider),
+                            success: true,
+                            message: "Copied to clipboard".into(),
+                        });
+                        app.auth.clipboard_fallback = None;
+                    } else {
+                        app.auth.ui_notice = None;
+                        app.auth.clipboard_fallback = app
+                            .auth
+                            .oauth_flow
+                            .as_ref()
+                            .map(|flow| flow.authorization_url.clone());
+                    }
+                }
+                ClipboardTarget::MeshInvite => {
+                    if success {
+                        app.set_status(LogLevel::Info, "mesh", "invite URL copied");
+                    } else if let Some(url) = app.mesh.invite_url().map(str::to_string) {
+                        app.mesh.set_clipboard_fallback(url);
+                    }
+                }
+            }
+            Vec::new()
+        }
+        RuntimeEvent::ExternalEditorFinished { outcome } => {
+            app.render.invalidate_card_cache();
+            app.render.invalidate_content_cache();
+            match outcome {
+                ExternalEditorOutcome::Completed(updated_input) => {
+                    app.composer.replace_input_from_editor(updated_input);
+                    app.set_status(
+                        LogLevel::Info,
+                        "editor",
+                        "loaded prompt from external editor",
+                    );
+                }
+                ExternalEditorOutcome::Cancelled => {
+                    app.set_status(LogLevel::Info, "editor", "external editor cancelled");
+                }
+                ExternalEditorOutcome::Failed(message) => {
+                    app.set_status(
+                        LogLevel::Error,
+                        "editor",
+                        format!("external editor failed: {message}"),
+                    );
+                }
+            }
+            vec![Effect::Terminal(TerminalAction::Redraw)]
+        }
+        RuntimeEvent::CommandFailed { command, message } => {
+            if let Command::Prompt { local_id, .. } = command {
+                app.chat.rollback_pending_prompt(&local_id);
+                app.render.invalidate_card_cache();
+            }
+            app.set_status(LogLevel::Error, "command", message);
+            Vec::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEventKind};
+
+    use super::*;
+    use crate::{
+        connection_state::ServerState,
+        domain::{
+            auth::{OAuthFlow, OAuthFlowKind},
+            chat::ChatEntry,
+            mesh::MeshInviteCreatedInfo,
+            profile::ProfileInfo,
+            session::{SessionGroup, SessionSummary},
+        },
+        navigation_state::Screen,
+    };
+
+    fn commands(effects: &[Effect]) -> Vec<&Command> {
+        effects
+            .iter()
+            .filter_map(|effect| match effect {
+                Effect::Command(command) => Some(command),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn key_and_mouse_events_dispatch_through_update() {
+        let mut app = App::new();
+        app.composer.input = "draft".into();
+
+        let effects = update(
+            &mut app,
+            AppEvent::Key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+        );
+        assert!(effects.is_empty());
+        assert!(app.composer.input.is_empty());
+
+        app.navigation.screen = Screen::Chat;
+        app.chat.scroll_offset = 2;
+        let effects = update(
+            &mut app,
+            AppEvent::Mouse(MouseEvent {
+                kind: MouseEventKind::ScrollUp,
+                column: 0,
+                row: 0,
+                modifiers: KeyModifiers::NONE,
+            }),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.chat.scroll_offset, 5);
+
+        let effects = update(
+            &mut app,
+            AppEvent::Mouse(MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: 0,
+                row: 0,
+                modifiers: KeyModifiers::NONE,
+            }),
+        );
+        assert!(effects.is_empty());
+    }
+
+    #[test]
+    fn acp_event_dispatches_command_effect_through_update() {
+        let mut app = App::new();
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::Profiles {
+                profiles: vec![ProfileInfo {
+                    id: "fast".into(),
+                    name: "Fast".into(),
+                    ..Default::default()
+                }],
+                active_profile_id: Some("fast".into()),
+            }),
+        );
+
+        assert_eq!(app.profiles.active_profile_id.as_deref(), Some("fast"));
+        assert_eq!(
+            effects,
+            vec![Effect::Command(Command::ListProfileAgents {
+                profile_id: "fast".into(),
+            })]
+        );
+    }
+
+    #[test]
+    fn connection_initialization_and_local_reconnect_effects_are_ordered() {
+        let mut app = App::new();
+        app.sessions.session_id = Some("session-1".into());
+        app.sessions.agent_id = Some("agent-1".into());
+        app.connection.launch_cwd = Some("/repo".into());
+
+        let effects = update(&mut app, AppEvent::Connection(ConnectionEvent::Connected));
+
+        assert_eq!(
+            commands(&effects),
+            vec![
+                &Command::Init,
+                &Command::list_sessions_browse(),
+                &Command::ListAllModels { refresh: false },
+                &Command::LoadSession {
+                    session_id: "session-1".into(),
+                    cwd: Some("/repo".into()),
+                },
+                &Command::SubscribeSession {
+                    session_id: "session-1".into(),
+                    agent_id: Some("agent-1".into()),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn connection_reconnect_attaches_remembered_remote_session() {
+        let mut app = App::new();
+        app.sessions.session_id = Some("remote-1".into());
+        app.sessions.remember_remote_session_location(
+            "remote-1",
+            "node-1",
+            Some("/remote/repo".into()),
+        );
+
+        let effects = update(&mut app, AppEvent::Connection(ConnectionEvent::Connected));
+
+        assert!(matches!(
+            commands(&effects).as_slice(),
+            [
+                Command::Init,
+                Command::ListSessions { .. },
+                Command::ListAllModels { refresh: false },
+                Command::AttachRemoteSession { node_id, session_id },
+            ] if node_id == "node-1" && session_id == "remote-1"
+        ));
+    }
+
+    #[test]
+    fn connection_reconnect_skips_remote_session_without_node_id() {
+        let mut app = App::new();
+        app.sessions.session_id = Some("remote-1".into());
+        app.sessions.session_groups = vec![SessionGroup {
+            sessions: vec![SessionSummary {
+                session_id: "remote-1".into(),
+                node: Some("remote".into()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }];
+
+        let effects = update(&mut app, AppEvent::Connection(ConnectionEvent::Connected));
+
+        assert_eq!(
+            commands(&effects),
+            vec![
+                &Command::Init,
+                &Command::list_sessions_browse(),
+                &Command::ListAllModels { refresh: false },
+            ]
+        );
+        assert_eq!(
+            app.diagnostics.status,
+            "remote session is missing node id; reconnect attach skipped"
+        );
+    }
+
+    #[test]
+    fn connected_to_disconnected_overrides_status_for_reconnect() {
+        let mut app = App::new();
+        app.connection.conn = ConnState::Connected;
+
+        let effects = update(
+            &mut app,
+            AppEvent::Connection(ConnectionEvent::Disconnected {
+                reason: "closed".into(),
+            }),
+        );
+
+        assert!(effects.is_empty());
+        assert_eq!(app.diagnostics.status, "connection lost - reconnecting...");
+    }
+
+    #[test]
+    fn supervisor_events_update_state_and_preserve_connected_status() {
+        let mut app = App::new();
+        let effects = update(&mut app, AppEvent::Supervisor(ServerEvent::Starting));
+        assert!(effects.is_empty());
+        assert_eq!(app.connection.server_state, ServerState::Starting);
+        assert_eq!(app.diagnostics.status, "starting qmtcode ACP agent...");
+
+        update(&mut app, AppEvent::Supervisor(ServerEvent::Started));
+        assert_eq!(app.connection.server_state, ServerState::Running);
+        assert_eq!(app.diagnostics.status, "qmtcode ACP agent started");
+
+        update(&mut app, AppEvent::Supervisor(ServerEvent::BinaryNotFound));
+        assert_eq!(app.connection.server_state, ServerState::BinaryNotFound);
+        assert_eq!(
+            app.diagnostics.status,
+            "qmtcode not found; install it or set acp.binary_path in ~/.qmt/qmtui.toml"
+        );
+
+        app.connection.conn = ConnState::Connected;
+        app.set_status(LogLevel::Debug, "test", "retained");
+        update(&mut app, AppEvent::Supervisor(ServerEvent::Starting));
+        assert_eq!(app.connection.server_state, ServerState::Starting);
+        assert_eq!(app.diagnostics.status, "retained");
+
+        update(&mut app, AppEvent::Supervisor(ServerEvent::Started));
+        update(&mut app, AppEvent::Supervisor(ServerEvent::BinaryNotFound));
+        assert_eq!(app.connection.server_state, ServerState::BinaryNotFound);
+        assert_eq!(app.diagnostics.status, "retained");
+
+        update(
+            &mut app,
+            AppEvent::Supervisor(ServerEvent::StartFailed {
+                error: "invalid command".into(),
+            }),
+        );
+        assert_eq!(app.diagnostics.status, "ACP start failed: invalid command");
+
+        update(
+            &mut app,
+            AppEvent::Supervisor(ServerEvent::Stopped {
+                reason: "process exited".into(),
+            }),
+        );
+        assert_eq!(app.diagnostics.status, "ACP agent stopped (process exited)");
+    }
+
+    #[test]
+    fn tick_updates_render_clock_and_clears_expired_cancel_confirmation() {
+        let mut app = App::new();
+        app.chat.pending_cancel_confirm_until = Some(Instant::now() - Duration::from_millis(1));
+        app.render.tick = u64::MAX;
+
+        app.diagnostics.started_at = Instant::now() - Duration::from_millis(240);
+        let effects = update(&mut app, AppEvent::Tick);
+
+        assert!(effects.is_empty());
+        assert!(app.render.tick >= 3);
+        assert_ne!(app.render.tick, u64::MAX);
+        assert!(app.chat.pending_cancel_confirm_until.is_none());
+    }
+
+    #[test]
+    fn empty_ctrl_c_produces_quit_without_mutating_control_state() {
+        let mut app = App::new();
+        let effects = update(
+            &mut app,
+            AppEvent::Key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+        );
+
+        assert_eq!(effects, vec![Effect::Quit]);
+        assert!(!app.should_quit);
+    }
+
+    #[test]
+    fn profile_selection_produces_persistence_after_local_mutation() {
+        let mut app = App::new();
+        app.connection.conn = ConnState::Connected;
+        app.navigation.popup = crate::navigation_state::Popup::ProfileSelect;
+        app.profiles.profiles = vec![crate::domain::profile::ProfileInfo {
+            id: "fast".into(),
+            name: "Fast".into(),
+            ..Default::default()
+        }];
+
+        let effects = update(
+            &mut app,
+            AppEvent::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        );
+
+        assert_eq!(app.profiles.active_profile_id.as_deref(), Some("fast"));
+        assert!(matches!(
+            effects.as_slice(),
+            [
+                Effect::Command(Command::ListProfileAgents { profile_id }),
+                Effect::PersistConfig,
+            ] if profile_id == "fast"
+        ));
+    }
+
+    #[test]
+    fn auth_clipboard_failure_uses_current_oauth_url() {
+        let mut app = App::new();
+        app.auth.oauth_flow = Some(OAuthFlow {
+            flow_id: "flow-1".into(),
+            provider: "codex".into(),
+            authorization_url: "https://auth.example.com/authorize".into(),
+            flow_kind: OAuthFlowKind::RedirectCode,
+        });
+        app.auth.ui_notice = Some(AuthUiNotice {
+            provider: None,
+            success: true,
+            message: "old notice".into(),
+        });
+
+        let effects = update(
+            &mut app,
+            AppEvent::Runtime(RuntimeEvent::ClipboardFinished {
+                target: ClipboardTarget::Auth {
+                    provider: "codex".into(),
+                },
+                success: false,
+            }),
+        );
+
+        assert!(effects.is_empty());
+        assert!(app.auth.ui_notice.is_none());
+        assert_eq!(
+            app.auth.clipboard_fallback.as_deref(),
+            Some("https://auth.example.com/authorize")
+        );
+    }
+
+    #[test]
+    fn mesh_clipboard_success_sets_exact_status() {
+        let mut app = App::new();
+
+        let effects = update(
+            &mut app,
+            AppEvent::Runtime(RuntimeEvent::ClipboardFinished {
+                target: ClipboardTarget::MeshInvite,
+                success: true,
+            }),
+        );
+
+        assert!(effects.is_empty());
+        assert_eq!(app.diagnostics.status, "invite URL copied");
+        assert!(app.mesh.mesh_clipboard_fallback.is_none());
+    }
+
+    #[test]
+    fn clipboard_success_and_failure_results_preserve_exact_feedback() {
+        let mut app = App::new();
+        app.auth.clipboard_fallback = Some("old fallback".into());
+
+        let effects = update(
+            &mut app,
+            AppEvent::Runtime(RuntimeEvent::ClipboardFinished {
+                target: ClipboardTarget::Auth {
+                    provider: "codex".into(),
+                },
+                success: true,
+            }),
+        );
+        assert!(effects.is_empty());
+        assert!(matches!(
+            app.auth.ui_notice.as_ref(),
+            Some(notice)
+                if notice.provider.as_deref() == Some("codex")
+                    && notice.success
+                    && notice.message == "Copied to clipboard"
+        ));
+        assert!(app.auth.clipboard_fallback.is_none());
+
+        app.apply_mesh_invite_created(MeshInviteCreatedInfo {
+            invite_id: "invite-1".into(),
+            url: "qmt://mesh/join/token".into(),
+            qr_code: None,
+            expires_at: 1,
+            max_uses: 1,
+            mesh_name: None,
+        });
+        let effects = update(
+            &mut app,
+            AppEvent::Runtime(RuntimeEvent::ClipboardFinished {
+                target: ClipboardTarget::MeshInvite,
+                success: false,
+            }),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(
+            app.mesh.mesh_clipboard_fallback.as_deref(),
+            Some("qmt://mesh/join/token")
+        );
+    }
+
+    #[test]
+    fn editor_results_apply_state_then_request_redraw() {
+        let mut app = App::new();
+        app.composer.input = "draft".into();
+        app.render.card_cache.processed_messages = 2;
+
+        let effects = update(
+            &mut app,
+            AppEvent::Runtime(RuntimeEvent::ExternalEditorFinished {
+                outcome: ExternalEditorOutcome::Completed("revised".into()),
+            }),
+        );
+
+        assert_eq!(app.composer.input, "revised");
+        assert_eq!(app.composer.input_cursor, "revised".len());
+        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert_eq!(app.diagnostics.status, "loaded prompt from external editor");
+        assert_eq!(effects, vec![Effect::Terminal(TerminalAction::Redraw)]);
+    }
+
+    #[test]
+    fn editor_cancel_and_failure_preserve_input_and_request_redraw() {
+        let mut app = App::new();
+        app.composer.input = "draft".into();
+
+        let effects = update(
+            &mut app,
+            AppEvent::Runtime(RuntimeEvent::ExternalEditorFinished {
+                outcome: ExternalEditorOutcome::Cancelled,
+            }),
+        );
+        assert_eq!(app.composer.input, "draft");
+        assert_eq!(app.diagnostics.status, "external editor cancelled");
+        assert_eq!(effects, vec![Effect::Terminal(TerminalAction::Redraw)]);
+
+        let effects = update(
+            &mut app,
+            AppEvent::Runtime(RuntimeEvent::ExternalEditorFinished {
+                outcome: ExternalEditorOutcome::Failed("editor exited".into()),
+            }),
+        );
+        assert_eq!(app.composer.input, "draft");
+        assert_eq!(
+            app.diagnostics.status,
+            "external editor failed: editor exited"
+        );
+        assert_eq!(effects, vec![Effect::Terminal(TerminalAction::Redraw)]);
+    }
+
+    #[test]
+    fn command_failure_rolls_back_only_matching_optimistic_prompt() {
+        let mut app = App::new();
+        let failed_id = app.chat.push_pending_prompt("failed".into());
+        let retained_id = app.chat.push_pending_prompt("retained".into());
+        app.render.card_cache.processed_messages = 2;
+
+        let effects = update(
+            &mut app,
+            AppEvent::Runtime(RuntimeEvent::CommandFailed {
+                command: Command::Prompt {
+                    prompt: vec![],
+                    local_id: failed_id.clone(),
+                },
+                message: "channel closed".into(),
+            }),
+        );
+
+        assert!(effects.is_empty());
+        assert!(app.chat.messages.iter().all(|entry| {
+            !matches!(entry, ChatEntry::User { message_id: Some(id), .. } if id == &failed_id)
+        }));
+        assert!(app.chat.messages.iter().any(|entry| {
+            matches!(entry, ChatEntry::User { message_id: Some(id), .. } if id == &retained_id)
+        }));
+        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert_eq!(app.diagnostics.status, "channel closed");
+    }
+}

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -3132,8 +3132,7 @@ mod model_popup_tests {
         app.sessions.agent_mode = "plan".into();
         app.composer.input = "/review".into();
         app.composer.input_cursor = app.composer.input.len();
-        let mut effects = TestEffects::default();
-        effects.extend(handle_chat_key(&mut app, key(KeyCode::Enter)));
+        let effects = handle_chat_key(&mut app, key(KeyCode::Enter));
         assert!(
             effects
                 .iter()
@@ -3142,8 +3141,8 @@ mod model_popup_tests {
         assert_eq!(app.sessions.agent_mode, "review");
         assert_eq!(app.sessions.mode_before_review.as_deref(), Some("plan"));
         assert_eq!(
-            effects.as_slice(),
-            &[
+            effects,
+            vec![
                 Effect::Command(Command::SetAgentMode {
                     mode: "review".into(),
                 }),

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,28 +1,20 @@
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
-use tokio::sync::mpsc;
-
 use crate::app::App;
-use crate::auth_state::{AuthPanel, AuthUiNotice};
+use crate::application::{ClipboardTarget, Effect};
+use crate::auth_state::AuthPanel;
 use crate::diagnostics::LogLevel;
 use crate::domain::activity::{ActivityState, SessionOp};
 use crate::domain::auth::{OAuthFlowKind, OAuthStatus};
 use crate::domain::chat::format_outcome_labels;
 use crate::domain::model::ModelEntry;
 use crate::navigation_state::{CommandPaletteAction, Popup, Screen};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 
 fn popup_page_step(visible_rows: usize) -> usize {
     visible_rows.saturating_sub(1).max(1)
 }
 use crate::command::{Command, PromptBlock};
-use crate::config;
 use crate::connection_state::ConnState;
 use crate::theme;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum AppAction {
-    None,
-    OpenExternalEditor,
-}
 
 pub(crate) fn can_send_server_commands(app: &mut App) -> bool {
     if app.connection.conn == ConnState::Connected {
@@ -38,36 +30,32 @@ pub(crate) fn can_send_server_commands(app: &mut App) -> bool {
 }
 
 fn send_load_session_commands(
-    cmd_tx: &mpsc::UnboundedSender<Command>,
     session_id: String,
     cwd: Option<String>,
     agent_id: Option<String>,
-) -> anyhow::Result<()> {
-    for command in Command::load_session_commands(session_id, cwd, agent_id) {
-        cmd_tx.send(command)?;
-    }
-    Ok(())
+) -> Vec<Effect> {
+    Command::load_session_commands(session_id, cwd, agent_id)
+        .into_iter()
+        .map(Effect::Command)
+        .collect()
 }
 
 /// Handle all keyboard input while an elicitation popup is active.
 ///
 /// Returns `Ok(())` in all cases; the caller should return immediately after
 /// this to avoid routing the key to the normal chat handler.
-pub(crate) fn handle_elicitation_key(
-    app: &mut App,
-    key: KeyEvent,
-    cmd_tx: &mpsc::UnboundedSender<Command>,
-) -> anyhow::Result<()> {
+pub(crate) fn handle_elicitation_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
     use crate::domain::elicitation::ElicitationFieldKind;
 
+    let mut effects = Vec::new();
     let (Some(state), Some(ui)) = (
         app.chat.elicitation.as_mut(),
         app.chat.elicitation_ui.as_mut(),
     ) else {
-        return Ok(());
+        return effects;
     };
     let Some(field_index) = ui.current_field_index(state.fields.len()) else {
-        return Ok(());
+        return effects;
     };
 
     let selected_display = |state: &crate::domain::elicitation::ElicitationState,
@@ -123,11 +111,11 @@ pub(crate) fn handle_elicitation_key(
                 let elicitation_id = state.elicitation_id.clone();
                 let content = state.build_accept_content(Some(&state.custom_input));
                 let display = selected_display(state, true);
-                cmd_tx.send(Command::ElicitationResponse {
+                effects.push(Effect::Command(Command::ElicitationResponse {
                     elicitation_id: elicitation_id.clone(),
                     action: "accept".into(),
                     content: Some(content),
-                })?;
+                }));
                 app.resolve_elicitation(&elicitation_id, &display);
             }
             KeyCode::Char(character) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -143,7 +131,7 @@ pub(crate) fn handle_elicitation_key(
             KeyCode::Down => ui.custom_move_visual(&state.custom_input, 1),
             _ => {}
         }
-        return Ok(());
+        return effects;
     }
 
     let field = &state.fields[field_index];
@@ -158,11 +146,11 @@ pub(crate) fn handle_elicitation_key(
     match key.code {
         KeyCode::Esc => {
             let elicitation_id = state.elicitation_id.clone();
-            cmd_tx.send(Command::ElicitationResponse {
+            effects.push(Effect::Command(Command::ElicitationResponse {
                 elicitation_id: elicitation_id.clone(),
                 action: "decline".into(),
                 content: None,
-            })?;
+            }));
             app.resolve_elicitation(&elicitation_id, "declined");
         }
         KeyCode::Down => {
@@ -184,7 +172,7 @@ pub(crate) fn handle_elicitation_key(
                     ui.custom_active = true;
                     ui.custom_cursor = state.custom_input.len();
                     state.clear_selection(field_index);
-                    return Ok(());
+                    return effects;
                 }
                 ElicitationFieldKind::SingleSelect { .. } => {
                     state.select_option(field_index, ui.option_cursor);
@@ -193,7 +181,7 @@ pub(crate) fn handle_elicitation_key(
                     ui.custom_active = true;
                     ui.custom_cursor = state.custom_input.len();
                     state.clear_selection(field_index);
-                    return Ok(());
+                    return effects;
                 }
                 ElicitationFieldKind::MultiSelect { .. }
                 | ElicitationFieldKind::TextInput
@@ -205,11 +193,11 @@ pub(crate) fn handle_elicitation_key(
                 let elicitation_id = state.elicitation_id.clone();
                 let content = state.build_accept_content(None);
                 let display = selected_display(state, false);
-                cmd_tx.send(Command::ElicitationResponse {
+                effects.push(Effect::Command(Command::ElicitationResponse {
                     elicitation_id: elicitation_id.clone(),
                     action: "accept".into(),
                     content: Some(content),
-                })?;
+                }));
                 app.resolve_elicitation(&elicitation_id, &display);
             }
         }
@@ -238,40 +226,35 @@ pub(crate) fn handle_elicitation_key(
         }
         _ => {}
     }
-    Ok(())
+    effects
 }
 
-fn open_model_popup(app: &mut App, cmd_tx: &mpsc::UnboundedSender<Command>) -> anyhow::Result<()> {
+fn open_model_popup(app: &mut App) -> Vec<Effect> {
     if app.navigation.screen != Screen::Chat {
         app.set_status(
             LogLevel::Warn,
             "model",
             "model select is only available in chat",
         );
-        return Ok(());
+        return Vec::new();
     }
     if !can_send_server_commands(app) {
-        return Ok(());
+        return Vec::new();
     }
     app.navigation.popup = Popup::ModelSelect;
     app.models.reset_for_open();
-    cmd_tx.send(Command::ListAllModels { refresh: true })?;
-    Ok(())
+    vec![Effect::Command(Command::ListAllModels { refresh: true })]
 }
 
-fn open_session_popup(
-    app: &mut App,
-    cmd_tx: &mpsc::UnboundedSender<Command>,
-) -> anyhow::Result<()> {
+fn open_session_popup(app: &mut App) -> Vec<Effect> {
     if !can_send_server_commands(app) {
-        return Ok(());
+        return Vec::new();
     }
     app.navigation.popup = Popup::SessionSelect;
     app.sessions.reset_browser_for_open();
-    if let Some(request) = app.begin_session_discovery() {
-        cmd_tx.send(request)?;
-    }
-    Ok(())
+    app.begin_session_discovery()
+        .map(|command| vec![Effect::Command(command)])
+        .unwrap_or_default()
 }
 
 fn open_log_popup(app: &mut App) {
@@ -280,43 +263,40 @@ fn open_log_popup(app: &mut App) {
     app.diagnostics.log_filter.clear();
 }
 
-fn execute_command_palette_action(
-    app: &mut App,
-    action: CommandPaletteAction,
-    cmd_tx: &mpsc::UnboundedSender<Command>,
-) -> anyhow::Result<()> {
+fn execute_command_palette_action(app: &mut App, action: CommandPaletteAction) -> Vec<Effect> {
+    let mut effects = Vec::new();
     match action {
         CommandPaletteAction::OpenMesh | CommandPaletteAction::AttachRemoteSession => {
             if !can_send_server_commands(app) {
-                return Ok(());
+                return effects;
             }
             app.open_mesh_popup();
-            cmd_tx.send(Command::ListRemoteNodes)?;
+            effects.push(Effect::Command(Command::ListRemoteNodes));
         }
         CommandPaletteAction::CreateRemoteSession => {
             if !can_send_server_commands(app) {
-                return Ok(());
+                return effects;
             }
             app.open_mesh_popup();
-            cmd_tx.send(Command::ListRemoteNodes)?;
+            effects.push(Effect::Command(Command::ListRemoteNodes));
         }
         CommandPaletteAction::CreateMeshInvite => {
             if !can_send_server_commands(app) {
-                return Ok(());
+                return effects;
             }
             app.open_mesh_invite_form();
         }
-        CommandPaletteAction::ModelSelect => open_model_popup(app, cmd_tx)?,
-        CommandPaletteAction::SessionSelect => open_session_popup(app, cmd_tx)?,
+        CommandPaletteAction::ModelSelect => effects.extend(open_model_popup(app)),
+        CommandPaletteAction::SessionSelect => effects.extend(open_session_popup(app)),
         CommandPaletteAction::DelegateSessions => {
             if !can_send_server_commands(app) {
-                return Ok(());
+                return effects;
             }
             app.open_delegate_popup();
         }
         CommandPaletteAction::NewSession => {
             if !can_send_server_commands(app) {
-                return Ok(());
+                return effects;
             }
             app.open_new_session_popup();
         }
@@ -328,41 +308,36 @@ fn execute_command_palette_action(
         CommandPaletteAction::Log => open_log_popup(app),
         CommandPaletteAction::ProviderAuth => {
             if !can_send_server_commands(app) {
-                return Ok(());
+                return effects;
             }
             app.open_auth_popup();
-            cmd_tx.send(Command::ListAuthProviders)?;
+            effects.push(Effect::Command(Command::ListAuthProviders));
         }
-        CommandPaletteAction::ForkTurnSelect => {
-            app.open_fork_turn_popup();
-        }
+        CommandPaletteAction::ForkTurnSelect => app.open_fork_turn_popup(),
         CommandPaletteAction::ProfileSelect => {
             if !can_send_server_commands(app) {
-                return Ok(());
+                return effects;
             }
             app.open_profile_popup();
-            cmd_tx.send(Command::ListProfiles)?;
+            effects.push(Effect::Command(Command::ListProfiles));
         }
     }
-    Ok(())
+    effects
 }
 
-pub(crate) fn handle_mesh_popup_key(
-    app: &mut App,
-    key: KeyEvent,
-    cmd_tx: &mpsc::UnboundedSender<Command>,
-) -> anyhow::Result<()> {
+pub(crate) fn handle_mesh_popup_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
+    let mut effects = Vec::new();
     match key.code {
         KeyCode::Esc => app.navigation.popup = Popup::None,
         KeyCode::Tab | KeyCode::Right | KeyCode::Left => app.mesh.toggle_focus(),
         KeyCode::Up => match app.mesh.mesh_focus {
             crate::mesh_state::MeshFocus::Nodes => {
                 if let Some(node_id) = app.mesh.move_mesh_node_cursor(-1) {
-                    cmd_tx.send(Command::ListRemoteSessions {
+                    effects.push(Effect::Command(Command::ListRemoteSessions {
                         node_id,
                         offset: 0,
                         limit: 50,
-                    })?;
+                    }));
                 }
             }
             crate::mesh_state::MeshFocus::Sessions => app.mesh.move_remote_session_cursor(-1),
@@ -370,66 +345,63 @@ pub(crate) fn handle_mesh_popup_key(
         KeyCode::Down => match app.mesh.mesh_focus {
             crate::mesh_state::MeshFocus::Nodes => {
                 if let Some(node_id) = app.mesh.move_mesh_node_cursor(1) {
-                    cmd_tx.send(Command::ListRemoteSessions {
+                    effects.push(Effect::Command(Command::ListRemoteSessions {
                         node_id,
                         offset: 0,
                         limit: 50,
-                    })?;
+                    }));
                 }
             }
             crate::mesh_state::MeshFocus::Sessions => app.mesh.move_remote_session_cursor(1),
         },
-        KeyCode::Char('r') => cmd_tx.send(Command::ListRemoteNodes)?,
+        KeyCode::Char('r') => effects.push(Effect::Command(Command::ListRemoteNodes)),
         KeyCode::Enter => match app.mesh.mesh_focus {
             crate::mesh_state::MeshFocus::Nodes => {
                 app.mesh.focus_sessions();
                 if let Some(node_id) = app.mesh.selected_mesh_node_id() {
-                    cmd_tx.send(Command::ListRemoteSessions {
+                    effects.push(Effect::Command(Command::ListRemoteSessions {
                         node_id: node_id.to_string(),
                         offset: 0,
                         limit: 50,
-                    })?;
+                    }));
                 }
             }
             crate::mesh_state::MeshFocus::Sessions => {
                 if let Some(session) = app.mesh.selected_remote_session() {
-                    cmd_tx.send(Command::AttachRemoteSession {
+                    effects.push(Effect::Command(Command::AttachRemoteSession {
                         node_id: session.node_id.clone(),
                         session_id: session.id.clone(),
-                    })?;
+                    }));
                 }
             }
         },
         KeyCode::Char('n') => {
             if let Some(node_id) = app.mesh.selected_mesh_node_id() {
-                cmd_tx.send(Command::CreateRemoteSession {
+                effects.push(Effect::Command(Command::CreateRemoteSession {
                     node_id: node_id.to_string(),
                     cwd: None,
-                })?;
+                }));
             }
         }
         _ => {}
     }
-    Ok(())
+    effects
 }
 
-pub(crate) fn handle_mesh_invite_popup_key(
-    app: &mut App,
-    key: KeyEvent,
-    cmd_tx: &mpsc::UnboundedSender<Command>,
-) -> anyhow::Result<()> {
+pub(crate) fn handle_mesh_invite_popup_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
     if app.mesh.consume_clipboard_fallback() {
-        return Ok(());
+        return Vec::new();
     }
 
+    let mut effects = Vec::new();
     match key.code {
         KeyCode::Esc => app.navigation.popup = Popup::None,
         KeyCode::Up => app.mesh.move_invite_form_field(-1),
         KeyCode::Down | KeyCode::Tab => app.mesh.move_invite_form_field(1),
         KeyCode::Backspace => app.mesh.invite_form_backspace(),
         KeyCode::Enter => {
-            if let Some(msg) = app.mesh_invite_form_command() {
-                cmd_tx.send(msg)?;
+            if let Some(command) = app.mesh_invite_form_command() {
+                effects.push(Effect::Command(command));
                 app.set_status(LogLevel::Info, "mesh", "creating invite...");
             }
         }
@@ -438,12 +410,12 @@ pub(crate) fn handle_mesh_invite_popup_key(
         }
         _ => {}
     }
-    Ok(())
+    effects
 }
 
-pub(crate) fn handle_mesh_invite_qr_popup_key(app: &mut App, key: KeyEvent) -> anyhow::Result<()> {
+pub(crate) fn handle_mesh_invite_qr_popup_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
     if app.mesh.consume_clipboard_fallback() {
-        return Ok(());
+        return Vec::new();
     }
 
     match key.code {
@@ -452,24 +424,19 @@ pub(crate) fn handle_mesh_invite_qr_popup_key(app: &mut App, key: KeyEvent) -> a
             app.mesh.show_invite_url_fallback();
         }
         KeyCode::Char('y') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-            if let Some(url) = app.mesh.invite_url().map(str::to_string) {
-                if copy_text_to_clipboard(&url) {
-                    app.set_status(LogLevel::Info, "mesh", "invite URL copied");
-                } else {
-                    app.mesh.set_clipboard_fallback(url);
-                }
+            if let Some(text) = app.mesh.invite_url().map(str::to_string) {
+                return vec![Effect::CopyToClipboard {
+                    target: ClipboardTarget::MeshInvite,
+                    text,
+                }];
             }
         }
         _ => {}
     }
-    Ok(())
+    Vec::new()
 }
 
-pub(crate) fn handle_command_palette_key(
-    app: &mut App,
-    key: KeyEvent,
-    cmd_tx: &mpsc::UnboundedSender<Command>,
-) -> anyhow::Result<()> {
+pub(crate) fn handle_command_palette_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
     match key.code {
         KeyCode::Esc => app.navigation.popup = Popup::None,
         KeyCode::Up => app.navigation.move_command_palette_cursor(-1),
@@ -477,7 +444,7 @@ pub(crate) fn handle_command_palette_key(
         KeyCode::Backspace => app.navigation.command_palette_filter_backspace(),
         KeyCode::Enter => {
             if let Some(action) = app.navigation.selected_command_palette_action() {
-                execute_command_palette_action(app, action, cmd_tx)?;
+                return execute_command_palette_action(app, action);
             }
         }
         KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -485,39 +452,31 @@ pub(crate) fn handle_command_palette_key(
         }
         _ => {}
     }
-    Ok(())
+    Vec::new()
 }
 
-pub(crate) fn handle_key(
-    app: &mut App,
-    key: KeyEvent,
-    cmd_tx: &mpsc::UnboundedSender<Command>,
-) -> anyhow::Result<AppAction> {
+pub(crate) fn handle_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
     if key.code != KeyCode::Esc && app.chat.pending_cancel_confirm_until.is_some() {
         app.chat.clear_cancel_confirm();
         app.refresh_transient_status();
     }
 
-    // ctrl-c: clear input first, quit on second press
     if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
         if !app.composer.input.is_empty() {
             app.composer.clear_input();
-        } else {
-            app.should_quit = true;
+            return Vec::new();
         }
-        return Ok(AppAction::None);
+        return vec![Effect::Quit];
     }
 
-    // direct: ctrl+p opens the command palette, replacing any active popup.
     if key.modifiers.contains(KeyModifiers::CONTROL)
         && matches!(key.code, KeyCode::Char('p') | KeyCode::Char('P'))
     {
         app.navigation.chord = false;
         app.navigation.open_command_palette();
-        return Ok(AppAction::None);
+        return Vec::new();
     }
 
-    // chord second key: ctrl+x was pressed, now handle the follow-up
     if app.navigation.chord {
         app.navigation.chord = false;
         app.set_status(LogLevel::Debug, "input", "ready");
@@ -528,33 +487,31 @@ pub(crate) fn handle_key(
                     "editor",
                     "external editor is only available in chat",
                 );
-                return Ok(AppAction::None);
+                return Vec::new();
             }
-            return Ok(AppAction::OpenExternalEditor);
+            return vec![Effect::OpenExternalEditor {
+                initial_text: app.composer.input.clone(),
+            }];
         }
-        handle_chord(app, key, cmd_tx)?;
-        return Ok(AppAction::None);
+        return handle_chord(app, key);
     }
 
-    // elicitation popup takes full control of input when active
     if app.chat.elicitation.is_some() {
-        handle_elicitation_key(app, key, cmd_tx)?;
-        return Ok(AppAction::None);
+        return handle_elicitation_key(app, key);
     }
 
-    // direct: ctrl+t cycles thinking level
     if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('t') {
         if !can_send_server_commands(app) {
-            return Ok(AppAction::None);
+            return Vec::new();
         }
-        match app.cycle_reasoning_effort() {
-            Some(msg) => {
-                cmd_tx.send(msg)?;
+        return match app.cycle_reasoning_effort() {
+            Some(command) => {
                 app.set_status(
                     LogLevel::Info,
                     "model",
                     format!("thinking: {}", app.models.reasoning_effort_label()),
                 );
+                vec![Effect::Command(command)]
             }
             None => {
                 app.set_status(
@@ -565,109 +522,67 @@ pub(crate) fn handle_key(
                         app.models.reasoning_effort
                     ),
                 );
+                Vec::new()
             }
-        }
-        return Ok(AppAction::None);
+        };
     }
 
-    // direct: ctrl+l opens log popup
     if key.modifiers.contains(KeyModifiers::CONTROL)
         && matches!(key.code, KeyCode::Char('l') | KeyCode::Char('L'))
     {
         open_log_popup(app);
-        return Ok(AppAction::None);
+        return Vec::new();
     }
 
-    // chord start: ctrl+x
     if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('x') {
         app.navigation.chord = true;
         app.set_status(LogLevel::Debug, "input", "C-x ...");
-        return Ok(AppAction::None);
+        return Vec::new();
     }
 
-    // popup handling
     match app.navigation.popup {
-        Popup::CommandPalette => {
-            handle_command_palette_key(app, key, cmd_tx)?;
-            return Ok(AppAction::None);
-        }
-        Popup::Mesh => {
-            handle_mesh_popup_key(app, key, cmd_tx)?;
-            return Ok(AppAction::None);
-        }
-        Popup::MeshInvite => {
-            handle_mesh_invite_popup_key(app, key, cmd_tx)?;
-            return Ok(AppAction::None);
-        }
-        Popup::MeshInviteQr => {
-            handle_mesh_invite_qr_popup_key(app, key)?;
-            return Ok(AppAction::None);
-        }
-        Popup::ModelSelect => {
-            handle_model_popup_key(app, key, cmd_tx)?;
-            return Ok(AppAction::None);
-        }
-        Popup::SessionSelect => {
-            handle_session_popup_key(app, key, cmd_tx)?;
-            return Ok(AppAction::None);
-        }
-        Popup::NewSession => {
-            handle_new_session_popup_key(app, key, cmd_tx)?;
-            return Ok(AppAction::None);
-        }
-        Popup::ThemeSelect => {
-            handle_theme_popup_key(app, key)?;
-            return Ok(AppAction::None);
-        }
+        Popup::CommandPalette => return handle_command_palette_key(app, key),
+        Popup::Mesh => return handle_mesh_popup_key(app, key),
+        Popup::MeshInvite => return handle_mesh_invite_popup_key(app, key),
+        Popup::MeshInviteQr => return handle_mesh_invite_qr_popup_key(app, key),
+        Popup::ModelSelect => return handle_model_popup_key(app, key),
+        Popup::SessionSelect => return handle_session_popup_key(app, key),
+        Popup::NewSession => return handle_new_session_popup_key(app, key),
+        Popup::ThemeSelect => return handle_theme_popup_key(app, key),
         Popup::Help => {
             match key.code {
-                KeyCode::Esc => {
-                    app.navigation.popup = Popup::None;
-                }
+                KeyCode::Esc => app.navigation.popup = Popup::None,
                 KeyCode::Up => app.navigation.scroll_help_up(),
                 KeyCode::Down => app.navigation.scroll_help_down(),
                 _ => {}
             }
-            return Ok(AppAction::None);
+            return Vec::new();
         }
         Popup::Log => {
-            handle_log_popup_key(app, key)?;
-            return Ok(AppAction::None);
+            let _ = handle_log_popup_key(app, key);
+            return Vec::new();
         }
-        Popup::ProviderAuth => {
-            handle_auth_popup_key(app, key, cmd_tx)?;
-            return Ok(AppAction::None);
-        }
-        Popup::ForkTurnSelect => {
-            handle_fork_turn_popup_key(app, key, cmd_tx)?;
-            return Ok(AppAction::None);
-        }
-        Popup::ProfileSelect => {
-            handle_profile_popup_key(app, key, cmd_tx)?;
-            return Ok(AppAction::None);
-        }
-
+        Popup::ProviderAuth => return handle_auth_popup_key(app, key),
+        Popup::ForkTurnSelect => return handle_fork_turn_popup_key(app, key),
+        Popup::ProfileSelect => return handle_profile_popup_key(app, key),
         Popup::None => {}
     }
 
-    // global: tab toggles mode when no popup is active
     if key.code == KeyCode::Tab {
         if !can_send_server_commands(app) {
-            return Ok(AppAction::None);
+            return Vec::new();
         }
-        switch_mode(app, cmd_tx, &app.sessions.next_mode())?;
-        return Ok(AppAction::None);
+        return switch_mode(app, &app.sessions.next_mode());
     }
 
     match app.navigation.screen {
-        Screen::Sessions => handle_sessions_key(app, key, cmd_tx)?,
-        Screen::Chat => return handle_chat_key(app, key, cmd_tx),
-        Screen::Delegate => return handle_delegate_view_key(app, key, cmd_tx),
+        Screen::Sessions => handle_sessions_key(app, key),
+        Screen::Chat => handle_chat_key(app, key),
+        Screen::Delegate => handle_delegate_view_key(app, key),
     }
-    Ok(AppAction::None)
 }
 
-pub(crate) fn handle_mouse(app: &mut App, mouse: MouseEvent) {
+pub(crate) fn handle_mouse(app: &mut App, mouse: MouseEvent) -> Vec<Effect> {
     match (mouse.kind, &app.navigation.screen, &app.navigation.popup) {
         (MouseEventKind::ScrollUp, Screen::Chat | Screen::Delegate, Popup::None) => {
             app.chat.scroll_offset = app.chat.scroll_offset.saturating_add(3);
@@ -677,58 +592,41 @@ pub(crate) fn handle_mouse(app: &mut App, mouse: MouseEvent) {
         }
         _ => {}
     }
-}
-
-/// Persist current app state to `~/.qmt/qmtui.toml`.  Called at every
-/// user-initiated change that should survive a restart.
-pub(crate) fn save_config(app: &App) {
-    let merged = config::TuiConfig::load().with_app_settings(app);
-    merged.save();
+    Vec::new()
 }
 
 /// Handle second key of a ctrl+x chord. Works in any screen.
-pub(crate) fn handle_chord(
-    app: &mut App,
-    key: KeyEvent,
-    cmd_tx: &mpsc::UnboundedSender<Command>,
-) -> anyhow::Result<()> {
+pub(crate) fn handle_chord(app: &mut App, key: KeyEvent) -> Vec<Effect> {
+    let mut effects = Vec::new();
     match key.code {
-        KeyCode::Char('m') => {
-            open_model_popup(app, cmd_tx)?;
-        }
+        KeyCode::Char('m') => effects.extend(open_model_popup(app)),
         KeyCode::Char('n') => {
             if !can_send_server_commands(app) {
-                return Ok(());
+                return effects;
             }
             app.open_new_session_popup();
         }
-        KeyCode::Char('q') => {
-            app.should_quit = true;
-        }
+        KeyCode::Char('q') => effects.push(Effect::Quit),
         KeyCode::Char('e') => {
             app.set_status(LogLevel::Warn, "editor", "external editor unavailable here");
         }
-
         KeyCode::Char('t') => app
             .navigation
             .open_theme_selector(theme::Theme::current_index()),
-        KeyCode::Char('l') => {
-            open_session_popup(app, cmd_tx)?;
-        }
+        KeyCode::Char('l') => effects.extend(open_session_popup(app)),
         KeyCode::Char('a') => {
             if !can_send_server_commands(app) {
-                return Ok(());
+                return effects;
             }
             app.open_auth_popup();
-            cmd_tx.send(Command::ListAuthProviders)?;
+            effects.push(Effect::Command(Command::ListAuthProviders));
         }
-
         KeyCode::Char('p') => {
             if !can_send_server_commands(app) {
-                return Ok(());
+                return effects;
             }
             app.open_profile_popup();
-            cmd_tx.send(Command::ListProfiles)?;
+            effects.push(Effect::Command(Command::ListProfiles));
         }
         KeyCode::Char('j') => {
             if !matches!(app.navigation.screen, Screen::Chat | Screen::Delegate) {
@@ -737,18 +635,17 @@ pub(crate) fn handle_chord(
                     "session",
                     "parent jump only available in chat",
                 );
-                return Ok(());
+                return effects;
             }
             if !can_send_server_commands(app) {
-                return Ok(());
+                return effects;
             }
             if let Some(parent_sid) = app.delegates.parent_session_id.clone() {
-                send_load_session_commands(
-                    cmd_tx,
+                effects.extend(send_load_session_commands(
                     parent_sid,
                     app.current_session_cwd(),
                     app.sessions.agent_id.clone(),
-                )?;
+                ));
             } else {
                 app.set_status(LogLevel::Info, "session", "no parent session");
             }
@@ -761,13 +658,13 @@ pub(crate) fn handle_chord(
                     "fork",
                     "fork selector is only available in chat",
                 );
-                return Ok(());
+                return effects;
             }
             app.open_fork_turn_popup();
         }
         KeyCode::Char('u') => {
             if !can_send_server_commands(app) {
-                return Ok(());
+                return effects;
             }
             if app.chat.is_turn_active() {
                 app.set_status(
@@ -784,16 +681,16 @@ pub(crate) fn handle_chord(
                 app.chat.push_pending_undo(&turn);
                 app.chat.activity = ActivityState::SessionOp(SessionOp::Undo);
                 app.set_status(LogLevel::Info, "session", "undoing...");
-                cmd_tx.send(Command::Undo {
+                effects.push(Effect::Command(Command::Undo {
                     message_id: turn.message_id,
-                })?;
+                }));
             } else {
                 app.set_status(LogLevel::Warn, "session", "nothing to undo");
             }
         }
         KeyCode::Char('r') => {
             if !can_send_server_commands(app) {
-                return Ok(());
+                return effects;
             }
             if app.chat.is_turn_active() {
                 app.set_status(
@@ -806,84 +703,45 @@ pub(crate) fn handle_chord(
             } else if app.chat.can_redo() {
                 app.chat.activity = ActivityState::SessionOp(SessionOp::Redo);
                 app.set_status(LogLevel::Info, "session", "redoing...");
-                cmd_tx.send(Command::Redo)?;
+                effects.push(Effect::Command(Command::Redo));
             } else {
                 app.set_status(LogLevel::Warn, "session", "nothing to redo");
             }
         }
-        _ => {
-            app.set_status(LogLevel::Debug, "input", "unknown chord");
-        }
+        _ => app.set_status(LogLevel::Debug, "input", "unknown chord"),
     }
-    Ok(())
+    effects
 }
 
-pub(crate) fn handle_sessions_key(
-    app: &mut App,
-    key: KeyEvent,
-    cmd_tx: &mpsc::UnboundedSender<Command>,
-) -> anyhow::Result<()> {
-    match key.code {
-        KeyCode::Char('q') | KeyCode::Esc => {
-            app.should_quit = true;
-            return Ok(());
-        }
-        _ => {}
-    }
-
-    if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('o') {
-        match apply_session_fork_toggle_key(app, false) {
-            SessionKeyAction::LoadMoreSessions {
-                group_idx,
-                parent_path,
-            } => {
-                if let Some(request) = app.session_child_page_request(group_idx, &parent_path) {
-                    cmd_tx.send(request)?;
-                }
-            }
-            SessionKeyAction::None => {}
-            _ => {}
-        }
-        return Ok(());
-    }
-
-    match apply_sessions_key(
-        app,
-        if key.modifiers.contains(KeyModifiers::CONTROL) {
-            KeyCode::Null
-        } else {
-            key.code
-        },
-    ) {
+fn session_action_effects(app: &mut App, action: SessionKeyAction) -> Vec<Effect> {
+    match action {
         SessionKeyAction::LoadSession {
             session_id,
             agent_id,
             cwd,
-        } => {
-            send_load_session_commands(
-                cmd_tx,
-                session_id,
-                cwd,
-                agent_id.or_else(|| app.sessions.agent_id.clone()),
-            )?;
-        }
+        } => send_load_session_commands(
+            session_id,
+            cwd,
+            agent_id.or_else(|| app.sessions.agent_id.clone()),
+        ),
         SessionKeyAction::AttachRemoteSession {
             node_id,
             session_id,
-        } => {
-            cmd_tx.send(Command::AttachRemoteSession {
-                node_id,
-                session_id,
-            })?;
-        }
+        } => vec![Effect::Command(Command::AttachRemoteSession {
+            node_id,
+            session_id,
+        })],
         SessionKeyAction::DeleteSession { session_id } => {
-            cmd_tx.send(Command::DeleteSession { session_id })?;
+            vec![Effect::Command(Command::DeleteSession { session_id })]
         }
         SessionKeyAction::DismissRemoteSession { session_id } => {
-            cmd_tx.send(Command::DismissRemoteSession { session_id })?;
+            vec![Effect::Command(Command::DismissRemoteSession {
+                session_id,
+            })]
         }
         SessionKeyAction::NewSession => {
             app.open_new_session_popup();
+            Vec::new()
         }
         SessionKeyAction::LoadMoreSessions {
             group_idx,
@@ -894,107 +752,80 @@ pub(crate) fn handle_sessions_key(
             } else {
                 app.session_child_page_request(group_idx, &parent_path)
             };
-            if let Some(request) = request {
-                cmd_tx.send(request)?;
-            }
+            request
+                .map(|command| vec![Effect::Command(command)])
+                .unwrap_or_default()
         }
-        SessionKeyAction::None => {}
+        SessionKeyAction::None => Vec::new(),
     }
-    Ok(())
 }
 
-pub(crate) fn handle_session_popup_key(
-    app: &mut App,
-    key: KeyEvent,
-    cmd_tx: &mpsc::UnboundedSender<Command>,
-) -> anyhow::Result<()> {
-    // Tab / BackTab: switch between sessions and delegates tabs
-    if matches!(key.code, KeyCode::Tab | KeyCode::BackTab) {
-        app.sessions.switch_session_popup_tab();
-        return Ok(());
-    }
-
-    if app.sessions.session_popup_tab == 1 {
-        // Delegates tab
-        return handle_delegate_popup_key(app, key, cmd_tx);
-    }
-
-    // Sessions tab
-    if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('n') {
-        if !can_send_server_commands(app) {
-            return Ok(());
-        }
-        app.open_new_session_popup();
-        return Ok(());
+pub(crate) fn handle_sessions_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
+    if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+        return vec![Effect::Quit];
     }
 
     if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('o') {
-        match apply_session_fork_toggle_key(app, true) {
-            SessionKeyAction::LoadMoreSessions {
-                group_idx,
-                parent_path,
-            } => {
-                if let Some(request) = app.session_child_page_request(group_idx, &parent_path) {
-                    cmd_tx.send(request)?;
-                }
-            }
-            SessionKeyAction::None => {}
-            _ => {}
+        if let SessionKeyAction::LoadMoreSessions {
+            group_idx,
+            parent_path,
+        } = apply_session_fork_toggle_key(app, false)
+            && let Some(request) = app.session_child_page_request(group_idx, &parent_path)
+        {
+            return vec![Effect::Command(request)];
         }
-        return Ok(());
+        return Vec::new();
     }
 
-    match apply_popup_session_key(
+    let action = apply_sessions_key(
         app,
         if key.modifiers.contains(KeyModifiers::CONTROL) {
             KeyCode::Null
         } else {
             key.code
         },
-    ) {
-        SessionKeyAction::LoadSession {
-            session_id,
-            agent_id,
-            cwd,
-        } => {
-            send_load_session_commands(
-                cmd_tx,
-                session_id,
-                cwd,
-                agent_id.or_else(|| app.sessions.agent_id.clone()),
-            )?;
+    );
+    session_action_effects(app, action)
+}
+
+pub(crate) fn handle_session_popup_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
+    if matches!(key.code, KeyCode::Tab | KeyCode::BackTab) {
+        app.sessions.switch_session_popup_tab();
+        return Vec::new();
+    }
+
+    if app.sessions.session_popup_tab == 1 {
+        return handle_delegate_popup_key(app, key);
+    }
+
+    if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('n') {
+        if can_send_server_commands(app) {
+            app.open_new_session_popup();
         }
-        SessionKeyAction::AttachRemoteSession {
-            node_id,
-            session_id,
-        } => {
-            cmd_tx.send(Command::AttachRemoteSession {
-                node_id,
-                session_id,
-            })?;
-        }
-        SessionKeyAction::DeleteSession { session_id } => {
-            cmd_tx.send(Command::DeleteSession { session_id })?;
-        }
-        SessionKeyAction::DismissRemoteSession { session_id } => {
-            cmd_tx.send(Command::DismissRemoteSession { session_id })?;
-        }
-        SessionKeyAction::LoadMoreSessions {
+        return Vec::new();
+    }
+
+    if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('o') {
+        if let SessionKeyAction::LoadMoreSessions {
             group_idx,
             parent_path,
-        } => {
-            let request = if parent_path.is_empty() {
-                app.session_group_page_request(group_idx)
-            } else {
-                app.session_child_page_request(group_idx, &parent_path)
-            };
-            if let Some(request) = request {
-                cmd_tx.send(request)?;
-            }
+        } = apply_session_fork_toggle_key(app, true)
+            && let Some(request) = app.session_child_page_request(group_idx, &parent_path)
+        {
+            return vec![Effect::Command(request)];
         }
-        SessionKeyAction::NewSession | SessionKeyAction::None => {}
+        return Vec::new();
     }
-    Ok(())
+
+    let action = apply_popup_session_key(
+        app,
+        if key.modifiers.contains(KeyModifiers::CONTROL) {
+            KeyCode::Null
+        } else {
+            key.code
+        },
+    );
+    session_action_effects(app, action)
 }
 
 /// Pure key-handler for the session popup. Returns a [`SessionKeyAction`] that
@@ -1150,82 +981,40 @@ pub(crate) fn apply_session_fork_toggle_key(app: &mut App, popup_items: bool) ->
 
 // ── Delegate view key handler (read-only child session) ──────────────────────
 
-fn handle_delegate_view_key(
-    app: &mut App,
-    key: KeyEvent,
-    cmd_tx: &mpsc::UnboundedSender<Command>,
-) -> anyhow::Result<AppAction> {
+fn handle_delegate_view_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
     match key.code {
-        KeyCode::Up => {
-            app.chat.scroll_offset = app.chat.scroll_offset.saturating_add(1);
-        }
-        KeyCode::Down => {
-            app.chat.scroll_offset = app.chat.scroll_offset.saturating_sub(1);
-        }
-        KeyCode::PageUp => {
-            app.chat.scroll_offset = app.chat.scroll_offset.saturating_add(10);
-        }
-        KeyCode::PageDown => {
-            app.chat.scroll_offset = app.chat.scroll_offset.saturating_sub(10);
-        }
-        KeyCode::Home => {
-            // Scroll to top: set a large offset (draw_messages clamps it).
-            app.chat.scroll_offset = u16::MAX;
-        }
-        KeyCode::End => {
-            app.chat.scroll_offset = 0;
-        }
+        KeyCode::Up => app.chat.scroll_offset = app.chat.scroll_offset.saturating_add(1),
+        KeyCode::Down => app.chat.scroll_offset = app.chat.scroll_offset.saturating_sub(1),
+        KeyCode::PageUp => app.chat.scroll_offset = app.chat.scroll_offset.saturating_add(10),
+        KeyCode::PageDown => app.chat.scroll_offset = app.chat.scroll_offset.saturating_sub(10),
+        KeyCode::Home => app.chat.scroll_offset = u16::MAX,
+        KeyCode::End => app.chat.scroll_offset = 0,
         KeyCode::Esc => {
-            // Go back to parent session.
             if let Some(parent_sid) = app.delegates.parent_session_id.clone() {
-                send_load_session_commands(
-                    cmd_tx,
+                return send_load_session_commands(
                     parent_sid,
                     app.current_session_cwd(),
                     app.sessions.agent_id.clone(),
-                )?;
+                );
             }
         }
         _ => {}
     }
-    Ok(AppAction::None)
+    Vec::new()
 }
 
 // ── Delegate popup key handler ────────────────────────────────────────────────
 
-pub(crate) fn handle_delegate_popup_key(
-    app: &mut App,
-    key: KeyEvent,
-    cmd_tx: &mpsc::UnboundedSender<Command>,
-) -> anyhow::Result<()> {
-    match apply_delegate_popup_key(
+pub(crate) fn handle_delegate_popup_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
+    let action = apply_delegate_popup_key(
         app,
         if key.modifiers.contains(KeyModifiers::CONTROL) {
             KeyCode::Null
         } else {
             key.code
         },
-    ) {
-        SessionKeyAction::LoadSession {
-            session_id,
-            agent_id,
-            cwd,
-        } => {
-            send_load_session_commands(
-                cmd_tx,
-                session_id,
-                cwd,
-                agent_id.or_else(|| app.sessions.agent_id.clone()),
-            )?;
-        }
-        SessionKeyAction::NewSession
-        | SessionKeyAction::AttachRemoteSession { .. }
-        | SessionKeyAction::DeleteSession { .. }
-        | SessionKeyAction::DismissRemoteSession { .. }
-        | SessionKeyAction::LoadMoreSessions { .. }
-        | SessionKeyAction::None => {}
-    }
-    Ok(())
+    );
+    session_action_effects(app, action)
 }
 
 /// Pure key-handler for the delegate popup. Returns a [`SessionKeyAction`]
@@ -1281,39 +1070,30 @@ pub(crate) fn apply_delegate_popup_key(
     SessionKeyAction::None
 }
 
-fn begin_fork_session(
-    app: &mut App,
-    message_id: String,
-    cmd_tx: &mpsc::UnboundedSender<Command>,
-) -> anyhow::Result<()> {
+fn begin_fork_session(app: &mut App, message_id: String) -> Vec<Effect> {
     if app.chat.pending_fork_message_id.is_some() {
         app.set_status(LogLevel::Warn, "fork", "fork already pending");
-        return Ok(());
+        return Vec::new();
     }
     if app.chat.is_turn_active() {
         app.set_status(LogLevel::Warn, "fork", "cannot fork while agent is active");
-        return Ok(());
+        return Vec::new();
     }
     if app.chat.has_pending_session_op() {
         app.set_status(LogLevel::Warn, "fork", "session operation already pending");
-        return Ok(());
+        return Vec::new();
     }
     if message_id.is_empty() {
         app.set_status(LogLevel::Warn, "fork", "selected turn has no message id");
-        return Ok(());
+        return Vec::new();
     }
 
     app.chat.pending_fork_message_id = Some(message_id.clone());
     app.set_status(LogLevel::Info, "fork", "forking session...");
-    cmd_tx.send(Command::ForkSession { message_id })?;
-    Ok(())
+    vec![Effect::Command(Command::ForkSession { message_id })]
 }
 
-pub(crate) fn handle_fork_turn_popup_key(
-    app: &mut App,
-    key: KeyEvent,
-    cmd_tx: &mpsc::UnboundedSender<Command>,
-) -> anyhow::Result<()> {
+pub(crate) fn handle_fork_turn_popup_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
     match key.code {
         KeyCode::Esc => app.navigation.popup = Popup::None,
         KeyCode::Up => app.chat.move_fork_cursor(-1),
@@ -1321,17 +1101,16 @@ pub(crate) fn handle_fork_turn_popup_key(
         KeyCode::Backspace => app.chat.fork_filter_backspace(),
         KeyCode::Enter => {
             if let Some(turn) = app.chat.selected_fork_turn() {
-                begin_fork_session(app, turn.message_id, cmd_tx)?;
-            } else {
-                app.set_status(LogLevel::Warn, "fork", "no forkable turns");
+                return begin_fork_session(app, turn.message_id);
             }
+            app.set_status(LogLevel::Warn, "fork", "no forkable turns");
         }
         KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
             app.chat.fork_filter_insert(c);
         }
         _ => {}
     }
-    Ok(())
+    Vec::new()
 }
 
 pub(crate) fn handle_log_popup_key(app: &mut App, key: KeyEvent) -> anyhow::Result<()> {
@@ -1376,15 +1155,10 @@ pub(crate) fn handle_log_popup_key(app: &mut App, key: KeyEvent) -> anyhow::Resu
     Ok(())
 }
 
-pub(crate) fn handle_profile_popup_key(
-    app: &mut App,
-    key: KeyEvent,
-    cmd_tx: &mpsc::UnboundedSender<Command>,
-) -> anyhow::Result<()> {
+pub(crate) fn handle_profile_popup_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
+    let mut effects = Vec::new();
     match key.code {
-        KeyCode::Esc => {
-            app.navigation.popup = Popup::None;
-        }
+        KeyCode::Esc => app.navigation.popup = Popup::None,
         KeyCode::Up => app.profiles.move_profile_cursor(-1),
         KeyCode::Down => app.profiles.move_profile_cursor(1),
         KeyCode::Backspace => {
@@ -1397,7 +1171,7 @@ pub(crate) fn handle_profile_popup_key(
         }
         KeyCode::Enter => {
             if !can_send_server_commands(app) {
-                return Ok(());
+                return effects;
             }
             if let Some(profile_id) = app
                 .profiles
@@ -1407,9 +1181,9 @@ pub(crate) fn handle_profile_popup_key(
                 app.profiles.active_profile_id = Some(profile_id.clone());
                 if app.current_session_profile_id().is_none() {
                     app.models.clear_profile_agents();
-                    cmd_tx.send(Command::ListProfileAgents {
+                    effects.push(Effect::Command(Command::ListProfileAgents {
                         profile_id: profile_id.clone(),
-                    })?;
+                    }));
                 }
                 app.navigation.popup = Popup::None;
                 app.set_status(
@@ -1417,31 +1191,21 @@ pub(crate) fn handle_profile_popup_key(
                     "profile",
                     format!("new sessions will use {profile_id}"),
                 );
-                save_config(app);
+                effects.push(Effect::PersistConfig);
             } else {
                 app.set_status(LogLevel::Warn, "profile", "no matching profile");
             }
         }
         _ => {}
     }
-    Ok(())
+    effects
 }
 
-pub(crate) fn handle_new_session_popup_key(
-    app: &mut App,
-    key: KeyEvent,
-    cmd_tx: &mpsc::UnboundedSender<Command>,
-) -> anyhow::Result<()> {
+pub(crate) fn handle_new_session_popup_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
     match key.code {
-        KeyCode::Esc => {
-            app.navigation.popup = Popup::None;
-        }
-        KeyCode::Up => {
-            app.sessions.move_new_session_completion_selection(-1);
-        }
-        KeyCode::Down => {
-            app.sessions.move_new_session_completion_selection(1);
-        }
+        KeyCode::Esc => app.navigation.popup = Popup::None,
+        KeyCode::Up => app.sessions.move_new_session_completion_selection(-1),
+        KeyCode::Down => app.sessions.move_new_session_completion_selection(1),
         KeyCode::Tab => {
             app.accept_selected_new_session_completion();
         }
@@ -1471,25 +1235,23 @@ pub(crate) fn handle_new_session_popup_key(
         }
         KeyCode::Enter => {
             if !can_send_server_commands(app) {
-                return Ok(());
+                return Vec::new();
             }
             let cwd = app.normalize_new_session_path(&app.sessions.new_session_path);
             app.navigation.popup = Popup::None;
-            cmd_tx.send(Command::NewSession {
+            return vec![Effect::Command(Command::NewSession {
                 cwd,
                 profile_id: app.profiles.active_profile_id.clone(),
-            })?;
+            })];
         }
         _ => {}
     }
-    Ok(())
+    Vec::new()
 }
 
-pub(crate) fn handle_theme_popup_key(app: &mut App, key: KeyEvent) -> anyhow::Result<()> {
+pub(crate) fn handle_theme_popup_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
     match key.code {
-        KeyCode::Esc => {
-            app.navigation.popup = Popup::None;
-        }
+        KeyCode::Esc => app.navigation.popup = Popup::None,
         KeyCode::Up => app.navigation.move_theme_cursor_up(),
         KeyCode::Down => {
             let filtered_len = app
@@ -1507,7 +1269,7 @@ pub(crate) fn handle_theme_popup_key(app: &mut App, key: KeyEvent) -> anyhow::Re
                 theme::Theme::begin_frame();
                 app.render.invalidate_theme_caches();
                 app.navigation.popup = Popup::None;
-                save_config(app);
+                return vec![Effect::PersistConfig];
             }
         }
         KeyCode::Backspace => app.navigation.theme_filter_backspace(),
@@ -1516,21 +1278,17 @@ pub(crate) fn handle_theme_popup_key(app: &mut App, key: KeyEvent) -> anyhow::Re
         }
         _ => {}
     }
-    Ok(())
+    Vec::new()
 }
 
-pub(crate) fn handle_chat_key(
-    app: &mut App,
-    key: KeyEvent,
-    cmd_tx: &mpsc::UnboundedSender<Command>,
-) -> anyhow::Result<AppAction> {
+pub(crate) fn handle_chat_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
     if app.composer.input_line_width == 0 {
         app.composer.input_line_width = 1;
     }
     let input_blocked = app.chat.input_blocked_by_activity();
+    let mut effects = Vec::new();
     match key.code {
         KeyCode::Esc => {
-            // Dismiss whichever completion popup is open first.
             if app.composer.mention_state.is_some() || app.composer.slash_state.is_some() {
                 app.composer.mention_state = None;
                 app.composer.slash_state = None;
@@ -1539,7 +1297,7 @@ pub(crate) fn handle_chat_key(
                 if app.chat.cancel_confirm_active() {
                     app.chat.clear_cancel_confirm();
                     app.set_status(LogLevel::Warn, "activity", "stopping...");
-                    cmd_tx.send(Command::CancelSession)?;
+                    effects.push(Effect::Command(Command::CancelSession));
                 } else {
                     app.arm_cancel_confirm();
                 }
@@ -1548,29 +1306,32 @@ pub(crate) fn handle_chat_key(
             }
         }
         KeyCode::Enter => {
-            // 1. Complete slash completion, then fall through to execute.
             if app.composer.slash_state.is_some() {
                 app.composer.accept_selected_slash_completion();
             }
-            // 2. Try slash command execution (input starts with '/').
             if !app.composer.input.is_empty() && app.composer.input.trim_start().starts_with('/') {
-                match try_execute_slash_command(app, cmd_tx)? {
-                    SlashResult::OpenEditor => return Ok(AppAction::OpenExternalEditor),
-                    SlashResult::Handled => return Ok(AppAction::None),
+                let (result, slash_effects) = try_execute_slash_command(app);
+                effects.extend(slash_effects);
+                match result {
+                    SlashResult::OpenEditor => {
+                        effects.push(Effect::OpenExternalEditor {
+                            initial_text: app.composer.input.clone(),
+                        });
+                        return effects;
+                    }
+                    SlashResult::Handled => return effects,
                     SlashResult::NotACommand => {}
                 }
             }
-            // 3. Accept mention completion.
             if app.composer.mention_state.is_some() && app.composer.accept_selected_mention() {
                 if app.composer.prepare_file_index_request() {
-                    cmd_tx.send(Command::GetFileIndex)?;
+                    effects.push(Effect::Command(Command::GetFileIndex));
                 }
-                return Ok(AppAction::None);
+                return effects;
             }
-            // 4. Normal prompt send.
             if !app.composer.input.is_empty() {
                 if input_blocked || !can_send_server_commands(app) {
-                    return Ok(AppAction::None);
+                    return effects;
                 }
                 let (text, links) = app
                     .composer
@@ -1578,7 +1339,7 @@ pub(crate) fn handle_chat_key(
                 let text = text.trim().to_string();
                 let _ = app.take_input();
                 if text.is_empty() {
-                    return Ok(AppAction::None);
+                    return effects;
                 }
                 let mut prompt = vec![PromptBlock::Text { text: text.clone() }];
                 for path in links {
@@ -1588,14 +1349,7 @@ pub(crate) fn handle_chat_key(
                     });
                 }
                 let local_id = app.push_pending_prompt(text);
-                if let Err(error) = cmd_tx.send(Command::Prompt {
-                    prompt,
-                    local_id: local_id.clone(),
-                }) {
-                    app.chat.rollback_pending_prompt(&local_id);
-                    app.render.invalidate_card_cache();
-                    return Err(error.into());
-                }
+                effects.push(Effect::Command(Command::Prompt { prompt, local_id }));
             }
         }
         KeyCode::Tab if !input_blocked => {
@@ -1605,18 +1359,18 @@ pub(crate) fn handle_chat_key(
                 && app.composer.accept_selected_mention()
                 && app.composer.prepare_file_index_request()
             {
-                cmd_tx.send(Command::GetFileIndex)?;
+                effects.push(Effect::Command(Command::GetFileIndex));
             }
         }
         KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) && !input_blocked => {
             app.composer.input_insert(c);
             if app.composer.prepare_file_index_request() {
-                cmd_tx.send(Command::GetFileIndex)?;
+                effects.push(Effect::Command(Command::GetFileIndex));
             }
         }
         KeyCode::Up => {
             if input_blocked {
-                return Ok(AppAction::None);
+                return effects;
             }
             if app.composer.slash_state.is_some() {
                 app.composer.move_slash_selection(-1);
@@ -1628,7 +1382,7 @@ pub(crate) fn handle_chat_key(
         }
         KeyCode::Down => {
             if input_blocked {
-                return Ok(AppAction::None);
+                return effects;
             }
             if app.composer.slash_state.is_some() {
                 app.composer.move_slash_selection(1);
@@ -1638,39 +1392,23 @@ pub(crate) fn handle_chat_key(
                 app.composer.input_down_visual(2);
             }
         }
-        KeyCode::PageUp => {
-            app.chat.scroll_offset = app.chat.scroll_offset.saturating_add(10);
-        }
-        KeyCode::PageDown => {
-            app.chat.scroll_offset = app.chat.scroll_offset.saturating_sub(10);
-        }
-        KeyCode::Backspace if !input_blocked => {
-            app.composer.input_backspace();
-        }
-        KeyCode::Delete if !input_blocked => {
-            app.composer.input_delete();
-        }
-        KeyCode::Left if !input_blocked => {
-            app.composer.input_left();
-        }
-        KeyCode::Right if !input_blocked => {
-            app.composer.input_right();
-        }
-        KeyCode::Home if !input_blocked => {
-            app.composer.input_home();
-        }
+        KeyCode::PageUp => app.chat.scroll_offset = app.chat.scroll_offset.saturating_add(10),
+        KeyCode::PageDown => app.chat.scroll_offset = app.chat.scroll_offset.saturating_sub(10),
+        KeyCode::Backspace if !input_blocked => app.composer.input_backspace(),
+        KeyCode::Delete if !input_blocked => app.composer.input_delete(),
+        KeyCode::Left if !input_blocked => app.composer.input_left(),
+        KeyCode::Right if !input_blocked => app.composer.input_right(),
+        KeyCode::Home if !input_blocked => app.composer.input_home(),
         KeyCode::End => {
-            if input_blocked {
+            if input_blocked || app.composer.input.is_empty() {
                 app.chat.scroll_offset = 0;
-            } else if app.composer.input.is_empty() {
-                app.chat.scroll_offset = 0; // snap to bottom
             } else {
                 app.composer.input_end();
             }
         }
         _ => {}
     }
-    Ok(AppAction::None)
+    effects
 }
 
 // ── Mode switching ─────────────────────────────────────────────────────────────
@@ -1678,19 +1416,12 @@ pub(crate) fn handle_chat_key(
 /// Switch the agent mode to `target` (e.g. "build", "plan").
 /// Caches the outgoing mode state, sends `SetAgentMode`, restores cached state
 /// for the target mode, and persists config/cache.
-fn switch_mode(
-    app: &mut App,
-    cmd_tx: &mpsc::UnboundedSender<Command>,
-    target: &str,
-) -> anyhow::Result<()> {
-    cmd_tx.send(Command::SetAgentMode {
+fn switch_mode(app: &mut App, target: &str) -> Vec<Effect> {
+    let command = Effect::Command(Command::SetAgentMode {
         mode: target.to_string(),
-    })?;
-
+    });
     app.sessions.apply_mode_transition(target);
-
-    save_config(app);
-    Ok(())
+    vec![command, Effect::PersistConfig]
 }
 
 // ── Slash command execution ────────────────────────────────────────────────────
@@ -1711,11 +1442,7 @@ enum SlashResult {
 /// Expects `app.composer.input` to begin with `/`.  Always calls `app.take_input()`
 /// before performing any side-effects so the command text is cleared first
 /// (this allows `/undo` to optionally restore the previous turn text).
-fn try_execute_slash_command(
-    app: &mut App,
-    cmd_tx: &mpsc::UnboundedSender<Command>,
-) -> anyhow::Result<SlashResult> {
-    // Extract the command name (first word after '/') and optional argument.
+fn try_execute_slash_command(app: &mut App) -> (SlashResult, Vec<Effect>) {
     let after_slash = app.composer.input.trim_start_matches('/');
     let cmd = after_slash
         .split_whitespace()
@@ -1727,9 +1454,10 @@ fn try_execute_slash_command(
         .unwrap_or("")
         .trim()
         .to_string();
+    let mut effects = Vec::new();
 
     if cmd.is_empty() {
-        return Ok(SlashResult::NotACommand);
+        return (SlashResult::NotACommand, effects);
     }
 
     match cmd.as_str() {
@@ -1741,10 +1469,10 @@ fn try_execute_slash_command(
                     "model",
                     "model select is only available in chat",
                 );
-                return Ok(SlashResult::Handled);
+                return (SlashResult::Handled, effects);
             }
             if !can_send_server_commands(app) {
-                return Ok(SlashResult::Handled);
+                return (SlashResult::Handled, effects);
             }
             app.navigation.popup = Popup::ModelSelect;
             if arg.is_empty() {
@@ -1757,11 +1485,10 @@ fn try_execute_slash_command(
         "mode" => {
             app.take_input();
             if !can_send_server_commands(app) {
-                return Ok(SlashResult::Handled);
+                return (SlashResult::Handled, effects);
             }
             if arg.is_empty() {
-                // No arg: cycle to next mode (same as Tab).
-                switch_mode(app, cmd_tx, &app.sessions.next_mode())?;
+                effects.extend(switch_mode(app, &app.sessions.next_mode()));
             } else {
                 match arg.as_str() {
                     "build" | "plan" => {
@@ -1772,28 +1499,26 @@ fn try_execute_slash_command(
                                 format!("already in {} mode", arg),
                             );
                         } else {
-                            switch_mode(app, cmd_tx, &arg)?;
+                            effects.extend(switch_mode(app, &arg));
                         }
                     }
-                    _ => {
-                        app.set_status(
-                            LogLevel::Warn,
-                            "mode",
-                            format!("unknown mode: {} (try build or plan)", arg),
-                        );
-                    }
+                    _ => app.set_status(
+                        LogLevel::Warn,
+                        "mode",
+                        format!("unknown mode: {} (try build or plan)", arg),
+                    ),
                 }
             }
         }
         "review" => {
             app.take_input();
             if !can_send_server_commands(app) {
-                return Ok(SlashResult::Handled);
+                return (SlashResult::Handled, effects);
             }
             if app.sessions.agent_mode == "review" {
                 app.set_status(LogLevel::Info, "mode", "already in review mode");
             } else {
-                switch_mode(app, cmd_tx, "review")?;
+                effects.extend(switch_mode(app, "review"));
             }
         }
         "thinking" => {
@@ -1817,10 +1542,11 @@ fn try_execute_slash_command(
                     );
                 } else {
                     if !can_send_server_commands(app) {
-                        return Ok(SlashResult::Handled);
+                        return (SlashResult::Handled, effects);
                     }
-                    let msg = app.set_reasoning_effort(Some(&level)).unwrap();
-                    cmd_tx.send(msg)?;
+                    effects.push(Effect::Command(
+                        app.set_reasoning_effort(Some(&level)).unwrap(),
+                    ));
                     app.set_status(
                         LogLevel::Info,
                         "model",
@@ -1837,25 +1563,25 @@ fn try_execute_slash_command(
         "profile" => {
             app.take_input();
             if !can_send_server_commands(app) {
-                return Ok(SlashResult::Handled);
+                return (SlashResult::Handled, effects);
             }
             if arg.is_empty() {
                 app.open_profile_popup();
-                cmd_tx.send(Command::ListProfiles)?;
+                effects.push(Effect::Command(Command::ListProfiles));
             } else if let Some(profile_id) = app.profiles.find_profile_id(&arg) {
                 app.profiles.active_profile_id = Some(profile_id.clone());
                 if app.current_session_profile_id().is_none() {
                     app.models.clear_profile_agents();
-                    cmd_tx.send(Command::ListProfileAgents {
+                    effects.push(Effect::Command(Command::ListProfileAgents {
                         profile_id: profile_id.clone(),
-                    })?;
+                    }));
                 }
                 app.set_status(
                     LogLevel::Info,
                     "profile",
                     format!("new sessions will use {profile_id}"),
                 );
-                save_config(app);
+                effects.push(Effect::PersistConfig);
             } else {
                 app.set_status(
                     LogLevel::Warn,
@@ -1867,12 +1593,12 @@ fn try_execute_slash_command(
         "sessions" => {
             app.take_input();
             if !can_send_server_commands(app) {
-                return Ok(SlashResult::Handled);
+                return (SlashResult::Handled, effects);
             }
             app.navigation.popup = Popup::SessionSelect;
             app.sessions.reset_browser_for_open();
             if let Some(request) = app.begin_session_discovery() {
-                cmd_tx.send(request)?;
+                effects.push(Effect::Command(request));
             }
         }
         "delegates" => {
@@ -1883,17 +1609,17 @@ fn try_execute_slash_command(
                     "delegates",
                     "delegates only available in chat",
                 );
-                return Ok(SlashResult::Handled);
+                return (SlashResult::Handled, effects);
             }
             if !can_send_server_commands(app) {
-                return Ok(SlashResult::Handled);
+                return (SlashResult::Handled, effects);
             }
             app.open_delegate_popup();
         }
         "new" => {
             app.take_input();
             if !can_send_server_commands(app) {
-                return Ok(SlashResult::Handled);
+                return (SlashResult::Handled, effects);
             }
             app.open_new_session_popup();
         }
@@ -1903,26 +1629,24 @@ fn try_execute_slash_command(
         }
         "logs" => {
             app.take_input();
-            app.navigation.popup = Popup::Log;
-            app.diagnostics.log_cursor = app.filtered_logs().len().saturating_sub(1);
-            app.diagnostics.log_filter.clear();
+            open_log_popup(app);
         }
         "auth" => {
             app.take_input();
             if !can_send_server_commands(app) {
-                return Ok(SlashResult::Handled);
+                return (SlashResult::Handled, effects);
             }
             app.open_auth_popup();
-            cmd_tx.send(Command::ListAuthProviders)?;
+            effects.push(Effect::Command(Command::ListAuthProviders));
         }
         "fork" => {
             app.take_input();
             if app.navigation.screen != Screen::Chat {
                 app.set_status(LogLevel::Warn, "fork", "forking is only available in chat");
-                return Ok(SlashResult::Handled);
+                return (SlashResult::Handled, effects);
             }
             if !can_send_server_commands(app) {
-                return Ok(SlashResult::Handled);
+                return (SlashResult::Handled, effects);
             }
             if app.chat.pending_fork_message_id.is_some() {
                 app.set_status(LogLevel::Warn, "fork", "fork already pending");
@@ -1931,17 +1655,15 @@ fn try_execute_slash_command(
             } else if app.chat.is_turn_active() {
                 app.set_status(LogLevel::Warn, "fork", "cannot fork while agent is active");
             } else if let Some(turn) = app.chat.latest_fork_boundary() {
-                begin_fork_session(app, turn.message_id, cmd_tx)?;
+                effects.extend(begin_fork_session(app, turn.message_id));
             } else {
                 app.set_status(LogLevel::Warn, "fork", "no forkable turns");
             }
         }
         "undo" => {
-            // Clear '/undo' first so the undo logic can optionally restore
-            // the previous turn's text into the now-empty input.
             app.take_input();
             if !can_send_server_commands(app) {
-                return Ok(SlashResult::Handled);
+                return (SlashResult::Handled, effects);
             }
             if app.chat.is_turn_active() {
                 app.set_status(
@@ -1958,9 +1680,9 @@ fn try_execute_slash_command(
                 app.chat.push_pending_undo(&turn);
                 app.chat.activity = ActivityState::SessionOp(SessionOp::Undo);
                 app.set_status(LogLevel::Info, "session", "undoing...");
-                cmd_tx.send(Command::Undo {
+                effects.push(Effect::Command(Command::Undo {
                     message_id: turn.message_id,
-                })?;
+                }));
             } else {
                 app.set_status(LogLevel::Warn, "session", "nothing to undo");
             }
@@ -1968,7 +1690,7 @@ fn try_execute_slash_command(
         "redo" => {
             app.take_input();
             if !can_send_server_commands(app) {
-                return Ok(SlashResult::Handled);
+                return (SlashResult::Handled, effects);
             }
             if app.chat.is_turn_active() {
                 app.set_status(
@@ -1981,48 +1703,44 @@ fn try_execute_slash_command(
             } else if app.chat.can_redo() {
                 app.chat.activity = ActivityState::SessionOp(SessionOp::Redo);
                 app.set_status(LogLevel::Info, "session", "redoing...");
-                cmd_tx.send(Command::Redo)?;
+                effects.push(Effect::Command(Command::Redo));
             } else {
                 app.set_status(LogLevel::Warn, "session", "nothing to redo");
             }
         }
         "editor" => {
             app.take_input();
-            return Ok(SlashResult::OpenEditor);
+            return (SlashResult::OpenEditor, effects);
         }
         "cancel" => {
             app.take_input();
             if app.chat.has_cancellable_activity() {
                 app.chat.clear_cancel_confirm();
                 app.set_status(LogLevel::Warn, "activity", "stopping...");
-                cmd_tx.send(Command::CancelSession)?;
+                effects.push(Effect::Command(Command::CancelSession));
             } else {
                 app.set_status(LogLevel::Warn, "activity", "nothing to cancel");
             }
         }
         "quit" => {
             app.take_input();
-            app.should_quit = true;
+            effects.push(Effect::Quit);
         }
-        _ => return Ok(SlashResult::NotACommand),
+        _ => return (SlashResult::NotACommand, effects),
     }
 
-    Ok(SlashResult::Handled)
+    (SlashResult::Handled, effects)
 }
 
 // ── Auth popup key handler ─────────────────────────────────────────────────────
 
-pub(crate) fn handle_auth_popup_key(
-    app: &mut App,
-    key: KeyEvent,
-    cmd_tx: &mpsc::UnboundedSender<Command>,
-) -> anyhow::Result<()> {
-    // Clipboard fallback popup: any key dismisses it
+pub(crate) fn handle_auth_popup_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
     if app.auth.clipboard_fallback.is_some() {
         app.auth.clipboard_fallback = None;
-        return Ok(());
+        return Vec::new();
     }
 
+    let mut effects = Vec::new();
     match app.auth.panel {
         AuthPanel::List => match key.code {
             KeyCode::Esc => {
@@ -2048,7 +1766,6 @@ pub(crate) fn handle_auth_popup_key(
                     app.auth.ui_notice = None;
                     if provider.is_unconfigurable() {
                         app.auth.selected = Some(real_idx);
-                        // Stay in list — the draw fn shows the info message
                     } else if provider.is_api_key_only() {
                         app.auth.selected = Some(real_idx);
                         app.auth.panel = AuthPanel::ApiKeyInput;
@@ -2058,35 +1775,29 @@ pub(crate) fn handle_auth_popup_key(
                         && provider.oauth_status != Some(OAuthStatus::Connected)
                     {
                         app.auth.selected = Some(real_idx);
-                        let provider_id = provider.provider.clone();
-                        cmd_tx.send(Command::StartOAuthLogin {
-                            provider: provider_id,
-                        })?;
+                        effects.push(Effect::Command(Command::StartOAuthLogin {
+                            provider: provider.provider.clone(),
+                        }));
                     } else {
-                        // Multi-method or connected OAuth-only: select for detail
                         app.auth.selected = Some(real_idx);
                     }
                 }
             }
             KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                // Ctrl+D: disconnect/clear credential for selected provider
                 if let Some(idx) = app.auth.selected {
                     let provider = &app.auth.providers[idx];
                     if provider.oauth_status == Some(OAuthStatus::Connected) {
-                        let provider_id = provider.provider.clone();
-                        cmd_tx.send(Command::DisconnectOAuth {
-                            provider: provider_id,
-                        })?;
+                        effects.push(Effect::Command(Command::DisconnectOAuth {
+                            provider: provider.provider.clone(),
+                        }));
                     } else if provider.has_stored_api_key {
-                        let provider_id = provider.provider.clone();
-                        cmd_tx.send(Command::ClearApiToken {
-                            provider: provider_id,
-                        })?;
+                        effects.push(Effect::Command(Command::ClearApiToken {
+                            provider: provider.provider.clone(),
+                        }));
                     }
                 }
             }
             KeyCode::Char('k') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                // Ctrl+K: open API key panel for selected provider
                 let filtered = app.auth.filtered_providers();
                 if let Some(&(real_idx, _)) = filtered.get(app.auth.cursor) {
                     let provider = &app.auth.providers[real_idx];
@@ -2100,17 +1811,15 @@ pub(crate) fn handle_auth_popup_key(
                 }
             }
             KeyCode::Char('o') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                // Ctrl+O: start OAuth for selected provider
                 let filtered = app.auth.filtered_providers();
                 if let Some(&(real_idx, _)) = filtered.get(app.auth.cursor) {
                     let provider = &app.auth.providers[real_idx];
                     if provider.supports_oauth {
                         app.auth.ui_notice = None;
                         app.auth.selected = Some(real_idx);
-                        let provider_id = provider.provider.clone();
-                        cmd_tx.send(Command::StartOAuthLogin {
-                            provider: provider_id,
-                        })?;
+                        effects.push(Effect::Command(Command::StartOAuthLogin {
+                            provider: provider.provider.clone(),
+                        }));
                     }
                 }
             }
@@ -2134,22 +1843,19 @@ pub(crate) fn handle_auth_popup_key(
                 if let Some(idx) = app.auth.selected {
                     let trimmed = app.auth.api_key_input.trim().to_string();
                     if !trimmed.is_empty() {
-                        let provider = app.auth.providers[idx].provider.clone();
-                        cmd_tx.send(Command::SetApiToken {
-                            provider,
+                        effects.push(Effect::Command(Command::SetApiToken {
+                            provider: app.auth.providers[idx].provider.clone(),
                             api_key: trimmed,
-                        })?;
+                        }));
                     }
                 }
             }
-            KeyCode::Tab => {
-                app.auth.api_key_masked = !app.auth.api_key_masked;
-            }
+            KeyCode::Tab => app.auth.api_key_masked = !app.auth.api_key_masked,
             KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                // Clear stored key
                 if let Some(idx) = app.auth.selected {
-                    let provider = app.auth.providers[idx].provider.clone();
-                    cmd_tx.send(Command::ClearApiToken { provider })?;
+                    effects.push(Effect::Command(Command::ClearApiToken {
+                        provider: app.auth.providers[idx].provider.clone(),
+                    }));
                 }
             }
             KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -2189,16 +1895,19 @@ pub(crate) fn handle_auth_popup_key(
                 app.auth.oauth_response_cursor = 0;
             }
             KeyCode::Char('y') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                // Copy authorization URL to clipboard (C-y to avoid global C-c quit)
                 if let Some(ref flow) = app.auth.oauth_flow {
-                    let provider = flow.provider.clone();
-                    let url = flow.authorization_url.clone();
-                    try_copy_to_clipboard(app, &provider, &url);
+                    app.auth.ui_notice = None;
+                    app.auth.clipboard_fallback = None;
+                    effects.push(Effect::CopyToClipboard {
+                        target: ClipboardTarget::Auth {
+                            provider: flow.provider.clone(),
+                        },
+                        text: flow.authorization_url.clone(),
+                    });
                 }
             }
             KeyCode::Enter => {
                 if let Some(ref flow) = app.auth.oauth_flow {
-                    let flow_id = flow.flow_id.clone();
                     let is_device_poll = flow.flow_kind == OAuthFlowKind::DevicePoll;
                     let response = if is_device_poll {
                         String::new()
@@ -2206,7 +1915,10 @@ pub(crate) fn handle_auth_popup_key(
                         app.auth.oauth_response.trim().to_string()
                     };
                     if is_device_poll || !response.is_empty() {
-                        cmd_tx.send(Command::CompleteOAuthLogin { flow_id, response })?;
+                        effects.push(Effect::Command(Command::CompleteOAuthLogin {
+                            flow_id: flow.flow_id.clone(),
+                            response,
+                        }));
                     }
                 }
             }
@@ -2242,68 +1954,16 @@ pub(crate) fn handle_auth_popup_key(
             _ => {}
         },
     }
-    Ok(())
+    effects
 }
 
-/// Try to copy text to the system clipboard. On failure, store in the fallback
-/// field so the draw function can show a popup with the URL for manual copy.
-fn copy_text_to_clipboard(text: &str) -> bool {
-    use std::io::Write;
-    use std::process::{Command, Stdio};
-
-    let commands = [
-        ("xclip", &["-selection", "clipboard"] as &[&str]),
-        ("xsel", &["--clipboard", "--input"]),
-        ("wl-copy", &[]),
-        ("pbcopy", &[]),
-    ];
-
-    for (cmd, args) in &commands {
-        if let Ok(mut child) = Command::new(cmd)
-            .args(*args)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-        {
-            if let Some(ref mut stdin) = child.stdin {
-                let _ = stdin.write_all(text.as_bytes());
-            }
-            if child.wait().is_ok_and(|s| s.success()) {
-                return true;
-            }
-        }
-    }
-    false
-}
-
-fn try_copy_to_clipboard(app: &mut App, provider: &str, text: &str) {
-    app.auth.ui_notice = None;
-    app.auth.clipboard_fallback = None;
-    if copy_text_to_clipboard(text) {
-        app.auth.ui_notice = Some(AuthUiNotice {
-            provider: Some(provider.to_string()),
-            success: true,
-            message: "Copied to clipboard".into(),
-        });
-    } else {
-        app.auth.ui_notice = None;
-        app.auth.clipboard_fallback = Some(text.to_string());
-    }
-}
-
-pub(crate) fn handle_model_popup_key(
-    app: &mut App,
-    key: KeyEvent,
-    cmd_tx: &mpsc::UnboundedSender<Command>,
-) -> anyhow::Result<()> {
+pub(crate) fn handle_model_popup_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
+    let mut effects = Vec::new();
     match key.code {
-        KeyCode::Esc => {
-            app.navigation.popup = Popup::None;
-        }
+        KeyCode::Esc => app.navigation.popup = Popup::None,
         KeyCode::Tab | KeyCode::BackTab => {
             if !app.models.model_popup_has_tabs() {
-                return Ok(());
+                return effects;
             }
             let agent_id = app
                 .models
@@ -2344,18 +2004,18 @@ pub(crate) fn handle_model_popup_key(
                 {
                     if !app.sessions.current_session_is_remote() {
                         if let Some(session_id) = app.sessions.session_id.clone() {
-                            cmd_tx.send(Command::SetSessionModel {
+                            effects.push(Effect::Command(Command::SetSessionModel {
                                 session_id,
                                 model_id: model.id.clone(),
                                 node_id: model.node_id.clone(),
-                            })?;
+                            }));
                         }
                         app.models.apply_model_selection_from_entry(&model);
                         if app.models.reasoning_effort.is_some() {
                             app.models.reasoning_effort = None;
-                            cmd_tx.send(Command::SetReasoningEffort {
+                            effects.push(Effect::Command(Command::SetReasoningEffort {
                                 reasoning_effort: "auto".into(),
-                            })?;
+                            }));
                         }
                     }
                     app.set_status(LogLevel::Info, "model", format!("session: {}", model.label));
@@ -2371,12 +2031,12 @@ pub(crate) fn handle_model_popup_key(
                     if app.delegates.parent_session_id.is_none()
                         && let Some(session_id) = app.sessions.session_id.clone()
                     {
-                        cmd_tx.send(Command::SetDelegateModel {
+                        effects.push(Effect::Command(Command::SetDelegateModel {
                             session_id,
                             agent_id,
                             model_id: Some(model.id.clone()),
                             node_id: model.node_id.clone(),
-                        })?;
+                        }));
                     }
                     app.set_status(
                         LogLevel::Info,
@@ -2384,7 +2044,7 @@ pub(crate) fn handle_model_popup_key(
                         format!("{tab_label}: {}", model.label),
                     );
                 }
-                save_config(app);
+                effects.push(Effect::PersistConfig);
             }
         }
         KeyCode::Delete
@@ -2403,19 +2063,19 @@ pub(crate) fn handle_model_popup_key(
                 if app.delegates.parent_session_id.is_none()
                     && let Some(session_id) = app.sessions.session_id.clone()
                 {
-                    cmd_tx.send(Command::SetDelegateModel {
+                    effects.push(Effect::Command(Command::SetDelegateModel {
                         session_id,
                         agent_id,
                         model_id: None,
                         node_id: None,
-                    })?;
+                    }));
                 }
                 app.set_status(
                     LogLevel::Info,
                     "model",
                     "delegate model uses profile default",
                 );
-                save_config(app);
+                effects.push(Effect::PersistConfig);
             }
         }
         KeyCode::Backspace => app.models.model_filter_backspace(),
@@ -2424,7 +2084,7 @@ pub(crate) fn handle_model_popup_key(
         }
         _ => {}
     }
-    Ok(())
+    effects
 }
 
 // ── Pure key logic for the sessions screen ────────────────────────────────────
@@ -2564,8 +2224,8 @@ mod model_popup_tests {
     use crate::domain::model::ModelEntry;
     use crate::domain::profile::{AgentInfo, ProfileInfo};
     use crate::domain::session::{SessionGroup, SessionSummary};
+    use crate::runtime::TestEffects;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-    use tokio::sync::mpsc;
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::empty())
@@ -2573,26 +2233,29 @@ mod model_popup_tests {
 
     #[test]
     fn mention_typing_prepares_and_sends_file_index_request_once() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
 
-        handle_chat_key(&mut app, key(KeyCode::Char('@')), &tx).unwrap();
-        handle_chat_key(&mut app, key(KeyCode::Char('s')), &tx).unwrap();
+        effects.extend(handle_chat_key(&mut app, key(KeyCode::Char('@'))));
+        effects.extend(handle_chat_key(&mut app, key(KeyCode::Char('s'))));
 
-        assert!(matches!(rx.try_recv(), Ok(Command::GetFileIndex)));
-        assert!(rx.try_recv().is_err());
+        assert!(matches!(
+            effects.next_command(),
+            Some(Command::GetFileIndex)
+        ));
+        assert!(effects.next_command().is_none());
         assert!(app.composer.file_index_loading);
         assert_eq!(app.composer.input, "@s");
     }
 
     #[test]
     fn prompt_send_is_optimistic_and_clears_input_before_dispatch() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.connection.conn = ConnState::Connected;
         app.composer.replace_input(" hello ".into());
 
-        handle_chat_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        effects.extend(handle_chat_key(&mut app, key(KeyCode::Enter)));
 
         assert!(app.composer.input.is_empty());
         let local_id = match app.chat.messages.as_slice() {
@@ -2605,8 +2268,8 @@ mod model_popup_tests {
             messages => panic!("unexpected optimistic messages: {messages:?}"),
         };
         assert!(matches!(
-            rx.try_recv(),
-            Ok(Command::Prompt { prompt, local_id: sent_id })
+            effects.next_command(),
+            Some(Command::Prompt { prompt, local_id: sent_id })
                 if sent_id == local_id
                     && matches!(prompt.as_slice(), [PromptBlock::Text { text }] if text == "hello")
         ));
@@ -2614,8 +2277,7 @@ mod model_popup_tests {
 
     #[test]
     fn failed_prompt_dispatch_rolls_back_only_optimistic_message() {
-        let (tx, rx) = mpsc::unbounded_channel::<Command>();
-        drop(rx);
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.connection.conn = ConnState::Connected;
         app.chat.messages.push(ChatEntry::Assistant {
@@ -2625,7 +2287,18 @@ mod model_popup_tests {
         });
         app.composer.replace_input("send me".into());
 
-        assert!(handle_chat_key(&mut app, key(KeyCode::Enter), &tx).is_err());
+        effects.extend(handle_chat_key(&mut app, key(KeyCode::Enter)));
+        let command = effects.next_command().expect("prompt effect");
+        assert!(matches!(command, Command::Prompt { .. }));
+        crate::application::update(
+            &mut app,
+            crate::application::AppEvent::Runtime(
+                crate::application::RuntimeEvent::CommandFailed {
+                    command,
+                    message: "command channel closed".into(),
+                },
+            ),
+        );
 
         assert!(app.composer.input.is_empty());
         assert!(matches!(
@@ -2771,14 +2444,11 @@ mod model_popup_tests {
         app.navigation.command_palette_filter = "old".into();
         app.navigation.theme_filter = "keep".into();
         app.navigation.help_scroll = 9;
-
-        let (tx, _rx) = mpsc::unbounded_channel();
-        handle_key(
+        let mut effects = TestEffects::default();
+        effects.extend(handle_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert!(matches!(app.navigation.popup, Popup::CommandPalette));
         assert!(!app.navigation.chord);
@@ -2793,19 +2463,19 @@ mod model_popup_tests {
         let mut app = App::new();
         app.navigation.open_help();
         app.sessions.session_filter = "keep".into();
-        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_key(&mut app, key(KeyCode::Char('x')), &tx).unwrap();
+        effects.extend(handle_key(&mut app, key(KeyCode::Char('x'))));
         assert_eq!(app.sessions.session_filter, "keep");
         assert_eq!(app.navigation.popup, Popup::Help);
 
-        handle_key(&mut app, key(KeyCode::Down), &tx).unwrap();
+        effects.extend(handle_key(&mut app, key(KeyCode::Down)));
         assert_eq!(app.navigation.help_scroll, 1);
-        handle_key(&mut app, key(KeyCode::Up), &tx).unwrap();
-        handle_key(&mut app, key(KeyCode::Up), &tx).unwrap();
+        effects.extend(handle_key(&mut app, key(KeyCode::Up)));
+        effects.extend(handle_key(&mut app, key(KeyCode::Up)));
         assert_eq!(app.navigation.help_scroll, 0);
 
-        handle_key(&mut app, key(KeyCode::Esc), &tx).unwrap();
+        effects.extend(handle_key(&mut app, key(KeyCode::Esc)));
         assert_eq!(app.navigation.popup, Popup::None);
     }
 
@@ -2816,9 +2486,9 @@ mod model_popup_tests {
         app.navigation.theme_filter = "no theme matches this".into();
         app.navigation.theme_cursor = 8;
 
-        handle_theme_popup_key(&mut app, key(KeyCode::Down)).unwrap();
+        handle_theme_popup_key(&mut app, key(KeyCode::Down));
         assert_eq!(app.navigation.theme_cursor, 0);
-        handle_theme_popup_key(&mut app, key(KeyCode::Enter)).unwrap();
+        handle_theme_popup_key(&mut app, key(KeyCode::Enter));
         assert_eq!(app.navigation.popup, Popup::ThemeSelect);
     }
 
@@ -2829,7 +2499,7 @@ mod model_popup_tests {
         app.navigation.popup = Popup::ThemeSelect;
         app.navigation.theme_cursor = theme::Theme::available_themes().len() + 10;
 
-        handle_theme_popup_key(&mut app, key(KeyCode::Enter)).unwrap();
+        handle_theme_popup_key(&mut app, key(KeyCode::Enter));
 
         assert_eq!(app.navigation.popup, Popup::None);
     }
@@ -2839,9 +2509,8 @@ mod model_popup_tests {
         let mut app = App::new();
         app.navigation.popup = Popup::CommandPalette;
         app.navigation.command_palette_filter = "theme".into();
-
-        let (tx, _rx) = mpsc::unbounded_channel();
-        handle_command_palette_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_command_palette_key(&mut app, key(KeyCode::Enter)));
 
         assert!(matches!(app.navigation.popup, Popup::ThemeSelect));
     }
@@ -2852,12 +2521,14 @@ mod model_popup_tests {
         app.connection.conn = ConnState::Connected;
         app.navigation.popup = Popup::CommandPalette;
         app.navigation.command_palette_filter = "open mesh".into();
-
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        handle_command_palette_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_command_palette_key(&mut app, key(KeyCode::Enter)));
 
         assert!(matches!(app.navigation.popup, Popup::Mesh));
-        assert!(matches!(rx.try_recv(), Ok(Command::ListRemoteNodes)));
+        assert!(matches!(
+            effects.next_command(),
+            Some(Command::ListRemoteNodes)
+        ));
     }
 
     #[test]
@@ -2879,13 +2550,12 @@ mod model_popup_tests {
                 ..Default::default()
             }],
         );
-
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        handle_mesh_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_mesh_popup_key(&mut app, key(KeyCode::Enter)));
 
         assert!(matches!(
-            rx.try_recv(),
-            Ok(Command::AttachRemoteSession { node_id, session_id })
+            effects.next_command(),
+            Some(Command::AttachRemoteSession { node_id, session_id })
                 if node_id == "node-1" && session_id == "remote-1"
         ));
     }
@@ -2900,12 +2570,11 @@ mod model_popup_tests {
             label: "framework".into(),
             ..Default::default()
         }];
-
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        handle_mesh_popup_key(&mut app, key(KeyCode::Char('n')), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_mesh_popup_key(&mut app, key(KeyCode::Char('n'))));
 
         assert_eq!(
-            rx.try_recv().unwrap(),
+            effects.next_command().unwrap(),
             Command::CreateRemoteSession {
                 node_id: "node-1".into(),
                 cwd: None,
@@ -2919,9 +2588,8 @@ mod model_popup_tests {
         app.connection.conn = ConnState::Connected;
         app.navigation.popup = Popup::CommandPalette;
         app.navigation.command_palette_filter = "mesh invite".into();
-
-        let (tx, _rx) = mpsc::unbounded_channel();
-        handle_command_palette_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_command_palette_key(&mut app, key(KeyCode::Enter)));
 
         assert!(matches!(app.navigation.popup, Popup::MeshInvite));
         assert_eq!(app.mesh.mesh_invite_ttl, "24h");
@@ -2932,9 +2600,8 @@ mod model_popup_tests {
     fn mesh_popup_i_no_longer_opens_invite_popup() {
         let mut app = App::new();
         app.navigation.popup = Popup::Mesh;
-
-        let (tx, _rx) = mpsc::unbounded_channel();
-        handle_mesh_popup_key(&mut app, key(KeyCode::Char('i')), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_mesh_popup_key(&mut app, key(KeyCode::Char('i'))));
 
         assert!(matches!(app.navigation.popup, Popup::Mesh));
     }
@@ -2952,14 +2619,14 @@ mod model_popup_tests {
             mesh_name: None,
         });
 
-        handle_mesh_invite_qr_popup_key(&mut app, key(KeyCode::Char('u'))).unwrap();
+        handle_mesh_invite_qr_popup_key(&mut app, key(KeyCode::Char('u')));
 
         assert_eq!(
             app.mesh.mesh_clipboard_fallback.as_deref(),
             Some("qmt://mesh/join/token")
         );
 
-        handle_mesh_invite_qr_popup_key(&mut app, key(KeyCode::Esc)).unwrap();
+        handle_mesh_invite_qr_popup_key(&mut app, key(KeyCode::Esc));
 
         assert!(matches!(app.navigation.popup, Popup::MeshInviteQr));
         assert!(app.mesh.mesh_clipboard_fallback.is_none());
@@ -2970,11 +2637,10 @@ mod model_popup_tests {
         let mut app = App::new();
         app.open_mesh_invite_form();
         app.mesh.mesh_invite_ttl = "lol".into();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_mesh_invite_popup_key(&mut app, key(KeyCode::Enter)));
 
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        handle_mesh_invite_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
-
-        assert!(rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
         assert_eq!(
             app.mesh.mesh_error.as_deref(),
             Some("ttl must be like 30m, 1d3h, or 1d3h5m")
@@ -2982,9 +2648,9 @@ mod model_popup_tests {
 
         app.mesh.mesh_invite_ttl = "24h".into();
         app.mesh.mesh_invite_max_uses = "0".into();
-        handle_mesh_invite_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        effects.extend(handle_mesh_invite_popup_key(&mut app, key(KeyCode::Enter)));
 
-        assert!(rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
         assert_eq!(
             app.mesh.mesh_error.as_deref(),
             Some("max uses must be at least 1")
@@ -2998,13 +2664,12 @@ mod model_popup_tests {
         app.open_mesh_invite_form();
         app.mesh.mesh_invite_name = "Team Mesh".into();
         app.mesh.mesh_invite_ttl = "1d3h5m".into();
-
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        handle_mesh_invite_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_mesh_invite_popup_key(&mut app, key(KeyCode::Enter)));
 
         assert!(matches!(
-            rx.try_recv(),
-            Ok(Command::CreateMeshInvite { mesh_name, ttl, max_uses })
+            effects.next_command(),
+            Some(Command::CreateMeshInvite { mesh_name, ttl, max_uses })
                 if mesh_name.as_deref() == Some("Team Mesh")
                     && ttl.as_deref() == Some("1d3h5m")
                     && max_uses == Some(1)
@@ -3023,7 +2688,7 @@ mod model_popup_tests {
             mesh_name: None,
         });
 
-        handle_mesh_invite_qr_popup_key(&mut app, key(KeyCode::Esc)).unwrap();
+        handle_mesh_invite_qr_popup_key(&mut app, key(KeyCode::Esc));
 
         assert!(matches!(app.navigation.popup, Popup::MeshInvite));
     }
@@ -3038,14 +2703,16 @@ mod model_popup_tests {
         app.profiles.active_profile_id = Some("deep".into());
         app.profiles.profile_filter = "stale".into();
         app.profiles.profile_cursor = 0;
-
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        handle_command_palette_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_command_palette_key(&mut app, key(KeyCode::Enter)));
 
         assert!(matches!(app.navigation.popup, Popup::ProfileSelect));
         assert!(app.profiles.profile_filter.is_empty());
         assert_eq!(app.profiles.profile_cursor, 1);
-        assert!(matches!(rx.try_recv(), Ok(Command::ListProfiles)));
+        assert!(matches!(
+            effects.next_command(),
+            Some(Command::ListProfiles)
+        ));
     }
 
     #[test]
@@ -3055,13 +2722,19 @@ mod model_popup_tests {
         app.navigation.screen = Screen::Chat;
         app.composer.input = "/profile".into();
         app.composer.input_cursor = app.composer.input.len();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_chat_key(&mut app, key(KeyCode::Enter)));
 
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        let action = handle_chat_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
-
-        assert!(matches!(action, AppAction::None));
+        assert!(
+            effects
+                .iter()
+                .all(|effect| !matches!(effect, Effect::OpenExternalEditor { .. }))
+        );
         assert!(matches!(app.navigation.popup, Popup::ProfileSelect));
-        assert!(matches!(rx.try_recv(), Ok(Command::ListProfiles)));
+        assert!(matches!(
+            effects.next_command(),
+            Some(Command::ListProfiles)
+        ));
     }
 
     #[test]
@@ -3074,19 +2747,21 @@ mod model_popup_tests {
         app.profiles.active_profile_id = Some("old".into());
         app.composer.input = "/profile Fast".into();
         app.composer.input_cursor = app.composer.input.len();
-
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        handle_chat_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_chat_key(&mut app, key(KeyCode::Enter)));
 
         assert!(matches!(
-            rx.try_recv(),
-            Ok(Command::ListProfileAgents { profile_id }) if profile_id == "fast"
+            effects.next_command(),
+            Some(Command::ListProfileAgents { profile_id }) if profile_id == "fast"
         ));
-        assert!(rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
         assert_eq!(app.profiles.active_profile_id.as_deref(), Some("fast"));
         assert_eq!(app.current_session_profile_id(), None);
-        let saved = crate::config::TuiConfig::load();
-        assert_eq!(saved.profile.id.as_deref(), Some("fast"));
+        assert!(
+            effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::PersistConfig))
+        );
     }
 
     #[test]
@@ -3097,19 +2772,21 @@ mod model_popup_tests {
         app.navigation.popup = Popup::ProfileSelect;
         app.profiles.profiles = vec![make_profile("fast", "Fast"), make_profile("deep", "Deep")];
         app.profiles.profile_cursor = 1;
-
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        handle_profile_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_profile_popup_key(&mut app, key(KeyCode::Enter)));
 
         assert!(matches!(app.navigation.popup, Popup::None));
         assert!(matches!(
-            rx.try_recv(),
-            Ok(Command::ListProfileAgents { profile_id }) if profile_id == "deep"
+            effects.next_command(),
+            Some(Command::ListProfileAgents { profile_id }) if profile_id == "deep"
         ));
-        assert!(rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
         assert_eq!(app.profiles.active_profile_id.as_deref(), Some("deep"));
-        let saved = crate::config::TuiConfig::load();
-        assert_eq!(saved.profile.id.as_deref(), Some("deep"));
+        assert!(
+            effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::PersistConfig))
+        );
     }
 
     #[test]
@@ -3122,11 +2799,10 @@ mod model_popup_tests {
         app.profiles
             .bind_session_profile("session".into(), "current".into());
         app.profiles.profiles = vec![make_profile("fast", "Fast")];
+        let mut effects = TestEffects::default();
+        effects.extend(handle_profile_popup_key(&mut app, key(KeyCode::Enter)));
 
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        handle_profile_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
-
-        assert!(rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
         assert_eq!(app.profiles.active_profile_id.as_deref(), Some("fast"));
         assert_eq!(app.current_session_profile_id(), Some("current"));
     }
@@ -3139,13 +2815,12 @@ mod model_popup_tests {
         app.sessions.new_session_path = "/repo".into();
         app.sessions.new_session_cursor = app.sessions.new_session_path.len();
         app.profiles.active_profile_id = Some("coder-delegate".into());
-
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        handle_new_session_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_new_session_popup_key(&mut app, key(KeyCode::Enter)));
 
         assert!(matches!(
-            rx.try_recv(),
-            Ok(Command::NewSession { profile_id: Some(profile_id), .. })
+            effects.next_command(),
+            Some(Command::NewSession { profile_id: Some(profile_id), .. })
                 if profile_id == "coder-delegate"
         ));
     }
@@ -3176,15 +2851,13 @@ mod model_popup_tests {
                     i,
                     crate::models_state::ModelPopupItem::Model { model_idx } if app.models.models[*model_idx].model == "claude-sonnet"
                 )
-            })
-            .unwrap();
-
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        handle_model_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+            }).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_model_popup_key(&mut app, key(KeyCode::Enter)));
 
         assert!(matches!(
-            rx.try_recv(),
-            Ok(Command::SetDelegateModel {
+            effects.next_command(),
+            Some(Command::SetDelegateModel {
                 ref session_id,
                 ref agent_id,
                 ref model_id,
@@ -3220,9 +2893,8 @@ mod model_popup_tests {
         let model = make_model("anthropic", "claude-sonnet");
         app.models
             .set_delegate_model_preference("profile", "coder", &model);
-
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        handle_model_popup_key(&mut app, key(KeyCode::Delete), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_model_popup_key(&mut app, key(KeyCode::Delete)));
 
         assert!(
             app.models
@@ -3230,8 +2902,8 @@ mod model_popup_tests {
                 .is_none()
         );
         assert!(matches!(
-            rx.try_recv(),
-            Ok(Command::SetDelegateModel {
+            effects.next_command(),
+            Some(Command::SetDelegateModel {
                 ref session_id,
                 ref agent_id,
                 model_id: None,
@@ -3257,11 +2929,10 @@ mod model_popup_tests {
         app.models.models = vec![make_model("anthropic", "claude-sonnet")];
         app.models.model_popup_agent_tab = 1;
         app.models.model_cursor = 1;
+        let mut effects = TestEffects::default();
+        effects.extend(handle_model_popup_key(&mut app, key(KeyCode::Enter)));
 
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        handle_model_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
-
-        assert!(rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
         assert!(
             app.models
                 .get_delegate_model_preference("profile", "coder")
@@ -3293,19 +2964,19 @@ mod model_popup_tests {
                     i,
                     crate::models_state::ModelPopupItem::Model { model_idx } if app.models.models[*model_idx].model == "claude-sonnet"
                 )
-            })
-            .unwrap();
+            }).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_model_popup_key(&mut app, key(KeyCode::Enter)));
 
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        handle_model_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
-
-        let msg1 = rx.try_recv().expect("expected SetSessionModel");
+        let msg1 = effects.next_command().expect("expected SetSessionModel");
         assert!(matches!(msg1, Command::SetSessionModel { .. }));
-        let msg2 = rx.try_recv().expect("expected SetReasoningEffort auto");
+        let msg2 = effects
+            .next_command()
+            .expect("expected SetReasoningEffort auto");
         assert!(
             matches!(msg2, Command::SetReasoningEffort { reasoning_effort } if reasoning_effort == "auto")
         );
-        assert!(rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
 
         assert_eq!(app.models.current_provider.as_deref(), Some("anthropic"));
         assert_eq!(app.models.current_model.as_deref(), Some("claude-sonnet"));
@@ -3343,13 +3014,11 @@ mod model_popup_tests {
                     i,
                     crate::models_state::ModelPopupItem::Model { model_idx } if app.models.models[*model_idx].node_id.is_some()
                 )
-            })
-            .unwrap();
+            }).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_model_popup_key(&mut app, key(KeyCode::Enter)));
 
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        handle_model_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
-
-        match rx.try_recv().expect("SetSessionModel") {
+        match effects.next_command().expect("SetSessionModel") {
             Command::SetSessionModel {
                 node_id, model_id, ..
             } => {
@@ -3358,7 +3027,7 @@ mod model_popup_tests {
             }
             other => panic!("unexpected {other:?}"),
         }
-        assert!(rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
         assert_eq!(app.models.current_provider.as_deref(), Some("anthropic"));
         assert_eq!(app.models.current_model.as_deref(), Some("claude"));
         assert_eq!(app.models.current_model_node_id.as_deref(), Some("node-a"));
@@ -3387,10 +3056,9 @@ mod model_popup_tests {
             .iter()
             .position(|i| matches!(i, crate::models_state::ModelPopupItem::Model { .. }))
             .unwrap();
-
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        handle_model_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
-        assert!(rx.try_recv().is_err());
+        let mut effects = TestEffects::default();
+        effects.extend(handle_model_popup_key(&mut app, key(KeyCode::Enter)));
+        assert!(effects.next_command().is_none());
     }
 
     #[test]
@@ -3402,9 +3070,8 @@ mod model_popup_tests {
         app.models.current_provider = Some("openai".into());
         app.models.current_model = Some("gpt-4o".into());
         app.models.models = vec![make_model("openai", "gpt-4o")];
-
-        let (tx, _rx) = mpsc::unbounded_channel();
-        handle_chord(&mut app, key(KeyCode::Char('m')), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_chord(&mut app, key(KeyCode::Char('m'))));
 
         assert!(matches!(app.navigation.popup, Popup::ModelSelect));
         assert_eq!(app.models.model_popup_agent_tab, 0);
@@ -3425,11 +3092,14 @@ mod model_popup_tests {
         app.models.models = vec![make_model("openai", "gpt-4o")];
         app.composer.input = "/model".into();
         app.composer.input_cursor = app.composer.input.len();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_chat_key(&mut app, key(KeyCode::Enter)));
 
-        let (tx, _rx) = mpsc::unbounded_channel();
-        let action = handle_chat_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
-
-        assert!(matches!(action, AppAction::None));
+        assert!(
+            effects
+                .iter()
+                .all(|effect| !matches!(effect, Effect::OpenExternalEditor { .. }))
+        );
         assert!(matches!(app.navigation.popup, Popup::ModelSelect));
         assert_eq!(app.models.model_popup_agent_tab, 0);
         assert_eq!(
@@ -3447,26 +3117,29 @@ mod model_popup_tests {
         app.sessions.agent_mode = "plan".into();
         app.composer.input = "/review".into();
         app.composer.input_cursor = app.composer.input.len();
-
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        let action = handle_chat_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
-        assert!(matches!(action, AppAction::None));
+        let mut effects = TestEffects::default();
+        effects.extend(handle_chat_key(&mut app, key(KeyCode::Enter)));
+        assert!(
+            effects
+                .iter()
+                .all(|effect| !matches!(effect, Effect::OpenExternalEditor { .. }))
+        );
         assert_eq!(app.sessions.agent_mode, "review");
         assert_eq!(app.sessions.mode_before_review.as_deref(), Some("plan"));
         assert!(matches!(
-            rx.try_recv().expect("expected SetAgentMode(review)"),
+            effects.next_command().expect("expected SetAgentMode(review)"),
             Command::SetAgentMode { mode } if mode == "review"
         ));
-        assert!(rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
 
-        handle_key(&mut app, key(KeyCode::Tab), &tx).unwrap();
+        effects.extend(handle_key(&mut app, key(KeyCode::Tab)));
         assert_eq!(app.sessions.agent_mode, "plan");
         assert_eq!(app.sessions.mode_before_review, None);
         assert!(matches!(
-            rx.try_recv().expect("expected SetAgentMode(plan)"),
+            effects.next_command().expect("expected SetAgentMode(plan)"),
             Command::SetAgentMode { mode } if mode == "plan"
         ));
-        assert!(rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
     }
 
     #[test]
@@ -3490,20 +3163,19 @@ mod model_popup_tests {
             ended_at: None,
             child_state: DelegateChildState::None,
         });
-
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        handle_delegate_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_delegate_popup_key(&mut app, key(KeyCode::Enter)));
 
         assert!(matches!(
-            rx.try_recv().expect("expected LoadSession"),
+            effects.next_command().expect("expected LoadSession"),
             Command::LoadSession { session_id, .. } if session_id == "child-1"
         ));
         assert!(matches!(
-            rx.try_recv().expect("expected SubscribeSession"),
+            effects.next_command().expect("expected SubscribeSession"),
             Command::SubscribeSession { session_id, agent_id }
                 if session_id == "child-1" && agent_id.as_deref() == Some("coder")
         ));
-        assert!(rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
     }
 
     #[test]
@@ -3515,13 +3187,16 @@ mod model_popup_tests {
         app.sessions.mode_before_review = Some("plan".into());
         app.composer.input = "/review".into();
         app.composer.input_cursor = app.composer.input.len();
-
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        let action = handle_chat_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
-        assert!(matches!(action, AppAction::None));
+        let mut effects = TestEffects::default();
+        effects.extend(handle_chat_key(&mut app, key(KeyCode::Enter)));
+        assert!(
+            effects
+                .iter()
+                .all(|effect| !matches!(effect, Effect::OpenExternalEditor { .. }))
+        );
         assert_eq!(app.sessions.agent_mode, "review");
         assert_eq!(app.sessions.mode_before_review.as_deref(), Some("plan"));
-        assert!(rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
         assert_eq!(app.diagnostics.status, "already in review mode");
     }
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,5 +1,5 @@
 use crate::app::App;
-use crate::application::{ClipboardTarget, Effect};
+use crate::application::{ClipboardTarget, Effect, RuntimeEvent};
 use crate::auth_state::AuthPanel;
 use crate::diagnostics::LogLevel;
 use crate::domain::activity::{ActivityState, SessionOp};
@@ -42,8 +42,8 @@ fn send_load_session_commands(
 
 /// Handle all keyboard input while an elicitation popup is active.
 ///
-/// Returns `Ok(())` in all cases; the caller should return immediately after
-/// this to avoid routing the key to the normal chat handler.
+/// Returns the ordered effects for the key; the caller should return immediately
+/// afterward to avoid routing the key to the normal chat handler.
 pub(crate) fn handle_elicitation_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
     use crate::domain::elicitation::ElicitationFieldKind;
 
@@ -111,12 +111,17 @@ pub(crate) fn handle_elicitation_key(app: &mut App, key: KeyEvent) -> Vec<Effect
                 let elicitation_id = state.elicitation_id.clone();
                 let content = state.build_accept_content(Some(&state.custom_input));
                 let display = selected_display(state, true);
-                effects.push(Effect::Command(Command::ElicitationResponse {
-                    elicitation_id: elicitation_id.clone(),
-                    action: "accept".into(),
-                    content: Some(content),
-                }));
-                app.resolve_elicitation(&elicitation_id, &display);
+                effects.push(Effect::CommandThen {
+                    command: Command::ElicitationResponse {
+                        elicitation_id: elicitation_id.clone(),
+                        action: "accept".into(),
+                        content: Some(content),
+                    },
+                    on_sent: RuntimeEvent::ElicitationResponseSent {
+                        elicitation_id,
+                        outcome: display,
+                    },
+                });
             }
             KeyCode::Char(character) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
                 ui.custom_insert(&mut state.custom_input, character);
@@ -146,12 +151,17 @@ pub(crate) fn handle_elicitation_key(app: &mut App, key: KeyEvent) -> Vec<Effect
     match key.code {
         KeyCode::Esc => {
             let elicitation_id = state.elicitation_id.clone();
-            effects.push(Effect::Command(Command::ElicitationResponse {
-                elicitation_id: elicitation_id.clone(),
-                action: "decline".into(),
-                content: None,
-            }));
-            app.resolve_elicitation(&elicitation_id, "declined");
+            effects.push(Effect::CommandThen {
+                command: Command::ElicitationResponse {
+                    elicitation_id: elicitation_id.clone(),
+                    action: "decline".into(),
+                    content: None,
+                },
+                on_sent: RuntimeEvent::ElicitationResponseSent {
+                    elicitation_id,
+                    outcome: "declined".into(),
+                },
+            });
         }
         KeyCode::Down => {
             let max = option_count + usize::from(custom_available);
@@ -193,12 +203,17 @@ pub(crate) fn handle_elicitation_key(app: &mut App, key: KeyEvent) -> Vec<Effect
                 let elicitation_id = state.elicitation_id.clone();
                 let content = state.build_accept_content(None);
                 let display = selected_display(state, false);
-                effects.push(Effect::Command(Command::ElicitationResponse {
-                    elicitation_id: elicitation_id.clone(),
-                    action: "accept".into(),
-                    content: Some(content),
-                }));
-                app.resolve_elicitation(&elicitation_id, &display);
+                effects.push(Effect::CommandThen {
+                    command: Command::ElicitationResponse {
+                        elicitation_id: elicitation_id.clone(),
+                        action: "accept".into(),
+                        content: Some(content),
+                    },
+                    on_sent: RuntimeEvent::ElicitationResponseSent {
+                        elicitation_id,
+                        outcome: display,
+                    },
+                });
             }
         }
         KeyCode::Char(character) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -3126,20 +3141,28 @@ mod model_popup_tests {
         );
         assert_eq!(app.sessions.agent_mode, "review");
         assert_eq!(app.sessions.mode_before_review.as_deref(), Some("plan"));
-        assert!(matches!(
-            effects.next_command().expect("expected SetAgentMode(review)"),
-            Command::SetAgentMode { mode } if mode == "review"
-        ));
-        assert!(effects.next_command().is_none());
+        assert_eq!(
+            effects.as_slice(),
+            &[
+                Effect::Command(Command::SetAgentMode {
+                    mode: "review".into(),
+                }),
+                Effect::PersistConfig,
+            ]
+        );
 
-        effects.extend(handle_key(&mut app, key(KeyCode::Tab)));
+        let effects = handle_key(&mut app, key(KeyCode::Tab));
         assert_eq!(app.sessions.agent_mode, "plan");
         assert_eq!(app.sessions.mode_before_review, None);
-        assert!(matches!(
-            effects.next_command().expect("expected SetAgentMode(plan)"),
-            Command::SetAgentMode { mode } if mode == "plan"
-        ));
-        assert!(effects.next_command().is_none());
+        assert_eq!(
+            effects,
+            vec![
+                Effect::Command(Command::SetAgentMode {
+                    mode: "plan".into(),
+                }),
+                Effect::PersistConfig,
+            ]
+        );
     }
 
     #[test]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,5 +1,5 @@
 use crate::app::App;
-use crate::application::{ClipboardTarget, Effect, RuntimeEvent};
+use crate::application::{ClipboardTarget, Effect};
 use crate::auth_state::AuthPanel;
 use crate::diagnostics::LogLevel;
 use crate::domain::activity::{ActivityState, SessionOp};
@@ -38,6 +38,20 @@ fn send_load_session_commands(
         .into_iter()
         .map(Effect::Command)
         .collect()
+}
+
+fn elicitation_response_effect(
+    elicitation_id: String,
+    action: &str,
+    content: Option<serde_json::Value>,
+    outcome: String,
+) -> Effect {
+    Effect::ElicitationResponse {
+        elicitation_id,
+        action: action.into(),
+        content,
+        outcome,
+    }
 }
 
 /// Handle all keyboard input while an elicitation popup is active.
@@ -111,17 +125,12 @@ pub(crate) fn handle_elicitation_key(app: &mut App, key: KeyEvent) -> Vec<Effect
                 let elicitation_id = state.elicitation_id.clone();
                 let content = state.build_accept_content(Some(&state.custom_input));
                 let display = selected_display(state, true);
-                effects.push(Effect::CommandThen {
-                    command: Command::ElicitationResponse {
-                        elicitation_id: elicitation_id.clone(),
-                        action: "accept".into(),
-                        content: Some(content),
-                    },
-                    on_sent: RuntimeEvent::ElicitationResponseSent {
-                        elicitation_id,
-                        outcome: display,
-                    },
-                });
+                effects.push(elicitation_response_effect(
+                    elicitation_id,
+                    "accept",
+                    Some(content),
+                    display,
+                ));
             }
             KeyCode::Char(character) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
                 ui.custom_insert(&mut state.custom_input, character);
@@ -151,17 +160,12 @@ pub(crate) fn handle_elicitation_key(app: &mut App, key: KeyEvent) -> Vec<Effect
     match key.code {
         KeyCode::Esc => {
             let elicitation_id = state.elicitation_id.clone();
-            effects.push(Effect::CommandThen {
-                command: Command::ElicitationResponse {
-                    elicitation_id: elicitation_id.clone(),
-                    action: "decline".into(),
-                    content: None,
-                },
-                on_sent: RuntimeEvent::ElicitationResponseSent {
-                    elicitation_id,
-                    outcome: "declined".into(),
-                },
-            });
+            effects.push(elicitation_response_effect(
+                elicitation_id,
+                "decline",
+                None,
+                "declined".into(),
+            ));
         }
         KeyCode::Down => {
             let max = option_count + usize::from(custom_available);
@@ -203,17 +207,12 @@ pub(crate) fn handle_elicitation_key(app: &mut App, key: KeyEvent) -> Vec<Effect
                 let elicitation_id = state.elicitation_id.clone();
                 let content = state.build_accept_content(None);
                 let display = selected_display(state, false);
-                effects.push(Effect::CommandThen {
-                    command: Command::ElicitationResponse {
-                        elicitation_id: elicitation_id.clone(),
-                        action: "accept".into(),
-                        content: Some(content),
-                    },
-                    on_sent: RuntimeEvent::ElicitationResponseSent {
-                        elicitation_id,
-                        outcome: display,
-                    },
-                });
+                effects.push(elicitation_response_effect(
+                    elicitation_id,
+                    "accept",
+                    Some(content),
+                    display,
+                ));
             }
         }
         KeyCode::Char(character) if !key.modifiers.contains(KeyModifiers::CONTROL) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 mod acp_client;
 mod acp_state;
 mod app;
+mod application;
 mod auth_state;
 mod chat_state;
 mod command;

--- a/src/runtime/editor.rs
+++ b/src/runtime/editor.rs
@@ -5,8 +5,7 @@ use std::{
     process::Command,
 };
 
-use crate::app::App;
-use crate::diagnostics::LogLevel;
+use crate::application::ExternalEditorOutcome;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct EditorCommand {
@@ -66,52 +65,35 @@ fn cleanup_temp_editor_file(path: &Path) -> anyhow::Result<()> {
     }
 }
 
-pub(super) fn open_external_editor(initial_text: &str) -> anyhow::Result<Option<String>> {
-    let command = system_editor_command()
-        .ok_or_else(|| anyhow::anyhow!("set $VISUAL or $EDITOR to use an external editor"))?;
-    let path = temp_editor_file_path();
-    fs::write(&path, initial_text)?;
-    let result = run_external_editor(&command, &path);
-    cleanup_temp_editor_file(&path)?;
-    result
+pub(super) fn open_external_editor(initial_text: &str) -> ExternalEditorOutcome {
+    open_external_editor_with_command(initial_text, system_editor_command())
 }
 
-pub(super) fn apply_external_editor_result(app: &mut App, updated_input: String) {
-    app.composer.replace_input_from_editor(updated_input);
-}
+fn open_external_editor_with_command(
+    initial_text: &str,
+    command: Option<EditorCommand>,
+) -> ExternalEditorOutcome {
+    let result = (|| {
+        let command = command
+            .ok_or_else(|| anyhow::anyhow!("set $VISUAL or $EDITOR to use an external editor"))?;
+        let path = temp_editor_file_path();
+        fs::write(&path, initial_text)?;
+        let result = run_external_editor(&command, &path);
+        cleanup_temp_editor_file(&path)?;
+        result
+    })();
 
-pub(super) fn apply_external_editor_outcome(app: &mut App, result: anyhow::Result<Option<String>>) {
     match result {
-        Ok(Some(updated_input)) => {
-            apply_external_editor_result(app, updated_input);
-            app.set_status(
-                LogLevel::Info,
-                "editor",
-                "loaded prompt from external editor",
-            );
-        }
-        Ok(None) => {
-            app.set_status(LogLevel::Info, "editor", "external editor cancelled");
-        }
-        Err(err) => {
-            app.set_status(
-                LogLevel::Error,
-                "editor",
-                format!("external editor failed: {err}"),
-            );
-        }
+        Ok(Some(updated_input)) => ExternalEditorOutcome::Completed(updated_input),
+        Ok(None) => ExternalEditorOutcome::Cancelled,
+        Err(error) => ExternalEditorOutcome::Failed(error.to_string()),
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::{editor_command_from_env, open_external_editor_with_command};
     use std::ffi::OsString;
-
-    use crate::app::App;
-
-    use super::{
-        apply_external_editor_outcome, apply_external_editor_result, editor_command_from_env,
-    };
 
     #[test]
     fn editor_command_prefers_visual_over_editor() {
@@ -134,42 +116,13 @@ mod tests {
         let env = [("VISUAL", Some("   ")), ("EDITOR", Some(""))];
         assert!(editor_command_from_env(&env).is_none());
     }
-
     #[test]
-    fn apply_external_editor_result_updates_input_and_cursor() {
-        let mut app = App::new();
-        app.composer.input = "old".into();
-        app.composer.input_cursor = 1;
-        app.composer.input_scroll = 3;
-
-        apply_external_editor_result(&mut app, "new text".into());
-
-        assert_eq!(app.composer.input, "new text");
-        assert_eq!(app.composer.input_cursor, "new text".len());
-        assert_eq!(app.composer.input_scroll, 0);
-    }
-
-    #[test]
-    fn apply_external_editor_outcome_updates_input_on_success() {
-        let mut app = App::new();
-        app.composer.input = "draft".into();
-
-        apply_external_editor_outcome(&mut app, Ok(Some("revised prompt".into())));
-
-        assert_eq!(app.composer.input, "revised prompt");
-        assert_eq!(app.composer.input_cursor, "revised prompt".len());
-        assert_eq!(app.diagnostics.status, "loaded prompt from external editor");
-        assert!(matches!(app.diagnostics.logs.last(), Some(entry) if entry.target == "editor"));
-    }
-
-    #[test]
-    fn apply_external_editor_outcome_keeps_input_on_cancel() {
-        let mut app = App::new();
-        app.composer.input = "draft".into();
-
-        apply_external_editor_outcome(&mut app, Ok(None));
-
-        assert_eq!(app.composer.input, "draft");
-        assert_eq!(app.diagnostics.status, "external editor cancelled");
+    fn missing_editor_returns_typed_failure() {
+        let outcome = open_external_editor_with_command("draft", None);
+        assert!(matches!(
+            outcome,
+            crate::application::ExternalEditorOutcome::Failed(message)
+                if message == "set $VISUAL or $EDITOR to use an external editor"
+        ));
     }
 }

--- a/src/runtime/editor.rs
+++ b/src/runtime/editor.rs
@@ -52,7 +52,7 @@ fn run_external_editor(command: &EditorCommand, path: &Path) -> anyhow::Result<O
         .arg(path)
         .status()?;
     if !status.success() {
-        return Ok(None);
+        anyhow::bail!("external editor exited with status {status}");
     }
     Ok(Some(fs::read_to_string(path)?))
 }
@@ -92,7 +92,8 @@ fn open_external_editor_with_command(
 
 #[cfg(test)]
 mod tests {
-    use super::{editor_command_from_env, open_external_editor_with_command};
+    use super::{EditorCommand, editor_command_from_env, open_external_editor_with_command};
+    use crate::application::ExternalEditorOutcome;
     use std::ffi::OsString;
 
     #[test]
@@ -121,8 +122,29 @@ mod tests {
         let outcome = open_external_editor_with_command("draft", None);
         assert!(matches!(
             outcome,
-            crate::application::ExternalEditorOutcome::Failed(message)
+            ExternalEditorOutcome::Failed(message)
                 if message == "set $VISUAL or $EDITOR to use an external editor"
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn nonzero_editor_exit_returns_typed_failure_with_status() {
+        let command = EditorCommand {
+            program: OsString::from("sh"),
+            args: vec![
+                OsString::from("-c"),
+                OsString::from("exit 7"),
+                OsString::from("sh"),
+            ],
+        };
+
+        let outcome = open_external_editor_with_command("draft", Some(command));
+
+        assert!(matches!(
+            outcome,
+            ExternalEditorOutcome::Failed(message)
+                if message == "external editor exited with status exit status: 7"
         ));
     }
 }

--- a/src/runtime/event_loop.rs
+++ b/src/runtime/event_loop.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use crossterm::event::{self, Event, EventStream};
+use crossterm::event::{Event, EventStream};
 use futures::{FutureExt, Stream, StreamExt};
 use tokio::{
     sync::mpsc,
@@ -151,17 +151,6 @@ pub(super) async fn run_loop(
             && execute_event(terminal, app, executor, event)?
         {
             return Ok(());
-        }
-
-        while let Ok(true) = event::poll(Duration::ZERO) {
-            let Ok(event) = event::read() else {
-                break;
-            };
-            if let Some(event) = crossterm_event(event)
-                && execute_event(terminal, app, executor, event)?
-            {
-                return Ok(());
-            }
         }
     }
 }
@@ -319,6 +308,61 @@ mod tests {
 
         assert!(saw_supervisor);
         assert!(!conn_rx.is_empty());
+    }
+
+    #[tokio::test]
+    async fn continuous_terminal_input_does_not_starve_other_sources_or_ticks() {
+        let (conn_tx, mut conn_rx) = mpsc::unbounded_channel();
+        let (srv_tx, mut srv_rx) = mpsc::unbounded_channel();
+        let (sup_tx, mut sup_rx) = mpsc::unbounded_channel();
+        let mut term_events = stream::repeat_with(|| {
+            Ok(Event::Key(KeyEvent::new(
+                KeyCode::Char('x'),
+                KeyModifiers::NONE,
+            )))
+        });
+        let mut tick_interval = application_tick_interval();
+        let mut scheduler = EventScheduler::new();
+
+        conn_tx.send(connection_event(1)).unwrap();
+        srv_tx
+            .send(ServerChannelMsg::Acp(AcpAppEvent::Error {
+                message: "acp-ready".into(),
+            }))
+            .unwrap();
+        sup_tx.send(server_manager::ServerEvent::Started).unwrap();
+        tokio::time::sleep(TICK_INTERVAL + Duration::from_millis(20)).await;
+
+        let mut saw_connection = false;
+        let mut saw_acp = false;
+        let mut saw_supervisor = false;
+        let mut saw_tick = false;
+        let mut terminal_events = 0;
+        for _ in 0..(NON_TICK_SOURCE_COUNT * 2 + 2) {
+            match scheduler
+                .next_event(
+                    &mut tick_interval,
+                    &mut conn_rx,
+                    &mut srv_rx,
+                    &mut sup_rx,
+                    &mut term_events,
+                )
+                .await
+            {
+                Some(AppEvent::Connection(_)) => saw_connection = true,
+                Some(AppEvent::Acp(_)) => saw_acp = true,
+                Some(AppEvent::Supervisor(_)) => saw_supervisor = true,
+                Some(AppEvent::Tick) => saw_tick = true,
+                Some(AppEvent::Key(_)) => terminal_events += 1,
+                _ => {}
+            }
+        }
+
+        assert!(saw_connection);
+        assert!(saw_acp);
+        assert!(saw_supervisor);
+        assert!(saw_tick);
+        assert!(terminal_events >= 2);
     }
 
     #[tokio::test]

--- a/src/runtime/event_loop.rs
+++ b/src/runtime/event_loop.rs
@@ -6,96 +6,11 @@ use tokio::sync::mpsc;
 
 use crate::{
     app::App,
-    command::Command,
-    connection_state::ConnState,
-    diagnostics::LogLevel,
-    handlers::{AppAction, handle_key, handle_mouse},
-    server_manager::{self, ServerEvent},
-    ui,
+    application::{self, AppEvent},
+    server_manager, ui,
 };
 
-use super::{
-    ConnectionManagerEvent, ServerChannelMsg,
-    terminal::{AppTerminal, open_external_editor_with_terminal},
-};
-
-/// Derive a UI tick from wall-clock elapsed time.
-/// Each tick step is about 80 ms so animations do not depend on event-loop activity.
-fn tick_from_elapsed(elapsed: Duration) -> u64 {
-    (elapsed.as_millis() / 80) as u64
-}
-
-fn send_command(cmd_tx: &mpsc::UnboundedSender<Command>, command: Command) -> anyhow::Result<()> {
-    cmd_tx.send(command)?;
-    Ok(())
-}
-
-fn reconnect_session_commands(app: &mut App) -> Vec<Command> {
-    let Some(session_id) = app.sessions.session_id.clone() else {
-        return Vec::new();
-    };
-
-    if let Some(node_id) = app.sessions.session_remote_node_id(&session_id) {
-        return vec![Command::AttachRemoteSession {
-            node_id: node_id.to_string(),
-            session_id,
-        }];
-    }
-    if app.sessions.is_remote_session_id(&session_id) {
-        app.set_status(
-            LogLevel::Warn,
-            "session",
-            "remote session is missing node id; reconnect attach skipped",
-        );
-        return Vec::new();
-    }
-
-    Command::load_session_commands(
-        session_id,
-        app.current_session_cwd(),
-        app.sessions.agent_id.clone(),
-    )
-    .into()
-}
-
-fn handle_server_event(app: &mut App, event: ServerEvent) {
-    match event {
-        ServerEvent::Starting => {
-            app.connection.apply_server_starting();
-            if app.connection.conn != ConnState::Connected {
-                app.set_status(LogLevel::Info, "acp", "starting qmtcode ACP agent...");
-            }
-        }
-        ServerEvent::Started => {
-            app.connection.apply_server_started();
-            if app.connection.conn != ConnState::Connected {
-                app.set_status(LogLevel::Info, "acp", "qmtcode ACP agent started");
-            }
-        }
-        ServerEvent::BinaryNotFound => {
-            app.connection.apply_server_binary_not_found();
-            if app.connection.conn != ConnState::Connected {
-                app.set_status(
-                    LogLevel::Warn,
-                    "acp",
-                    "qmtcode not found; install it or set acp.binary_path in ~/.qmt/qmtui.toml",
-                );
-            }
-        }
-        ServerEvent::StartFailed { error } => {
-            app.connection.apply_server_start_failed(error.clone());
-            app.set_status(LogLevel::Error, "acp", format!("ACP start failed: {error}"));
-        }
-        ServerEvent::Stopped { reason } => {
-            app.connection.apply_server_stopped(reason.clone());
-            app.set_status(
-                LogLevel::Warn,
-                "acp",
-                format!("ACP agent stopped ({reason})"),
-            );
-        }
-    }
-}
+use super::{ConnectionManagerEvent, EffectExecutor, ServerChannelMsg, terminal::AppTerminal};
 
 pub(super) async fn run_loop(
     terminal: &mut AppTerminal,
@@ -103,85 +18,40 @@ pub(super) async fn run_loop(
     srv_rx: &mut mpsc::UnboundedReceiver<ServerChannelMsg>,
     conn_rx: &mut mpsc::UnboundedReceiver<ConnectionManagerEvent>,
     sup_rx: &mut mpsc::UnboundedReceiver<server_manager::ServerEvent>,
-    cmd_tx: &mpsc::UnboundedSender<Command>,
+    executor: &mut EffectExecutor<'_>,
 ) -> anyhow::Result<()> {
     let mut term_events = EventStream::new();
 
     loop {
-        app.render
-            .replace_tick(tick_from_elapsed(app.diagnostics.started_at.elapsed()));
-        app.clear_expired_cancel_confirm();
         terminal.draw(|frame| ui::draw(frame, app))?;
 
-        tokio::select! {
+        let event = tokio::select! {
             biased;
-            Some(event) = conn_rx.recv() => {
-                match event {
-                    ConnectionManagerEvent::State(state) => {
-                        let was_connected = app.connection.conn == ConnState::Connected;
-                        app.handle_connection_event(state);
-                        if app.connection.conn == ConnState::Connected {
-                            cmd_tx.send(Command::Init)?;
-                            cmd_tx.send(Command::list_sessions_browse())?;
-                            cmd_tx.send(Command::ListAllModels { refresh: false })?;
-                            for command in reconnect_session_commands(app) {
-                                cmd_tx.send(command)?;
-                            }
-                        } else if was_connected
-                            && app.connection.conn == ConnState::Disconnected
-                        {
-                            app.set_status(
-                                LogLevel::Warn,
-                                "connection",
-                                "connection lost - reconnecting...",
-                            );
-                        }
-                    }
-                }
+            Some(event) = conn_rx.recv() => match event {
+                ConnectionManagerEvent::State(state) => Some(AppEvent::Connection(state)),
+            },
+            Some(ServerChannelMsg::Acp(event)) = srv_rx.recv() => Some(AppEvent::Acp(event)),
+            Some(event) = sup_rx.recv() => Some(AppEvent::Supervisor(event)),
+            Some(event_result) = term_events.next() => terminal_event(event_result),
+            _ = tokio::time::sleep(Duration::from_millis(80)) => Some(AppEvent::Tick),
+        };
+
+        if let Some(event) = event {
+            let effects = application::update(app, event);
+            executor.execute(terminal, app, effects)?;
+        }
+
+        while let Ok(true) = event::poll(Duration::from_millis(0)) {
+            let Ok(event) = event::read() else {
+                break;
+            };
+            if let Some(event) = crossterm_event(event) {
+                let effects = application::update(app, event);
+                executor.execute(terminal, app, effects)?;
             }
-            Some(ServerChannelMsg::Acp(event)) = srv_rx.recv() => {
-                for command in app.handle_acp_event(event) {
-                    send_command(cmd_tx, command)?;
-                }
+            if app.should_quit {
+                break;
             }
-            Some(sup_event) = sup_rx.recv() => {
-                handle_server_event(app, sup_event);
-            }
-            Some(event_result) = term_events.next() => {
-                match event_result {
-                    Ok(Event::Key(key)) if key.kind == crossterm::event::KeyEventKind::Press => {
-                        let action = handle_key(app, key, cmd_tx)?;
-                        if matches!(action, AppAction::OpenExternalEditor) {
-                            open_external_editor_with_terminal(terminal, app)?;
-                        }
-                        if app.should_quit {
-                            return Ok(());
-                        }
-                        while let Ok(true) = event::poll(Duration::from_millis(0)) {
-                            match event::read() {
-                                Ok(Event::Key(key)) if key.kind == crossterm::event::KeyEventKind::Press => {
-                                    let action = handle_key(app, key, cmd_tx)?;
-                                    if matches!(action, AppAction::OpenExternalEditor) {
-                                        open_external_editor_with_terminal(terminal, app)?;
-                                    }
-                                    if app.should_quit {
-                                        return Ok(());
-                                    }
-                                }
-                                Ok(Event::Mouse(mouse)) => {
-                                    handle_mouse(app, mouse);
-                                }
-                                _ => {}
-                            }
-                        }
-                    }
-                    Ok(Event::Mouse(mouse)) => {
-                        handle_mouse(app, mouse);
-                    }
-                    _ => {}
-                }
-            }
-            _ = tokio::time::sleep(Duration::from_millis(80)) => {}
         }
 
         if app.should_quit {
@@ -190,199 +60,16 @@ pub(super) async fn run_loop(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use std::time::Duration;
+fn terminal_event(event: std::io::Result<Event>) -> Option<AppEvent> {
+    event.ok().and_then(crossterm_event)
+}
 
-    use tokio::sync::mpsc;
-
-    use super::{handle_server_event, reconnect_session_commands, send_command, tick_from_elapsed};
-    use crate::app::App;
-    use crate::command::Command;
-    use crate::connection_state::{ConnState, ServerState};
-    use crate::server_manager::ServerEvent;
-
-    #[test]
-    fn send_command_sends_each_command_once_without_implicit_subscribe() {
-        let (tx, mut rx) = mpsc::unbounded_channel();
-
-        send_command(
-            &tx,
-            Command::LoadSession {
-                session_id: "session-1".into(),
-                cwd: Some("/repo".into()),
-            },
-        )
-        .unwrap();
-
-        assert!(matches!(
-            rx.try_recv().unwrap(),
-            Command::LoadSession {
-                session_id,
-                cwd: Some(cwd),
-            } if session_id == "session-1" && cwd == "/repo"
-        ));
-        assert!(rx.try_recv().is_err());
-    }
-
-    #[test]
-    fn reconnect_attaches_remembered_remote_session_without_loading() {
-        let mut app = App::new();
-        app.sessions.session_id = Some("remote-1".into());
-        app.sessions.remember_remote_session_location(
-            "remote-1",
-            "node-1",
-            Some("/remote/repo".into()),
-        );
-
-        assert_eq!(
-            reconnect_session_commands(&mut app),
-            vec![Command::AttachRemoteSession {
-                node_id: "node-1".into(),
-                session_id: "remote-1".into(),
-            }]
-        );
-    }
-
-    #[test]
-    fn reconnect_warns_for_remote_session_missing_node() {
-        let mut app = App::new();
-        app.sessions.session_id = Some("remote-1".into());
-        app.sessions.session_groups = vec![crate::domain::session::SessionGroup {
-            sessions: vec![crate::domain::session::SessionSummary {
-                session_id: "remote-1".into(),
-                node: Some("remote".into()),
-                ..Default::default()
-            }],
-            ..Default::default()
-        }];
-
-        assert!(reconnect_session_commands(&mut app).is_empty());
-        assert!(app.diagnostics.status.contains("missing node id"));
-    }
-
-    #[test]
-    fn reconnect_loads_and_subscribes_local_session() {
-        let mut app = App::new();
-        app.sessions.session_id = Some("local-1".into());
-        app.sessions.agent_id = Some("agent-1".into());
-        app.connection.launch_cwd = Some("/local/repo".into());
-
-        assert_eq!(
-            reconnect_session_commands(&mut app),
-            vec![
-                Command::LoadSession {
-                    session_id: "local-1".into(),
-                    cwd: Some("/local/repo".into()),
-                },
-                Command::SubscribeSession {
-                    session_id: "local-1".into(),
-                    agent_id: Some("agent-1".into()),
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn reconnect_without_active_session_does_nothing() {
-        assert!(reconnect_session_commands(&mut App::new()).is_empty());
-    }
-
-    #[test]
-    fn server_lifecycle_events_report_exact_statuses_while_disconnected() {
-        let mut app = App::new();
-        app.connection.conn = ConnState::Disconnected;
-
-        handle_server_event(&mut app, ServerEvent::Starting);
-        assert_eq!(app.connection.server_state, ServerState::Starting);
-        assert_eq!(app.diagnostics.status, "starting qmtcode ACP agent...");
-
-        handle_server_event(&mut app, ServerEvent::Started);
-        assert_eq!(app.connection.server_state, ServerState::Running);
-        assert_eq!(app.diagnostics.status, "qmtcode ACP agent started");
-
-        handle_server_event(&mut app, ServerEvent::BinaryNotFound);
-        assert_eq!(app.connection.server_state, ServerState::BinaryNotFound);
-        assert_eq!(
-            app.diagnostics.status,
-            "qmtcode not found; install it or set acp.binary_path in ~/.qmt/qmtui.toml"
-        );
-    }
-
-    #[test]
-    fn server_statuses_are_suppressed_while_connected_but_state_still_updates() {
-        let mut app = App::new();
-        app.connection.conn = ConnState::Connected;
-        app.set_status(crate::diagnostics::LogLevel::Debug, "test", "retained");
-
-        handle_server_event(&mut app, ServerEvent::Starting);
-        assert_eq!(app.connection.server_state, ServerState::Starting);
-        assert_eq!(app.diagnostics.status, "retained");
-
-        handle_server_event(&mut app, ServerEvent::Started);
-        assert_eq!(app.connection.server_state, ServerState::Running);
-        assert_eq!(app.diagnostics.status, "retained");
-
-        handle_server_event(&mut app, ServerEvent::BinaryNotFound);
-        assert_eq!(app.connection.server_state, ServerState::BinaryNotFound);
-        assert_eq!(app.diagnostics.status, "retained");
-    }
-
-    #[test]
-    fn server_failures_always_report_exact_status_and_payload() {
-        let mut app = App::new();
-        app.connection.conn = ConnState::Connected;
-
-        handle_server_event(
-            &mut app,
-            ServerEvent::StartFailed {
-                error: "invalid command".into(),
-            },
-        );
-        assert_eq!(
-            app.connection.server_state,
-            ServerState::StartFailed {
-                error: "invalid command".into()
-            }
-        );
-        assert_eq!(app.diagnostics.status, "ACP start failed: invalid command");
-
-        handle_server_event(
-            &mut app,
-            ServerEvent::Stopped {
-                reason: "process exited".into(),
-            },
-        );
-        assert_eq!(
-            app.connection.server_state,
-            ServerState::Restarting {
-                reason: "process exited".into()
-            }
-        );
-        assert_eq!(app.diagnostics.status, "ACP agent stopped (process exited)");
-    }
-
-    #[test]
-    fn tick_from_elapsed_zero_is_zero() {
-        assert_eq!(tick_from_elapsed(Duration::ZERO), 0);
-    }
-
-    #[test]
-    fn tick_from_elapsed_advances_every_80ms() {
-        assert_eq!(tick_from_elapsed(Duration::from_millis(0)), 0);
-        assert_eq!(tick_from_elapsed(Duration::from_millis(79)), 0);
-        assert_eq!(tick_from_elapsed(Duration::from_millis(80)), 1);
-        assert_eq!(tick_from_elapsed(Duration::from_millis(159)), 1);
-        assert_eq!(tick_from_elapsed(Duration::from_millis(160)), 2);
-    }
-
-    #[test]
-    fn tick_from_elapsed_spinner_frame_changes_every_two_ticks() {
-        let tick_at_0ms = tick_from_elapsed(Duration::from_millis(0));
-        let tick_at_150ms = tick_from_elapsed(Duration::from_millis(150));
-        let tick_at_160ms = tick_from_elapsed(Duration::from_millis(160));
-
-        assert_eq!(tick_at_0ms / 2, tick_at_150ms / 2);
-        assert_ne!(tick_at_0ms / 2, tick_at_160ms / 2);
+fn crossterm_event(event: Event) -> Option<AppEvent> {
+    match event {
+        Event::Key(key) if key.kind == crossterm::event::KeyEventKind::Press => {
+            Some(AppEvent::Key(key))
+        }
+        Event::Mouse(mouse) => Some(AppEvent::Mouse(mouse)),
+        _ => None,
     }
 }

--- a/src/runtime/event_loop.rs
+++ b/src/runtime/event_loop.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use crossterm::event::{self, Event, EventStream};
-use futures::{Stream, StreamExt};
+use futures::{FutureExt, Stream, StreamExt};
 use tokio::{
     sync::mpsc,
     time::{Instant, Interval, MissedTickBehavior},
@@ -16,6 +16,111 @@ use crate::{
 use super::{ConnectionManagerEvent, EffectExecutor, ServerChannelMsg, terminal::AppTerminal};
 
 const TICK_INTERVAL: Duration = Duration::from_millis(80);
+const NON_TICK_SOURCE_COUNT: usize = 4;
+
+struct EventScheduler {
+    prefer_tick: bool,
+    next_non_tick_source: usize,
+}
+
+impl EventScheduler {
+    fn new() -> Self {
+        Self {
+            prefer_tick: true,
+            next_non_tick_source: 0,
+        }
+    }
+
+    async fn next_event<S>(
+        &mut self,
+        tick_interval: &mut Interval,
+        conn_rx: &mut mpsc::UnboundedReceiver<ConnectionManagerEvent>,
+        srv_rx: &mut mpsc::UnboundedReceiver<ServerChannelMsg>,
+        sup_rx: &mut mpsc::UnboundedReceiver<server_manager::ServerEvent>,
+        term_events: &mut S,
+    ) -> Option<AppEvent>
+    where
+        S: Stream<Item = std::io::Result<Event>> + Unpin,
+    {
+        let prefer_tick = self.prefer_tick;
+        let (is_tick, event) = if prefer_tick {
+            tokio::select! {
+                biased;
+                _ = tick_interval.tick() => (true, None),
+                event = self.next_non_tick_event(conn_rx, srv_rx, sup_rx, term_events) => {
+                    (false, event)
+                },
+            }
+        } else {
+            tokio::select! {
+                biased;
+                event = self.next_non_tick_event(conn_rx, srv_rx, sup_rx, term_events) => {
+                    (false, event)
+                },
+                _ = tick_interval.tick() => (true, None),
+            }
+        };
+
+        if is_tick {
+            self.prefer_tick = false;
+            Some(AppEvent::Tick)
+        } else {
+            self.prefer_tick = true;
+            event
+        }
+    }
+
+    async fn next_non_tick_event<S>(
+        &mut self,
+        conn_rx: &mut mpsc::UnboundedReceiver<ConnectionManagerEvent>,
+        srv_rx: &mut mpsc::UnboundedReceiver<ServerChannelMsg>,
+        sup_rx: &mut mpsc::UnboundedReceiver<server_manager::ServerEvent>,
+        term_events: &mut S,
+    ) -> Option<AppEvent>
+    where
+        S: Stream<Item = std::io::Result<Event>> + Unpin,
+    {
+        for offset in 0..NON_TICK_SOURCE_COUNT {
+            let source = (self.next_non_tick_source + offset) % NON_TICK_SOURCE_COUNT;
+            let event = match source {
+                0 => conn_rx.try_recv().ok().map(|event| match event {
+                    ConnectionManagerEvent::State(state) => Some(AppEvent::Connection(state)),
+                }),
+                1 => srv_rx.try_recv().ok().map(|event| match event {
+                    ServerChannelMsg::Acp(event) => Some(AppEvent::Acp(event)),
+                }),
+                2 => sup_rx
+                    .try_recv()
+                    .ok()
+                    .map(|event| Some(AppEvent::Supervisor(event))),
+                3 => term_events
+                    .next()
+                    .now_or_never()
+                    .flatten()
+                    .map(terminal_event),
+                _ => unreachable!("non-tick source index must be in range"),
+            };
+            if let Some(event) = event {
+                self.next_non_tick_source = (source + 1) % NON_TICK_SOURCE_COUNT;
+                return event;
+            }
+        }
+
+        let (source, event) = tokio::select! {
+            Some(event) = conn_rx.recv() => (0, match event {
+                ConnectionManagerEvent::State(state) => Some(AppEvent::Connection(state)),
+            }),
+            Some(event) = srv_rx.recv() => (1, match event {
+                ServerChannelMsg::Acp(event) => Some(AppEvent::Acp(event)),
+            }),
+            Some(event) = sup_rx.recv() => (2, Some(AppEvent::Supervisor(event))),
+            Some(event_result) = term_events.next() => (3, terminal_event(event_result)),
+            else => return std::future::pending().await,
+        };
+        self.next_non_tick_source = (source + 1) % NON_TICK_SOURCE_COUNT;
+        event
+    }
+}
 
 pub(super) async fn run_loop(
     terminal: &mut AppTerminal,
@@ -27,18 +132,20 @@ pub(super) async fn run_loop(
 ) -> anyhow::Result<()> {
     let mut term_events = EventStream::new();
     let mut tick_interval = application_tick_interval();
+    let mut scheduler = EventScheduler::new();
 
     loop {
         terminal.draw(|frame| ui::draw(frame, app))?;
 
-        let event = next_event(
-            &mut tick_interval,
-            conn_rx,
-            srv_rx,
-            sup_rx,
-            &mut term_events,
-        )
-        .await;
+        let event = scheduler
+            .next_event(
+                &mut tick_interval,
+                conn_rx,
+                srv_rx,
+                sup_rx,
+                &mut term_events,
+            )
+            .await;
 
         if let Some(event) = event
             && execute_event(terminal, app, executor, event)?
@@ -76,28 +183,6 @@ fn application_tick_interval() -> Interval {
     interval
 }
 
-async fn next_event<S>(
-    tick_interval: &mut Interval,
-    conn_rx: &mut mpsc::UnboundedReceiver<ConnectionManagerEvent>,
-    srv_rx: &mut mpsc::UnboundedReceiver<ServerChannelMsg>,
-    sup_rx: &mut mpsc::UnboundedReceiver<server_manager::ServerEvent>,
-    term_events: &mut S,
-) -> Option<AppEvent>
-where
-    S: Stream<Item = std::io::Result<Event>> + Unpin,
-{
-    tokio::select! {
-        biased;
-        _ = tick_interval.tick() => Some(AppEvent::Tick),
-        Some(event) = conn_rx.recv() => match event {
-            ConnectionManagerEvent::State(state) => Some(AppEvent::Connection(state)),
-        },
-        Some(ServerChannelMsg::Acp(event)) = srv_rx.recv() => Some(AppEvent::Acp(event)),
-        Some(event) = sup_rx.recv() => Some(AppEvent::Supervisor(event)),
-        Some(event_result) = term_events.next() => terminal_event(event_result),
-    }
-}
-
 fn terminal_event(event: std::io::Result<Event>) -> Option<AppEvent> {
     event.ok().and_then(crossterm_event)
 }
@@ -114,12 +199,11 @@ fn crossterm_event(event: Event) -> Option<AppEvent> {
 
 #[cfg(test)]
 mod tests {
-    use std::pin::Pin;
-
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use futures::stream;
 
     use super::*;
+    use crate::acp_state::AcpAppEvent;
 
     fn test_terminal() -> AppTerminal {
         ratatui::Terminal::with_options(
@@ -150,60 +234,114 @@ mod tests {
         assert!(app.should_quit);
     }
 
-    #[tokio::test]
-    async fn persistent_tick_wins_when_connection_channel_stays_busy() {
-        let (conn_tx, mut conn_rx) = mpsc::unbounded_channel();
-        let (_srv_tx, mut srv_rx) = mpsc::unbounded_channel();
-        let (_sup_tx, mut sup_rx) = mpsc::unbounded_channel();
-        let mut term_events = stream::pending::<std::io::Result<Event>>();
-        let mut tick_interval = application_tick_interval();
-
-        conn_tx
-            .send(ConnectionManagerEvent::State(
-                crate::app::ConnectionEvent::Connecting {
-                    attempt: 1,
-                    delay_ms: 10,
-                },
-            ))
-            .unwrap();
-        tokio::time::sleep(TICK_INTERVAL + Duration::from_millis(10)).await;
-
-        assert!(matches!(
-            next_event(
-                &mut tick_interval,
-                &mut conn_rx,
-                &mut srv_rx,
-                &mut sup_rx,
-                &mut term_events,
-            )
-            .await,
-            Some(AppEvent::Tick)
-        ));
-        assert_eq!(conn_rx.len(), 1);
+    fn connection_event(attempt: u32) -> ConnectionManagerEvent {
+        ConnectionManagerEvent::State(crate::app::ConnectionEvent::Connecting {
+            attempt,
+            delay_ms: 10,
+        })
     }
 
     #[tokio::test]
-    async fn persistent_tick_reaches_each_interval_boundary_under_busy_traffic() {
+    async fn acp_progresses_while_connection_source_stays_ready() {
+        let (conn_tx, mut conn_rx) = mpsc::unbounded_channel();
+        let (srv_tx, mut srv_rx) = mpsc::unbounded_channel();
+        let (_sup_tx, mut sup_rx) = mpsc::unbounded_channel();
+        let mut term_events = stream::pending::<std::io::Result<Event>>();
+        let mut tick_interval = application_tick_interval();
+        let mut scheduler = EventScheduler::new();
+
+        for attempt in 1..=8 {
+            conn_tx.send(connection_event(attempt)).unwrap();
+        }
+        srv_tx
+            .send(ServerChannelMsg::Acp(AcpAppEvent::Error {
+                message: "acp-ready".into(),
+            }))
+            .unwrap();
+
+        let mut saw_acp = false;
+        for _ in 0..NON_TICK_SOURCE_COUNT {
+            let event = scheduler
+                .next_event(
+                    &mut tick_interval,
+                    &mut conn_rx,
+                    &mut srv_rx,
+                    &mut sup_rx,
+                    &mut term_events,
+                )
+                .await;
+            saw_acp |= matches!(
+                event,
+                Some(AppEvent::Acp(AcpAppEvent::Error { message })) if message == "acp-ready"
+            );
+            if saw_acp {
+                break;
+            }
+        }
+
+        assert!(saw_acp);
+        assert!(!conn_rx.is_empty());
+    }
+
+    #[tokio::test]
+    async fn supervisor_progresses_while_connection_source_stays_ready() {
         let (conn_tx, mut conn_rx) = mpsc::unbounded_channel();
         let (_srv_tx, mut srv_rx) = mpsc::unbounded_channel();
-        let (_sup_tx, mut sup_rx) = mpsc::unbounded_channel();
-        let mut term_events: Pin<Box<dyn Stream<Item = std::io::Result<Event>> + Send>> =
-            Box::pin(stream::pending());
+        let (sup_tx, mut sup_rx) = mpsc::unbounded_channel();
+        let mut term_events = stream::pending::<std::io::Result<Event>>();
         let mut tick_interval = application_tick_interval();
+        let mut scheduler = EventScheduler::new();
 
-        for attempt in 1..=3 {
-            conn_tx
-                .send(ConnectionManagerEvent::State(
-                    crate::app::ConnectionEvent::Connecting {
-                        attempt,
-                        delay_ms: 10,
-                    },
-                ))
-                .unwrap();
-            tokio::time::sleep(TICK_INTERVAL + Duration::from_millis(10)).await;
+        for attempt in 1..=8 {
+            conn_tx.send(connection_event(attempt)).unwrap();
+        }
+        sup_tx.send(server_manager::ServerEvent::Started).unwrap();
 
-            assert!(matches!(
-                next_event(
+        let mut saw_supervisor = false;
+        for _ in 0..NON_TICK_SOURCE_COUNT {
+            let event = scheduler
+                .next_event(
+                    &mut tick_interval,
+                    &mut conn_rx,
+                    &mut srv_rx,
+                    &mut sup_rx,
+                    &mut term_events,
+                )
+                .await;
+            saw_supervisor |= matches!(
+                event,
+                Some(AppEvent::Supervisor(server_manager::ServerEvent::Started))
+            );
+            if saw_supervisor {
+                break;
+            }
+        }
+
+        assert!(saw_supervisor);
+        assert!(!conn_rx.is_empty());
+    }
+
+    #[tokio::test]
+    async fn tick_progresses_while_non_tick_sources_are_busy() {
+        let (conn_tx, mut conn_rx) = mpsc::unbounded_channel();
+        let (srv_tx, mut srv_rx) = mpsc::unbounded_channel();
+        let (sup_tx, mut sup_rx) = mpsc::unbounded_channel();
+        let mut term_events = stream::pending::<std::io::Result<Event>>();
+        let mut tick_interval = application_tick_interval();
+        let mut scheduler = EventScheduler::new();
+
+        conn_tx.send(connection_event(1)).unwrap();
+        srv_tx
+            .send(ServerChannelMsg::Acp(AcpAppEvent::Error {
+                message: "busy".into(),
+            }))
+            .unwrap();
+        sup_tx.send(server_manager::ServerEvent::Started).unwrap();
+        tokio::time::sleep(TICK_INTERVAL + Duration::from_millis(20)).await;
+
+        assert!(matches!(
+            scheduler
+                .next_event(
                     &mut tick_interval,
                     &mut conn_rx,
                     &mut srv_rx,
@@ -211,10 +349,37 @@ mod tests {
                     &mut term_events,
                 )
                 .await,
-                Some(AppEvent::Tick)
-            ));
+            Some(AppEvent::Tick)
+        ));
+    }
+
+    #[tokio::test]
+    async fn overdue_tick_alternates_with_ready_non_tick_work() {
+        let (conn_tx, mut conn_rx) = mpsc::unbounded_channel();
+        let (_srv_tx, mut srv_rx) = mpsc::unbounded_channel();
+        let (_sup_tx, mut sup_rx) = mpsc::unbounded_channel();
+        let mut term_events = stream::pending::<std::io::Result<Event>>();
+        let mut tick_interval = application_tick_interval();
+        let mut scheduler = EventScheduler::new();
+
+        for attempt in 1..=4 {
+            conn_tx.send(connection_event(attempt)).unwrap();
         }
 
-        assert_eq!(conn_rx.len(), 3);
+        for expect_tick in [true, false, true, false] {
+            tokio::time::sleep(TICK_INTERVAL * 2 + Duration::from_millis(20)).await;
+            let event = scheduler
+                .next_event(
+                    &mut tick_interval,
+                    &mut conn_rx,
+                    &mut srv_rx,
+                    &mut sup_rx,
+                    &mut term_events,
+                )
+                .await;
+            assert_eq!(matches!(event, Some(AppEvent::Tick)), expect_tick);
+        }
+
+        assert_eq!(conn_rx.len(), 2);
     }
 }

--- a/src/runtime/event_loop.rs
+++ b/src/runtime/event_loop.rs
@@ -1,8 +1,11 @@
 use std::time::Duration;
 
 use crossterm::event::{self, Event, EventStream};
-use futures::StreamExt;
-use tokio::sync::mpsc;
+use futures::{Stream, StreamExt};
+use tokio::{
+    sync::mpsc,
+    time::{Instant, Interval, MissedTickBehavior},
+};
 
 use crate::{
     app::App,
@@ -11,6 +14,8 @@ use crate::{
 };
 
 use super::{ConnectionManagerEvent, EffectExecutor, ServerChannelMsg, terminal::AppTerminal};
+
+const TICK_INTERVAL: Duration = Duration::from_millis(80);
 
 pub(super) async fn run_loop(
     terminal: &mut AppTerminal,
@@ -21,42 +26,75 @@ pub(super) async fn run_loop(
     executor: &mut EffectExecutor<'_>,
 ) -> anyhow::Result<()> {
     let mut term_events = EventStream::new();
+    let mut tick_interval = application_tick_interval();
 
     loop {
         terminal.draw(|frame| ui::draw(frame, app))?;
 
-        let event = tokio::select! {
-            biased;
-            Some(event) = conn_rx.recv() => match event {
-                ConnectionManagerEvent::State(state) => Some(AppEvent::Connection(state)),
-            },
-            Some(ServerChannelMsg::Acp(event)) = srv_rx.recv() => Some(AppEvent::Acp(event)),
-            Some(event) = sup_rx.recv() => Some(AppEvent::Supervisor(event)),
-            Some(event_result) = term_events.next() => terminal_event(event_result),
-            _ = tokio::time::sleep(Duration::from_millis(80)) => Some(AppEvent::Tick),
-        };
+        let event = next_event(
+            &mut tick_interval,
+            conn_rx,
+            srv_rx,
+            sup_rx,
+            &mut term_events,
+        )
+        .await;
 
-        if let Some(event) = event {
-            let effects = application::update(app, event);
-            executor.execute(terminal, app, effects)?;
+        if let Some(event) = event
+            && execute_event(terminal, app, executor, event)?
+        {
+            return Ok(());
         }
 
-        while let Ok(true) = event::poll(Duration::from_millis(0)) {
+        while let Ok(true) = event::poll(Duration::ZERO) {
             let Ok(event) = event::read() else {
                 break;
             };
-            if let Some(event) = crossterm_event(event) {
-                let effects = application::update(app, event);
-                executor.execute(terminal, app, effects)?;
-            }
-            if app.should_quit {
-                break;
+            if let Some(event) = crossterm_event(event)
+                && execute_event(terminal, app, executor, event)?
+            {
+                return Ok(());
             }
         }
+    }
+}
 
-        if app.should_quit {
-            return Ok(());
-        }
+fn execute_event(
+    terminal: &mut AppTerminal,
+    app: &mut App,
+    executor: &mut EffectExecutor<'_>,
+    event: AppEvent,
+) -> anyhow::Result<bool> {
+    let effects = application::update(app, event);
+    executor.execute(terminal, app, effects)?;
+    Ok(app.should_quit)
+}
+
+fn application_tick_interval() -> Interval {
+    let mut interval = tokio::time::interval_at(Instant::now() + TICK_INTERVAL, TICK_INTERVAL);
+    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    interval
+}
+
+async fn next_event<S>(
+    tick_interval: &mut Interval,
+    conn_rx: &mut mpsc::UnboundedReceiver<ConnectionManagerEvent>,
+    srv_rx: &mut mpsc::UnboundedReceiver<ServerChannelMsg>,
+    sup_rx: &mut mpsc::UnboundedReceiver<server_manager::ServerEvent>,
+    term_events: &mut S,
+) -> Option<AppEvent>
+where
+    S: Stream<Item = std::io::Result<Event>> + Unpin,
+{
+    tokio::select! {
+        biased;
+        _ = tick_interval.tick() => Some(AppEvent::Tick),
+        Some(event) = conn_rx.recv() => match event {
+            ConnectionManagerEvent::State(state) => Some(AppEvent::Connection(state)),
+        },
+        Some(ServerChannelMsg::Acp(event)) = srv_rx.recv() => Some(AppEvent::Acp(event)),
+        Some(event) = sup_rx.recv() => Some(AppEvent::Supervisor(event)),
+        Some(event_result) = term_events.next() => terminal_event(event_result),
     }
 }
 
@@ -71,5 +109,112 @@ fn crossterm_event(event: Event) -> Option<AppEvent> {
         }
         Event::Mouse(mouse) => Some(AppEvent::Mouse(mouse)),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::pin::Pin;
+
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use futures::stream;
+
+    use super::*;
+
+    fn test_terminal() -> AppTerminal {
+        ratatui::Terminal::with_options(
+            ratatui::backend::CrosstermBackend::new(std::io::stdout()),
+            ratatui::TerminalOptions {
+                viewport: ratatui::Viewport::Fixed(ratatui::layout::Rect::new(0, 0, 80, 24)),
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn execute_event_reports_quit_immediately_after_effect_execution() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut executor = EffectExecutor::new(&tx);
+        let mut terminal = test_terminal();
+        let mut app = App::new();
+
+        let should_stop = execute_event(
+            &mut terminal,
+            &mut app,
+            &mut executor,
+            AppEvent::Key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+        )
+        .unwrap();
+
+        assert!(should_stop);
+        assert!(app.should_quit);
+    }
+
+    #[tokio::test]
+    async fn persistent_tick_wins_when_connection_channel_stays_busy() {
+        let (conn_tx, mut conn_rx) = mpsc::unbounded_channel();
+        let (_srv_tx, mut srv_rx) = mpsc::unbounded_channel();
+        let (_sup_tx, mut sup_rx) = mpsc::unbounded_channel();
+        let mut term_events = stream::pending::<std::io::Result<Event>>();
+        let mut tick_interval = application_tick_interval();
+
+        conn_tx
+            .send(ConnectionManagerEvent::State(
+                crate::app::ConnectionEvent::Connecting {
+                    attempt: 1,
+                    delay_ms: 10,
+                },
+            ))
+            .unwrap();
+        tokio::time::sleep(TICK_INTERVAL + Duration::from_millis(10)).await;
+
+        assert!(matches!(
+            next_event(
+                &mut tick_interval,
+                &mut conn_rx,
+                &mut srv_rx,
+                &mut sup_rx,
+                &mut term_events,
+            )
+            .await,
+            Some(AppEvent::Tick)
+        ));
+        assert_eq!(conn_rx.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn persistent_tick_reaches_each_interval_boundary_under_busy_traffic() {
+        let (conn_tx, mut conn_rx) = mpsc::unbounded_channel();
+        let (_srv_tx, mut srv_rx) = mpsc::unbounded_channel();
+        let (_sup_tx, mut sup_rx) = mpsc::unbounded_channel();
+        let mut term_events: Pin<Box<dyn Stream<Item = std::io::Result<Event>> + Send>> =
+            Box::pin(stream::pending());
+        let mut tick_interval = application_tick_interval();
+
+        for attempt in 1..=3 {
+            conn_tx
+                .send(ConnectionManagerEvent::State(
+                    crate::app::ConnectionEvent::Connecting {
+                        attempt,
+                        delay_ms: 10,
+                    },
+                ))
+                .unwrap();
+            tokio::time::sleep(TICK_INTERVAL + Duration::from_millis(10)).await;
+
+            assert!(matches!(
+                next_event(
+                    &mut tick_interval,
+                    &mut conn_rx,
+                    &mut srv_rx,
+                    &mut sup_rx,
+                    &mut term_events,
+                )
+                .await,
+                Some(AppEvent::Tick)
+            ));
+        }
+
+        assert_eq!(conn_rx.len(), 3);
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -65,10 +65,25 @@ impl<'a> EffectExecutor<'a> {
         while let Some(effect) = effects.next() {
             let runtime_event = match effect {
                 Effect::Command(command) => self.send_command(command),
-                Effect::CommandThen { command, on_sent } => match self.send_command(command) {
-                    Some(failed) => Some(failed),
-                    None => Some(on_sent),
-                },
+                Effect::ElicitationResponse {
+                    elicitation_id,
+                    action,
+                    content,
+                    outcome,
+                } => {
+                    let command = Command::ElicitationResponse {
+                        elicitation_id: elicitation_id.clone(),
+                        action,
+                        content,
+                    };
+                    match self.send_command(command) {
+                        Some(failed) => Some(failed),
+                        None => Some(RuntimeEvent::ElicitationResponseSent {
+                            elicitation_id,
+                            outcome,
+                        }),
+                    }
+                }
                 Effect::PersistConfig => {
                     config::TuiConfig::load().with_app_settings(app).save();
                     None
@@ -107,13 +122,16 @@ impl<'a> EffectExecutor<'a> {
     }
 
     fn send_command(&self, command: Command) -> Option<RuntimeEvent> {
-        self.cmd_tx
-            .send(command.clone())
-            .err()
-            .map(|error| RuntimeEvent::CommandFailed {
-                command,
-                message: error.to_string(),
-            })
+        match self.cmd_tx.send(command) {
+            Ok(()) => None,
+            Err(error) => {
+                let message = error.to_string();
+                Some(RuntimeEvent::CommandFailed {
+                    command: error.0,
+                    message,
+                })
+            }
+        }
     }
 }
 
@@ -159,12 +177,22 @@ impl TestEffects {
     pub(crate) fn next_command(&mut self) -> Option<Command> {
         if !matches!(
             self.effects.first(),
-            Some(Effect::Command(_) | Effect::CommandThen { .. })
+            Some(Effect::Command(_) | Effect::ElicitationResponse { .. })
         ) {
             return None;
         }
         match self.effects.remove(0) {
-            Effect::Command(command) | Effect::CommandThen { command, .. } => Some(command),
+            Effect::Command(command) => Some(command),
+            Effect::ElicitationResponse {
+                elicitation_id,
+                action,
+                content,
+                ..
+            } => Some(Command::ElicitationResponse {
+                elicitation_id,
+                action,
+                content,
+            }),
             _ => unreachable!("first effect must contain a command"),
         }
     }
@@ -185,6 +213,7 @@ impl TestEffects {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::command::PromptBlock;
     use crate::domain::chat::{ChatEntry, OUTCOME_BULLET};
     use crate::domain::elicitation::{
         ElicitationField, ElicitationFieldKind, ElicitationOption, ElicitationState,
@@ -272,12 +301,11 @@ mod tests {
                 &mut terminal,
                 &mut app,
                 vec![
-                    Effect::CommandThen {
-                        command: command.clone(),
-                        on_sent: RuntimeEvent::ElicitationResponseSent {
-                            elicitation_id: "test-id".into(),
-                            outcome: format!("{OUTCOME_BULLET}Alpha"),
-                        },
+                    Effect::ElicitationResponse {
+                        elicitation_id: "test-id".into(),
+                        action: "accept".into(),
+                        content: Some(serde_json::json!({ "choice": "a" })),
+                        outcome: format!("{OUTCOME_BULLET}Alpha"),
                     },
                     Effect::Command(Command::Init),
                 ],
@@ -296,28 +324,21 @@ mod tests {
     }
 
     #[test]
-    fn effect_executor_command_then_failure_keeps_elicitation_open() {
+    fn effect_executor_elicitation_send_failure_keeps_elicitation_open() {
         let (tx, rx) = mpsc::unbounded_channel();
         drop(rx);
         let mut executor = EffectExecutor::new(&tx);
         let mut terminal = test_terminal();
         let mut app = make_app_with_elicitation(make_elicitation_single_select());
-        let command = Command::ElicitationResponse {
-            elicitation_id: "test-id".into(),
-            action: "decline".into(),
-            content: None,
-        };
-
         executor
             .execute(
                 &mut terminal,
                 &mut app,
-                vec![Effect::CommandThen {
-                    command,
-                    on_sent: RuntimeEvent::ElicitationResponseSent {
-                        elicitation_id: "test-id".into(),
-                        outcome: "declined".into(),
-                    },
+                vec![Effect::ElicitationResponse {
+                    elicitation_id: "test-id".into(),
+                    action: "decline".into(),
+                    content: None,
+                    outcome: "declined".into(),
                 }],
             )
             .unwrap();
@@ -349,6 +370,31 @@ mod tests {
         let persisted = config::TuiConfig::load();
         assert_eq!(persisted.profile.id.as_deref(), Some("fast"));
         assert_eq!(persisted.show_thinking, Some(false));
+    }
+
+    #[test]
+    fn effect_executor_failed_send_preserves_owned_command() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        drop(rx);
+        let executor = EffectExecutor::new(&tx);
+        let command = Command::Prompt {
+            prompt: vec![PromptBlock::Text {
+                text: "owned payload".into(),
+            }],
+            local_id: "local-owned".into(),
+        };
+
+        let event = executor
+            .send_command(command.clone())
+            .expect("closed receiver should reject command");
+
+        assert!(matches!(
+            event,
+            RuntimeEvent::CommandFailed {
+                command: failed,
+                message,
+            } if failed == command && message.contains("channel closed")
+        ));
     }
 
     #[test]
@@ -452,16 +498,11 @@ mod tests {
 
         assert_eq!(
             effects,
-            vec![Effect::CommandThen {
-                command: Command::ElicitationResponse {
-                    elicitation_id: "test-id".into(),
-                    action: "accept".into(),
-                    content: Some(serde_json::json!({ "choice": "b" })),
-                },
-                on_sent: RuntimeEvent::ElicitationResponseSent {
-                    elicitation_id: "test-id".into(),
-                    outcome: format!("{OUTCOME_BULLET}Beta"),
-                },
+            vec![Effect::ElicitationResponse {
+                elicitation_id: "test-id".into(),
+                action: "accept".into(),
+                content: Some(serde_json::json!({ "choice": "b" })),
+                outcome: format!("{OUTCOME_BULLET}Beta"),
             }]
         );
         assert!(app.chat.elicitation.is_some());
@@ -501,16 +542,11 @@ mod tests {
         assert!(app.chat.elicitation.is_some());
         assert_eq!(
             effects.as_slice(),
-            &[Effect::CommandThen {
-                command: Command::ElicitationResponse {
-                    elicitation_id: "test-id".into(),
-                    action: "accept".into(),
-                    content: Some(serde_json::json!({ "choice": "custom\nanswer" })),
-                },
-                on_sent: RuntimeEvent::ElicitationResponseSent {
-                    elicitation_id: "test-id".into(),
-                    outcome: format!("{OUTCOME_BULLET}custom\nanswer"),
-                },
+            &[Effect::ElicitationResponse {
+                elicitation_id: "test-id".into(),
+                action: "accept".into(),
+                content: Some(serde_json::json!({ "choice": "custom\nanswer" })),
+                outcome: format!("{OUTCOME_BULLET}custom\nanswer"),
             }]
         );
     }
@@ -537,16 +573,11 @@ mod tests {
         assert!(app.chat.elicitation.is_some());
         assert_eq!(
             effects.as_slice(),
-            &[Effect::CommandThen {
-                command: Command::ElicitationResponse {
-                    elicitation_id: "test-id".into(),
-                    action: "decline".into(),
-                    content: None,
-                },
-                on_sent: RuntimeEvent::ElicitationResponseSent {
-                    elicitation_id: "test-id".into(),
-                    outcome: "declined".into(),
-                },
+            &[Effect::ElicitationResponse {
+                elicitation_id: "test-id".into(),
+                action: "decline".into(),
+                content: None,
+                outcome: "declined".into(),
             }]
         );
     }
@@ -574,16 +605,11 @@ mod tests {
 
         assert_eq!(
             effects,
-            vec![Effect::CommandThen {
-                command: Command::ElicitationResponse {
-                    elicitation_id: "test-id".into(),
-                    action: "decline".into(),
-                    content: None,
-                },
-                on_sent: RuntimeEvent::ElicitationResponseSent {
-                    elicitation_id: "test-id".into(),
-                    outcome: "declined".into(),
-                },
+            vec![Effect::ElicitationResponse {
+                elicitation_id: "test-id".into(),
+                action: "decline".into(),
+                content: None,
+                outcome: "declined".into(),
             }]
         );
         assert!(app.chat.elicitation.is_some());
@@ -608,16 +634,11 @@ mod tests {
 
         assert_eq!(
             effects,
-            vec![Effect::CommandThen {
-                command: Command::ElicitationResponse {
-                    elicitation_id: "test-id".into(),
-                    action: "accept".into(),
-                    content: Some(serde_json::json!({ "name": "Alice" })),
-                },
-                on_sent: RuntimeEvent::ElicitationResponseSent {
-                    elicitation_id: "test-id".into(),
-                    outcome: "Alice".into(),
-                },
+            vec![Effect::ElicitationResponse {
+                elicitation_id: "test-id".into(),
+                action: "accept".into(),
+                content: Some(serde_json::json!({ "name": "Alice" })),
+                outcome: "Alice".into(),
             }]
         );
         assert!(app.chat.elicitation.is_some());
@@ -699,16 +720,11 @@ mod tests {
         assert!(app.chat.elicitation.is_some());
         assert_eq!(
             effects.as_slice(),
-            &[Effect::CommandThen {
-                command: Command::ElicitationResponse {
-                    elicitation_id: "test-id".into(),
-                    action: "accept".into(),
-                    content: Some(serde_json::json!({ "confirm": true })),
-                },
-                on_sent: RuntimeEvent::ElicitationResponseSent {
-                    elicitation_id: "test-id".into(),
-                    outcome: "Yes".into(),
-                },
+            &[Effect::ElicitationResponse {
+                elicitation_id: "test-id".into(),
+                action: "accept".into(),
+                content: Some(serde_json::json!({ "confirm": true })),
+                outcome: "Yes".into(),
             }]
         );
     }
@@ -733,16 +749,11 @@ mod tests {
         assert!(app.chat.elicitation.is_some());
         assert_eq!(
             effects.as_slice(),
-            &[Effect::CommandThen {
-                command: Command::ElicitationResponse {
-                    elicitation_id: "test-id".into(),
-                    action: "accept".into(),
-                    content: Some(serde_json::json!({ "confirm": false })),
-                },
-                on_sent: RuntimeEvent::ElicitationResponseSent {
-                    elicitation_id: "test-id".into(),
-                    outcome: "No".into(),
-                },
+            &[Effect::ElicitationResponse {
+                elicitation_id: "test-id".into(),
+                action: "accept".into(),
+                content: Some(serde_json::json!({ "confirm": false })),
+                outcome: "No".into(),
             }]
         );
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4,12 +4,17 @@ mod endpoint;
 mod event_loop;
 mod terminal;
 
-use std::time::Duration;
+use std::{
+    io::Write,
+    process::{Command as ProcessCommand, Stdio},
+    time::Duration,
+};
 
 use crate::{
     acp_client,
     acp_state::AcpAppEvent,
     app::{self, App},
+    application::{self, AppEvent, Effect, RuntimeEvent, TerminalAction},
     command::Command,
     config,
     connection_state::ServerState,
@@ -24,6 +29,7 @@ use endpoint::{
     Cli, EndpointSelection, default_acp_ws_url, detect_launch_cwd, select_acp_endpoint,
 };
 use event_loop::run_loop;
+use terminal::AppTerminal;
 
 use tokio::sync::mpsc;
 
@@ -40,6 +46,131 @@ pub(crate) enum ServerChannelMsg {
     Acp(AcpAppEvent),
 }
 
+pub(super) struct EffectExecutor<'a> {
+    cmd_tx: &'a mpsc::UnboundedSender<Command>,
+}
+
+impl<'a> EffectExecutor<'a> {
+    fn new(cmd_tx: &'a mpsc::UnboundedSender<Command>) -> Self {
+        Self { cmd_tx }
+    }
+
+    pub(super) fn execute(
+        &mut self,
+        terminal: &mut AppTerminal,
+        app: &mut App,
+        effects: Vec<Effect>,
+    ) -> anyhow::Result<()> {
+        let mut effects = effects.into_iter();
+        while let Some(effect) = effects.next() {
+            let runtime_event = match effect {
+                Effect::Command(command) => self.cmd_tx.send(command.clone()).err().map(|error| {
+                    RuntimeEvent::CommandFailed {
+                        command,
+                        message: error.to_string(),
+                    }
+                }),
+                Effect::PersistConfig => {
+                    config::TuiConfig::load().with_app_settings(app).save();
+                    None
+                }
+                Effect::CopyToClipboard { target, text } => Some(RuntimeEvent::ClipboardFinished {
+                    target,
+                    success: copy_text_to_clipboard(&text),
+                }),
+                Effect::OpenExternalEditor { initial_text } => {
+                    Some(RuntimeEvent::ExternalEditorFinished {
+                        outcome: terminal::open_external_editor_with_terminal(
+                            terminal,
+                            &initial_text,
+                        ),
+                    })
+                }
+                Effect::Terminal(TerminalAction::Redraw) => {
+                    terminal::redraw(terminal)?;
+                    None
+                }
+                Effect::Quit => {
+                    app.should_quit = true;
+                    None
+                }
+            };
+
+            if let Some(event) = runtime_event {
+                effects = application::update(app, AppEvent::Runtime(event))
+                    .into_iter()
+                    .chain(effects)
+                    .collect::<Vec<_>>()
+                    .into_iter();
+            }
+        }
+        Ok(())
+    }
+}
+
+fn copy_text_to_clipboard(text: &str) -> bool {
+    let commands = [
+        ("xclip", &["-selection", "clipboard"] as &[&str]),
+        ("xsel", &["--clipboard", "--input"]),
+        ("wl-copy", &[]),
+        ("pbcopy", &[]),
+    ];
+
+    for (command, args) in commands {
+        if let Ok(mut child) = ProcessCommand::new(command)
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            if let Some(stdin) = child.stdin.as_mut() {
+                let _ = stdin.write_all(text.as_bytes());
+            }
+            if child.wait().is_ok_and(|status| status.success()) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+#[derive(Default)]
+pub(crate) struct TestEffects {
+    effects: Vec<Effect>,
+}
+
+#[cfg(test)]
+impl TestEffects {
+    pub(crate) fn extend(&mut self, effects: Vec<Effect>) {
+        self.effects.extend(effects);
+    }
+
+    pub(crate) fn next_command(&mut self) -> Option<Command> {
+        let index = self
+            .effects
+            .iter()
+            .position(|effect| matches!(effect, Effect::Command(_)))?;
+        match self.effects.remove(index) {
+            Effect::Command(command) => Some(command),
+            _ => unreachable!("located effect must be a command"),
+        }
+    }
+
+    pub(crate) fn as_slice(&self) -> &[Effect] {
+        &self.effects
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &Effect> {
+        self.effects.iter()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.effects.is_empty()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -50,7 +181,6 @@ mod tests {
     use crate::domain::tool::ToolDetail;
     use crate::handlers::*;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-    use tokio::sync::mpsc;
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::empty())
@@ -58,6 +188,102 @@ mod tests {
 
     fn modified_key(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
         KeyEvent::new(code, modifiers)
+    }
+
+    fn test_terminal() -> AppTerminal {
+        ratatui::Terminal::with_options(
+            ratatui::backend::CrosstermBackend::new(std::io::stdout()),
+            ratatui::TerminalOptions {
+                viewport: ratatui::Viewport::Fixed(ratatui::layout::Rect::new(0, 0, 80, 24)),
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_effects_next_command_preserves_non_command_effects() {
+        let mut effects = TestEffects::default();
+        effects.extend(vec![
+            Effect::PersistConfig,
+            Effect::Command(Command::Init),
+            Effect::Quit,
+        ]);
+
+        assert_eq!(effects.next_command(), Some(Command::Init));
+        assert_eq!(effects.as_slice(), &[Effect::PersistConfig, Effect::Quit]);
+    }
+
+    #[test]
+    fn effect_executor_sends_commands_once_in_order_and_applies_quit() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut executor = EffectExecutor::new(&tx);
+        let mut terminal = test_terminal();
+        let mut app = App::new();
+
+        executor
+            .execute(
+                &mut terminal,
+                &mut app,
+                vec![
+                    Effect::Command(Command::Init),
+                    Effect::Quit,
+                    Effect::Command(Command::ListAllModels { refresh: false }),
+                ],
+            )
+            .unwrap();
+
+        assert!(matches!(rx.try_recv(), Ok(Command::Init)));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(Command::ListAllModels { refresh: false })
+        ));
+        assert!(rx.try_recv().is_err());
+        assert!(app.should_quit);
+    }
+
+    #[test]
+    fn effect_executor_persists_current_app_settings() {
+        let _guard = crate::config::TestPersistenceGuard::new("effect-executor-persist");
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut executor = EffectExecutor::new(&tx);
+        let mut terminal = test_terminal();
+        let mut app = App::new();
+        app.profiles.active_profile_id = Some("fast".into());
+        app.chat.show_thinking = false;
+
+        executor
+            .execute(&mut terminal, &mut app, vec![Effect::PersistConfig])
+            .unwrap();
+
+        let persisted = config::TuiConfig::load();
+        assert_eq!(persisted.profile.id.as_deref(), Some("fast"));
+        assert_eq!(persisted.show_thinking, Some(false));
+    }
+
+    #[test]
+    fn effect_executor_routes_command_failure_back_through_update() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        drop(rx);
+        let mut executor = EffectExecutor::new(&tx);
+        let mut terminal = test_terminal();
+        let mut app = App::new();
+        let local_id = app.chat.push_pending_prompt("pending".into());
+
+        executor
+            .execute(
+                &mut terminal,
+                &mut app,
+                vec![Effect::Command(Command::Prompt {
+                    prompt: vec![],
+                    local_id: local_id.clone(),
+                })],
+            )
+            .unwrap();
+
+        assert!(app.chat.messages.iter().all(|entry| {
+            !matches!(entry, ChatEntry::User { message_id: Some(id), .. } if id == &local_id)
+        }));
+        assert!(app.diagnostics.status.contains("channel closed"));
     }
 
     fn make_elicitation_single_select() -> ElicitationState {
@@ -113,32 +339,32 @@ mod tests {
     #[test]
     fn elicitation_down_moves_option_cursor() {
         let mut app = make_app_with_elicitation(make_elicitation_single_select());
-        let (tx, _rx) = mpsc::unbounded_channel();
-        handle_elicitation_key(&mut app, key(KeyCode::Down), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Down)));
         assert_eq!(app.chat.elicitation_ui.as_ref().unwrap().option_cursor, 1);
     }
 
     #[test]
     fn elicitation_up_does_not_go_below_zero() {
         let mut app = make_app_with_elicitation(make_elicitation_single_select());
-        let (tx, _rx) = mpsc::unbounded_channel();
-        handle_elicitation_key(&mut app, key(KeyCode::Up), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Up)));
         assert_eq!(app.chat.elicitation_ui.as_ref().unwrap().option_cursor, 0);
     }
 
     #[test]
     fn elicitation_enter_on_single_select_sends_accept_and_resolves() {
         let mut app = make_app_with_elicitation(make_elicitation_single_select());
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
         // Move to Beta and press Enter
-        handle_elicitation_key(&mut app, key(KeyCode::Down), &tx).unwrap();
-        handle_elicitation_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Down)));
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Enter)));
 
         // Elicitation should be cleared
         assert!(app.chat.elicitation.is_none());
 
         // Accept response sent
-        let msg = rx.try_recv().expect("message sent");
+        let msg = effects.next_command().expect("message sent");
         assert!(matches!(msg,
             Command::ElicitationResponse { action, content: Some(ref c), .. }
             if action == "accept" && c["choice"] == "b"
@@ -153,11 +379,11 @@ mod tests {
     #[test]
     fn elicitation_other_opens_multiline_editor_and_submits_custom_answer() {
         let mut app = make_app_with_elicitation(make_elicitation_single_select());
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_elicitation_key(&mut app, key(KeyCode::Down), &tx).unwrap();
-        handle_elicitation_key(&mut app, key(KeyCode::Down), &tx).unwrap();
-        handle_elicitation_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Down)));
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Down)));
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Enter)));
         assert!(
             app.chat
                 .elicitation_ui
@@ -166,21 +392,19 @@ mod tests {
         );
 
         for c in "custom".chars() {
-            handle_elicitation_key(&mut app, key(KeyCode::Char(c)), &tx).unwrap();
+            effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Char(c))));
         }
-        handle_elicitation_key(
+        effects.extend(handle_elicitation_key(
             &mut app,
             modified_key(KeyCode::Enter, KeyModifiers::SHIFT),
-            &tx,
-        )
-        .unwrap();
+        ));
         for c in "answer".chars() {
-            handle_elicitation_key(&mut app, key(KeyCode::Char(c)), &tx).unwrap();
+            effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Char(c))));
         }
-        handle_elicitation_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Enter)));
 
         assert!(app.chat.elicitation.is_none());
-        assert!(matches!(rx.try_recv().expect("message sent"),
+        assert!(matches!(effects.next_command().expect("message sent"),
             Command::ElicitationResponse { action, content: Some(ref c), .. }
             if action == "accept" && c["choice"] == "custom\nanswer"
         ));
@@ -189,12 +413,12 @@ mod tests {
     #[test]
     fn elicitation_custom_esc_returns_to_choices_before_declining() {
         let mut app = make_app_with_elicitation(make_elicitation_single_select());
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
         for _ in 0..2 {
-            handle_elicitation_key(&mut app, key(KeyCode::Down), &tx).unwrap();
+            effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Down)));
         }
-        handle_elicitation_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
-        handle_elicitation_key(&mut app, key(KeyCode::Esc), &tx).unwrap();
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Enter)));
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Esc)));
 
         assert!(
             app.chat
@@ -202,11 +426,11 @@ mod tests {
                 .as_ref()
                 .is_some_and(|ui| !ui.custom_active)
         );
-        assert!(rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
 
-        handle_elicitation_key(&mut app, key(KeyCode::Esc), &tx).unwrap();
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Esc)));
         assert!(app.chat.elicitation.is_none());
-        assert!(matches!(rx.try_recv().expect("decline sent"),
+        assert!(matches!(effects.next_command().expect("decline sent"),
             Command::ElicitationResponse { action, .. } if action == "decline"
         ));
     }
@@ -214,26 +438,26 @@ mod tests {
     #[test]
     fn elicitation_empty_custom_answer_stays_open() {
         let mut app = make_app_with_elicitation(make_elicitation_single_select());
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
         for _ in 0..2 {
-            handle_elicitation_key(&mut app, key(KeyCode::Down), &tx).unwrap();
+            effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Down)));
         }
-        handle_elicitation_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
-        handle_elicitation_key(&mut app, key(KeyCode::Char(' ')), &tx).unwrap();
-        handle_elicitation_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Enter)));
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Char(' '))));
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Enter)));
 
         assert!(app.chat.elicitation.is_some());
-        assert!(rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
     }
 
     #[test]
     fn elicitation_esc_sends_decline_and_resolves() {
         let mut app = make_app_with_elicitation(make_elicitation_single_select());
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        handle_elicitation_key(&mut app, key(KeyCode::Esc), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Esc)));
 
         assert!(app.chat.elicitation.is_none());
-        let msg = rx.try_recv().expect("message sent");
+        let msg = effects.next_command().expect("message sent");
         assert!(matches!(msg,
             Command::ElicitationResponse { action, .. } if action == "decline"
         ));
@@ -253,11 +477,11 @@ mod tests {
                 kind: ElicitationFieldKind::TextInput,
             }]));
         app.chat.elicitation.as_mut().unwrap().text_input = "Alice".into();
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        handle_elicitation_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Enter)));
 
         assert!(app.chat.elicitation.is_none());
-        let msg = rx.try_recv().expect("message sent");
+        let msg = effects.next_command().expect("message sent");
         assert!(matches!(msg,
             Command::ElicitationResponse { action, content: Some(ref c), .. }
             if action == "accept" && c["name"] == "Alice"
@@ -277,9 +501,9 @@ mod tests {
                 required: false,
                 kind: ElicitationFieldKind::TextInput,
             }]));
-        let (tx, _rx) = mpsc::unbounded_channel();
-        handle_elicitation_key(&mut app, key(KeyCode::Char('H')), &tx).unwrap();
-        handle_elicitation_key(&mut app, key(KeyCode::Char('i')), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Char('H'))));
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Char('i'))));
         assert_eq!(app.chat.elicitation.as_ref().unwrap().text_input, "Hi");
     }
 
@@ -295,20 +519,23 @@ mod tests {
             }]));
         app.chat.elicitation.as_mut().unwrap().text_input = "Hi".into();
         app.chat.elicitation_ui.as_mut().unwrap().text_cursor = 2;
-        let (tx, _rx) = mpsc::unbounded_channel();
-        handle_elicitation_key(&mut app, key(KeyCode::Backspace), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Backspace)));
         assert_eq!(app.chat.elicitation.as_ref().unwrap().text_input, "H");
     }
 
     #[test]
     fn elicitation_enter_on_required_boolean_without_toggle_does_not_submit() {
         let mut app = make_app_with_elicitation(make_boolean_elicitation(true));
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_elicitation_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Enter)));
 
         assert!(app.chat.elicitation.is_some(), "popup should remain open");
-        assert!(rx.try_recv().is_err(), "no response should be sent");
+        assert!(
+            effects.next_command().is_none(),
+            "no response should be sent"
+        );
         assert!(
             app.chat
                 .messages
@@ -320,9 +547,9 @@ mod tests {
     #[test]
     fn elicitation_boolean_space_toggles_true_then_enter_submits() {
         let mut app = make_app_with_elicitation(make_boolean_elicitation(true));
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_elicitation_key(&mut app, key(KeyCode::Char(' ')), &tx).unwrap();
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Char(' '))));
         assert_eq!(
             app.chat
                 .elicitation
@@ -331,10 +558,10 @@ mod tests {
             Some(&serde_json::json!(true))
         );
 
-        handle_elicitation_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Enter)));
 
         assert!(app.chat.elicitation.is_none());
-        let msg = rx.try_recv().expect("message sent");
+        let msg = effects.next_command().expect("message sent");
         assert!(matches!(msg,
             Command::ElicitationResponse { action, content: Some(ref c), .. }
             if action == "accept" && c["confirm"] == true
@@ -347,10 +574,10 @@ mod tests {
     #[test]
     fn elicitation_boolean_second_space_toggles_false_and_still_submits() {
         let mut app = make_app_with_elicitation(make_boolean_elicitation(true));
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_elicitation_key(&mut app, key(KeyCode::Char(' ')), &tx).unwrap();
-        handle_elicitation_key(&mut app, key(KeyCode::Char(' ')), &tx).unwrap();
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Char(' '))));
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Char(' '))));
         assert_eq!(
             app.chat
                 .elicitation
@@ -359,10 +586,10 @@ mod tests {
             Some(&serde_json::json!(false))
         );
 
-        handle_elicitation_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Enter)));
 
         assert!(app.chat.elicitation.is_none());
-        let msg = rx.try_recv().expect("message sent");
+        let msg = effects.next_command().expect("message sent");
         assert!(matches!(msg,
             Command::ElicitationResponse { action, content: Some(ref c), .. }
             if action == "accept" && c["confirm"] == false
@@ -375,16 +602,19 @@ mod tests {
     #[test]
     fn elicitation_key_handler_ignores_empty_field_list() {
         let mut app = make_app_with_elicitation(ElicitationState::new_for_test(vec![]));
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_elicitation_key(&mut app, key(KeyCode::Down), &tx).unwrap();
-        handle_elicitation_key(&mut app, key(KeyCode::Char(' ')), &tx).unwrap();
-        handle_elicitation_key(&mut app, key(KeyCode::Char('x')), &tx).unwrap();
-        handle_elicitation_key(&mut app, key(KeyCode::Backspace), &tx).unwrap();
-        handle_elicitation_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Down)));
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Char(' '))));
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Char('x'))));
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Backspace)));
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Enter)));
 
         assert!(app.chat.elicitation.is_some());
-        assert!(rx.try_recv().is_err(), "no response should be sent");
+        assert!(
+            effects.next_command().is_none(),
+            "no response should be sent"
+        );
     }
 
     #[test]
@@ -512,7 +742,7 @@ mod external_editor_tests {
 
     #[test]
     fn chat_up_down_navigate_wrapped_input_without_scrolling_history() {
-        let (tx, _rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.composer.input = "abcdef".into();
@@ -520,97 +750,83 @@ mod external_editor_tests {
         app.composer.input_line_width = 4;
         app.chat.scroll_offset = 7;
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Up, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
         assert_eq!(app.composer.input_cursor, 2);
         assert_eq!(app.chat.scroll_offset, 7);
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Down, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
         assert_eq!(app.composer.input_cursor, 4);
         assert_eq!(app.chat.scroll_offset, 7);
     }
 
     #[test]
     fn chat_pageup_pagedown_still_scroll_history() {
-        let (tx, _rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.chat.scroll_offset = 3;
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::PageUp, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
         assert_eq!(app.chat.scroll_offset, 13);
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::PageDown, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
         assert_eq!(app.chat.scroll_offset, 3);
     }
 
     #[test]
     fn ctrl_x_e_returns_open_editor_action_in_chat() {
-        let (tx, _rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.composer.input = "draft".into();
-        assert_eq!(
-            handle_key(&mut app, ctrl_x(), &tx).unwrap(),
-            AppAction::None
-        );
+        assert!(handle_key(&mut app, ctrl_x()).is_empty());
 
-        let action = handle_key(&mut app, plain_key('e'), &tx).unwrap();
+        effects.extend(handle_key(&mut app, plain_key('e')));
 
-        assert_eq!(action, AppAction::OpenExternalEditor);
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::OpenExternalEditor { initial_text }] if initial_text == "draft"
+        ));
         assert!(!app.navigation.chord);
         assert_eq!(app.composer.input, "draft");
     }
 
     #[test]
     fn ctrl_x_e_outside_chat_stays_in_tui() {
-        let (tx, _rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Sessions;
-        assert_eq!(
-            handle_key(&mut app, ctrl_x(), &tx).unwrap(),
-            AppAction::None
-        );
+        assert!(handle_key(&mut app, ctrl_x()).is_empty());
 
-        let action = handle_key(&mut app, plain_key('e'), &tx).unwrap();
+        effects.extend(handle_key(&mut app, plain_key('e')));
 
-        assert_eq!(action, AppAction::None);
+        assert!(effects.is_empty());
         assert!(app.diagnostics.status.contains("only available in chat"));
         assert!(matches!(app.diagnostics.logs.last(), Some(entry) if entry.target == "editor"));
     }
 
     #[test]
     fn ctrl_x_m_outside_chat_does_not_open_model_popup() {
-        let (tx, _rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Sessions;
-        assert_eq!(
-            handle_key(&mut app, ctrl_x(), &tx).unwrap(),
-            AppAction::None
-        );
+        assert!(handle_key(&mut app, ctrl_x()).is_empty());
 
-        let action = handle_key(&mut app, plain_key('m'), &tx).unwrap();
+        effects.extend(handle_key(&mut app, plain_key('m')));
 
-        assert_eq!(action, AppAction::None);
+        assert!(effects.is_empty());
         assert_ne!(app.navigation.popup, Popup::ModelSelect);
         assert!(app.diagnostics.status.contains("only available in chat"));
         assert!(matches!(app.diagnostics.logs.last(), Some(entry) if entry.target == "model"));
@@ -658,7 +874,7 @@ mod external_editor_tests {
 
     #[test]
     fn chat_input_accepts_typing_and_submit_while_turn_active() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.connection.conn = ConnState::Connected;
@@ -666,21 +882,17 @@ mod external_editor_tests {
             name: "read_tool".into(),
         };
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('n'), KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
-        handle_chat_key(
+        ));
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert!(matches!(
-            rx.try_recv().expect("prompt sent"),
+            effects.next_command().expect("prompt sent"),
             Command::Prompt { prompt, local_id }
                 if local_id.starts_with("local:pending:")
                     && matches!(prompt.as_slice(), [PromptBlock::Text { text }] if text == "n")
@@ -695,22 +907,20 @@ mod external_editor_tests {
 
     #[test]
     fn chat_submit_normalizes_prompt_before_sending_and_rendering() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.connection.conn = ConnState::Connected;
         app.composer.input = "  first line\nsecond line\n  ".into();
         app.composer.input_cursor = app.composer.input.len();
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert!(matches!(
-            rx.try_recv().expect("prompt sent"),
+            effects.next_command().expect("prompt sent"),
             Command::Prompt { prompt, .. }
                 if matches!(prompt.as_slice(), [PromptBlock::Text { text }]
                     if text == "first line\nsecond line")
@@ -723,21 +933,19 @@ mod external_editor_tests {
 
     #[test]
     fn whitespace_only_chat_submit_does_not_send_or_render_prompt() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.connection.conn = ConnState::Connected;
         app.composer.input = " \n  ".into();
         app.composer.input_cursor = app.composer.input.len();
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
-        assert!(rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
         assert!(app.chat.messages.is_empty());
         assert!(app.composer.input.is_empty());
     }
@@ -746,7 +954,7 @@ mod external_editor_tests {
 
     #[test]
     fn left_arrow_with_slash_input_does_not_crash() {
-        let (tx, _rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.composer.input = "/model".into();
@@ -756,12 +964,10 @@ mod external_editor_tests {
 
         // hold left until cursor reaches 0 — must not panic at any step
         for _ in 0..=app.composer.input.len() {
-            handle_chat_key(
+            effects.extend(handle_chat_key(
                 &mut app,
                 KeyEvent::new(KeyCode::Left, KeyModifiers::empty()),
-                &tx,
-            )
-            .unwrap();
+            ));
         }
         assert_eq!(app.composer.input_cursor, 0);
         assert!(app.composer.slash_state.is_none());
@@ -769,7 +975,7 @@ mod external_editor_tests {
 
     #[test]
     fn slash_esc_clears_slash_state() {
-        let (tx, _rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.composer.input = "/mo".into();
@@ -777,31 +983,27 @@ mod external_editor_tests {
         app.composer.refresh_slash_state();
         assert!(app.composer.slash_state.is_some());
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert!(app.composer.slash_state.is_none());
     }
 
     #[test]
     fn slash_enter_opens_help_popup() {
-        let (tx, _rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.composer.input = "/help".into();
         app.composer.input_cursor = "/help".len();
         app.composer.refresh_slash_state();
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert_eq!(app.navigation.popup, Popup::Help);
         assert!(app.composer.input.is_empty());
@@ -809,7 +1011,7 @@ mod external_editor_tests {
 
     #[test]
     fn slash_enter_with_partial_completion_executes_command() {
-        let (tx, _rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.composer.input = "/hel".into();
@@ -817,12 +1019,10 @@ mod external_editor_tests {
         app.composer.refresh_slash_state();
         assert!(app.composer.slash_state.is_some());
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert_eq!(app.navigation.popup, Popup::Help);
         assert!(app.composer.input.is_empty());
@@ -831,19 +1031,17 @@ mod external_editor_tests {
 
     #[test]
     fn slash_tab_completes_command_name_without_executing() {
-        let (tx, _rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.composer.input = "/hel".into();
         app.composer.input_cursor = "/hel".len();
         app.composer.refresh_slash_state();
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Tab, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         // Completed but not executed — no popup opened
         assert_eq!(app.composer.input, "/help ");
@@ -853,7 +1051,7 @@ mod external_editor_tests {
 
     #[test]
     fn slash_down_up_navigates_selection() {
-        let (tx, _rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.composer.input = "/".into();
@@ -861,23 +1059,19 @@ mod external_editor_tests {
         app.composer.refresh_slash_state();
         let initial = app.composer.slash_state.as_ref().unwrap().selected_index;
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Down, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
         assert_eq!(
             app.composer.slash_state.as_ref().unwrap().selected_index,
             initial + 1
         );
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Up, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
         assert_eq!(
             app.composer.slash_state.as_ref().unwrap().selected_index,
             initial
@@ -888,7 +1082,7 @@ mod external_editor_tests {
     #[serial]
     fn slash_mode_no_arg_cycles_mode() {
         let _guard = TestPersistenceGuard::new("slash-mode-cycle");
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.connection.conn = ConnState::Connected;
@@ -897,18 +1091,16 @@ mod external_editor_tests {
         app.composer.input = "/mode".into();
         app.composer.input_cursor = "/mode".len();
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert_eq!(app.sessions.agent_mode, "plan");
         assert!(app.composer.input.is_empty());
         // SetAgentMode should have been sent
         assert!(matches!(
-            rx.try_recv().expect("SetAgentMode sent"),
+            effects.next_command().expect("SetAgentMode sent"),
             Command::SetAgentMode { mode } if mode == "plan"
         ));
     }
@@ -917,7 +1109,7 @@ mod external_editor_tests {
     #[serial]
     fn slash_mode_plan_switches_to_plan() {
         let _guard = TestPersistenceGuard::new("slash-mode-plan");
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.connection.conn = ConnState::Connected;
@@ -926,23 +1118,21 @@ mod external_editor_tests {
         app.composer.input = "/mode plan".into();
         app.composer.input_cursor = "/mode plan".len();
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert_eq!(app.sessions.agent_mode, "plan");
         assert!(matches!(
-            rx.try_recv().expect("SetAgentMode sent"),
+            effects.next_command().expect("SetAgentMode sent"),
             Command::SetAgentMode { mode } if mode == "plan"
         ));
     }
 
     #[test]
     fn slash_mode_same_is_idempotent() {
-        let (tx, _rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.connection.conn = ConnState::Connected;
@@ -951,12 +1141,10 @@ mod external_editor_tests {
         app.composer.input = "/mode build".into();
         app.composer.input_cursor = "/mode build".len();
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert_eq!(app.sessions.agent_mode, "build");
         assert!(app.diagnostics.status.contains("already in build"));
@@ -964,7 +1152,7 @@ mod external_editor_tests {
 
     #[test]
     fn slash_mode_unknown_shows_error() {
-        let (tx, _rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.connection.conn = ConnState::Connected;
@@ -972,12 +1160,10 @@ mod external_editor_tests {
         app.composer.input = "/mode xyz".into();
         app.composer.input_cursor = "/mode xyz".len();
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert!(app.diagnostics.status.contains("unknown mode"));
     }
@@ -986,7 +1172,7 @@ mod external_editor_tests {
     #[serial]
     fn slash_thinking_high_sets_level() {
         let _guard = TestPersistenceGuard::new("slash-thinking-high");
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.connection.conn = ConnState::Connected;
@@ -994,16 +1180,14 @@ mod external_editor_tests {
         app.composer.input = "/thinking high".into();
         app.composer.input_cursor = "/thinking high".len();
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert_eq!(app.models.reasoning_effort, Some("high".into()));
         assert!(matches!(
-            rx.try_recv().expect("SetReasoningEffort sent"),
+            effects.next_command().expect("SetReasoningEffort sent"),
             Command::SetReasoningEffort { reasoning_effort } if reasoning_effort == "high"
         ));
     }
@@ -1012,7 +1196,7 @@ mod external_editor_tests {
     #[serial]
     fn slash_thinking_auto_clears_level() {
         let _guard = TestPersistenceGuard::new("slash-thinking-auto");
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.connection.conn = ConnState::Connected;
@@ -1021,16 +1205,14 @@ mod external_editor_tests {
         app.composer.input = "/thinking auto".into();
         app.composer.input_cursor = "/thinking auto".len();
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert_eq!(app.models.reasoning_effort, None);
         assert!(matches!(
-            rx.try_recv().expect("SetReasoningEffort sent"),
+            effects.next_command().expect("SetReasoningEffort sent"),
             Command::SetReasoningEffort { reasoning_effort } if reasoning_effort == "auto"
         ));
     }
@@ -1039,7 +1221,7 @@ mod external_editor_tests {
     #[serial]
     fn slash_thinking_med_alias_sets_medium() {
         let _guard = TestPersistenceGuard::new("slash-thinking-med");
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.connection.conn = ConnState::Connected;
@@ -1047,72 +1229,64 @@ mod external_editor_tests {
         app.composer.input = "/thinking med".into();
         app.composer.input_cursor = "/thinking med".len();
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert_eq!(app.models.reasoning_effort, Some("medium".into()));
         assert!(matches!(
-            rx.try_recv().expect("SetReasoningEffort sent"),
+            effects.next_command().expect("SetReasoningEffort sent"),
             Command::SetReasoningEffort { reasoning_effort } if reasoning_effort == "medium"
         ));
     }
 
     #[test]
     fn slash_thinking_no_arg_shows_current() {
-        let (tx, _rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.models.reasoning_effort = Some("high".into());
         app.composer.input = "/thinking".into();
         app.composer.input_cursor = "/thinking".len();
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert!(app.diagnostics.status.contains("thinking: high"));
     }
 
     #[test]
     fn slash_thinking_unknown_shows_error() {
-        let (tx, _rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.composer.input = "/thinking xyz".into();
         app.composer.input_cursor = "/thinking xyz".len();
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert!(app.diagnostics.status.contains("unknown level"));
     }
 
     #[test]
     fn slash_thinking_when_disconnected_does_not_change_state() {
-        let (tx, _rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.models.reasoning_effort = Some("high".into());
         app.composer.input = "/thinking max".into();
         app.composer.input_cursor = "/thinking max".len();
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         // state must not change when disconnected
         assert_eq!(app.models.reasoning_effort, Some("high".into()));
@@ -1143,20 +1317,18 @@ mod external_editor_tests {
 
     #[test]
     fn slash_fork_sends_latest_boundary() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = app_with_forkable_messages();
         app.composer.input = "/fork".into();
         app.composer.input_cursor = "/fork".len();
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert!(matches!(
-            rx.try_recv().expect("ForkSession sent"),
+            effects.next_command().expect("ForkSession sent"),
             Command::ForkSession { message_id } if message_id == "user-2"
         ));
         assert_eq!(app.chat.pending_fork_message_id.as_deref(), Some("user-2"));
@@ -1164,12 +1336,12 @@ mod external_editor_tests {
 
     #[test]
     fn ctrl_x_f_opens_fork_popup_and_filter_captures_text() {
-        let (tx, _rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = app_with_forkable_messages();
 
-        handle_key(&mut app, ctrl_x(), &tx).unwrap();
-        handle_key(&mut app, plain_key('f'), &tx).unwrap();
-        handle_key(&mut app, plain_key('b'), &tx).unwrap();
+        effects.extend(handle_key(&mut app, ctrl_x()));
+        effects.extend(handle_key(&mut app, plain_key('f')));
+        effects.extend(handle_key(&mut app, plain_key('b')));
 
         assert_eq!(app.navigation.popup, Popup::ForkTurnSelect);
         assert_eq!(app.chat.fork_filter, "b");
@@ -1179,35 +1351,33 @@ mod external_editor_tests {
 
     #[test]
     fn ctrl_x_f_in_delegate_view_does_not_open_fork_popup() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = app_with_forkable_messages();
         app.navigation.screen = Screen::Delegate;
 
-        handle_key(&mut app, ctrl_x(), &tx).unwrap();
-        handle_key(&mut app, plain_key('f'), &tx).unwrap();
+        effects.extend(handle_key(&mut app, ctrl_x()));
+        effects.extend(handle_key(&mut app, plain_key('f')));
 
         assert_ne!(app.navigation.popup, Popup::ForkTurnSelect);
-        assert!(rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
         assert!(app.diagnostics.status.contains("only available in chat"));
         assert!(matches!(app.diagnostics.logs.last(), Some(entry) if entry.target == "fork"));
     }
 
     #[test]
     fn slash_fork_in_delegate_view_sends_nothing() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = app_with_forkable_messages();
         app.navigation.screen = Screen::Delegate;
         app.composer.input = "/fork".into();
         app.composer.input_cursor = "/fork".len();
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
-        assert!(rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
         assert!(app.chat.pending_fork_message_id.is_none());
         assert!(app.diagnostics.status.contains("only available in chat"));
         assert!(matches!(app.diagnostics.logs.last(), Some(entry) if entry.target == "fork"));
@@ -1215,20 +1385,18 @@ mod external_editor_tests {
 
     #[test]
     fn fork_popup_enter_sends_selected_turn() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = app_with_forkable_messages();
         app.open_fork_turn_popup();
         app.chat.fork_filter = "alpha".into();
 
-        handle_fork_turn_popup_key(
+        effects.extend(handle_fork_turn_popup_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert!(matches!(
-            rx.try_recv().expect("ForkSession sent"),
+            effects.next_command().expect("ForkSession sent"),
             Command::ForkSession { message_id } if message_id == "asst-1"
         ));
         assert_eq!(app.chat.pending_fork_message_id.as_deref(), Some("asst-1"));
@@ -1236,19 +1404,17 @@ mod external_editor_tests {
 
     #[test]
     fn fork_popup_enter_with_default_cursor_sends_latest_visible_turn() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = app_with_forkable_messages();
         app.open_fork_turn_popup();
 
-        handle_fork_turn_popup_key(
+        effects.extend(handle_fork_turn_popup_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert!(matches!(
-            rx.try_recv().expect("ForkSession sent"),
+            effects.next_command().expect("ForkSession sent"),
             Command::ForkSession { message_id } if message_id == "user-2"
         ));
         assert_eq!(app.chat.pending_fork_message_id.as_deref(), Some("user-2"));
@@ -1256,26 +1422,24 @@ mod external_editor_tests {
 
     #[test]
     fn fork_popup_enter_with_no_eligible_turns_sends_nothing() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.connection.conn = ConnState::Connected;
         app.open_fork_turn_popup();
 
-        handle_fork_turn_popup_key(
+        effects.extend(handle_fork_turn_popup_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
-        assert!(rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
         assert!(app.diagnostics.status.contains("no forkable turns"));
     }
 
     #[test]
     fn slash_model_with_arg_prefilters_popup() {
-        let (tx, _rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.connection.conn = ConnState::Connected;
@@ -1283,12 +1447,10 @@ mod external_editor_tests {
         app.composer.input = "/model sonnet".into();
         app.composer.input_cursor = "/model sonnet".len();
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert_eq!(app.navigation.popup, Popup::ModelSelect);
         assert_eq!(app.models.model_filter, "sonnet");
@@ -1297,7 +1459,7 @@ mod external_editor_tests {
 
     #[test]
     fn slash_model_no_arg_opens_popup_unfiltered() {
-        let (tx, _rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.connection.conn = ConnState::Connected;
@@ -1305,12 +1467,10 @@ mod external_editor_tests {
         app.composer.input = "/model".into();
         app.composer.input_cursor = "/model".len();
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert_eq!(app.navigation.popup, Popup::ModelSelect);
         assert!(app.models.model_filter.is_empty());
@@ -1318,29 +1478,25 @@ mod external_editor_tests {
 
     #[test]
     fn chat_double_esc_cancels_running_tool_phase() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.chat.activity = ActivityState::RunningTool {
             name: "read_tool".into(),
         };
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
         assert!(app.chat.cancel_confirm_active());
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
         assert!(matches!(
-            rx.try_recv().expect("cancel sent"),
+            effects.next_command().expect("cancel sent"),
             Command::CancelSession
         ));
         assert_eq!(app.diagnostics.status, "stopping...");
@@ -1352,7 +1508,7 @@ mod external_editor_tests {
 
     #[test]
     fn chat_input_is_blocked_while_undo_is_pending() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.connection.conn = ConnState::Connected;
@@ -1360,43 +1516,35 @@ mod external_editor_tests {
         app.composer.input = "draft".into();
         app.composer.input_cursor = app.composer.input.len();
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('x'), KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
         assert_eq!(app.composer.input, "draft");
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Backspace, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
         assert_eq!(app.composer.input, "draft");
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Left, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
         assert_eq!(app.composer.input_cursor, "draft".len());
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
         assert_eq!(app.composer.input, "draft");
-        assert!(rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
     }
 
     #[test]
     fn chat_input_is_blocked_while_cancel_confirm_is_active() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.connection.conn = ConnState::Connected;
@@ -1406,48 +1554,37 @@ mod external_editor_tests {
         app.composer.input = "draft".into();
         app.composer.input_cursor = app.composer.input.len();
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
         assert!(app.chat.cancel_confirm_active());
         assert!(app.chat.input_blocked_by_activity());
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('x'), KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
         assert_eq!(app.composer.input, "draft");
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
         assert_eq!(app.diagnostics.status, "press Esc again to stop");
-        assert!(rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
 
-        handle_chat_key(
+        effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()),
-            &tx,
-        )
-        .unwrap();
+        ));
         assert_eq!(app.diagnostics.status, "stopping...");
         assert!(matches!(
-            rx.try_recv().expect("cancel sent"),
+            effects.next_command().expect("cancel sent"),
             Command::CancelSession
         ));
     }
 }
-
-#[cfg(test)]
-use crate::handlers::handle_key;
 
 fn log_server_binary_discovery(
     app: &mut App,
@@ -1603,13 +1740,14 @@ pub async fn run() -> anyhow::Result<()> {
     let mut terminal = terminal::enter()?;
 
     app.connection.server_state = initial_server_state;
+    let mut executor = EffectExecutor::new(&cmd_tx);
     let result = run_loop(
         &mut terminal,
         &mut app,
         &mut srv_rx,
         &mut conn_rx,
         &mut sup_event_rx,
-        &cmd_tx,
+        &mut executor,
     )
     .await;
 
@@ -1645,7 +1783,6 @@ mod sessions_key_tests {
     use crate::domain::session::{SessionGroup, SessionSummary};
     use crate::handlers::*;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-    use tokio::sync::mpsc;
 
     fn make_group(cwd: Option<&str>, ids: &[&str]) -> SessionGroup {
         SessionGroup {
@@ -1748,26 +1885,24 @@ mod sessions_key_tests {
         app.sessions.agent_id = Some("agent-1".into());
         app.sessions.session_groups = vec![make_group(Some("/a"), &["abc12345"])];
         app.sessions.session_cursor = 1;
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_sessions_key(
+        effects.extend(handle_sessions_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert!(matches!(
-            rx.try_recv(),
-            Ok(Command::LoadSession { session_id, cwd: Some(cwd) })
+            effects.next_command(),
+            Some(Command::LoadSession { session_id, cwd: Some(cwd) })
                 if session_id == "abc12345" && cwd == "/a"
         ));
         assert!(matches!(
-            rx.try_recv(),
-            Ok(Command::SubscribeSession { session_id, agent_id })
+            effects.next_command(),
+            Some(Command::SubscribeSession { session_id, agent_id })
                 if session_id == "abc12345" && agent_id.as_deref() == Some("agent-1")
         ));
-        assert!(rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
     }
 
     #[test]
@@ -1849,19 +1984,17 @@ mod sessions_key_tests {
         app.sessions.session_groups = vec![make_group(Some("/a"), &["root"])];
         app.sessions.session_groups[0].sessions[0].fork_count = 1;
         app.sessions.session_cursor = 1;
-        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_sessions_key(
+        effects.extend(handle_sessions_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL),
-            &cmd_tx,
-        )
-        .unwrap();
+        ));
 
         assert!(app.sessions.expanded_session_children.contains("root"));
         assert!(matches!(
-            cmd_rx.try_recv(),
-            Ok(Command::ListSessionChildren {
+            effects.next_command(),
+            Some(Command::ListSessionChildren {
                 parent_session_id,
                 ..
             }) if parent_session_id == "root"
@@ -1877,17 +2010,15 @@ mod sessions_key_tests {
             .expanded_session_children
             .insert("root".to_string());
         app.sessions.session_cursor = 1;
-        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_sessions_key(
+        effects.extend(handle_sessions_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL),
-            &cmd_tx,
-        )
-        .unwrap();
+        ));
 
         assert!(!app.sessions.expanded_session_children.contains("root"));
-        assert!(cmd_rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
     }
 
     #[test]
@@ -2354,20 +2485,18 @@ mod session_popup_key_tests {
         app.sessions.session_groups = vec![make_group(Some("/a"), &["root"])];
         app.sessions.session_groups[0].sessions[0].fork_count = 1;
         app.sessions.session_cursor = 1;
-        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_session_popup_key(
+        effects.extend(handle_session_popup_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL),
-            &cmd_tx,
-        )
-        .unwrap();
+        ));
 
         assert!(app.sessions.expanded_session_children.contains("root"));
         assert_eq!(app.navigation.popup, Popup::SessionSelect);
         assert!(matches!(
-            cmd_rx.try_recv(),
-            Ok(Command::ListSessionChildren {
+            effects.next_command(),
+            Some(Command::ListSessionChildren {
                 parent_session_id,
                 ..
             }) if parent_session_id == "root"
@@ -2384,18 +2513,16 @@ mod session_popup_key_tests {
             .expanded_session_children
             .insert("root".to_string());
         app.sessions.session_cursor = 1;
-        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_session_popup_key(
+        effects.extend(handle_session_popup_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL),
-            &cmd_tx,
-        )
-        .unwrap();
+        ));
 
         assert!(!app.sessions.expanded_session_children.contains("root"));
         assert_eq!(app.navigation.popup, Popup::SessionSelect);
-        assert!(cmd_rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
     }
 
     #[test]
@@ -2405,19 +2532,17 @@ mod session_popup_key_tests {
         app.sessions.session_groups = vec![make_group(Some("/a"), &["root"])];
         app.sessions.session_groups[0].sessions[0].fork_count = 1;
         app.sessions.session_cursor = 1;
-        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_session_popup_key(
+        effects.extend(handle_session_popup_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE),
-            &cmd_tx,
-        )
-        .unwrap();
+        ));
 
         assert_eq!(app.sessions.session_filter, "o");
         assert!(!app.sessions.expanded_session_children.contains("root"));
         assert_eq!(app.navigation.popup, Popup::SessionSelect);
-        assert!(cmd_rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
     }
 
     #[test]
@@ -2542,9 +2667,8 @@ mod session_popup_key_tests {
         app.navigation.popup = Popup::SessionSelect;
         app.connection.conn = ConnState::Connected;
         app.connection.launch_cwd = Some("/launch".into());
-
-        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
-        handle_session_popup_key(
+        let mut effects = TestEffects::default();
+        effects.extend(handle_session_popup_key(
             &mut app,
             KeyEvent {
                 code: KeyCode::Char('n'),
@@ -2552,13 +2676,11 @@ mod session_popup_key_tests {
                 kind: crossterm::event::KeyEventKind::Press,
                 state: crossterm::event::KeyEventState::NONE,
             },
-            &cmd_tx,
-        )
-        .unwrap();
+        ));
 
         assert_eq!(app.navigation.popup, Popup::NewSession);
         assert_eq!(app.sessions.new_session_path, "/launch");
-        assert!(cmd_rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
     }
 
     #[test]
@@ -2566,18 +2688,15 @@ mod session_popup_key_tests {
         let mut app = App::new();
         app.navigation.popup = Popup::SessionSelect;
         app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
-
-        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
-        handle_session_popup_key(
+        let mut effects = TestEffects::default();
+        effects.extend(handle_session_popup_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE),
-            &cmd_tx,
-        )
-        .unwrap();
+        ));
 
         assert_eq!(app.navigation.popup, Popup::SessionSelect);
         assert_eq!(app.sessions.session_filter, "n");
-        assert!(cmd_rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
     }
 
     #[test]
@@ -2585,44 +2704,36 @@ mod session_popup_key_tests {
         let mut app = App::new();
         app.connection.conn = ConnState::Connected;
         app.connection.launch_cwd = Some("/launch".into());
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_key(
+        effects.extend(handle_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL),
-            &tx,
-        )
-        .unwrap();
-        handle_key(
+        ));
+        effects.extend(handle_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert_eq!(app.navigation.popup, Popup::NewSession);
         assert_eq!(app.sessions.new_session_path, "/launch");
-        assert!(rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
     }
 
     #[test]
     fn global_ctrl_x_l_opens_session_popup() {
         let mut app = App::new();
         app.connection.conn = ConnState::Connected;
-        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_key(
+        effects.extend(handle_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL),
-            &tx,
-        )
-        .unwrap();
-        handle_key(
+        ));
+        effects.extend(handle_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert_eq!(app.navigation.popup, Popup::SessionSelect);
         assert_eq!(app.sessions.session_popup_tab, 0);
@@ -2631,14 +2742,12 @@ mod session_popup_key_tests {
     #[test]
     fn global_ctrl_l_opens_log_popup() {
         let mut app = App::new();
-        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_key(
+        effects.extend(handle_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('l'), KeyModifiers::CONTROL),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert_eq!(app.navigation.popup, Popup::Log);
         assert_eq!(app.diagnostics.log_cursor, 0);
@@ -2651,39 +2760,30 @@ mod session_popup_key_tests {
         app.navigation.popup = Popup::Log;
         app.diagnostics.log_cursor = 2;
         app.diagnostics.log_level_filter = LogLevel::Info;
-
-        let (tx, _rx) = mpsc::unbounded_channel();
-        handle_key(
+        let mut effects = TestEffects::default();
+        effects.extend(handle_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
-            &tx,
-        )
-        .unwrap();
+        ));
         assert_eq!(app.diagnostics.log_filter, "x");
         assert_eq!(app.diagnostics.log_cursor, 0);
 
-        handle_key(
+        effects.extend(handle_key(
             &mut app,
             KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE),
-            &tx,
-        )
-        .unwrap();
+        ));
         assert!(app.diagnostics.log_filter.is_empty());
 
-        handle_key(
+        effects.extend(handle_key(
             &mut app,
             KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE),
-            &tx,
-        )
-        .unwrap();
+        ));
         assert_eq!(app.diagnostics.log_level_filter, LogLevel::Warn);
 
-        handle_key(
+        effects.extend(handle_key(
             &mut app,
             KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
-            &tx,
-        )
-        .unwrap();
+        ));
         assert_eq!(app.navigation.popup, Popup::None);
     }
 
@@ -2695,19 +2795,16 @@ mod session_popup_key_tests {
         app.connection.launch_cwd = Some("/launch".into());
         app.sessions.new_session_path.clear();
         app.sessions.new_session_cursor = 0;
-
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        handle_new_session_popup_key(
+        let mut effects = TestEffects::default();
+        effects.extend(handle_new_session_popup_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert_eq!(app.navigation.popup, Popup::None);
         assert!(matches!(
-            rx.try_recv(),
-            Ok(Command::NewSession {
+            effects.next_command(),
+            Some(Command::NewSession {
                 cwd: Some(ref cwd),
                 profile_id: None
             }) if cwd == "/launch"
@@ -2722,18 +2819,15 @@ mod session_popup_key_tests {
         app.connection.launch_cwd = Some("/launch".into());
         app.sessions.new_session_path = "proj/subdir".into();
         app.sessions.new_session_cursor = app.sessions.new_session_path.len();
-
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        handle_new_session_popup_key(
+        let mut effects = TestEffects::default();
+        effects.extend(handle_new_session_popup_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert!(matches!(
-            rx.try_recv(),
-            Ok(Command::NewSession {
+            effects.next_command(),
+            Some(Command::NewSession {
                 cwd: Some(ref cwd),
                 profile_id: None
             }) if cwd == "/launch/proj/subdir"
@@ -2752,14 +2846,11 @@ mod session_popup_key_tests {
                 is_dir: true,
             }],
         });
-
-        let (tx, _rx) = mpsc::unbounded_channel();
-        handle_new_session_popup_key(
+        let mut effects = TestEffects::default();
+        effects.extend(handle_new_session_popup_key(
             &mut app,
             KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert_eq!(app.sessions.new_session_path, "/launch/project/");
         assert!(app.sessions.new_session_completion.is_none());
@@ -2779,19 +2870,16 @@ mod session_popup_key_tests {
                 is_dir: true,
             }],
         });
-
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        handle_key(
+        let mut effects = TestEffects::default();
+        effects.extend(handle_key(
             &mut app,
             KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert_eq!(app.sessions.new_session_path, "/launch/project/");
         assert!(app.sessions.new_session_completion.is_none());
         assert_eq!(app.sessions.agent_mode, "build");
-        assert!(rx.try_recv().is_err());
+        assert!(effects.next_command().is_none());
     }
 
     #[test]
@@ -3057,9 +3145,9 @@ mod delegate_popup_key_tests {
 #[cfg(test)]
 mod chord_reasoning_effort_tests {
     use super::*;
+    use crate::handlers::handle_key;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use serial_test::serial;
-    use tokio::sync::mpsc;
 
     fn ctrl_t() -> KeyEvent {
         KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL)
@@ -3071,15 +3159,17 @@ mod chord_reasoning_effort_tests {
     #[serial]
     fn ctrl_t_cycles_effort_and_sends_msg() {
         let _guard = PersistenceGuard::new("main-test");
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.connection.conn = ConnState::Connected;
         assert_eq!(app.models.reasoning_effort, None);
 
-        handle_key(&mut app, ctrl_t(), &tx).unwrap();
+        effects.extend(handle_key(&mut app, ctrl_t()));
 
         assert_eq!(app.models.reasoning_effort, Some("low".into()));
-        let msg = rx.try_recv().expect("expected SetReasoningEffort message");
+        let msg = effects
+            .next_command()
+            .expect("expected SetReasoningEffort message");
         match msg {
             Command::SetReasoningEffort { reasoning_effort } => {
                 assert_eq!(reasoning_effort, "low");
@@ -3092,15 +3182,17 @@ mod chord_reasoning_effort_tests {
     #[serial]
     fn ctrl_t_full_cycle_sends_auto_on_wrap() {
         let _guard = PersistenceGuard::new("main-test");
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.connection.conn = ConnState::Connected;
         app.models.reasoning_effort = Some("max".into());
 
-        handle_key(&mut app, ctrl_t(), &tx).unwrap();
+        effects.extend(handle_key(&mut app, ctrl_t()));
 
         assert_eq!(app.models.reasoning_effort, None);
-        let msg = rx.try_recv().expect("expected SetReasoningEffort message");
+        let msg = effects
+            .next_command()
+            .expect("expected SetReasoningEffort message");
         match msg {
             Command::SetReasoningEffort { reasoning_effort } => {
                 assert_eq!(reasoning_effort, "auto");
@@ -3113,10 +3205,10 @@ mod chord_reasoning_effort_tests {
     #[serial]
     fn ctrl_t_status_updated() {
         let _guard = PersistenceGuard::new("main-test");
-        let (tx, _rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.connection.conn = ConnState::Connected;
-        handle_key(&mut app, ctrl_t(), &tx).unwrap();
+        effects.extend(handle_key(&mut app, ctrl_t()));
         // status should reflect the new level
         assert!(
             app.diagnostics.status.contains("low"),
@@ -3127,11 +3219,11 @@ mod chord_reasoning_effort_tests {
 
     #[test]
     fn ctrl_t_when_disconnected_does_not_change_state() {
-        let (tx, _rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.models.reasoning_effort = Some("high".into());
 
-        handle_key(&mut app, ctrl_t(), &tx).unwrap();
+        effects.extend(handle_key(&mut app, ctrl_t()));
 
         // state must not change when disconnected
         assert_eq!(app.models.reasoning_effort, Some("high".into()));
@@ -3143,9 +3235,9 @@ mod chord_reasoning_effort_tests {
 mod reasoning_effort_integration_tests {
     use super::*;
     use crate::domain::model::ModelEntry;
+    use crate::handlers::handle_key;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use serial_test::serial;
-    use tokio::sync::mpsc;
 
     fn make_model(provider: &str, model: &str) -> ModelEntry {
         ModelEntry {
@@ -3172,21 +3264,19 @@ mod reasoning_effort_integration_tests {
     #[serial]
     fn ctrl_t_cycles_reasoning_effort() {
         let _guard = PersistenceGuard::new("main-test");
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.connection.conn = ConnState::Connected;
 
-        handle_key(
+        effects.extend(handle_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert_eq!(app.models.reasoning_effort, Some("low".into()));
         assert!(matches!(
-            rx.try_recv(),
-            Ok(Command::SetReasoningEffort { reasoning_effort }) if reasoning_effort == "low"
+            effects.next_command(),
+            Some(Command::SetReasoningEffort { reasoning_effort }) if reasoning_effort == "low"
         ));
     }
 
@@ -3194,7 +3284,7 @@ mod reasoning_effort_integration_tests {
     #[serial]
     fn tab_switches_mode_without_changing_model_or_effort() {
         let _guard = PersistenceGuard::new("main-test");
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.connection.conn = ConnState::Connected;
         app.sessions.session_id = Some("s1".into());
@@ -3203,13 +3293,13 @@ mod reasoning_effort_integration_tests {
         app.models.current_model = Some("claude-sonnet".into());
         app.models.reasoning_effort = Some("high".into());
 
-        handle_key(&mut app, tab_key(), &tx).unwrap();
+        effects.extend(handle_key(&mut app, tab_key()));
 
         assert_eq!(app.sessions.agent_mode, "plan");
         assert_eq!(app.models.current_model.as_deref(), Some("claude-sonnet"));
         assert_eq!(app.models.reasoning_effort, Some("high".into()));
 
-        let msgs: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        let msgs: Vec<_> = std::iter::from_fn(|| effects.next_command()).collect();
         assert!(
             msgs.iter()
                 .any(|m| matches!(m, Command::SetAgentMode { mode } if mode == "plan")),
@@ -3227,7 +3317,7 @@ mod reasoning_effort_integration_tests {
     #[serial]
     fn tab_no_cache_entry_leaves_model_and_effort_unchanged() {
         let _guard = PersistenceGuard::new("main-test");
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.connection.conn = ConnState::Connected;
         app.sessions.session_id = Some("s1".into());
@@ -3237,13 +3327,13 @@ mod reasoning_effort_integration_tests {
         app.models.reasoning_effort = Some("high".into());
         // No plan cache entry
 
-        handle_key(&mut app, tab_key(), &tx).unwrap();
+        effects.extend(handle_key(&mut app, tab_key()));
 
         // Mode switched but model/effort unchanged (no cache to restore from)
         assert_eq!(app.sessions.agent_mode, "plan");
         assert_eq!(app.models.reasoning_effort, Some("high".into()));
         assert_eq!(app.models.current_model.as_deref(), Some("claude-sonnet"));
-        let msgs: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        let msgs: Vec<_> = std::iter::from_fn(|| effects.next_command()).collect();
         assert!(
             !msgs
                 .iter()
@@ -3258,7 +3348,7 @@ mod reasoning_effort_integration_tests {
     #[serial]
     fn ctrl_x_m_opens_model_popup_at_current_mode_model() {
         let _guard = PersistenceGuard::new("main-test");
-        let (tx, _rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.connection.conn = ConnState::Connected;
@@ -3272,18 +3362,14 @@ mod reasoning_effort_integration_tests {
             make_model("openai", "o3-mini"),
         ];
 
-        handle_key(
+        effects.extend(handle_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL),
-            &tx,
-        )
-        .unwrap();
-        handle_key(
+        ));
+        effects.extend(handle_key(
             &mut app,
             KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert_eq!(app.navigation.popup, Popup::ModelSelect);
         assert_eq!(app.models.model_filter, "");
@@ -3295,7 +3381,7 @@ mod reasoning_effort_integration_tests {
     #[serial]
     fn model_select_drops_effort_to_auto() {
         let _guard = PersistenceGuard::new("main-test");
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.connection.conn = ConnState::Connected;
         app.sessions.session_id = Some("s1".into());
@@ -3313,16 +3399,14 @@ mod reasoning_effort_integration_tests {
             .position(|i| matches!(i, crate::models_state::ModelPopupItem::Model { .. }))
             .unwrap();
 
-        handle_key(
+        effects.extend(handle_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
-            &tx,
-        )
-        .unwrap();
+        ));
 
         assert_eq!(app.models.reasoning_effort, None);
 
-        let msgs: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        let msgs: Vec<_> = std::iter::from_fn(|| effects.next_command()).collect();
         assert!(
             msgs.iter().any(|m| matches!(
                 m,
@@ -3337,7 +3421,7 @@ mod reasoning_effort_integration_tests {
     #[serial]
     fn model_select_no_effort_msg_when_already_auto() {
         let _guard = PersistenceGuard::new("main-test");
-        let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.connection.conn = ConnState::Connected;
         app.sessions.session_id = Some("s1".into());
@@ -3355,14 +3439,12 @@ mod reasoning_effort_integration_tests {
             .position(|i| matches!(i, crate::models_state::ModelPopupItem::Model { .. }))
             .unwrap();
 
-        handle_key(
+        effects.extend(handle_key(
             &mut app,
             KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
-            &tx,
-        )
-        .unwrap();
+        ));
 
-        let msgs: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        let msgs: Vec<_> = std::iter::from_fn(|| effects.next_command()).collect();
         assert!(
             !msgs
                 .iter()
@@ -3495,8 +3577,8 @@ mod auth_tests {
     #[test]
     fn auth_list_esc_closes_popup_when_no_selection() {
         let mut app = make_app_with_providers(vec![make_provider("OpenAI")]);
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-        handle_auth_popup_key(&mut app, key(KeyCode::Esc), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Esc)));
         assert_eq!(app.navigation.popup, Popup::None);
     }
 
@@ -3514,8 +3596,8 @@ mod auth_tests {
             success: true,
             message: "old notice".into(),
         });
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-        handle_auth_popup_key(&mut app, key(KeyCode::Esc), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Esc)));
         assert_eq!(app.navigation.popup, Popup::ProviderAuth);
         assert!(app.auth.selected.is_none());
         assert!(app.auth.last_result.is_none());
@@ -3529,15 +3611,15 @@ mod auth_tests {
             make_provider("Groq"),
             make_provider("DeepSeek"),
         ]);
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
         assert_eq!(app.auth.cursor, 0);
-        handle_auth_popup_key(&mut app, key(KeyCode::Down), &tx).unwrap();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Down)));
         assert_eq!(app.auth.cursor, 1);
-        handle_auth_popup_key(&mut app, key(KeyCode::Down), &tx).unwrap();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Down)));
         assert_eq!(app.auth.cursor, 2);
-        handle_auth_popup_key(&mut app, key(KeyCode::Down), &tx).unwrap();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Down)));
         assert_eq!(app.auth.cursor, 2); // clamped
-        handle_auth_popup_key(&mut app, key(KeyCode::Up), &tx).unwrap();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Up)));
         assert_eq!(app.auth.cursor, 1);
     }
 
@@ -3554,8 +3636,8 @@ mod auth_tests {
             success: true,
             message: "old notice".into(),
         });
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-        handle_auth_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Enter)));
         assert_eq!(app.auth.panel, AuthPanel::ApiKeyInput);
         assert_eq!(app.auth.selected, Some(0));
         assert!(app.auth.last_result.is_none());
@@ -3570,10 +3652,10 @@ mod auth_tests {
             success: true,
             message: "old notice".into(),
         });
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-        handle_auth_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Enter)));
         assert_eq!(app.auth.selected, Some(0));
-        let msg = rx.try_recv().expect("message sent");
+        let msg = effects.next_command().expect("message sent");
         assert!(matches!(msg, Command::StartOAuthLogin { provider } if provider == "codex"));
         assert!(app.auth.ui_notice.is_none());
     }
@@ -3586,8 +3668,8 @@ mod auth_tests {
             success: true,
             message: "old notice".into(),
         });
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-        handle_auth_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Enter)));
         assert_eq!(app.auth.selected, Some(0));
         assert_eq!(app.auth.panel, AuthPanel::List);
         assert!(app.auth.ui_notice.is_none());
@@ -3596,8 +3678,8 @@ mod auth_tests {
     #[test]
     fn auth_list_char_input_filters() {
         let mut app = make_app_with_providers(vec![make_provider("OpenAI"), make_provider("Groq")]);
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-        handle_auth_popup_key(&mut app, key(KeyCode::Char('g')), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Char('g'))));
         assert_eq!(app.auth.filter, "g");
         assert_eq!(app.auth.cursor, 0);
     }
@@ -3606,8 +3688,8 @@ mod auth_tests {
     fn auth_list_backspace_removes_filter() {
         let mut app = make_app_with_providers(vec![make_provider("OpenAI")]);
         app.auth.filter = "op".into();
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-        handle_auth_popup_key(&mut app, key(KeyCode::Backspace), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Backspace)));
         assert_eq!(app.auth.filter, "o");
     }
 
@@ -3619,8 +3701,8 @@ mod auth_tests {
             success: true,
             message: "old notice".into(),
         });
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-        handle_auth_popup_key(&mut app, ctrl('k'), &tx).unwrap();
+        let mut effects = TestEffects::default();
+        effects.extend(handle_auth_popup_key(&mut app, ctrl('k')));
         assert_eq!(app.auth.panel, AuthPanel::ApiKeyInput);
         assert_eq!(app.auth.selected, Some(0));
         assert!(app.auth.ui_notice.is_none());
@@ -3634,9 +3716,9 @@ mod auth_tests {
             success: true,
             message: "old notice".into(),
         });
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-        handle_auth_popup_key(&mut app, ctrl('o'), &tx).unwrap();
-        let msg = rx.try_recv().expect("message sent");
+        let mut effects = TestEffects::default();
+        effects.extend(handle_auth_popup_key(&mut app, ctrl('o')));
+        let msg = effects.next_command().expect("message sent");
         assert!(matches!(msg, Command::StartOAuthLogin { provider } if provider == "openai"));
         assert!(app.auth.ui_notice.is_none());
     }
@@ -3648,20 +3730,20 @@ mod auth_tests {
         let mut app = make_app_with_providers(vec![make_api_key_only("Groq")]);
         app.auth.selected = Some(0);
         app.auth.panel = AuthPanel::ApiKeyInput;
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_auth_popup_key(&mut app, key(KeyCode::Char('é')), &tx).unwrap();
-        handle_auth_popup_key(&mut app, key(KeyCode::Char('ß')), &tx).unwrap();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Char('é'))));
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Char('ß'))));
         assert_eq!(app.auth.api_key_input, "éß");
         assert_eq!(app.auth.api_key_cursor, 4);
 
-        handle_auth_popup_key(&mut app, key(KeyCode::Left), &tx).unwrap();
-        handle_auth_popup_key(&mut app, key(KeyCode::Char('x')), &tx).unwrap();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Left)));
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Char('x'))));
         assert_eq!(app.auth.api_key_input, "éxß");
         assert_eq!(app.auth.api_key_cursor, 3);
 
-        handle_auth_popup_key(&mut app, key(KeyCode::Backspace), &tx).unwrap();
-        handle_auth_popup_key(&mut app, key(KeyCode::Right), &tx).unwrap();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Backspace)));
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Right)));
         assert_eq!(app.auth.api_key_input, "éß");
         assert_eq!(app.auth.api_key_cursor, 4);
     }
@@ -3671,15 +3753,15 @@ mod auth_tests {
         let mut app = make_app_with_providers(vec![make_api_key_only("Groq")]);
         app.auth.selected = Some(0);
         app.auth.panel = AuthPanel::ApiKeyInput;
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_auth_popup_key(&mut app, key(KeyCode::Char('s')), &tx).unwrap();
-        handle_auth_popup_key(&mut app, key(KeyCode::Char('k')), &tx).unwrap();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Char('s'))));
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Char('k'))));
         assert_eq!(app.auth.api_key_input, "sk");
         assert_eq!(app.auth.api_key_cursor, 2);
 
-        handle_auth_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
-        let msg = rx.try_recv().expect("message sent");
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Enter)));
+        let msg = effects.next_command().expect("message sent");
         assert!(matches!(
             msg,
             Command::SetApiToken { provider, api_key }
@@ -3694,9 +3776,9 @@ mod auth_tests {
         app.auth.panel = AuthPanel::ApiKeyInput;
         app.auth.api_key_input = "abc".into();
         app.auth.api_key_cursor = 3;
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_auth_popup_key(&mut app, key(KeyCode::Backspace), &tx).unwrap();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Backspace)));
         assert_eq!(app.auth.api_key_input, "ab");
         assert_eq!(app.auth.api_key_cursor, 2);
     }
@@ -3707,9 +3789,9 @@ mod auth_tests {
         app.auth.selected = Some(0);
         app.auth.panel = AuthPanel::ApiKeyInput;
         app.auth.api_key_input = "draft".into();
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_auth_popup_key(&mut app, key(KeyCode::Esc), &tx).unwrap();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Esc)));
         assert_eq!(app.auth.panel, AuthPanel::List);
         assert!(app.auth.api_key_input.is_empty());
     }
@@ -3720,11 +3802,11 @@ mod auth_tests {
         app.auth.selected = Some(0);
         app.auth.panel = AuthPanel::ApiKeyInput;
         assert!(app.auth.api_key_masked);
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_auth_popup_key(&mut app, key(KeyCode::Tab), &tx).unwrap();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Tab)));
         assert!(!app.auth.api_key_masked);
-        handle_auth_popup_key(&mut app, key(KeyCode::Tab), &tx).unwrap();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Tab)));
         assert!(app.auth.api_key_masked);
     }
 
@@ -3733,10 +3815,10 @@ mod auth_tests {
         let mut app = make_app_with_providers(vec![make_api_key_only("Groq")]);
         app.auth.selected = Some(0);
         app.auth.panel = AuthPanel::ApiKeyInput;
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_auth_popup_key(&mut app, ctrl('d'), &tx).unwrap();
-        let msg = rx.try_recv().expect("message sent");
+        effects.extend(handle_auth_popup_key(&mut app, ctrl('d')));
+        let msg = effects.next_command().expect("message sent");
         assert!(matches!(msg, Command::ClearApiToken { provider } if provider == "groq"));
     }
 
@@ -3745,10 +3827,10 @@ mod auth_tests {
         let mut app = make_app_with_providers(vec![make_api_key_only("Groq")]);
         app.auth.selected = Some(0);
         app.auth.panel = AuthPanel::ApiKeyInput;
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_auth_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
-        assert!(rx.try_recv().is_err()); // nothing sent
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Enter)));
+        assert!(effects.next_command().is_none()); // nothing sent
     }
 
     // ── Key handler tests: OAuth flow panel ───────────────────────────────────
@@ -3764,9 +3846,9 @@ mod auth_tests {
             authorization_url: "https://example.com".into(),
             flow_kind: OAuthFlowKind::RedirectCode,
         });
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_auth_popup_key(&mut app, key(KeyCode::Esc), &tx).unwrap();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Esc)));
         assert_eq!(app.auth.panel, AuthPanel::List);
         assert!(app.auth.oauth_flow.is_none());
     }
@@ -3782,16 +3864,16 @@ mod auth_tests {
             authorization_url: "https://example.com".into(),
             flow_kind: OAuthFlowKind::RedirectCode,
         });
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_auth_popup_key(&mut app, key(KeyCode::Char('c')), &tx).unwrap();
-        handle_auth_popup_key(&mut app, key(KeyCode::Char('o')), &tx).unwrap();
-        handle_auth_popup_key(&mut app, key(KeyCode::Char('d')), &tx).unwrap();
-        handle_auth_popup_key(&mut app, key(KeyCode::Char('e')), &tx).unwrap();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Char('c'))));
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Char('o'))));
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Char('d'))));
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Char('e'))));
         assert_eq!(app.auth.oauth_response, "code");
 
-        handle_auth_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
-        let msg = rx.try_recv().expect("message sent");
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Enter)));
+        let msg = effects.next_command().expect("message sent");
         assert!(matches!(
             msg,
             Command::CompleteOAuthLogin { flow_id, response }
@@ -3810,10 +3892,10 @@ mod auth_tests {
             authorization_url: "https://example.com/device".into(),
             flow_kind: OAuthFlowKind::DevicePoll,
         });
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_auth_popup_key(&mut app, key(KeyCode::Enter), &tx).unwrap();
-        let msg = rx.try_recv().expect("message sent");
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Enter)));
+        let msg = effects.next_command().expect("message sent");
         assert!(matches!(
             msg,
             Command::CompleteOAuthLogin { flow_id, response }
@@ -3832,17 +3914,17 @@ mod auth_tests {
             authorization_url: "https://example.com".into(),
             flow_kind: OAuthFlowKind::RedirectCode,
         });
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_auth_popup_key(&mut app, key(KeyCode::Char('é')), &tx).unwrap();
-        handle_auth_popup_key(&mut app, key(KeyCode::Char('ß')), &tx).unwrap();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Char('é'))));
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Char('ß'))));
         assert_eq!(app.auth.oauth_response, "éß");
         assert_eq!(app.auth.oauth_response_cursor, 4);
 
-        handle_auth_popup_key(&mut app, key(KeyCode::Left), &tx).unwrap();
-        handle_auth_popup_key(&mut app, key(KeyCode::Char('x')), &tx).unwrap();
-        handle_auth_popup_key(&mut app, key(KeyCode::Backspace), &tx).unwrap();
-        handle_auth_popup_key(&mut app, key(KeyCode::Right), &tx).unwrap();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Left)));
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Char('x'))));
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Backspace)));
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Right)));
         assert_eq!(app.auth.oauth_response, "éß");
         assert_eq!(app.auth.oauth_response_cursor, 4);
     }
@@ -3986,7 +4068,10 @@ mod auth_tests {
         }));
 
         assert_eq!(cmds.len(), 1);
-        assert!(matches!(cmds[0], Command::ListAuthProviders));
+        assert!(matches!(
+            cmds[0],
+            Effect::Command(Command::ListAuthProviders)
+        ));
         assert!(app.auth.oauth_flow.is_none());
         assert_eq!(app.auth.panel, AuthPanel::List);
         assert_eq!(
@@ -4019,7 +4104,10 @@ mod auth_tests {
         let cmds = app.handle_acp_event(AcpAppEvent::OAuthResult(result.clone()));
 
         assert_eq!(cmds.len(), 1);
-        assert!(matches!(cmds[0], Command::ListAuthProviders));
+        assert!(matches!(
+            cmds[0],
+            Effect::Command(Command::ListAuthProviders)
+        ));
         assert_eq!(app.auth.oauth_flow, Some(flow));
         assert_eq!(app.auth.panel, AuthPanel::OAuthFlow);
         assert_eq!(app.auth.last_result, Some(result));
@@ -4051,10 +4139,10 @@ mod auth_tests {
         provider.oauth_status = Some(OAuthStatus::Connected);
         let mut app = make_app_with_providers(vec![provider]);
         app.auth.selected = Some(0);
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_auth_popup_key(&mut app, ctrl('d'), &tx).unwrap();
-        let msg = rx.try_recv().expect("message sent");
+        effects.extend(handle_auth_popup_key(&mut app, ctrl('d')));
+        let msg = effects.next_command().expect("message sent");
         assert!(matches!(
             msg,
             Command::DisconnectOAuth { provider } if provider == "openai"
@@ -4067,10 +4155,10 @@ mod auth_tests {
         provider.has_stored_api_key = true;
         let mut app = make_app_with_providers(vec![provider]);
         app.auth.selected = Some(0);
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_auth_popup_key(&mut app, ctrl('d'), &tx).unwrap();
-        let msg = rx.try_recv().expect("message sent");
+        effects.extend(handle_auth_popup_key(&mut app, ctrl('d')));
+        let msg = effects.next_command().expect("message sent");
         assert!(matches!(
             msg,
             Command::ClearApiToken { provider } if provider == "groq"
@@ -4082,10 +4170,10 @@ mod auth_tests {
         let app_provider = make_provider("OpenAI"); // not connected, no stored key
         let mut app = make_app_with_providers(vec![app_provider]);
         app.auth.selected = Some(0);
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_auth_popup_key(&mut app, ctrl('d'), &tx).unwrap();
-        assert!(rx.try_recv().is_err()); // nothing sent
+        effects.extend(handle_auth_popup_key(&mut app, ctrl('d')));
+        assert!(effects.next_command().is_none()); // nothing sent
     }
 
     #[test]
@@ -4094,10 +4182,10 @@ mod auth_tests {
         provider.oauth_status = Some(OAuthStatus::Connected);
         let mut app = make_app_with_providers(vec![provider]);
         // auth_selected is None
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_auth_popup_key(&mut app, ctrl('d'), &tx).unwrap();
-        assert!(rx.try_recv().is_err()); // nothing sent
+        effects.extend(handle_auth_popup_key(&mut app, ctrl('d')));
+        assert!(effects.next_command().is_none()); // nothing sent
     }
 
     #[test]
@@ -4108,10 +4196,10 @@ mod auth_tests {
         provider.has_stored_api_key = true;
         let mut app = make_app_with_providers(vec![provider]);
         app.auth.selected = Some(0);
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_auth_popup_key(&mut app, ctrl('d'), &tx).unwrap();
-        let msg = rx.try_recv().expect("message sent");
+        effects.extend(handle_auth_popup_key(&mut app, ctrl('d')));
+        let msg = effects.next_command().expect("message sent");
         // Should disconnect OAuth first, not clear API key
         assert!(matches!(msg, Command::DisconnectOAuth { .. }));
     }
@@ -4129,26 +4217,19 @@ mod auth_tests {
             authorization_url: "https://auth.example.com/authorize".into(),
             flow_kind: OAuthFlowKind::RedirectCode,
         });
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_auth_popup_key(&mut app, ctrl('y'), &tx).unwrap();
+        effects.extend(handle_auth_popup_key(&mut app, ctrl('y')));
 
-        let expected_notice = AuthUiNotice {
-            provider: Some("codex".into()),
-            success: true,
-            message: "Copied to clipboard".into(),
-        };
-        let expected_url = "https://auth.example.com/authorize";
-        assert!(
-            matches!(
-                (&app.auth.ui_notice, &app.auth.clipboard_fallback),
-                (Some(notice), None) if notice == &expected_notice
-            ) || matches!(
-                (&app.auth.ui_notice, &app.auth.clipboard_fallback),
-                (None, Some(url)) if url == expected_url
-            ),
-            "C-y should show the provider notice or exact fallback URL"
-        );
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::CopyToClipboard {
+                target: crate::application::ClipboardTarget::Auth { provider },
+                text,
+            }] if provider == "codex" && text == "https://auth.example.com/authorize"
+        ));
+        assert!(app.auth.ui_notice.is_none());
+        assert!(app.auth.clipboard_fallback.is_none());
         assert!(app.auth.last_result.is_none());
     }
 
@@ -4156,9 +4237,9 @@ mod auth_tests {
     fn auth_clipboard_fallback_dismisses_on_any_key() {
         let mut app = make_app_with_providers(vec![make_oauth_only("Codex")]);
         app.auth.clipboard_fallback = Some("https://example.com".into());
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
 
-        handle_auth_popup_key(&mut app, key(KeyCode::Char('x')), &tx).unwrap();
+        effects.extend(handle_auth_popup_key(&mut app, key(KeyCode::Char('x'))));
         assert!(app.auth.clipboard_fallback.is_none());
     }
 
@@ -4166,21 +4247,21 @@ mod auth_tests {
 
     #[test]
     fn chord_a_opens_auth_popup_and_sends_list() {
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut effects = TestEffects::default();
         let mut app = App::new();
         app.connection.conn = ConnState::Connected;
 
         // Activate chord mode
         let ctrl_x = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL);
-        handle_key(&mut app, ctrl_x, &tx).unwrap();
+        effects.extend(handle_key(&mut app, ctrl_x));
         assert!(app.navigation.chord);
 
         // Press 'a'
-        handle_key(&mut app, key(KeyCode::Char('a')), &tx).unwrap();
+        effects.extend(handle_key(&mut app, key(KeyCode::Char('a'))));
         assert_eq!(app.navigation.popup, Popup::ProviderAuth);
         assert!(!app.navigation.chord);
 
-        let msg = rx.try_recv().expect("message sent");
+        let msg = effects.next_command().expect("message sent");
         assert!(matches!(msg, Command::ListAuthProviders));
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -64,12 +64,11 @@ impl<'a> EffectExecutor<'a> {
         let mut effects = effects.into_iter();
         while let Some(effect) = effects.next() {
             let runtime_event = match effect {
-                Effect::Command(command) => self.cmd_tx.send(command.clone()).err().map(|error| {
-                    RuntimeEvent::CommandFailed {
-                        command,
-                        message: error.to_string(),
-                    }
-                }),
+                Effect::Command(command) => self.send_command(command),
+                Effect::CommandThen { command, on_sent } => match self.send_command(command) {
+                    Some(failed) => Some(failed),
+                    None => Some(on_sent),
+                },
                 Effect::PersistConfig => {
                     config::TuiConfig::load().with_app_settings(app).save();
                     None
@@ -83,7 +82,7 @@ impl<'a> EffectExecutor<'a> {
                         outcome: terminal::open_external_editor_with_terminal(
                             terminal,
                             &initial_text,
-                        ),
+                        )?,
                     })
                 }
                 Effect::Terminal(TerminalAction::Redraw) => {
@@ -92,7 +91,7 @@ impl<'a> EffectExecutor<'a> {
                 }
                 Effect::Quit => {
                     app.should_quit = true;
-                    None
+                    return Ok(());
                 }
             };
 
@@ -105,6 +104,16 @@ impl<'a> EffectExecutor<'a> {
             }
         }
         Ok(())
+    }
+
+    fn send_command(&self, command: Command) -> Option<RuntimeEvent> {
+        self.cmd_tx
+            .send(command.clone())
+            .err()
+            .map(|error| RuntimeEvent::CommandFailed {
+                command,
+                message: error.to_string(),
+            })
     }
 }
 
@@ -148,13 +157,15 @@ impl TestEffects {
     }
 
     pub(crate) fn next_command(&mut self) -> Option<Command> {
-        let index = self
-            .effects
-            .iter()
-            .position(|effect| matches!(effect, Effect::Command(_)))?;
-        match self.effects.remove(index) {
-            Effect::Command(command) => Some(command),
-            _ => unreachable!("located effect must be a command"),
+        if !matches!(
+            self.effects.first(),
+            Some(Effect::Command(_) | Effect::CommandThen { .. })
+        ) {
+            return None;
+        }
+        match self.effects.remove(0) {
+            Effect::Command(command) | Effect::CommandThen { command, .. } => Some(command),
+            _ => unreachable!("first effect must contain a command"),
         }
     }
 
@@ -201,7 +212,7 @@ mod tests {
     }
 
     #[test]
-    fn test_effects_next_command_preserves_non_command_effects() {
+    fn test_effects_next_command_does_not_skip_non_command_effects() {
         let mut effects = TestEffects::default();
         effects.extend(vec![
             Effect::PersistConfig,
@@ -209,8 +220,15 @@ mod tests {
             Effect::Quit,
         ]);
 
-        assert_eq!(effects.next_command(), Some(Command::Init));
-        assert_eq!(effects.as_slice(), &[Effect::PersistConfig, Effect::Quit]);
+        assert_eq!(effects.next_command(), None);
+        assert_eq!(
+            effects.as_slice(),
+            &[
+                Effect::PersistConfig,
+                Effect::Command(Command::Init),
+                Effect::Quit,
+            ]
+        );
     }
 
     #[test]
@@ -232,13 +250,86 @@ mod tests {
             )
             .unwrap();
 
-        assert!(matches!(rx.try_recv(), Ok(Command::Init)));
-        assert!(matches!(
-            rx.try_recv(),
-            Ok(Command::ListAllModels { refresh: false })
-        ));
+        assert_eq!(rx.try_recv(), Ok(Command::Init));
         assert!(rx.try_recv().is_err());
         assert!(app.should_quit);
+    }
+
+    #[test]
+    fn effect_executor_runs_runtime_effects_before_remaining_effects() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut executor = EffectExecutor::new(&tx);
+        let mut terminal = test_terminal();
+        let mut app = make_app_with_elicitation(make_elicitation_single_select());
+        let command = Command::ElicitationResponse {
+            elicitation_id: "test-id".into(),
+            action: "accept".into(),
+            content: Some(serde_json::json!({ "choice": "a" })),
+        };
+
+        executor
+            .execute(
+                &mut terminal,
+                &mut app,
+                vec![
+                    Effect::CommandThen {
+                        command: command.clone(),
+                        on_sent: RuntimeEvent::ElicitationResponseSent {
+                            elicitation_id: "test-id".into(),
+                            outcome: format!("{OUTCOME_BULLET}Alpha"),
+                        },
+                    },
+                    Effect::Command(Command::Init),
+                ],
+            )
+            .unwrap();
+
+        assert_eq!(rx.try_recv(), Ok(command));
+        assert_eq!(rx.try_recv(), Ok(Command::Init));
+        assert!(rx.try_recv().is_err());
+        assert!(app.chat.elicitation.is_none());
+        assert!(app.chat.messages.iter().any(|entry| matches!(
+            entry,
+            ChatEntry::Elicitation { outcome: Some(outcome), .. }
+                if outcome == &format!("{OUTCOME_BULLET}Alpha")
+        )));
+    }
+
+    #[test]
+    fn effect_executor_command_then_failure_keeps_elicitation_open() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        drop(rx);
+        let mut executor = EffectExecutor::new(&tx);
+        let mut terminal = test_terminal();
+        let mut app = make_app_with_elicitation(make_elicitation_single_select());
+        let command = Command::ElicitationResponse {
+            elicitation_id: "test-id".into(),
+            action: "decline".into(),
+            content: None,
+        };
+
+        executor
+            .execute(
+                &mut terminal,
+                &mut app,
+                vec![Effect::CommandThen {
+                    command,
+                    on_sent: RuntimeEvent::ElicitationResponseSent {
+                        elicitation_id: "test-id".into(),
+                        outcome: "declined".into(),
+                    },
+                }],
+            )
+            .unwrap();
+
+        assert!(app.chat.elicitation.is_some());
+        assert!(
+            app.chat
+                .messages
+                .iter()
+                .any(|entry| matches!(entry, ChatEntry::Elicitation { outcome: None, .. }))
+        );
+        assert!(app.diagnostics.status.contains("channel closed"));
     }
 
     #[test]
@@ -353,27 +444,31 @@ mod tests {
     }
 
     #[test]
-    fn elicitation_enter_on_single_select_sends_accept_and_resolves() {
+    fn elicitation_enter_on_single_select_defers_resolution_until_send_ack() {
         let mut app = make_app_with_elicitation(make_elicitation_single_select());
-        let mut effects = TestEffects::default();
-        // Move to Beta and press Enter
-        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Down)));
-        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Enter)));
+        assert!(handle_elicitation_key(&mut app, key(KeyCode::Down)).is_empty());
 
-        // Elicitation should be cleared
-        assert!(app.chat.elicitation.is_none());
+        let effects = handle_elicitation_key(&mut app, key(KeyCode::Enter));
 
-        // Accept response sent
-        let msg = effects.next_command().expect("message sent");
-        assert!(matches!(msg,
-            Command::ElicitationResponse { action, content: Some(ref c), .. }
-            if action == "accept" && c["choice"] == "b"
+        assert_eq!(
+            effects,
+            vec![Effect::CommandThen {
+                command: Command::ElicitationResponse {
+                    elicitation_id: "test-id".into(),
+                    action: "accept".into(),
+                    content: Some(serde_json::json!({ "choice": "b" })),
+                },
+                on_sent: RuntimeEvent::ElicitationResponseSent {
+                    elicitation_id: "test-id".into(),
+                    outcome: format!("{OUTCOME_BULLET}Beta"),
+                },
+            }]
+        );
+        assert!(app.chat.elicitation.is_some());
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::Elicitation { outcome: None, .. }]
         ));
-
-        // Chat card updated with the selected label
-        assert!(app.chat.messages.iter().any(|m| matches!(m,
-            ChatEntry::Elicitation { outcome: Some(o), .. } if *o == format!("{OUTCOME_BULLET}Beta")
-        )));
     }
 
     #[test]
@@ -403,11 +498,21 @@ mod tests {
         }
         effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Enter)));
 
-        assert!(app.chat.elicitation.is_none());
-        assert!(matches!(effects.next_command().expect("message sent"),
-            Command::ElicitationResponse { action, content: Some(ref c), .. }
-            if action == "accept" && c["choice"] == "custom\nanswer"
-        ));
+        assert!(app.chat.elicitation.is_some());
+        assert_eq!(
+            effects.as_slice(),
+            &[Effect::CommandThen {
+                command: Command::ElicitationResponse {
+                    elicitation_id: "test-id".into(),
+                    action: "accept".into(),
+                    content: Some(serde_json::json!({ "choice": "custom\nanswer" })),
+                },
+                on_sent: RuntimeEvent::ElicitationResponseSent {
+                    elicitation_id: "test-id".into(),
+                    outcome: format!("{OUTCOME_BULLET}custom\nanswer"),
+                },
+            }]
+        );
     }
 
     #[test]
@@ -429,10 +534,21 @@ mod tests {
         assert!(effects.next_command().is_none());
 
         effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Esc)));
-        assert!(app.chat.elicitation.is_none());
-        assert!(matches!(effects.next_command().expect("decline sent"),
-            Command::ElicitationResponse { action, .. } if action == "decline"
-        ));
+        assert!(app.chat.elicitation.is_some());
+        assert_eq!(
+            effects.as_slice(),
+            &[Effect::CommandThen {
+                command: Command::ElicitationResponse {
+                    elicitation_id: "test-id".into(),
+                    action: "decline".into(),
+                    content: None,
+                },
+                on_sent: RuntimeEvent::ElicitationResponseSent {
+                    elicitation_id: "test-id".into(),
+                    outcome: "declined".into(),
+                },
+            }]
+        );
     }
 
     #[test]
@@ -451,19 +567,30 @@ mod tests {
     }
 
     #[test]
-    fn elicitation_esc_sends_decline_and_resolves() {
+    fn elicitation_esc_defers_decline_resolution_until_send_ack() {
         let mut app = make_app_with_elicitation(make_elicitation_single_select());
-        let mut effects = TestEffects::default();
-        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Esc)));
 
-        assert!(app.chat.elicitation.is_none());
-        let msg = effects.next_command().expect("message sent");
-        assert!(matches!(msg,
-            Command::ElicitationResponse { action, .. } if action == "decline"
+        let effects = handle_elicitation_key(&mut app, key(KeyCode::Esc));
+
+        assert_eq!(
+            effects,
+            vec![Effect::CommandThen {
+                command: Command::ElicitationResponse {
+                    elicitation_id: "test-id".into(),
+                    action: "decline".into(),
+                    content: None,
+                },
+                on_sent: RuntimeEvent::ElicitationResponseSent {
+                    elicitation_id: "test-id".into(),
+                    outcome: "declined".into(),
+                },
+            }]
+        );
+        assert!(app.chat.elicitation.is_some());
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::Elicitation { outcome: None, .. }]
         ));
-        assert!(app.chat.messages.iter().any(|m| matches!(m,
-            ChatEntry::Elicitation { outcome: Some(o), .. } if o == "declined"
-        )));
     }
 
     #[test]
@@ -477,18 +604,27 @@ mod tests {
                 kind: ElicitationFieldKind::TextInput,
             }]));
         app.chat.elicitation.as_mut().unwrap().text_input = "Alice".into();
-        let mut effects = TestEffects::default();
-        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Enter)));
+        let effects = handle_elicitation_key(&mut app, key(KeyCode::Enter));
 
-        assert!(app.chat.elicitation.is_none());
-        let msg = effects.next_command().expect("message sent");
-        assert!(matches!(msg,
-            Command::ElicitationResponse { action, content: Some(ref c), .. }
-            if action == "accept" && c["name"] == "Alice"
+        assert_eq!(
+            effects,
+            vec![Effect::CommandThen {
+                command: Command::ElicitationResponse {
+                    elicitation_id: "test-id".into(),
+                    action: "accept".into(),
+                    content: Some(serde_json::json!({ "name": "Alice" })),
+                },
+                on_sent: RuntimeEvent::ElicitationResponseSent {
+                    elicitation_id: "test-id".into(),
+                    outcome: "Alice".into(),
+                },
+            }]
+        );
+        assert!(app.chat.elicitation.is_some());
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::Elicitation { outcome: None, .. }]
         ));
-        assert!(app.chat.messages.iter().any(|m| matches!(m,
-            ChatEntry::Elicitation { outcome: Some(o), .. } if o == "Alice"
-        )));
     }
 
     #[test]
@@ -560,15 +696,21 @@ mod tests {
 
         effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Enter)));
 
-        assert!(app.chat.elicitation.is_none());
-        let msg = effects.next_command().expect("message sent");
-        assert!(matches!(msg,
-            Command::ElicitationResponse { action, content: Some(ref c), .. }
-            if action == "accept" && c["confirm"] == true
-        ));
-        assert!(app.chat.messages.iter().any(|m| matches!(m,
-            ChatEntry::Elicitation { outcome: Some(o), .. } if o == "Yes"
-        )));
+        assert!(app.chat.elicitation.is_some());
+        assert_eq!(
+            effects.as_slice(),
+            &[Effect::CommandThen {
+                command: Command::ElicitationResponse {
+                    elicitation_id: "test-id".into(),
+                    action: "accept".into(),
+                    content: Some(serde_json::json!({ "confirm": true })),
+                },
+                on_sent: RuntimeEvent::ElicitationResponseSent {
+                    elicitation_id: "test-id".into(),
+                    outcome: "Yes".into(),
+                },
+            }]
+        );
     }
 
     #[test]
@@ -588,15 +730,21 @@ mod tests {
 
         effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Enter)));
 
-        assert!(app.chat.elicitation.is_none());
-        let msg = effects.next_command().expect("message sent");
-        assert!(matches!(msg,
-            Command::ElicitationResponse { action, content: Some(ref c), .. }
-            if action == "accept" && c["confirm"] == false
-        ));
-        assert!(app.chat.messages.iter().any(|m| matches!(m,
-            ChatEntry::Elicitation { outcome: Some(o), .. } if o == "No"
-        )));
+        assert!(app.chat.elicitation.is_some());
+        assert_eq!(
+            effects.as_slice(),
+            &[Effect::CommandThen {
+                command: Command::ElicitationResponse {
+                    elicitation_id: "test-id".into(),
+                    action: "accept".into(),
+                    content: Some(serde_json::json!({ "confirm": false })),
+                },
+                on_sent: RuntimeEvent::ElicitationResponseSent {
+                    elicitation_id: "test-id".into(),
+                    outcome: "No".into(),
+                },
+            }]
+        );
     }
 
     #[test]

--- a/src/runtime/terminal.rs
+++ b/src/runtime/terminal.rs
@@ -5,9 +5,9 @@ use crossterm::{
 };
 use ratatui::{Terminal, backend::CrosstermBackend};
 
-use crate::{app::App, ui};
+use crate::application::ExternalEditorOutcome;
 
-use super::editor::{apply_external_editor_outcome, open_external_editor};
+use super::editor::open_external_editor;
 
 pub(super) type AppTerminal = Terminal<CrosstermBackend<std::io::Stdout>>;
 
@@ -32,22 +32,34 @@ pub(super) fn leave(terminal: &mut AppTerminal) -> anyhow::Result<()> {
 
 pub(super) fn open_external_editor_with_terminal(
     terminal: &mut AppTerminal,
-    app: &mut App,
-) -> anyhow::Result<()> {
+    initial_text: &str,
+) -> ExternalEditorOutcome {
+    match run_external_editor_with_terminal(terminal, initial_text) {
+        Ok(outcome) => outcome,
+        Err(error) => ExternalEditorOutcome::Failed(error.to_string()),
+    }
+}
+
+fn run_external_editor_with_terminal(
+    terminal: &mut AppTerminal,
+    initial_text: &str,
+) -> anyhow::Result<ExternalEditorOutcome> {
     terminal.show_cursor()?;
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
 
-    let result = open_external_editor(&app.composer.input);
+    let outcome = open_external_editor(initial_text);
 
     enable_raw_mode()?;
     execute!(terminal.backend_mut(), EnterAlternateScreen)?;
     terminal.hide_cursor()?;
     terminal.clear()?;
     terminal.autoresize()?;
-    app.render.invalidate_card_cache();
-    app.render.invalidate_content_cache();
-    apply_external_editor_outcome(app, result);
-    terminal.draw(|frame| ui::draw(frame, app))?;
+    Ok(outcome)
+}
+
+pub(super) fn redraw(terminal: &mut AppTerminal) -> anyhow::Result<()> {
+    terminal.clear()?;
+    terminal.autoresize()?;
     Ok(())
 }

--- a/src/runtime/terminal.rs
+++ b/src/runtime/terminal.rs
@@ -33,16 +33,6 @@ pub(super) fn leave(terminal: &mut AppTerminal) -> anyhow::Result<()> {
 pub(super) fn open_external_editor_with_terminal(
     terminal: &mut AppTerminal,
     initial_text: &str,
-) -> ExternalEditorOutcome {
-    match run_external_editor_with_terminal(terminal, initial_text) {
-        Ok(outcome) => outcome,
-        Err(error) => ExternalEditorOutcome::Failed(error.to_string()),
-    }
-}
-
-fn run_external_editor_with_terminal(
-    terminal: &mut AppTerminal,
-    initial_text: &str,
 ) -> anyhow::Result<ExternalEditorOutcome> {
     terminal.show_cursor()?;
     disable_raw_mode()?;
@@ -53,8 +43,6 @@ fn run_external_editor_with_terminal(
     enable_raw_mode()?;
     execute!(terminal.backend_mut(), EnterAlternateScreen)?;
     terminal.hide_cursor()?;
-    terminal.clear()?;
-    terminal.autoresize()?;
     Ok(outcome)
 }
 


### PR DESCRIPTION
## what changed

- add a private application boundary with typed `AppEvent`, `RuntimeEvent`, and ordered `Effect` values
- migrate key, mouse, ACP, connection, supervisor, tick, and runtime-result dispatch through `application::update`
- move command dispatch, persistence, clipboard, external editor, terminal redraw, and quit handling to the runtime effect executor
- preserve ACP/runtime channels, command payloads and ordering, persistence schema, status strings, and phase 4 state owners
- reconcile the inherited duplicate application test modules into one focused 16-test suite

## validation

- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --all-targets --all-features`
- `cargo test --all-targets --all-features` (902 passed)
- `git diff --check`

## boundary proof

- exactly one private `mod application`, one `AppEvent`, one `Effect`, and one `application::update`
- exactly eight phase 5 source files changed
- zero command sender parameters, direct command sends, config writes, clipboard launches, pending command queues, or direct quit mutation in handlers
- `Command` definitions and phase 6 ACP transport files are unchanged
- `App` remains 13 direct fields; all 12 phase 4 owner modules remain private; four phase 11 compatibility forwards remain
