### PR TITLE
refactor: extract feature reducers

### DIFF
--- a/src/acp/contract_tests.rs
+++ b/src/acp/contract_tests.rs
@@ -17,7 +17,10 @@ use super::inbound;
 use super::runtime::RuntimeState;
 use super::transport::jsonrpc::Peer;
 use crate::acp_state::{AcpAppEvent, AcpSessionUpdate};
+use crate::app::App;
+use crate::application::{self, AppEvent};
 use crate::command::{Command, SessionListRequest};
+use crate::domain::chat::ChatEntry;
 use crate::runtime_events::ServerChannelMsg;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -355,6 +358,58 @@ async fn load_emits_loaded_replay_delegation_provider_and_stack_in_order() {
             .collect::<Vec<_>>(),
         ["session/load", "_querymt/session/undoStack"]
     );
+}
+
+#[tokio::test]
+async fn session_notification_reaches_application_reducer_coordination() {
+    let connection = RecordingConnection::default();
+    let (state, events, mut rx) = harness(&connection);
+    let mut app = App::new();
+    app.sessions.session_id = Some("session".into());
+    let local_id = app.push_pending_prompt("hello".into());
+    app.render.card_cache.processed_messages = 7;
+    let original_logs = app.diagnostics.logs.clone();
+    let original_log_cursor = app.diagnostics.log_cursor;
+    let original_log_filter = app.diagnostics.log_filter.clone();
+    let original_log_level_filter = app.diagnostics.log_level_filter;
+    let original_status = app.diagnostics.status.clone();
+
+    inbound::session_notification(
+        &state,
+        &events,
+        acp::SessionNotification::new(
+            "session",
+            acp::SessionUpdate::UserMessageChunk(
+                acp::ContentChunk::new(acp::ContentBlock::Text(acp::TextContent::new("hello")))
+                    .message_id(Some(acp::MessageId::from("u1"))),
+            ),
+        ),
+    )
+    .await;
+
+    let event = match rx.try_recv().expect("session notification event") {
+        ServerChannelMsg::Acp(event) => AppEvent::Acp(event),
+    };
+    let effects = application::update(&mut app, event);
+
+    assert!(app.sessions.session_activity.contains_key("session"));
+    assert!(matches!(
+        app.chat.messages.as_slice(),
+        [ChatEntry::User {
+            text,
+            message_id: Some(message_id),
+        }] if text == "hello" && message_id == "u1" && message_id != &local_id
+    ));
+    assert_eq!(app.chat.undoable_turns.len(), 1);
+    assert_eq!(app.chat.undoable_turns[0].message_id, "u1");
+    assert_eq!(app.render.card_cache.processed_messages, 0);
+    assert_eq!(app.diagnostics.logs, original_logs);
+    assert_eq!(app.diagnostics.log_cursor, original_log_cursor);
+    assert_eq!(app.diagnostics.log_filter, original_log_filter);
+    assert_eq!(app.diagnostics.log_level_filter, original_log_level_filter);
+    assert_eq!(app.diagnostics.status, original_status);
+    assert_eq!(effects, Vec::new());
+    assert!(rx.try_recv().is_err());
 }
 
 #[tokio::test]

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -209,7 +209,9 @@ impl crate::app::App {
                         !matches!(effect, Effect::Command(Command::ListProfileAgents { .. }))
                     }));
                 }
-                self.sessions.agent_id = Some(agent_id.clone());
+                let effects =
+                    self.apply_session_action(SessionAction::InitializeAgentId(agent_id.clone()));
+                debug_assert!(effects.is_empty());
                 let effects = self.apply_model_action(
                     ModelAction::InitializePrimaryAgent(AgentInfo {
                         id: agent_id,
@@ -231,7 +233,8 @@ impl crate::app::App {
                     );
                     debug_assert!(effects.is_empty());
                 }
-                self.auth.ui_notice = None;
+                let effects = self.apply_auth_action(AuthAction::ClearUiNotice);
+                debug_assert!(effects.is_empty());
                 self.set_status(LogLevel::Info, "connection", "connected");
                 vec![]
             }
@@ -717,7 +720,6 @@ impl crate::app::App {
     fn reset_active_session_view(&mut self) {
         self.chat.reset_for_session_switch();
         self.render.invalidate_content_cache();
-        self.chat.clear_streaming_thinking();
         self.render.invalidate_thinking_cache();
         self.render.invalidate_card_cache();
         let effects = self.apply_delegate_action(DelegateAction::ClearRootSessionState);
@@ -922,10 +924,6 @@ impl crate::app::App {
                 })
             }
         }
-    }
-
-    fn push_undoable_user_turn(&mut self, message_id: String, text: String) {
-        self.chat.push_undoable_user_turn(message_id, text);
     }
 
     fn apply_acp_control_capabilities_log(&mut self, data: Value) {

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -25,6 +25,7 @@ use crate::domain::tool::ToolDetail;
 use crate::models_state::{ModelAction, ModelContext, ModelCoordination, ModelOutcome};
 use crate::navigation_state::{Popup, Screen};
 use crate::profiles_state::{ProfileAction, ProfileOutcome};
+use crate::session_state::{SessionAction, SessionCoordination, SessionOutcome};
 use crate::tool_detail;
 
 #[derive(Debug, Clone, Default)]
@@ -217,7 +218,8 @@ impl crate::app::App {
                 );
                 debug_assert!(effects.is_empty());
                 if let Some(mode) = agent_mode {
-                    self.sessions.replace_agent_mode(mode);
+                    let effects = self.apply_session_action(SessionAction::ReplaceAgentMode(mode));
+                    debug_assert!(effects.is_empty());
                 }
                 if let Some(effort) = reasoning_effort {
                     let effects = self.apply_model_action(
@@ -231,8 +233,7 @@ impl crate::app::App {
                 vec![]
             }
             AcpAppEvent::AgentMode { mode } => {
-                self.sessions.replace_agent_mode(mode);
-                vec![]
+                self.apply_session_action(SessionAction::ReplaceAgentMode(mode))
             }
             AcpAppEvent::ReasoningEffort { reasoning_effort } => self.apply_model_action(
                 ModelAction::ReasoningEffort(reasoning_effort),
@@ -312,24 +313,29 @@ impl crate::app::App {
                 effects(self.apply_remote_session_attached(attached))
             }
             AcpAppEvent::SessionList { request, page } => {
-                effects(self.apply_acp_session_list(request, page))
+                self.apply_session_action(SessionAction::CatalogPage { request, page })
             }
             AcpAppEvent::SessionListFailed { request, message } => {
-                self.apply_acp_session_list_failure(&request);
-                self.push_acp_error(&message);
-                self.set_status(LogLevel::Error, "acp", format!("error: {message}"));
-                vec![]
+                self.apply_session_action(SessionAction::CatalogFailed { request, message })
             }
             AcpAppEvent::SessionCreated {
                 agent_id,
                 session_id,
                 profile_id,
-            } => effects(self.apply_acp_session_created(agent_id, session_id, profile_id)),
+            } => self.apply_session_action(SessionAction::Created {
+                agent_id,
+                session_id,
+                profile_id,
+            }),
             AcpAppEvent::SessionLoaded {
                 agent_id,
                 session_id,
                 profile_id,
-            } => effects(self.apply_acp_session_loaded(agent_id, session_id, profile_id)),
+            } => self.apply_session_action(SessionAction::Loaded {
+                agent_id,
+                session_id,
+                profile_id,
+            }),
             AcpAppEvent::SessionUpdate {
                 session_id,
                 update,
@@ -596,113 +602,70 @@ impl crate::app::App {
         )
     }
 
-    fn apply_acp_session_list(
-        &mut self,
-        request: SessionListRequest,
-        page: SessionListPage,
-    ) -> Vec<Command> {
-        let SessionListPage {
-            groups,
-            next_cursor,
-            total_count: _,
-        } = page;
-        match request {
-            SessionListRequest::Discovery => {
-                let (workspaces, next_discovery_cursor) =
-                    self.sessions.apply_discovery_page(groups, next_cursor);
-                let mut commands = workspaces
-                    .into_iter()
-                    .map(Command::list_sessions_workspace)
-                    .collect::<Vec<_>>();
-                if let Some(cursor) = next_discovery_cursor {
-                    commands.push(Command::list_sessions_discovery(Some(cursor)));
+    fn apply_session_action(&mut self, action: SessionAction) -> Vec<Effect> {
+        let SessionOutcome {
+            coordination,
+            mut effects,
+        } = self.sessions.reduce(action);
+        for coordination in coordination {
+            match coordination {
+                SessionCoordination::PushChatError(message) => self.push_acp_error(&message),
+                SessionCoordination::ClearDelegateParent => {
+                    self.delegates.parent_session_id = None;
+                    self.delegates.pending_parent_session_id = None;
                 }
-                commands
-            }
-            SessionListRequest::WorkspaceFirstPage { cwd } => {
-                self.sessions.apply_workspace_first_page(cwd, groups);
-                Vec::new()
-            }
-            SessionListRequest::WorkspaceContinuation { cwd } => {
-                self.sessions.apply_workspace_continuation(cwd, groups);
-                Vec::new()
-            }
-        }
-    }
-
-    fn apply_acp_session_list_failure(&mut self, request: &SessionListRequest) {
-        match request {
-            SessionListRequest::Discovery => self.sessions.fail_discovery(),
-            SessionListRequest::WorkspaceFirstPage { cwd }
-            | SessionListRequest::WorkspaceContinuation { cwd } => {
-                self.sessions.fail_workspace_request(cwd);
-            }
-        }
-    }
-
-    fn apply_acp_session_created(
-        &mut self,
-        agent_id: String,
-        session_id: String,
-        profile_id: Option<String>,
-    ) -> Vec<Command> {
-        self.delegates.parent_session_id = None;
-        self.delegates.pending_parent_session_id = None;
-        self.sessions.session_id = Some(session_id.clone());
-        self.apply_session_profile_binding(&session_id, profile_id);
-        self.sessions.agent_id = Some(agent_id);
-        self.reset_active_session_view();
-        self.navigation.screen = Screen::Chat;
-        self.set_status(LogLevel::Info, "session", "session created");
-        let mut commands = vec![Command::SubscribeSession {
-            session_id: session_id.clone(),
-            agent_id: self.sessions.agent_id.clone(),
-        }];
-        if let Some(profile_id) = self.current_session_profile_id().map(str::to_string) {
-            if self.models.agents_profile_id.as_deref() == Some(profile_id.as_str()) {
-                commands.extend(self.delegate_model_commands_for_session(&session_id, &profile_id));
-            } else {
-                commands.push(Command::ListProfileAgents { profile_id });
-            }
-        }
-        commands
-    }
-
-    fn apply_acp_session_loaded(
-        &mut self,
-        agent_id: String,
-        session_id: String,
-        profile_id: Option<String>,
-    ) -> Vec<Command> {
-        self.chat.activity = ActivityState::Idle;
-        let discovered_parent = self
-            .sessions
-            .session_parent_id(&session_id)
-            .map(str::to_owned);
-        self.delegates.resolve_parent_session_id(discovered_parent);
-        self.apply_session_profile_binding(&session_id, profile_id);
-        self.sessions.session_id = Some(session_id.clone());
-        self.sessions.agent_id = Some(agent_id);
-        self.reset_active_session_view();
-        self.navigation.screen = if self.delegates.parent_session_id.is_some() {
-            Screen::Delegate
-        } else {
-            Screen::Chat
-        };
-        self.set_status(LogLevel::Debug, "activity", "ready");
-        let mut commands = vec![Command::SetAgentMode {
-            mode: self.sessions.agent_mode.clone(),
-        }];
-        if self.delegates.parent_session_id.is_none()
-            && let Some(profile_id) = self.current_session_profile_id().map(str::to_string)
-        {
-            if self.models.agents_profile_id.as_deref() == Some(profile_id.as_str()) {
-                commands.extend(self.delegate_model_commands_for_session(&session_id, &profile_id));
-            } else {
-                commands.push(Command::ListProfileAgents { profile_id });
+                SessionCoordination::SetChatIdle => self.chat.activity = ActivityState::Idle,
+                SessionCoordination::ResolveDelegateParent(discovered_parent) => {
+                    self.delegates.resolve_parent_session_id(discovered_parent);
+                }
+                SessionCoordination::ApplyProfileBinding {
+                    session_id,
+                    profile_id,
+                    remove_if_missing,
+                } => {
+                    if let Some(profile_id) = profile_id {
+                        self.profiles.bind_session_profile(session_id, profile_id);
+                    } else if remove_if_missing {
+                        self.profiles.remove_session_profile(&session_id);
+                    }
+                }
+                SessionCoordination::ResetActiveSessionView => self.reset_active_session_view(),
+                SessionCoordination::SelectChat => self.navigation.screen = Screen::Chat,
+                SessionCoordination::SelectLoadedSessionScreen => {
+                    self.navigation.screen = if self.delegates.parent_session_id.is_some() {
+                        Screen::Delegate
+                    } else {
+                        Screen::Chat
+                    };
+                }
+                SessionCoordination::Status {
+                    level,
+                    target,
+                    message,
+                } => self.set_status(level, target, message),
+                SessionCoordination::SynchronizeProfileCommands {
+                    session_id,
+                    root_only,
+                } => {
+                    if (!root_only || self.delegates.parent_session_id.is_none())
+                        && let Some(profile_id) =
+                            self.current_session_profile_id().map(str::to_string)
+                    {
+                        if self.models.agents_profile_id.as_deref() == Some(profile_id.as_str()) {
+                            effects.extend(
+                                self.delegate_model_commands_for_session(&session_id, &profile_id)
+                                    .into_iter()
+                                    .map(Effect::Command),
+                            );
+                        } else {
+                            effects
+                                .push(Effect::Command(Command::ListProfileAgents { profile_id }));
+                        }
+                    }
+                }
             }
         }
-        commands
+        effects
     }
 
     fn reset_active_session_view(&mut self) {
@@ -715,7 +678,6 @@ impl crate::app::App {
             self.delegates.clear_for_root_session();
         }
         self.composer.reset_for_session_switch();
-        self.sessions.mode_before_review = None;
     }
 
     fn upsert_provisional_delegate(
@@ -2485,21 +2447,15 @@ mod tests {
                 .contains(&Some("/repo".into()))
         );
         assert_eq!(app.sessions.session_groups[0].next_cursor, None);
-        assert!(replies.iter().any(|reply| matches!(
-            reply,
-            Effect::Command(Command::ListSessions {
-                request: SessionListRequest::WorkspaceFirstPage { cwd },
-                cursor: None,
-                ..
-            }) if cwd == "/repo"
-        )));
-        assert!(replies.iter().any(|reply| matches!(
-            reply,
-            Effect::Command(Command::ListSessions {
-                request: SessionListRequest::Discovery,
-                cursor: Some(cursor),
-            }) if cursor == "opaque-root-2"
-        )));
+        assert_eq!(
+            replies,
+            vec![
+                Effect::Command(Command::list_sessions_workspace("/repo".into())),
+                Effect::Command(Command::list_sessions_discovery(Some(
+                    "opaque-root-2".into()
+                ))),
+            ]
+        );
     }
 
     #[test]
@@ -2616,7 +2572,7 @@ mod tests {
             .pending_session_group_loads
             .insert(Some("/repo".into()));
 
-        app.handle_acp_event(AcpAppEvent::SessionListFailed {
+        let replies = app.handle_acp_event(AcpAppEvent::SessionListFailed {
             request: SessionListRequest::WorkspaceContinuation {
                 cwd: "/repo".into(),
             },
@@ -2624,6 +2580,16 @@ mod tests {
         });
 
         assert!(app.sessions.pending_session_group_loads.is_empty());
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::Error(message)] if message == "failed"
+        ));
+        assert_eq!(app.diagnostics.status, "error: failed");
+        let diagnostic = app.diagnostics.logs.last().expect("failure diagnostic");
+        assert_eq!(diagnostic.level, LogLevel::Error);
+        assert_eq!(diagnostic.target, "acp");
+        assert_eq!(diagnostic.message, "error: failed");
+        assert!(replies.is_empty());
     }
 
     fn seed_model_state(app: &mut App) {
@@ -2715,6 +2681,7 @@ mod tests {
 
         assert_eq!(app.sessions.session_id.as_deref(), Some("session-1"));
         assert_eq!(app.sessions.agent_id.as_deref(), Some("agent-1"));
+        assert_eq!(app.profiles.session_profile_id("session-1"), Some("code"));
         assert_eq!(app.navigation.screen, Screen::Chat);
         assert_eq!(app.delegates.parent_session_id, None);
         assert_eq!(app.delegates.pending_parent_session_id, None);
@@ -2740,6 +2707,11 @@ mod tests {
         assert_eq!(app.mesh.selected_mesh_node_id(), Some("node-1"));
         assert_eq!(app.mesh.mesh_invite_name, "preserved");
         assert_seeded_model_state(&app);
+        assert_eq!(app.diagnostics.status, "session created");
+        let diagnostic = app.diagnostics.logs.last().expect("creation diagnostic");
+        assert_eq!(diagnostic.level, LogLevel::Info);
+        assert_eq!(diagnostic.target, "session");
+        assert_eq!(diagnostic.message, "session created");
         assert!(matches!(
             command_refs(&replies).as_slice(),
             [
@@ -2809,6 +2781,9 @@ mod tests {
             profile_id: None,
         });
 
+        assert_eq!(app.sessions.session_id.as_deref(), Some("child"));
+        assert_eq!(app.sessions.agent_id.as_deref(), Some("agent-1"));
+        assert_eq!(app.chat.activity, ActivityState::Idle);
         assert_eq!(app.delegates.parent_session_id.as_deref(), Some("parent"));
         assert_eq!(app.navigation.screen, Screen::Delegate);
         assert!(app.chat.messages.is_empty());
@@ -2824,6 +2799,11 @@ mod tests {
         assert_eq!(app.chat.session_stats.total_tool_calls, 0);
         assert_eq!(app.delegates.delegate_entries.len(), 1);
         assert_seeded_model_state(&app);
+        assert_eq!(app.diagnostics.status, "ready");
+        let diagnostic = app.diagnostics.logs.last().expect("load diagnostic");
+        assert_eq!(diagnostic.level, LogLevel::Debug);
+        assert_eq!(diagnostic.target, "activity");
+        assert_eq!(diagnostic.message, "ready");
         assert!(matches!(
             command_refs(&replies).as_slice(),
             [Command::SetAgentMode { mode }] if mode == "plan"
@@ -2979,9 +2959,10 @@ mod tests {
         app.sessions.agent_mode = "review".into();
         app.sessions.mode_before_review = Some("plan".into());
 
-        app.handle_acp_event(AcpAppEvent::AgentMode {
+        let replies = app.handle_acp_event(AcpAppEvent::AgentMode {
             mode: "build".into(),
         });
+        assert!(replies.is_empty());
         assert_eq!(app.sessions.agent_mode, "build");
         assert_eq!(app.sessions.mode_before_review, None);
 

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -4,6 +4,7 @@ use serde_json::Value;
 
 use crate::application::Effect;
 use crate::auth_state::{AuthAction, AuthOutcome};
+use crate::chat_state::{ChatAction, ChatCoordination, ChatOutcome};
 use crate::command::{Command, SessionListRequest};
 use crate::delegates_state::{
     DelegateAction, DelegateChildActivity, DelegateContext, DelegateCoordination, DelegateOutcome,
@@ -340,10 +341,7 @@ impl crate::app::App {
                 session_id,
                 update,
                 is_replay,
-            } => {
-                self.apply_acp_session_update(&session_id, update, is_replay);
-                vec![]
-            }
+            } => self.apply_acp_session_update(&session_id, update, is_replay),
             AcpAppEvent::SessionReplay {
                 session_id,
                 updates,
@@ -354,10 +352,11 @@ impl crate::app::App {
                     "session",
                     format!("session replay: {} update(s)", updates.len()),
                 );
+                let mut effects = Vec::new();
                 for update in updates {
-                    self.apply_acp_session_update(&session_id, update, true);
+                    effects.extend(self.apply_acp_session_update(&session_id, update, true));
                 }
-                vec![]
+                effects
             }
             AcpAppEvent::UndoStack(undo_stack) => {
                 self.chat.undo_state =
@@ -668,22 +667,78 @@ impl crate::app::App {
     }
 
     fn apply_delegate_action(&mut self, action: DelegateAction) -> Vec<Effect> {
-        let context = DelegateContext {
-            active_session_id: self.sessions.session_id.clone(),
-        };
+        let outcome = self.delegates.reduce(
+            action,
+            DelegateContext {
+                active_session_id: self.sessions.session_id.clone(),
+                inactive_activity_session_id: None,
+            },
+        );
+        self.apply_delegate_outcome(outcome)
+    }
+
+    fn apply_inactive_delegate_action(
+        &mut self,
+        session_id: &str,
+        activity: DelegateChildActivity,
+    ) -> Vec<Effect> {
+        self.sessions.note_session_activity(session_id);
+        let inactive_activity_session_id = self
+            .sessions
+            .session_activity
+            .contains_key(session_id)
+            .then(|| session_id.to_string());
+        let outcome = self.delegates.reduce(
+            DelegateAction::InactiveChildActivity {
+                session_id: session_id.to_string(),
+                activity,
+            },
+            DelegateContext {
+                active_session_id: self.sessions.session_id.clone(),
+                inactive_activity_session_id,
+            },
+        );
+        self.apply_delegate_outcome(outcome)
+    }
+
+    fn apply_delegate_outcome(&mut self, outcome: DelegateOutcome) -> Vec<Effect> {
         let DelegateOutcome {
             changed: _,
             coordination,
             effects,
-        } = self.delegates.reduce(action, context);
+        } = outcome;
         for coordination in coordination {
             match coordination {
-                DelegateCoordination::NoteSessionActivity(session_id) => {
-                    self.sessions.note_session_activity(&session_id);
-                }
                 DelegateCoordination::InvalidateCardCache => {
                     self.render.invalidate_card_cache();
                 }
+            }
+        }
+        effects
+    }
+
+    fn apply_chat_action(&mut self, action: ChatAction) -> Vec<Effect> {
+        let ChatOutcome {
+            transition: _,
+            coordination,
+            effects,
+        } = self.chat.reduce(action);
+        for coordination in coordination {
+            match coordination {
+                ChatCoordination::InvalidateContentCache => {
+                    self.render.invalidate_content_cache();
+                }
+                ChatCoordination::InvalidateThinkingCache => {
+                    self.render.invalidate_thinking_cache();
+                }
+                ChatCoordination::InvalidateCardCache => {
+                    self.render.invalidate_card_cache();
+                }
+                ChatCoordination::Status {
+                    level,
+                    target,
+                    message,
+                } => self.set_status(level, target, message),
             }
         }
         effects
@@ -754,10 +809,7 @@ impl crate::app::App {
             | AcpSessionUpdate::Cancelled
             | AcpSessionUpdate::Finished { .. } => DelegateChildActivity::Unchanged,
         };
-        self.apply_delegate_action(DelegateAction::InactiveChildActivity {
-            session_id: session_id.to_string(),
-            activity,
-        })
+        self.apply_inactive_delegate_action(session_id, activity)
     }
 
     fn apply_acp_session_update(
@@ -765,64 +817,63 @@ impl crate::app::App {
         session_id: &str,
         update: AcpSessionUpdate,
         is_replay: bool,
-    ) {
+    ) -> Vec<Effect> {
         if self.sessions.session_id.as_deref() != Some(session_id) {
-            let effects = self.apply_acp_delegate_child_update(session_id, &update);
-            debug_assert!(effects.is_empty());
-            return;
+            return self.apply_acp_delegate_child_update(session_id, &update);
         }
         self.sessions.note_session_activity(session_id);
 
         match update {
             AcpSessionUpdate::TurnStarted => {
-                self.chat.begin_turn(is_replay);
-                self.render.invalidate_content_cache();
-                self.render.invalidate_thinking_cache();
-                self.set_status(LogLevel::Debug, "activity", "thinking...");
+                return self.apply_chat_action(ChatAction::TurnStarted { is_replay });
             }
             AcpSessionUpdate::UserMessage {
                 content,
                 message_id,
-            } => self.push_acp_user_message(content, message_id, is_replay),
+            } => {
+                return self.apply_chat_action(ChatAction::UserMessage {
+                    text: acp_content_to_string(&content),
+                    message_id,
+                    is_replay,
+                });
+            }
             AcpSessionUpdate::AssistantContentDelta {
                 content,
                 message_id,
             } => {
-                let transition = self.chat.append_streaming_content(&content, message_id);
-                if transition.finalized_previous {
-                    self.render.invalidate_content_cache();
-                    self.render.invalidate_thinking_cache();
-                    self.render.invalidate_card_cache();
-                }
+                return self.apply_chat_action(ChatAction::AssistantContentDelta {
+                    content,
+                    message_id,
+                });
             }
             AcpSessionUpdate::AssistantThinkingDelta {
                 content,
                 message_id,
             } => {
-                let transition = self
-                    .chat
-                    .append_streaming_thinking(&content, message_id, is_replay);
-                if transition.ignored_duplicate {
-                    return;
-                }
-                if transition.finalized_previous {
-                    self.render.invalidate_content_cache();
-                    self.render.invalidate_thinking_cache();
-                    self.render.invalidate_card_cache();
-                }
+                return self.apply_chat_action(ChatAction::AssistantThinkingDelta {
+                    content,
+                    message_id,
+                    is_replay,
+                });
             }
             AcpSessionUpdate::AssistantMessage {
                 content,
                 thinking,
                 message_id,
-            } => self.push_acp_assistant_message(content, thinking, message_id),
+            } => {
+                return self.apply_chat_action(ChatAction::AssistantMessage {
+                    content,
+                    thinking,
+                    message_id,
+                });
+            }
             AcpSessionUpdate::ToolCallStart {
                 tool_call_id,
                 name,
                 arguments,
             } => {
                 if self.chat.suppress_turn_output {
-                    return;
+                    return Vec::new();
                 }
                 self.chat.activity = ActivityState::RunningTool { name: name.clone() };
                 self.set_status(LogLevel::Debug, "tool", format!("tool: {name}"));
@@ -847,7 +898,7 @@ impl crate::app::App {
                         self.chat.clear_streaming_thinking();
                         self.render.invalidate_thinking_cache();
                         self.render.invalidate_card_cache();
-                        return;
+                        return Vec::new();
                     }
                     self.chat.record_tool_call();
                     if self.chat.push_streaming_thinking_entry() {
@@ -938,38 +989,16 @@ impl crate::app::App {
                 );
             }
             AcpSessionUpdate::Cancelled => {
-                self.chat.cancel_turn(is_replay);
-                self.render.invalidate_content_cache();
-                self.render.invalidate_thinking_cache();
-                self.set_status(LogLevel::Warn, "activity", "cancelled");
+                return self.apply_chat_action(ChatAction::Cancelled { is_replay });
             }
             AcpSessionUpdate::Finished { finish_reason } => {
-                self.chat.finish_turn(is_replay);
-                self.render.invalidate_content_cache();
-                self.render.invalidate_thinking_cache();
-                self.set_status(
-                    LogLevel::Debug,
-                    "activity",
-                    format!("finished: {finish_reason}"),
-                );
+                return self.apply_chat_action(ChatAction::Finished {
+                    finish_reason,
+                    is_replay,
+                });
             }
         }
-    }
-
-    fn push_acp_user_message(
-        &mut self,
-        content: Value,
-        message_id: Option<String>,
-        is_replay: bool,
-    ) {
-        let text = acp_content_to_string(&content);
-        let transition = self.chat.push_user_message(text, message_id, is_replay);
-        if matches!(
-            transition,
-            crate::chat_state::UserMessageTransition::Reconciled
-        ) {
-            self.render.invalidate_card_cache();
-        }
+        Vec::new()
     }
 
     fn finalize_streaming_segment(&mut self) {
@@ -983,22 +1012,6 @@ impl crate::app::App {
 
     fn push_undoable_user_turn(&mut self, message_id: String, text: String) {
         self.chat.push_undoable_user_turn(message_id, text);
-    }
-
-    fn push_acp_assistant_message(
-        &mut self,
-        content: String,
-        thinking: Option<String>,
-        message_id: Option<String>,
-    ) {
-        self.render.invalidate_content_cache();
-        let replaced = self
-            .chat
-            .push_assistant_message(content, thinking, message_id);
-        self.render.invalidate_thinking_cache();
-        if replaced {
-            self.render.invalidate_card_cache();
-        }
     }
 
     fn push_acp_error(&mut self, message: &str) {

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -528,18 +528,10 @@ impl crate::app::App {
                 vec![]
             }
             AcpAppEvent::Error { message } => {
-                self.chat.end_llm_request_span(None);
-                self.push_acp_error(&message);
-                self.set_status(LogLevel::Error, "acp", format!("error: {message}"));
-                vec![]
+                self.apply_chat_action(ChatAction::AcpError { message })
             }
             AcpAppEvent::PromptFailed { local_id, message } => {
-                self.chat.end_llm_request_span(None);
-                self.chat.rollback_pending_prompt(&local_id);
-                self.render.invalidate_card_cache();
-                self.push_acp_error(&message);
-                self.set_status(LogLevel::Error, "acp", format!("error: {message}"));
-                vec![]
+                self.apply_chat_action(ChatAction::BackendPromptFailed { local_id, message })
             }
         }
     }
@@ -608,7 +600,9 @@ impl crate::app::App {
         } = self.sessions.reduce(action);
         for coordination in coordination {
             match coordination {
-                SessionCoordination::PushChatError(message) => self.push_acp_error(&message),
+                SessionCoordination::PushChatError(message) => {
+                    self.chat.push_error(&message);
+                }
                 SessionCoordination::ClearDelegateParent => {
                     effects.extend(self.apply_delegate_action(DelegateAction::ClearNewRootParent));
                 }
@@ -719,7 +713,7 @@ impl crate::app::App {
         effects
     }
 
-    fn apply_chat_action(&mut self, action: ChatAction) -> Vec<Effect> {
+    pub(crate) fn apply_chat_action(&mut self, action: ChatAction) -> Vec<Effect> {
         let ChatOutcome {
             transition: _,
             coordination,
@@ -1004,10 +998,6 @@ impl crate::app::App {
 
     fn push_undoable_user_turn(&mut self, message_id: String, text: String) {
         self.chat.push_undoable_user_turn(message_id, text);
-    }
-
-    fn push_acp_error(&mut self, message: &str) {
-        self.chat.push_error(message);
     }
 
     fn handle_acp_elicitation_requested(

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -2223,21 +2223,24 @@ mod tests {
         let mut app = App::new();
         let before = app.diagnostics.logs.len();
 
-        app.handle_acp_event(AcpAppEvent::MeshStatus(MeshStatusInfo {
+        let replies = app.handle_acp_event(AcpAppEvent::MeshStatus(MeshStatusInfo {
             enabled: true,
             known_peer_count: 2,
             ..Default::default()
         }));
 
+        assert!(replies.is_empty());
         assert!(
             app.mesh
                 .mesh_status
                 .as_ref()
                 .is_some_and(|status| { status.enabled && status.known_peer_count == 2 })
         );
-        let log = &app.diagnostics.logs[before];
-        assert_eq!(log.target, "mesh");
-        assert_eq!(log.message, "mesh status: enabled=true, peers=2");
+        let logs = &app.diagnostics.logs[before..];
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].level, LogLevel::Debug);
+        assert_eq!(logs[0].target, "mesh");
+        assert_eq!(logs[0].message, "mesh status: enabled=true, peers=2");
     }
 
     #[test]
@@ -2249,6 +2252,7 @@ mod tests {
             ..Default::default()
         }];
         app.mesh.remote_session_cursor = 4;
+        let before = app.diagnostics.logs.len();
 
         let replies = app.handle_acp_event(AcpAppEvent::RemoteSessions(RemoteSessionListInfo {
             node_id: "node-1".into(),
@@ -2278,13 +2282,22 @@ mod tests {
             app.sessions.session_remote_cwd("session-1"),
             Some("/remote/repo".into())
         );
+        let location = &app.sessions.remote_session_locations["session-1"];
+        assert_eq!(location.node_id, "node-1");
+        assert_eq!(location.cwd.as_deref(), Some("/remote/repo"));
+        let logs = &app.diagnostics.logs[before..];
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].level, LogLevel::Info);
+        assert_eq!(logs[0].target, "mesh");
+        assert_eq!(logs[0].message, "remote sessions: 1 for node-1");
     }
 
     #[test]
     fn native_mesh_invite_created_stores_invite_and_opens_invite_view() {
         let mut app = App::new();
+        let before = app.diagnostics.logs.len();
 
-        app.handle_acp_event(AcpAppEvent::MeshInviteCreated(MeshInviteCreatedInfo {
+        let replies = app.handle_acp_event(AcpAppEvent::MeshInviteCreated(MeshInviteCreatedInfo {
             invite_id: "invite-1".into(),
             url: "qmt://mesh/join/token".into(),
             qr_code: Some("QR".into()),
@@ -2293,8 +2306,18 @@ mod tests {
             mesh_name: Some("Team Mesh".into()),
         }));
 
+        assert!(replies.is_empty());
         assert!(matches!(app.navigation.popup, Popup::MeshInviteQr));
         assert_eq!(app.mesh.invite_url(), Some("qmt://mesh/join/token"));
+        assert_eq!(app.diagnostics.status, "mesh invite created");
+        let logs = &app.diagnostics.logs[before..];
+        assert_eq!(logs.len(), 2);
+        assert_eq!(logs[0].level, LogLevel::Info);
+        assert_eq!(logs[0].target, "mesh");
+        assert_eq!(logs[0].message, "mesh invite created");
+        assert_eq!(logs[1].level, LogLevel::Info);
+        assert_eq!(logs[1].target, "mesh");
+        assert_eq!(logs[1].message, "mesh invite: qmt://mesh/join/token");
     }
 
     #[test]

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -4,7 +4,10 @@ use serde_json::Value;
 
 use crate::application::Effect;
 use crate::auth_state::{AuthAction, AuthOutcome};
-use crate::chat_state::{ChatAction, ChatCoordination, ChatOutcome};
+use crate::chat_state::{
+    ChatAction, ChatCoordination, ChatOutcome, ChatToolAction, ChatToolOutcome, ChatToolTransition,
+    ToolStartPreparationTransition,
+};
 use crate::command::{Command, SessionListRequest};
 use crate::delegates_state::{
     DelegateAction, DelegateChildActivity, DelegateContext, DelegateCoordination, DelegateOutcome,
@@ -22,7 +25,6 @@ use crate::domain::profile::{AgentInfo, ProfileInfo};
 use crate::domain::session::{
     ForkResult, RedoResult, SessionListPage, UndoResult, UndoStackSnapshot,
 };
-use crate::domain::tool::ToolDetail;
 use crate::models_state::{ModelAction, ModelContext, ModelCoordination, ModelOutcome};
 use crate::navigation_state::{Popup, Screen};
 use crate::profiles_state::{ProfileAction, ProfileOutcome};
@@ -723,6 +725,24 @@ impl crate::app::App {
             coordination,
             effects,
         } = self.chat.reduce(action);
+        self.apply_chat_coordination(coordination);
+        effects
+    }
+
+    fn apply_chat_tool_action(
+        &mut self,
+        action: ChatToolAction,
+    ) -> (ChatToolTransition, Vec<Effect>) {
+        let ChatToolOutcome {
+            transition,
+            coordination,
+            effects,
+        } = self.chat.reduce_tool(action);
+        self.apply_chat_coordination(coordination);
+        (transition, effects)
+    }
+
+    fn apply_chat_coordination(&mut self, coordination: Vec<ChatCoordination>) {
         for coordination in coordination {
             match coordination {
                 ChatCoordination::InvalidateContentCache => {
@@ -741,7 +761,6 @@ impl crate::app::App {
                 } => self.set_status(level, target, message),
             }
         }
-        effects
     }
 
     fn reset_active_session_view(&mut self) {
@@ -872,40 +891,43 @@ impl crate::app::App {
                 name,
                 arguments,
             } => {
-                if self.chat.suppress_turn_output {
-                    return Vec::new();
+                let (transition, mut effects) =
+                    self.apply_chat_tool_action(ChatToolAction::PrepareToolStart {
+                        name: name.clone(),
+                    });
+                match transition {
+                    ChatToolTransition::StartPrepared(
+                        ToolStartPreparationTransition::Suppressed,
+                    ) => return effects,
+                    ChatToolTransition::StartPrepared(
+                        ToolStartPreparationTransition::QuestionOnly { .. },
+                    ) => return effects,
+                    ChatToolTransition::StartPrepared(
+                        ToolStartPreparationTransition::Prepared { .. },
+                    ) => {}
+                    _ => unreachable!("prepare tool start returned a non-prepare transition"),
                 }
-                self.chat.activity = ActivityState::RunningTool { name: name.clone() };
-                self.set_status(LogLevel::Debug, "tool", format!("tool: {name}"));
-                self.finalize_streaming_segment();
+
                 if name == "delegate" {
-                    let effects =
-                        self.apply_delegate_action(DelegateAction::ProvisionalToolDelegate {
+                    effects.extend(self.apply_delegate_action(
+                        DelegateAction::ProvisionalToolDelegate {
                             tool_call_id: tool_call_id.clone(),
                             arguments: arguments.clone(),
-                        });
-                    debug_assert!(effects.is_empty());
+                        },
+                    ));
                 }
-                if name != "question" {
-                    let cwd = self.current_session_cwd();
-                    let detail =
-                        tool_detail::parse_tool_detail(&name, arguments.as_ref(), cwd.as_deref());
-                    if self.chat.reconcile_tool_call_start(
-                        tool_call_id.as_deref(),
-                        &name,
-                        detail.clone(),
-                    ) {
-                        self.chat.clear_streaming_thinking();
-                        self.render.invalidate_thinking_cache();
-                        self.render.invalidate_card_cache();
-                        return Vec::new();
-                    }
-                    self.chat.record_tool_call();
-                    if self.chat.push_streaming_thinking_entry() {
-                        self.render.invalidate_thinking_cache();
-                    }
-                    self.chat.push_tool_call(tool_call_id, name, false, detail);
-                }
+
+                let cwd = self.current_session_cwd();
+                let detail =
+                    tool_detail::parse_tool_detail(&name, arguments.as_ref(), cwd.as_deref());
+                let (_, insertion_effects) =
+                    self.apply_chat_tool_action(ChatToolAction::InsertOrReconcileToolStart {
+                        tool_call_id,
+                        name,
+                        detail,
+                    });
+                effects.extend(insertion_effects);
+                return effects;
             }
             AcpSessionUpdate::ToolCallEnd {
                 tool_call_id,
@@ -913,33 +935,13 @@ impl crate::app::App {
                 is_error,
                 result,
             } => {
-                let mut updated = false;
-                if let Some(result) = result.as_deref() {
-                    updated = tool_detail::update_tool_detail(
-                        &mut self.chat.messages,
-                        tool_call_id.as_deref(),
-                        result,
-                    );
-                }
-                if is_error {
-                    if self
-                        .chat
-                        .mark_tool_call_failed(tool_call_id.as_deref(), &name)
-                    {
-                        updated = true;
-                    } else {
-                        self.chat.push_tool_call(
-                            tool_call_id,
-                            format!("{name} (failed)"),
-                            true,
-                            result.map(ToolDetail::Summary).unwrap_or(ToolDetail::None),
-                        );
-                        updated = true;
-                    }
-                }
-                if updated {
-                    self.render.invalidate_card_cache();
-                }
+                let (_, effects) = self.apply_chat_tool_action(ChatToolAction::ToolCallEnd {
+                    tool_call_id,
+                    name,
+                    is_error,
+                    result,
+                });
+                return effects;
             }
             AcpSessionUpdate::UsageUpdate {
                 used,
@@ -999,15 +1001,6 @@ impl crate::app::App {
             }
         }
         Vec::new()
-    }
-
-    fn finalize_streaming_segment(&mut self) {
-        if self.chat.finalize_streaming_segment() {
-            self.render.invalidate_content_cache();
-            self.chat.clear_streaming_thinking();
-            self.render.invalidate_thinking_cache();
-            self.render.invalidate_card_cache();
-        }
     }
 
     fn push_undoable_user_turn(&mut self, message_id: String, text: String) {
@@ -1524,6 +1517,7 @@ mod tests {
         SessionGroup, SessionListPage, SessionSummary, UndoFrame, UndoFrameStatus, UndoState,
         UndoableTurn,
     };
+    use crate::domain::tool::ToolDetail;
 
     const TEST_SESSION_ID: &str = "session-1";
     const TEST_ASSISTANT_ID: &str = "a1";

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -5,11 +5,11 @@ use serde_json::Value;
 use crate::application::Effect;
 use crate::auth_state::{AuthAction, AuthOutcome};
 use crate::command::{Command, SessionListRequest};
-use crate::delegates_state::DelegateLifecycleUpdate;
-use crate::diagnostics::LogLevel;
-use crate::domain::activity::{
-    ActivityState, DelegateChildState, DelegateStatus, DelegationState, DelegationUpdate,
+use crate::delegates_state::{
+    DelegateAction, DelegateChildActivity, DelegateContext, DelegateCoordination, DelegateOutcome,
 };
+use crate::diagnostics::LogLevel;
+use crate::domain::activity::{ActivityState, DelegationUpdate};
 use crate::domain::auth::{AuthProviderEntry, OAuthFlow, OAuthResult};
 use crate::domain::elicitation::ElicitationState;
 use crate::domain::mesh::{
@@ -489,20 +489,18 @@ impl crate::app::App {
                 }
                 vec![]
             }
-            AcpAppEvent::DelegationUpdate(update) => {
-                self.apply_acp_delegation_update(update);
-                vec![]
-            }
+            AcpAppEvent::DelegationUpdate(update) => self.apply_acp_delegation_update(update),
             AcpAppEvent::DelegationReplay {
                 session_id,
                 updates,
             } => {
+                let mut effects = Vec::new();
                 if self.sessions.session_id.as_deref() == Some(session_id.as_str()) {
                     for update in updates {
-                        self.apply_acp_delegation_update(update);
+                        effects.extend(self.apply_acp_delegation_update(update));
                     }
                 }
-                vec![]
+                effects
             }
             AcpAppEvent::Models { models, meta } => {
                 let meta = meta.unwrap_or_default();
@@ -611,12 +609,13 @@ impl crate::app::App {
             match coordination {
                 SessionCoordination::PushChatError(message) => self.push_acp_error(&message),
                 SessionCoordination::ClearDelegateParent => {
-                    self.delegates.parent_session_id = None;
-                    self.delegates.pending_parent_session_id = None;
+                    effects.extend(self.apply_delegate_action(DelegateAction::ClearNewRootParent));
                 }
                 SessionCoordination::SetChatIdle => self.chat.activity = ActivityState::Idle,
                 SessionCoordination::ResolveDelegateParent(discovered_parent) => {
-                    self.delegates.resolve_parent_session_id(discovered_parent);
+                    effects.extend(self.apply_delegate_action(
+                        DelegateAction::ResolveLoadedSessionParent(discovered_parent),
+                    ));
                 }
                 SessionCoordination::ApplyProfileBinding {
                     session_id,
@@ -668,147 +667,97 @@ impl crate::app::App {
         effects
     }
 
+    fn apply_delegate_action(&mut self, action: DelegateAction) -> Vec<Effect> {
+        let context = DelegateContext {
+            active_session_id: self.sessions.session_id.clone(),
+        };
+        let DelegateOutcome {
+            changed: _,
+            coordination,
+            effects,
+        } = self.delegates.reduce(action, context);
+        for coordination in coordination {
+            match coordination {
+                DelegateCoordination::NoteSessionActivity(session_id) => {
+                    self.sessions.note_session_activity(&session_id);
+                }
+                DelegateCoordination::InvalidateCardCache => {
+                    self.render.invalidate_card_cache();
+                }
+            }
+        }
+        effects
+    }
+
     fn reset_active_session_view(&mut self) {
         self.chat.reset_for_session_switch();
         self.render.invalidate_content_cache();
         self.chat.clear_streaming_thinking();
         self.render.invalidate_thinking_cache();
         self.render.invalidate_card_cache();
-        if self.delegates.parent_session_id.is_none() {
-            self.delegates.clear_for_root_session();
-        }
+        let effects = self.apply_delegate_action(DelegateAction::ClearRootSessionState);
+        debug_assert!(effects.is_empty());
         self.composer.reset_for_session_switch();
     }
 
-    fn upsert_provisional_delegate(
+    fn apply_acp_delegation_update(&mut self, update: DelegationUpdate) -> Vec<Effect> {
+        self.apply_delegate_action(DelegateAction::LifecycleUpdate(update))
+    }
+
+    fn apply_acp_delegate_child_update(
         &mut self,
-        tool_call_id: Option<&str>,
-        arguments: Option<&Value>,
-    ) {
-        let Some(tool_call_id) = tool_call_id else {
-            return;
-        };
-        let target_agent_id = arguments
-            .and_then(|value| value.get("target_agent_id"))
-            .and_then(Value::as_str)
-            .map(str::to_string);
-        let objective = arguments
-            .and_then(|value| value.get("objective"))
-            .and_then(Value::as_str)
-            .unwrap_or_default()
-            .to_string();
-        if self
-            .delegates
-            .upsert_provisional_delegate(tool_call_id, target_agent_id, objective)
-        {
-            self.render.invalidate_card_cache();
-        }
-    }
-
-    fn apply_acp_delegation_update(&mut self, update: DelegationUpdate) {
-        if self.sessions.session_id.as_deref() != Some(update.session_id.as_str()) {
-            return;
-        }
-        let status = match update.state {
-            DelegationState::Requested | DelegationState::Forked => DelegateStatus::InProgress,
-            DelegationState::Completed => DelegateStatus::Completed,
-            DelegationState::Failed => DelegateStatus::Failed,
-            DelegationState::Cancelled => DelegateStatus::Cancelled,
-        };
-        let lifecycle_rank = delegation_state_rank(update.state);
-        if self
-            .delegates
-            .apply_lifecycle_update(DelegateLifecycleUpdate {
-                delegation_id: update.delegation_id,
-                tool_call_id: update.tool_call_id,
-                target_agent_id: update.target_agent_id,
-                objective: update.objective,
-                child_session_id: update.child_session_id,
-                status,
-                lifecycle_rank,
-                requested_at: update.requested_at,
-                finished_at: update.finished_at,
-                updated_at: update.updated_at,
-                result_summary: update.result_summary,
-                error: update.error,
-            })
-        {
-            self.render.invalidate_card_cache();
-        }
-    }
-
-    fn apply_acp_delegate_child_update(&mut self, session_id: &str, update: &AcpSessionUpdate) {
-        let (mut state, mut stats) = self.delegates.child_snapshot(session_id);
-        match update {
-            AcpSessionUpdate::ToolCallStart { .. } => {
-                stats.tool_calls = stats.tool_calls.saturating_add(1);
-                state = DelegateChildState::OtherProgress;
-            }
+        session_id: &str,
+        update: &AcpSessionUpdate,
+    ) -> Vec<Effect> {
+        let activity = match update {
+            AcpSessionUpdate::ToolCallStart { .. } => DelegateChildActivity::ToolCallStarted,
             AcpSessionUpdate::AssistantMessage { message_id, .. } => {
-                if self
-                    .delegates
-                    .record_child_message_id(session_id, message_id.as_deref(), true)
-                {
-                    stats.messages = stats.messages.saturating_add(1);
+                DelegateChildActivity::AssistantMessage {
+                    message_id: message_id.clone(),
                 }
-                state = DelegateChildState::AssistantMessage;
             }
             AcpSessionUpdate::AssistantContentDelta { message_id, .. } => {
-                if self
-                    .delegates
-                    .record_child_message_id(session_id, message_id.as_deref(), false)
-                {
-                    stats.messages = stats.messages.saturating_add(1);
+                DelegateChildActivity::AssistantContent {
+                    message_id: message_id.clone(),
                 }
-                state = DelegateChildState::AssistantMessage;
             }
             AcpSessionUpdate::AssistantThinkingDelta { .. } | AcpSessionUpdate::TurnStarted => {
-                state = DelegateChildState::OtherProgress;
+                DelegateChildActivity::Progress
             }
-            AcpSessionUpdate::UserMessage { .. } => state = DelegateChildState::UserMessage,
+            AcpSessionUpdate::UserMessage { .. } => DelegateChildActivity::UserMessage,
             AcpSessionUpdate::UsageUpdate {
                 used,
                 size,
                 cost_usd,
-            } => {
-                if *used > 0 {
-                    stats.context_tokens = *used;
-                }
-                if *size > 0 {
-                    stats.context_limit = *size;
-                }
-                if let Some(cost) = cost_usd {
-                    stats.cost_usd = *cost;
-                }
-            }
+            } => DelegateChildActivity::Usage {
+                used: *used,
+                size: *size,
+                cost_usd: *cost_usd,
+            },
             AcpSessionUpdate::ElicitationRequested {
                 elicitation_id,
                 message,
                 requested_schema,
                 source,
                 ..
-            } => {
-                state = DelegateChildState::PendingElicitation {
-                    elicitation_id: elicitation_id.clone(),
-                    message: message.clone(),
-                    requested_schema: requested_schema.clone(),
-                    source: source.clone(),
-                };
-            }
+            } => DelegateChildActivity::PendingElicitation {
+                elicitation_id: elicitation_id.clone(),
+                message: message.clone(),
+                requested_schema: requested_schema.clone(),
+                source: source.clone(),
+            },
             AcpSessionUpdate::ToolCallEnd { name, .. } if name == "question" => {
-                state = DelegateChildState::QuestionToolFinished;
+                DelegateChildActivity::QuestionToolFinished
             }
             AcpSessionUpdate::ToolCallEnd { .. }
             | AcpSessionUpdate::TimingUpdate { .. }
             | AcpSessionUpdate::Cancelled
-            | AcpSessionUpdate::Finished { .. } => {}
-        }
-        if self
-            .delegates
-            .apply_child_snapshot(session_id, state, stats)
-        {
-            self.render.invalidate_card_cache();
-        }
+            | AcpSessionUpdate::Finished { .. } => DelegateChildActivity::Unchanged,
+        };
+        self.apply_delegate_action(DelegateAction::InactiveChildActivity {
+            session_id: session_id.to_string(),
+            activity,
+        })
     }
 
     fn apply_acp_session_update(
@@ -818,8 +767,8 @@ impl crate::app::App {
         is_replay: bool,
     ) {
         if self.sessions.session_id.as_deref() != Some(session_id) {
-            self.sessions.note_session_activity(session_id);
-            self.apply_acp_delegate_child_update(session_id, &update);
+            let effects = self.apply_acp_delegate_child_update(session_id, &update);
+            debug_assert!(effects.is_empty());
             return;
         }
         self.sessions.note_session_activity(session_id);
@@ -879,7 +828,12 @@ impl crate::app::App {
                 self.set_status(LogLevel::Debug, "tool", format!("tool: {name}"));
                 self.finalize_streaming_segment();
                 if name == "delegate" {
-                    self.upsert_provisional_delegate(tool_call_id.as_deref(), arguments.as_ref());
+                    let effects =
+                        self.apply_delegate_action(DelegateAction::ProvisionalToolDelegate {
+                            tool_call_id: tool_call_id.clone(),
+                            arguments: arguments.clone(),
+                        });
+                    debug_assert!(effects.is_empty());
                 }
                 if name != "question" {
                     let cwd = self.current_session_cwd();
@@ -1518,14 +1472,6 @@ fn message_id_matches(left: Option<&String>, right: Option<&String>) -> bool {
     }
 }
 
-fn delegation_state_rank(state: DelegationState) -> u8 {
-    match state {
-        DelegationState::Requested => 1,
-        DelegationState::Forked => 2,
-        DelegationState::Completed | DelegationState::Failed | DelegationState::Cancelled => 3,
-    }
-}
-
 fn acp_content_to_string(value: &Value) -> String {
     match value {
         Value::String(s) => s.clone(),
@@ -1555,7 +1501,8 @@ mod tests {
     use crate::chat_state::ElicitationUiState;
     use crate::composer_state::{FileIndexEntryLite, MentionState};
     use crate::domain::activity::{
-        DelegateEntry, DelegateStats, PendingDelegateToolCall, SessionOp,
+        DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus, DelegationState,
+        PendingDelegateToolCall, SessionOp,
     };
     use crate::domain::chat::ChatEntry;
     use crate::domain::mesh::{RemoteNodeInfo, RemoteSessionInfo};
@@ -1889,13 +1836,14 @@ mod tests {
     #[test]
     fn delegation_snapshots_reconcile_by_tool_id_and_ignore_stale_updates() {
         let mut app = app_with_active_session();
-        app.upsert_provisional_delegate(
-            Some("call-1"),
-            Some(&serde_json::json!({
+        let effects = app.apply_delegate_action(DelegateAction::ProvisionalToolDelegate {
+            tool_call_id: Some("call-1".into()),
+            arguments: Some(serde_json::json!({
                 "target_agent_id": "coder",
                 "objective": "Implement the feature"
             })),
-        );
+        });
+        assert!(effects.is_empty());
 
         app.handle_acp_event(AcpAppEvent::DelegationUpdate(delegation_update(
             DelegationState::Completed,

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use serde_json::Value;
 
 use crate::application::Effect;
+use crate::auth_state::{AuthAction, AuthOutcome};
 use crate::command::{Command, SessionListRequest};
 use crate::delegates_state::DelegateLifecycleUpdate;
 use crate::diagnostics::LogLevel;
@@ -508,34 +509,13 @@ impl crate::app::App {
                 vec![]
             }
             AcpAppEvent::AuthProviders(providers) => {
-                self.auth.providers = providers;
-                self.push_log(
-                    LogLevel::Debug,
-                    "auth",
-                    format!("{} auth provider(s)", self.auth.providers.len()),
-                );
-                vec![]
+                self.apply_auth_action(AuthAction::Providers(providers))
             }
             AcpAppEvent::OAuthFlowStarted(flow) => {
-                self.push_log(
-                    LogLevel::Info,
-                    "auth",
-                    format!("OAuth flow started for {}", flow.provider),
-                );
-                self.auth.begin_oauth_flow(flow);
-                vec![]
+                self.apply_auth_action(AuthAction::OAuthFlowStarted(flow))
             }
             AcpAppEvent::OAuthResult(result) => {
-                let is_success = result.is_success();
-                let level = if is_success {
-                    LogLevel::Info
-                } else {
-                    LogLevel::Warn
-                };
-                self.push_log(level, "auth", &result.message);
-                let applied_success = self.auth.apply_oauth_result(result);
-                debug_assert_eq!(applied_success, is_success);
-                vec![Effect::Command(Command::ListAuthProviders)]
+                self.apply_auth_action(AuthAction::OAuthResult(result))
             }
             AcpAppEvent::InfoLog { target, message } => {
                 self.push_log(LogLevel::Info, target, message);
@@ -556,6 +536,17 @@ impl crate::app::App {
                 vec![]
             }
         }
+    }
+
+    pub(crate) fn apply_auth_action(&mut self, action: AuthAction) -> Vec<Effect> {
+        let AuthOutcome {
+            diagnostics,
+            effects,
+        } = self.auth.reduce(action);
+        for diagnostic in diagnostics {
+            self.push_log(diagnostic.level, "auth", diagnostic.message);
+        }
+        effects
     }
 
     fn apply_profile_catalog(

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -6,7 +6,7 @@ use crate::application::Effect;
 use crate::auth_state::{AuthAction, AuthOutcome};
 use crate::chat_state::{
     ChatAction, ChatCoordination, ChatOutcome, ChatToolAction, ChatToolOutcome, ChatToolTransition,
-    ToolStartPreparationTransition,
+    ChatUsageAction, ChatUsageOutcome, ToolStartPreparationTransition,
 };
 use crate::command::{Command, SessionListRequest};
 use crate::delegates_state::{
@@ -742,6 +742,16 @@ impl crate::app::App {
         (transition, effects)
     }
 
+    fn apply_chat_usage_action(&mut self, action: ChatUsageAction) -> Vec<Effect> {
+        let ChatUsageOutcome {
+            transition: _,
+            coordination,
+            effects,
+        } = self.chat.reduce_usage(action);
+        self.apply_chat_coordination(coordination);
+        effects
+    }
+
     fn apply_chat_coordination(&mut self, coordination: Vec<ChatCoordination>) {
         for coordination in coordination {
             match coordination {
@@ -754,6 +764,11 @@ impl crate::app::App {
                 ChatCoordination::InvalidateCardCache => {
                     self.render.invalidate_card_cache();
                 }
+                ChatCoordination::Log {
+                    level,
+                    target,
+                    message,
+                } => self.push_log(level, target, message),
                 ChatCoordination::Status {
                     level,
                     target,
@@ -948,31 +963,15 @@ impl crate::app::App {
                 size,
                 cost_usd,
             } => {
-                self.chat.apply_usage(used, size, cost_usd);
-                let pct = if used > 0 && size > 0 {
-                    format!(" ({}%)", (used as f64 / size as f64 * 100.0) as u32)
-                } else {
-                    String::new()
-                };
-                let cost = cost_usd
-                    .map(|amount| format!(", cost ${amount:.4}"))
-                    .unwrap_or_default();
-                self.push_log(
-                    LogLevel::Info,
-                    "usage",
-                    format!("usage: context {used}/{size} tokens{pct}{cost}"),
-                );
+                return self.apply_chat_usage_action(ChatUsageAction::UsageUpdated {
+                    used,
+                    size,
+                    cost_usd,
+                });
             }
             AcpSessionUpdate::TimingUpdate { duration_secs } => {
-                if duration_secs > 0 {
-                    self.chat
-                        .add_active_llm_duration(std::time::Duration::from_secs(duration_secs));
-                    self.push_log(
-                        LogLevel::Info,
-                        "usage",
-                        format!("usage: active time {duration_secs}s"),
-                    );
-                }
+                return self
+                    .apply_chat_usage_action(ChatUsageAction::TimingUpdated { duration_secs });
             }
             AcpSessionUpdate::ElicitationRequested {
                 elicitation_id,

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -6,8 +6,8 @@ use crate::application::Effect;
 use crate::auth_state::{AuthAction, AuthOutcome};
 use crate::chat_state::{
     ChatAction, ChatCoordination, ChatOutcome, ChatToolAction, ChatToolOutcome, ChatToolTransition,
-    ChatUsageAction, ChatUsageOutcome, ElicitationAction, ElicitationOutcome,
-    ToolStartPreparationTransition,
+    ChatUsageAction, ChatUsageOutcome, ElicitationAction, ElicitationOutcome, HistoryAction,
+    HistoryCoordination, HistoryOutcome, ToolStartPreparationTransition,
 };
 use crate::command::{Command, SessionListRequest};
 use crate::delegates_state::{
@@ -360,135 +360,17 @@ impl crate::app::App {
                 }
                 effects
             }
-            AcpAppEvent::UndoStack(undo_stack) => {
-                self.chat.undo_state =
-                    self.chat
-                        .build_undo_state_from_server_stack(&undo_stack, None, None);
-                vec![]
+            AcpAppEvent::UndoStack(stack) => {
+                self.apply_chat_history_action(HistoryAction::ReplaceStack(stack))
             }
             AcpAppEvent::UndoResult(result) => {
-                self.chat.activity = ActivityState::Idle;
-                match result {
-                    UndoResult::Applied {
-                        target_message_id,
-                        reverted_files,
-                        message: _,
-                        stack,
-                    } => {
-                        let message_id_for_files =
-                            target_message_id.or_else(|| stack.message_ids.last().cloned());
-                        self.chat.undo_state = self.chat.build_undo_state_from_server_stack(
-                            &stack,
-                            message_id_for_files.as_deref(),
-                            Some(&reverted_files),
-                        );
-                        self.chat.recent_prompt_text = None;
-                        self.chat.streaming_content.clear();
-                        self.chat.streaming_content_message_id = None;
-                        self.render.invalidate_content_cache();
-                        self.set_status(LogLevel::Info, "session", "undone - reloading session");
-                        if let Some(ref sid) = self.sessions.session_id {
-                            return effects(
-                                Command::load_session_commands(
-                                    sid.clone(),
-                                    self.current_session_cwd(),
-                                    self.sessions.agent_id.clone(),
-                                )
-                                .into(),
-                            );
-                        }
-                    }
-                    UndoResult::Rejected {
-                        target_message_id,
-                        message,
-                        stack,
-                    } => {
-                        let preferred =
-                            target_message_id.or_else(|| stack.message_ids.last().cloned());
-                        self.chat.undo_state = self.chat.build_undo_state_from_server_stack(
-                            &stack,
-                            preferred.as_deref(),
-                            None,
-                        );
-                        self.set_status(
-                            LogLevel::Warn,
-                            "session",
-                            message.unwrap_or_else(|| "undo failed".into()),
-                        );
-                    }
-                }
-                vec![]
+                self.apply_chat_history_action(HistoryAction::UndoCompleted(result))
             }
             AcpAppEvent::RedoResult(result) => {
-                self.chat.activity = ActivityState::Idle;
-                match result {
-                    RedoResult::Applied { message: _, stack } => {
-                        self.chat.undo_state = self
-                            .chat
-                            .build_undo_state_from_server_stack(&stack, None, None);
-                        self.set_status(LogLevel::Info, "session", "redone - reloading session");
-                        if let Some(ref sid) = self.sessions.session_id {
-                            return effects(
-                                Command::load_session_commands(
-                                    sid.clone(),
-                                    self.current_session_cwd(),
-                                    self.sessions.agent_id.clone(),
-                                )
-                                .into(),
-                            );
-                        }
-                    }
-                    RedoResult::Rejected { message, stack } => {
-                        self.chat.undo_state = self
-                            .chat
-                            .build_undo_state_from_server_stack(&stack, None, None);
-                        self.set_status(
-                            LogLevel::Warn,
-                            "session",
-                            message.unwrap_or_else(|| "redo failed".into()),
-                        );
-                    }
-                }
-                vec![]
+                self.apply_chat_history_action(HistoryAction::RedoCompleted(result))
             }
             AcpAppEvent::ForkResult(result) => {
-                self.chat.pending_fork_message_id = None;
-                match result {
-                    ForkResult::Succeeded {
-                        source_session_id: _,
-                        forked_session_id: Some(forked_session_id),
-                        message: _,
-                    } => {
-                        self.navigation.popup = Popup::None;
-                        self.set_status(LogLevel::Info, "fork", "forked - loading session");
-                        return effects(
-                            Command::load_session_commands(
-                                forked_session_id,
-                                self.current_session_cwd(),
-                                self.sessions.agent_id.clone(),
-                            )
-                            .into(),
-                        );
-                    }
-                    ForkResult::Succeeded {
-                        source_session_id: _,
-                        forked_session_id: None,
-                        message,
-                    } => self.set_status(
-                        LogLevel::Warn,
-                        "fork",
-                        message.unwrap_or_else(|| "fork succeeded without session id".into()),
-                    ),
-                    ForkResult::Failed {
-                        source_session_id: _,
-                        message,
-                    } => self.set_status(
-                        LogLevel::Warn,
-                        "fork",
-                        message.unwrap_or_else(|| "fork failed".into()),
-                    ),
-                }
-                vec![]
+                self.apply_chat_history_action(HistoryAction::ForkCompleted(result))
             }
             AcpAppEvent::DelegationUpdate(update) => self.apply_acp_delegation_update(update),
             AcpAppEvent::DelegationReplay {
@@ -720,6 +602,52 @@ impl crate::app::App {
             effects,
         } = self.chat.reduce(action);
         self.apply_chat_coordination(coordination);
+        effects
+    }
+
+    fn apply_chat_history_action(&mut self, action: HistoryAction) -> Vec<Effect> {
+        let HistoryOutcome {
+            transition: _,
+            coordination,
+            mut effects,
+        } = self.chat.reduce_history(action);
+        for coordination in coordination {
+            match coordination {
+                HistoryCoordination::InvalidateContentCache => {
+                    self.render.invalidate_content_cache();
+                }
+                HistoryCoordination::Status {
+                    level,
+                    target,
+                    message,
+                } => self.set_status(level, target, message),
+                HistoryCoordination::ClosePopup => self.navigation.popup = Popup::None,
+                HistoryCoordination::ReloadActiveSession => {
+                    if let Some(session_id) = self.sessions.session_id.clone() {
+                        effects.extend(
+                            Command::load_session_commands(
+                                session_id,
+                                self.current_session_cwd(),
+                                self.sessions.agent_id.clone(),
+                            )
+                            .into_iter()
+                            .map(Effect::Command),
+                        );
+                    }
+                }
+                HistoryCoordination::LoadForkedSession { session_id } => {
+                    effects.extend(
+                        Command::load_session_commands(
+                            session_id,
+                            self.current_session_cwd(),
+                            self.sessions.agent_id.clone(),
+                        )
+                        .into_iter()
+                        .map(Effect::Command),
+                    );
+                }
+            }
+        }
         effects
     }
 

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -22,7 +22,9 @@ use crate::domain::session::{
     ForkResult, RedoResult, SessionListPage, UndoResult, UndoStackSnapshot,
 };
 use crate::domain::tool::ToolDetail;
+use crate::models_state::{ModelAction, ModelContext, ModelCoordination, ModelOutcome};
 use crate::navigation_state::{Popup, Screen};
+use crate::profiles_state::{ProfileAction, ProfileOutcome};
 use crate::tool_detail;
 
 #[derive(Debug, Clone, Default)]
@@ -198,20 +200,31 @@ impl crate::app::App {
                 // ACP initialization sends a placeholder empty catalog before
                 // capability-gated profile discovery completes.
                 if !profiles.is_empty() {
-                    self.apply_profile_catalog(profiles, active_profile_id);
+                    let discarded_effects = self.apply_profile_catalog(profiles, active_profile_id);
+                    debug_assert!(!discarded_effects.iter().any(|effect| {
+                        !matches!(effect, Effect::Command(Command::ListProfileAgents { .. }))
+                    }));
                 }
                 self.sessions.agent_id = Some(agent_id.clone());
-                self.models.initialize_primary_agent(AgentInfo {
-                    id: agent_id,
-                    name: agent_name,
-                    description: None,
-                    capabilities: Vec::new(),
-                });
+                let effects = self.apply_model_action(
+                    ModelAction::InitializePrimaryAgent(AgentInfo {
+                        id: agent_id,
+                        name: agent_name,
+                        description: None,
+                        capabilities: Vec::new(),
+                    }),
+                    ModelContext::default(),
+                );
+                debug_assert!(effects.is_empty());
                 if let Some(mode) = agent_mode {
                     self.sessions.replace_agent_mode(mode);
                 }
                 if let Some(effort) = reasoning_effort {
-                    self.models.reasoning_effort = effort;
+                    let effects = self.apply_model_action(
+                        ModelAction::InitializeReasoningEffort(effort),
+                        ModelContext::default(),
+                    );
+                    debug_assert!(effects.is_empty());
                 }
                 self.auth.ui_notice = None;
                 self.set_status(LogLevel::Info, "connection", "connected");
@@ -221,65 +234,55 @@ impl crate::app::App {
                 self.sessions.replace_agent_mode(mode);
                 vec![]
             }
-            AcpAppEvent::ReasoningEffort { reasoning_effort } => {
-                if let Some(validated) =
-                    crate::models_state::validate_reasoning_effort(reasoning_effort.as_deref())
-                {
-                    self.models.reasoning_effort = validated;
-                }
-                vec![]
-            }
+            AcpAppEvent::ReasoningEffort { reasoning_effort } => self.apply_model_action(
+                ModelAction::ReasoningEffort(reasoning_effort),
+                ModelContext::default(),
+            ),
             AcpAppEvent::Profiles {
                 profiles,
                 active_profile_id,
-            } => effects(self.apply_profile_catalog(profiles, active_profile_id)),
+            } => self.apply_profile_catalog(profiles, active_profile_id),
             AcpAppEvent::ProfileAgents { profile_id, agents } => {
-                if self.desired_agents_profile_id() == Some(profile_id.as_str()) {
-                    self.models.replace_profile_agents(profile_id, agents);
-                    if self.delegates.parent_session_id.is_none()
-                        && let (Some(session_id), Some(profile_id)) = (
-                            self.sessions.session_id.as_deref(),
-                            self.models.agents_profile_id.as_deref(),
-                        )
-                    {
-                        return effects(
-                            self.delegate_model_commands_for_session(session_id, profile_id),
-                        );
-                    }
-                }
-                vec![]
+                let context = ModelContext {
+                    desired_profile_id: self.desired_agents_profile_id().map(str::to_string),
+                    root_session_id: self
+                        .delegates
+                        .parent_session_id
+                        .is_none()
+                        .then(|| self.sessions.session_id.clone())
+                        .flatten(),
+                };
+                self.apply_model_action(
+                    ModelAction::ReplaceProfileAgents { profile_id, agents },
+                    context,
+                )
             }
             AcpAppEvent::DelegateModelSet {
                 session_id,
                 agent_id,
                 model,
-            } => {
-                self.set_status(
-                    LogLevel::Info,
-                    "model",
-                    match model {
-                        Some(model) => format!(
-                            "delegate model set for {agent_id} in {session_id}: {}",
-                            model.model_id
-                        ),
-                        None => format!("delegate model reset for {agent_id} in {session_id}"),
-                    },
-                );
-                vec![]
-            }
+            } => self.apply_model_action(
+                ModelAction::DelegateModelSet {
+                    session_id,
+                    agent_id,
+                    model_id: model.map(|model| model.model_id),
+                },
+                ModelContext::default(),
+            ),
             AcpAppEvent::ProviderChanged {
                 provider,
                 model,
                 context_limit,
                 provider_node_id,
-            } => {
-                self.models
-                    .replace_live_selection(provider, model, provider_node_id);
-                if let Some(limit) = context_limit {
-                    self.chat.context_limit = limit;
-                }
-                vec![]
-            }
+            } => self.apply_model_action(
+                ModelAction::ProviderChanged {
+                    provider,
+                    model,
+                    node_id: provider_node_id,
+                    context_limit,
+                },
+                ModelContext::default(),
+            ),
             AcpAppEvent::ControlCapabilities(data) => {
                 self.apply_acp_control_capabilities_log(data);
                 vec![]
@@ -496,17 +499,15 @@ impl crate::app::App {
                 vec![]
             }
             AcpAppEvent::Models { models, meta } => {
-                let (total_models, remote_models) = self.models.replace_catalog(models);
-                let remote_nodes = meta.as_ref().map(|m| m.remote_node_count).unwrap_or(0);
-                let timeouts = meta.as_ref().map(|m| m.remote_timeout_count).unwrap_or(0);
-                let mut line = format!("models: {total_models} total, {remote_models} remote");
-                if remote_nodes > 0 || timeouts > 0 {
-                    line.push_str(&format!(
-                        " (inventory nodes={remote_nodes}, timeouts={timeouts})"
-                    ));
-                }
-                self.push_log(LogLevel::Info, "models", line);
-                vec![]
+                let meta = meta.unwrap_or_default();
+                self.apply_model_action(
+                    ModelAction::ReplaceCatalog {
+                        models,
+                        remote_node_count: meta.remote_node_count,
+                        remote_timeout_count: meta.remote_timeout_count,
+                    },
+                    ModelContext::default(),
+                )
             }
             AcpAppEvent::AuthProviders(providers) => {
                 self.apply_auth_action(AuthAction::Providers(providers))
@@ -549,25 +550,50 @@ impl crate::app::App {
         effects
     }
 
+    fn apply_model_action(&mut self, action: ModelAction, context: ModelContext) -> Vec<Effect> {
+        let ModelOutcome {
+            coordination,
+            effects,
+        } = self.models.reduce(action, context);
+        for coordination in coordination {
+            match coordination {
+                ModelCoordination::Log {
+                    level,
+                    target,
+                    message,
+                } => self.push_log(level, target, message),
+                ModelCoordination::Status {
+                    level,
+                    target,
+                    message,
+                } => self.set_status(level, target, message),
+                ModelCoordination::SetContextLimit(limit) => self.chat.context_limit = limit,
+            }
+        }
+        effects
+    }
+
     fn apply_profile_catalog(
         &mut self,
         profiles: Vec<ProfileInfo>,
         backend_active_profile_id: Option<String>,
-    ) -> Vec<Command> {
-        let active_profile_changed = self
-            .profiles
-            .apply_catalog(profiles, backend_active_profile_id);
-        let desired_profile_id = self.desired_agents_profile_id().map(str::to_string);
-        if active_profile_changed
-            || self.models.agents_profile_id.as_deref() != desired_profile_id.as_deref()
-            || self.models.agents.len() <= 1
-        {
-            self.models.clear_profile_agents();
-            return desired_profile_id
-                .map(|profile_id| vec![Command::ListProfileAgents { profile_id }])
-                .unwrap_or_default();
-        }
-        vec![]
+    ) -> Vec<Effect> {
+        let ProfileOutcome {
+            active_profile_changed,
+        } = self.profiles.reduce(ProfileAction::ReplaceCatalog {
+            profiles,
+            backend_active_profile_id,
+        });
+        let context = ModelContext {
+            desired_profile_id: self.desired_agents_profile_id().map(str::to_string),
+            root_session_id: None,
+        };
+        self.apply_model_action(
+            ModelAction::SynchronizeProfileCatalog {
+                active_profile_changed,
+            },
+            context,
+        )
     }
 
     fn apply_acp_session_list(

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -6,7 +6,8 @@ use crate::application::Effect;
 use crate::auth_state::{AuthAction, AuthOutcome};
 use crate::chat_state::{
     ChatAction, ChatCoordination, ChatOutcome, ChatToolAction, ChatToolOutcome, ChatToolTransition,
-    ChatUsageAction, ChatUsageOutcome, ToolStartPreparationTransition,
+    ChatUsageAction, ChatUsageOutcome, ElicitationAction, ElicitationOutcome,
+    ToolStartPreparationTransition,
 };
 use crate::command::{Command, SessionListRequest};
 use crate::delegates_state::{
@@ -15,7 +16,6 @@ use crate::delegates_state::{
 use crate::diagnostics::LogLevel;
 use crate::domain::activity::{ActivityState, DelegationUpdate};
 use crate::domain::auth::{AuthProviderEntry, OAuthFlow, OAuthResult};
-use crate::domain::elicitation::ElicitationState;
 use crate::domain::mesh::{
     MeshInviteCreatedInfo, MeshNodesInfo, MeshStatusInfo, RemoteSessionAttachInfo,
     RemoteSessionListInfo,
@@ -746,6 +746,19 @@ impl crate::app::App {
         effects
     }
 
+    pub(crate) fn apply_chat_elicitation_action(
+        &mut self,
+        action: ElicitationAction,
+    ) -> Vec<Effect> {
+        let ElicitationOutcome {
+            transition: _,
+            coordination,
+            effects,
+        } = self.chat.reduce_elicitation(action);
+        self.apply_chat_coordination(coordination);
+        effects
+    }
+
     fn apply_chat_coordination(&mut self, coordination: Vec<ChatCoordination>) {
         for coordination in coordination {
             match coordination {
@@ -768,6 +781,7 @@ impl crate::app::App {
                     target,
                     message,
                 } => self.set_status(level, target, message),
+                ChatCoordination::RefreshTransientStatus => self.refresh_transient_status(),
             }
         }
     }
@@ -853,48 +867,40 @@ impl crate::app::App {
 
         match update {
             AcpSessionUpdate::TurnStarted => {
-                return self.apply_chat_action(ChatAction::TurnStarted { is_replay });
+                self.apply_chat_action(ChatAction::TurnStarted { is_replay })
             }
             AcpSessionUpdate::UserMessage {
                 content,
                 message_id,
-            } => {
-                return self.apply_chat_action(ChatAction::UserMessage {
-                    text: acp_content_to_string(&content),
-                    message_id,
-                    is_replay,
-                });
-            }
+            } => self.apply_chat_action(ChatAction::UserMessage {
+                text: acp_content_to_string(&content),
+                message_id,
+                is_replay,
+            }),
             AcpSessionUpdate::AssistantContentDelta {
                 content,
                 message_id,
-            } => {
-                return self.apply_chat_action(ChatAction::AssistantContentDelta {
-                    content,
-                    message_id,
-                });
-            }
+            } => self.apply_chat_action(ChatAction::AssistantContentDelta {
+                content,
+                message_id,
+            }),
             AcpSessionUpdate::AssistantThinkingDelta {
                 content,
                 message_id,
-            } => {
-                return self.apply_chat_action(ChatAction::AssistantThinkingDelta {
-                    content,
-                    message_id,
-                    is_replay,
-                });
-            }
+            } => self.apply_chat_action(ChatAction::AssistantThinkingDelta {
+                content,
+                message_id,
+                is_replay,
+            }),
             AcpSessionUpdate::AssistantMessage {
                 content,
                 thinking,
                 message_id,
-            } => {
-                return self.apply_chat_action(ChatAction::AssistantMessage {
-                    content,
-                    thinking,
-                    message_id,
-                });
-            }
+            } => self.apply_chat_action(ChatAction::AssistantMessage {
+                content,
+                thinking,
+                message_id,
+            }),
             AcpSessionUpdate::ToolCallStart {
                 tool_call_id,
                 name,
@@ -936,7 +942,7 @@ impl crate::app::App {
                         detail,
                     });
                 effects.extend(insertion_effects);
-                return effects;
+                effects
             }
             AcpSessionUpdate::ToolCallEnd {
                 tool_call_id,
@@ -950,22 +956,19 @@ impl crate::app::App {
                     is_error,
                     result,
                 });
-                return effects;
+                effects
             }
             AcpSessionUpdate::UsageUpdate {
                 used,
                 size,
                 cost_usd,
-            } => {
-                return self.apply_chat_usage_action(ChatUsageAction::UsageUpdated {
-                    used,
-                    size,
-                    cost_usd,
-                });
-            }
+            } => self.apply_chat_usage_action(ChatUsageAction::UsageUpdated {
+                used,
+                size,
+                cost_usd,
+            }),
             AcpSessionUpdate::TimingUpdate { duration_secs } => {
-                return self
-                    .apply_chat_usage_action(ChatUsageAction::TimingUpdated { duration_secs });
+                self.apply_chat_usage_action(ChatUsageAction::TimingUpdated { duration_secs })
             }
             AcpSessionUpdate::ElicitationRequested {
                 elicitation_id,
@@ -973,83 +976,28 @@ impl crate::app::App {
                 requested_schema,
                 source,
                 allow_custom,
-            } => {
-                self.handle_acp_elicitation_requested(
-                    &elicitation_id,
-                    &message,
-                    &source,
-                    &requested_schema,
-                    allow_custom,
-                    is_replay,
-                );
-            }
+            } => self.apply_chat_elicitation_action(ElicitationAction::Requested {
+                elicitation_id,
+                message,
+                source,
+                requested_schema,
+                allow_custom,
+                is_replay,
+            }),
             AcpSessionUpdate::Cancelled => {
-                return self.apply_chat_action(ChatAction::Cancelled { is_replay });
+                self.apply_chat_action(ChatAction::Cancelled { is_replay })
             }
             AcpSessionUpdate::Finished { finish_reason } => {
-                return self.apply_chat_action(ChatAction::Finished {
+                self.apply_chat_action(ChatAction::Finished {
                     finish_reason,
                     is_replay,
-                });
+                })
             }
         }
-        Vec::new()
     }
 
     fn push_undoable_user_turn(&mut self, message_id: String, text: String) {
         self.chat.push_undoable_user_turn(message_id, text);
-    }
-
-    fn handle_acp_elicitation_requested(
-        &mut self,
-        elicitation_id: &str,
-        message: &str,
-        source: &str,
-        requested_schema: &Value,
-        allow_custom: bool,
-        is_replay: bool,
-    ) {
-        let fields = ElicitationState::parse_schema(requested_schema);
-        let supported = !fields.is_empty();
-        let active = (supported && !is_replay).then(|| ElicitationState {
-            elicitation_id: elicitation_id.to_string(),
-            message: message.to_string(),
-            source: source.to_string(),
-            fields,
-            selected: std::collections::HashMap::new(),
-            text_input: String::new(),
-            custom_input: String::new(),
-            allow_custom,
-        });
-        let outcome = (!supported).then(|| "unsupported schema - cannot answer in TUI".into());
-        let transition = self.chat.push_elicitation(
-            active,
-            elicitation_id.to_string(),
-            message.to_string(),
-            source.to_string(),
-            outcome,
-        );
-        if !transition.inserted {
-            return;
-        }
-        if transition.finalized_streaming {
-            self.render.invalidate_content_cache();
-            self.render.invalidate_thinking_cache();
-            self.render.invalidate_card_cache();
-        }
-        if supported {
-            self.set_status(
-                LogLevel::Info,
-                "elicitation",
-                "question - answer in the panel above input",
-            );
-        } else {
-            self.set_status(
-                LogLevel::Warn,
-                "elicitation",
-                "question skipped - unsupported schema",
-            );
-        }
     }
 
     fn apply_acp_control_capabilities_log(&mut self, data: Value) {
@@ -1500,6 +1448,7 @@ mod tests {
         PendingDelegateToolCall, SessionOp,
     };
     use crate::domain::chat::ChatEntry;
+    use crate::domain::elicitation::ElicitationState;
     use crate::domain::mesh::{RemoteNodeInfo, RemoteSessionInfo};
     use crate::domain::model::DelegateModelPreference;
     use crate::domain::session::{
@@ -4172,7 +4121,10 @@ mod tests {
                 updates: updates.clone(),
             });
         }
-        app.resolve_elicitation("elic-1", "staging");
+        app.apply_chat_elicitation_action(ElicitationAction::ResponseAcknowledged {
+            elicitation_id: "elic-1".into(),
+            outcome: "staging".into(),
+        });
         app.handle_acp_event(AcpAppEvent::SessionReplay {
             session_id: TEST_SESSION_ID.into(),
             updates,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use crate::auth_state::AuthState;
 use crate::chat_state::ChatState;
 use crate::command::Command;
@@ -409,26 +407,8 @@ impl App {
         session_id: &str,
         profile_id: &str,
     ) -> Vec<Command> {
-        let known_agents: HashSet<&str> = self
-            .models
-            .agents
-            .iter()
-            .skip(1)
-            .map(|agent| agent.id.as_str())
-            .collect();
         self.models
-            .delegate_model_preferences
-            .get(profile_id)
-            .into_iter()
-            .flat_map(|preferences| preferences.iter())
-            .filter(|(agent_id, _)| known_agents.contains(agent_id.as_str()))
-            .map(|(agent_id, preference)| Command::SetDelegateModel {
-                session_id: session_id.to_string(),
-                agent_id: agent_id.clone(),
-                model_id: Some(preference.model_id.clone()),
-                node_id: preference.node_id.clone(),
-            })
-            .collect()
+            .delegate_model_commands_for_session(session_id, profile_id)
     }
 
     /// Cursor position for a delegate agent's preferred model in the popup list.

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,117 +5,12 @@ use crate::composer_state::ComposerState;
 use crate::connection_state::{ConnState, ConnectionState};
 use crate::delegates_state::DelegatesState;
 use crate::diagnostics::{AppLogEntry, DiagnosticsState, LogLevel};
-use crate::domain::activity::{DelegateChildState, DelegateStats};
 use crate::mesh_state::MeshState;
 use crate::models_state::ModelsState;
 use crate::navigation_state::{NavigationState, Popup};
 use crate::profiles_state::ProfilesState;
-use crate::protocol::audit::EventKind;
 use crate::render_state::RenderState;
 use crate::session_state::SessionsState;
-
-// ── Delegation tracking ───────────────────────────────────────────────────────
-
-/// Update per-delegation stats from a single event arriving on a child session.
-pub(crate) fn accumulate_delegate_stats(stats: &mut DelegateStats, kind: &EventKind) {
-    match kind {
-        EventKind::ToolCallStart { .. } => {
-            stats.tool_calls = stats.tool_calls.saturating_add(1);
-        }
-        EventKind::AssistantMessageStored { .. } => {
-            stats.messages = stats.messages.saturating_add(1);
-        }
-        EventKind::LlmRequestEnd {
-            cost_usd,
-            context_tokens,
-            ..
-        } => {
-            if let Some(c) = cost_usd {
-                stats.cost_usd += c;
-            }
-            if let Some(ctx) = context_tokens {
-                stats.context_tokens = *ctx;
-            }
-        }
-        EventKind::ProviderChanged {
-            context_limit: Some(limit),
-            ..
-        } => {
-            stats.context_limit = *limit;
-        }
-        EventKind::LlmRequestStart { .. }
-        | EventKind::SnapshotStart { .. }
-        | EventKind::SnapshotEnd { .. }
-        | EventKind::ProgressRecorded { .. }
-        | EventKind::ArtifactRecorded { .. }
-        | EventKind::SessionQueued { .. }
-        | EventKind::SessionConfigured { .. }
-        | EventKind::ToolsAvailable { .. }
-        | EventKind::SessionCreated
-        | EventKind::Unknown => {}
-        _ => {}
-    }
-}
-
-pub(crate) fn update_delegate_child_state(state: &mut DelegateChildState, kind: &EventKind) {
-    match kind {
-        EventKind::ElicitationRequested {
-            elicitation_id,
-            message,
-            source,
-            requested_schema,
-            ..
-        } => {
-            *state = DelegateChildState::PendingElicitation {
-                elicitation_id: elicitation_id.clone(),
-                message: message.clone(),
-                requested_schema: requested_schema.clone(),
-                source: source.clone(),
-            };
-        }
-        EventKind::ToolCallEnd { tool_name, .. } if tool_name == "question" => {
-            *state = DelegateChildState::QuestionToolFinished;
-        }
-        EventKind::AssistantMessageStored { .. } => {
-            *state = DelegateChildState::AssistantMessage;
-        }
-        EventKind::UserMessageStored { .. } => {
-            *state = DelegateChildState::UserMessage;
-        }
-        EventKind::ToolCallStart { .. }
-        | EventKind::AssistantContentDelta { .. }
-        | EventKind::AssistantThinkingDelta { .. }
-        | EventKind::PromptReceived { .. }
-        | EventKind::LlmRequestStart { .. }
-        | EventKind::LlmRequestEnd { .. }
-        | EventKind::CompactionStart { .. }
-        | EventKind::CompactionEnd { .. }
-        | EventKind::SnapshotStart { .. }
-        | EventKind::SnapshotEnd { .. }
-        | EventKind::ProgressRecorded { .. }
-        | EventKind::ArtifactRecorded { .. }
-        | EventKind::SessionQueued { .. }
-        | EventKind::ProviderChanged { .. }
-        | EventKind::Error { .. }
-        | EventKind::Cancelled => {
-            *state = DelegateChildState::OtherProgress;
-        }
-        EventKind::TurnStarted
-        | EventKind::SessionModeChanged { .. }
-        | EventKind::SessionConfigured { .. }
-        | EventKind::ToolsAvailable { .. }
-        | EventKind::SessionCreated
-        | EventKind::DelegationRequested { .. }
-        | EventKind::DelegationCompleted { .. }
-        | EventKind::DelegationFailed { .. }
-        | EventKind::DelegationCancelled { .. }
-        | EventKind::SessionForked { .. }
-        | EventKind::Unknown => {}
-        EventKind::ToolCallEnd { .. } => {
-            *state = DelegateChildState::OtherProgress;
-        }
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConnectionEvent {
@@ -327,23 +222,6 @@ impl App {
     pub fn clear_expired_cancel_confirm(&mut self) {
         if self.chat.clear_expired_cancel_confirm() {
             self.refresh_transient_status();
-        }
-    }
-
-    pub fn apply_event_stats(&mut self, kind: &EventKind, timestamp: Option<i64>) {
-        match kind {
-            EventKind::ToolCallStart { .. } => self.chat.record_tool_call(),
-            EventKind::LlmRequestStart { .. } => self.chat.begin_llm_request_span(timestamp),
-            EventKind::LlmRequestEnd { context_tokens, .. } => {
-                self.chat.end_llm_request_span(timestamp);
-                if let Some(context_tokens) = context_tokens {
-                    self.chat.record_context_tokens(*context_tokens);
-                }
-            }
-            EventKind::Cancelled | EventKind::Error { .. } => {
-                self.chat.end_llm_request_span(timestamp);
-            }
-            _ => {}
         }
     }
 
@@ -753,7 +631,9 @@ mod reasoning_effort_tests {
 #[cfg(test)]
 mod delegate_entry_tests {
     use super::*;
-    use crate::domain::activity::{DelegateEntry, DelegateStatus};
+    use crate::domain::activity::{
+        DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus,
+    };
 
     fn make_entry(delegation_id: &str, objective: &str, status: DelegateStatus) -> DelegateEntry {
         DelegateEntry {
@@ -856,162 +736,6 @@ mod delegate_entry_tests {
             vec![make_entry("d1", "Build Feature", DelegateStatus::Completed)];
         app.delegates.delegate_filter = "BUILD".into();
         assert_eq!(app.delegates.visible_entries().len(), 1);
-    }
-
-    // ── delegation event processing ───────────────────────────────────────────
-
-    // ── DelegateStats accumulation ────────────────────────────────────────────
-
-    #[test]
-    fn stats_tool_call_increments() {
-        let mut stats = DelegateStats::default();
-        accumulate_delegate_stats(
-            &mut stats,
-            &EventKind::ToolCallStart {
-                tool_call_id: None,
-                tool_name: "read_tool".into(),
-                arguments: None,
-            },
-        );
-        assert_eq!(stats.tool_calls, 1);
-    }
-
-    #[test]
-    fn stats_message_increments_on_assistant_message() {
-        let mut stats = DelegateStats::default();
-        accumulate_delegate_stats(
-            &mut stats,
-            &EventKind::AssistantMessageStored {
-                content: "hello".into(),
-                thinking: None,
-                message_id: None,
-            },
-        );
-        assert_eq!(stats.messages, 1);
-    }
-
-    #[test]
-    fn stats_cost_accumulates_across_llm_requests() {
-        let mut stats = DelegateStats::default();
-        accumulate_delegate_stats(
-            &mut stats,
-            &EventKind::LlmRequestEnd {
-                finish_reason: None,
-                cost_usd: Some(0.01),
-                cumulative_cost_usd: None,
-                context_tokens: None,
-                tool_calls: None,
-                metrics: None,
-            },
-        );
-        accumulate_delegate_stats(
-            &mut stats,
-            &EventKind::LlmRequestEnd {
-                finish_reason: None,
-                cost_usd: Some(0.02),
-                cumulative_cost_usd: None,
-                context_tokens: None,
-                tool_calls: None,
-                metrics: None,
-            },
-        );
-        assert!((stats.cost_usd - 0.03).abs() < 1e-9);
-    }
-
-    #[test]
-    fn stats_context_tokens_takes_latest_value() {
-        let mut stats = DelegateStats::default();
-        accumulate_delegate_stats(
-            &mut stats,
-            &EventKind::LlmRequestEnd {
-                finish_reason: None,
-                cost_usd: None,
-                cumulative_cost_usd: None,
-                context_tokens: Some(1000),
-                tool_calls: None,
-                metrics: None,
-            },
-        );
-        accumulate_delegate_stats(
-            &mut stats,
-            &EventKind::LlmRequestEnd {
-                finish_reason: None,
-                cost_usd: None,
-                cumulative_cost_usd: None,
-                context_tokens: Some(2048),
-                tool_calls: None,
-                metrics: None,
-            },
-        );
-        assert_eq!(stats.context_tokens, 2048);
-    }
-
-    #[test]
-    fn stats_context_limit_set_from_provider_changed() {
-        let mut stats = DelegateStats::default();
-        accumulate_delegate_stats(
-            &mut stats,
-            &EventKind::ProviderChanged {
-                provider: "anthropic".into(),
-                model: "claude-sonnet".into(),
-                config_id: None,
-                context_limit: Some(200_000),
-                provider_node_id: None,
-            },
-        );
-        assert_eq!(stats.context_limit, 200_000);
-    }
-
-    #[test]
-    fn child_state_tracks_pending_elicitation_and_terminal_progress() {
-        let mut state = DelegateChildState::None;
-        update_delegate_child_state(
-            &mut state,
-            &EventKind::ElicitationRequested {
-                elicitation_id: "elic-1".into(),
-                session_id: "child-1".into(),
-                message: "Choose".into(),
-                requested_schema: serde_json::json!({"type":"string"}),
-                source: "builtin:question".into(),
-            },
-        );
-        assert!(matches!(
-            state,
-            DelegateChildState::PendingElicitation { ref elicitation_id, ref message, .. }
-                if elicitation_id == "elic-1" && message == "Choose"
-        ));
-
-        update_delegate_child_state(
-            &mut state,
-            &EventKind::AssistantMessageStored {
-                content: "answer".into(),
-                thinking: None,
-                message_id: None,
-            },
-        );
-        assert_eq!(state, DelegateChildState::AssistantMessage);
-
-        update_delegate_child_state(
-            &mut state,
-            &EventKind::ToolCallEnd {
-                tool_call_id: None,
-                tool_name: "question".into(),
-                result: None,
-                is_error: Some(false),
-            },
-        );
-        assert_eq!(state, DelegateChildState::QuestionToolFinished);
-
-        update_delegate_child_state(
-            &mut state,
-            &EventKind::ToolCallEnd {
-                tool_call_id: None,
-                tool_name: "read_tool".into(),
-                result: None,
-                is_error: Some(false),
-            },
-        );
-        assert_eq!(state, DelegateChildState::OtherProgress);
     }
 
     #[test]
@@ -1399,68 +1123,6 @@ mod tests {
         app.chat.activity = ActivityState::SessionOp(SessionOp::Redo);
         app.refresh_transient_status();
         assert_eq!(app.diagnostics.status, "redoing...");
-    }
-
-    #[test]
-    fn session_stats_track_llm_request_elapsed_context_and_tool_calls_from_events() {
-        let mut app = App::new();
-        app.apply_event_stats(
-            &EventKind::PromptReceived {
-                content: serde_json::json!("hi"),
-                message_id: None,
-            },
-            Some(100),
-        );
-        app.apply_event_stats(
-            &EventKind::LlmRequestStart {
-                message_count: Some(2),
-            },
-            Some(120),
-        );
-        app.apply_event_stats(
-            &EventKind::ToolCallStart {
-                tool_call_id: Some("call-1".into()),
-                tool_name: "read_tool".into(),
-                arguments: None,
-            },
-            Some(130),
-        );
-        app.apply_event_stats(
-            &EventKind::LlmRequestEnd {
-                finish_reason: None,
-                cost_usd: None,
-                cumulative_cost_usd: None,
-                context_tokens: Some(2048),
-                tool_calls: Some(99),
-                metrics: None,
-            },
-            Some(160),
-        );
-
-        assert_eq!(app.chat.session_stats.latest_context_tokens, Some(2048));
-        assert_eq!(app.chat.session_stats.total_tool_calls, 1);
-        assert_eq!(
-            app.chat.llm_request_elapsed(),
-            Some(Duration::from_secs(40))
-        );
-    }
-
-    #[test]
-    fn cancelled_closes_open_llm_request_span() {
-        let mut app = App::new();
-        app.apply_event_stats(
-            &EventKind::LlmRequestStart {
-                message_count: Some(1),
-            },
-            Some(200),
-        );
-        app.apply_event_stats(&EventKind::Cancelled, Some(215));
-        assert_eq!(
-            app.chat.llm_request_elapsed(),
-            Some(Duration::from_secs(15))
-        );
-        assert_eq!(app.chat.session_stats.open_llm_request_ts, None);
-        assert_eq!(app.chat.session_stats.open_llm_request_instant, None);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -384,13 +384,6 @@ impl App {
         }
     }
 
-    /// Mark the pending elicitation chat card with an outcome and clear the active state.
-    pub fn resolve_elicitation(&mut self, elicitation_id: &str, outcome: &str) {
-        self.chat.resolve_elicitation(elicitation_id, outcome);
-        self.render.invalidate_card_cache();
-        self.refresh_transient_status();
-    }
-
     // ── delegate model preference coordination ───────────────────────────────
 
     pub fn delegate_preference_profile_id(&self) -> Option<&str> {

--- a/src/application.rs
+++ b/src/application.rs
@@ -272,15 +272,18 @@ mod tests {
     use crate::auth_state::AuthUiNotice;
     use crate::{
         chat_state::ElicitationUiState,
+        command::SessionListRequest,
+        composer_state::FileIndexEntryLite,
         connection_state::ServerState,
         domain::{
+            activity::{ActivityState, DelegateChildState},
             auth::{OAuthFlow, OAuthFlowKind, OAuthResult, OAuthResultStatus},
             chat::ChatEntry,
             elicitation::ElicitationState,
             mesh::{MeshInviteCreatedInfo, MeshNodesInfo, RemoteNodeInfo},
             model::DelegateModelPreference,
             profile::{AgentInfo, ProfileInfo},
-            session::{SessionGroup, SessionSummary},
+            session::{SessionGroup, SessionListPage, SessionSummary},
         },
         navigation_state::Screen,
     };
@@ -690,6 +693,339 @@ mod tests {
             app.sessions.session_id.as_deref(),
             Some("preserved session")
         );
+    }
+
+    #[test]
+    fn session_catalog_acp_route_preserves_order_and_remote_location() {
+        let mut app = App::new();
+        app.sessions.session_discovery_in_progress = true;
+        app.sessions.remember_remote_session_location(
+            "remote-1",
+            "node-1",
+            Some("/remote/repo".into()),
+        );
+        app.auth.filter = "preserved auth".into();
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::SessionList {
+                request: SessionListRequest::Discovery,
+                page: SessionListPage {
+                    groups: vec![
+                        SessionGroup {
+                            cwd: Some("/first".into()),
+                            sessions: vec![SessionSummary {
+                                session_id: "remote-1".into(),
+                                cwd: Some("/catalog/repo".into()),
+                                ..Default::default()
+                            }],
+                            ..Default::default()
+                        },
+                        SessionGroup {
+                            cwd: Some("/second".into()),
+                            sessions: vec![SessionSummary {
+                                session_id: "local-1".into(),
+                                ..Default::default()
+                            }],
+                            ..Default::default()
+                        },
+                    ],
+                    next_cursor: Some("discovery-2".into()),
+                    total_count: Some(2),
+                },
+            }),
+        );
+
+        assert_eq!(
+            effects,
+            vec![
+                Effect::Command(Command::list_sessions_workspace("/first".into())),
+                Effect::Command(Command::list_sessions_workspace("/second".into())),
+                Effect::Command(Command::list_sessions_discovery(Some("discovery-2".into()))),
+            ]
+        );
+        let location = &app.sessions.remote_session_locations["remote-1"];
+        assert_eq!(location.node_id, "node-1");
+        assert_eq!(location.cwd.as_deref(), Some("/remote/repo"));
+        assert_eq!(app.auth.filter, "preserved auth");
+    }
+
+    #[test]
+    fn session_catalog_failure_acp_route_applies_ordered_release_coordination() {
+        let mut app = App::new();
+        app.sessions
+            .pending_session_group_loads
+            .insert(Some("/repo".into()));
+        app.chat
+            .messages
+            .push(ChatEntry::Error("preserved first".into()));
+        app.models.reasoning_effort = Some("high".into());
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::SessionListFailed {
+                request: SessionListRequest::WorkspaceContinuation {
+                    cwd: "/repo".into(),
+                },
+                message: "catalog unavailable".into(),
+            }),
+        );
+
+        assert!(effects.is_empty());
+        assert!(app.sessions.pending_session_group_loads.is_empty());
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::Error(first), ChatEntry::Error(second)]
+                if first == "preserved first" && second == "catalog unavailable"
+        ));
+        assert_eq!(app.diagnostics.status, "error: catalog unavailable");
+        let diagnostic = app.diagnostics.logs.last().expect("failure diagnostic");
+        assert_eq!(diagnostic.level, LogLevel::Error);
+        assert_eq!(diagnostic.target, "acp");
+        assert_eq!(diagnostic.message, "error: catalog unavailable");
+        assert_eq!(app.models.reasoning_effort.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn session_created_acp_route_applies_resets_diagnostic_and_effect_order() {
+        let mut app = App::new();
+        app.delegates.parent_session_id = Some("old-parent".into());
+        app.delegates.pending_parent_session_id = Some("staged-parent".into());
+        app.delegates
+            .pending_delegate_child_states
+            .insert("old-child".into(), DelegateChildState::OtherProgress);
+        app.chat
+            .messages
+            .push(ChatEntry::Error("stale chat".into()));
+        app.chat.streaming_content = "stale stream".into();
+        app.composer.input = "preserved draft".into();
+        app.composer.input_cursor = 4;
+        app.composer.file_index = vec![FileIndexEntryLite {
+            path: "src/main.rs".into(),
+            is_dir: false,
+        }];
+        app.render.streaming_cache.store(7, Vec::new());
+        app.render.streaming_thinking_cache.store(8, Vec::new());
+        app.render.card_cache.processed_messages = 2;
+        app.sessions.mode_before_review = Some("plan".into());
+        app.models.agents_profile_id = Some("code".into());
+        app.models.agents = vec![agent("primary"), agent("coder")];
+        app.models.delegate_model_preferences.insert(
+            "code".into(),
+            [(
+                "coder".into(),
+                DelegateModelPreference {
+                    model_id: "openai/gpt-5".into(),
+                    provider: "openai".into(),
+                    model: "gpt-5".into(),
+                    node_id: Some("node-1".into()),
+                },
+            )]
+            .into_iter()
+            .collect(),
+        );
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::SessionCreated {
+                agent_id: "agent-1".into(),
+                session_id: "session-1".into(),
+                profile_id: Some("code".into()),
+            }),
+        );
+
+        assert_eq!(app.sessions.session_id.as_deref(), Some("session-1"));
+        assert_eq!(app.sessions.agent_id.as_deref(), Some("agent-1"));
+        assert_eq!(app.sessions.mode_before_review, None);
+        assert_eq!(app.navigation.screen, Screen::Chat);
+        assert_eq!(app.delegates.parent_session_id, None);
+        assert_eq!(app.delegates.pending_parent_session_id, None);
+        assert!(app.delegates.pending_delegate_child_states.is_empty());
+        assert_eq!(app.profiles.session_profile_id("session-1"), Some("code"));
+        assert!(app.chat.messages.is_empty());
+        assert!(app.chat.streaming_content.is_empty());
+        assert_eq!(app.composer.input, "preserved draft");
+        assert_eq!(app.composer.input_cursor, 4);
+        assert!(app.composer.file_index.is_empty());
+        assert!(app.render.streaming_cache.get(7).is_none());
+        assert!(app.render.streaming_thinking_cache.get(8).is_none());
+        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert_eq!(app.diagnostics.status, "session created");
+        let diagnostic = app.diagnostics.logs.last().expect("creation diagnostic");
+        assert_eq!(diagnostic.level, LogLevel::Info);
+        assert_eq!(diagnostic.target, "session");
+        assert_eq!(diagnostic.message, "session created");
+        assert_eq!(
+            effects,
+            vec![
+                Effect::Command(Command::SubscribeSession {
+                    session_id: "session-1".into(),
+                    agent_id: Some("agent-1".into()),
+                }),
+                Effect::Command(Command::SetDelegateModel {
+                    session_id: "session-1".into(),
+                    agent_id: "coder".into(),
+                    model_id: Some("openai/gpt-5".into()),
+                    node_id: Some("node-1".into()),
+                }),
+            ]
+        );
+    }
+
+    #[test]
+    fn session_loaded_acp_route_preserves_local_and_removes_remote_profile_binding() {
+        let mut app = App::new();
+        app.sessions.agent_mode = "plan".into();
+        app.profiles
+            .bind_session_profile("local".into(), "code".into());
+        app.models.agents_profile_id = Some("code".into());
+        app.models.agents = vec![agent("primary"), agent("coder")];
+        app.models.delegate_model_preferences.insert(
+            "code".into(),
+            [(
+                "coder".into(),
+                DelegateModelPreference {
+                    model_id: "openai/gpt-5".into(),
+                    provider: "openai".into(),
+                    model: "gpt-5".into(),
+                    node_id: None,
+                },
+            )]
+            .into_iter()
+            .collect(),
+        );
+        app.delegates.parent_session_id = Some("old-parent".into());
+        app.delegates
+            .pending_delegate_child_states
+            .insert("old-child".into(), DelegateChildState::OtherProgress);
+        app.chat.activity = ActivityState::Streaming;
+        app.chat
+            .messages
+            .push(ChatEntry::Error("stale chat".into()));
+        app.composer.file_index = vec![FileIndexEntryLite {
+            path: "src/lib.rs".into(),
+            is_dir: false,
+        }];
+        app.sessions.mode_before_review = Some("build".into());
+
+        let local_effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::SessionLoaded {
+                agent_id: "agent-local".into(),
+                session_id: "local".into(),
+                profile_id: None,
+            }),
+        );
+
+        assert_eq!(app.chat.activity, ActivityState::Idle);
+        assert_eq!(app.delegates.parent_session_id, None);
+        assert!(app.delegates.pending_delegate_child_states.is_empty());
+        assert_eq!(app.navigation.screen, Screen::Chat);
+        assert_eq!(app.profiles.session_profile_id("local"), Some("code"));
+        assert_eq!(app.sessions.session_id.as_deref(), Some("local"));
+        assert_eq!(app.sessions.agent_id.as_deref(), Some("agent-local"));
+        assert_eq!(app.sessions.mode_before_review, None);
+        assert!(app.chat.messages.is_empty());
+        assert!(app.composer.file_index.is_empty());
+        assert_eq!(app.diagnostics.status, "ready");
+        let diagnostic = app.diagnostics.logs.last().expect("load diagnostic");
+        assert_eq!(diagnostic.level, LogLevel::Debug);
+        assert_eq!(diagnostic.target, "activity");
+        assert_eq!(diagnostic.message, "ready");
+        assert_eq!(
+            local_effects,
+            vec![
+                Effect::Command(Command::SetAgentMode {
+                    mode: "plan".into(),
+                }),
+                Effect::Command(Command::SetDelegateModel {
+                    session_id: "local".into(),
+                    agent_id: "coder".into(),
+                    model_id: Some("openai/gpt-5".into()),
+                    node_id: None,
+                }),
+            ]
+        );
+
+        let mut app = App::new();
+        app.sessions.remember_remote_session_location(
+            "remote-child",
+            "node-1",
+            Some("/remote".into()),
+        );
+        app.profiles
+            .bind_session_profile("remote-child".into(), "stale".into());
+        app.sessions.session_groups = vec![SessionGroup {
+            sessions: vec![SessionSummary {
+                session_id: "remote-child".into(),
+                parent_session_id: Some("catalog-parent".into()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }];
+        app.delegates.pending_parent_session_id = Some("staged-parent".into());
+        app.delegates
+            .pending_delegate_child_states
+            .insert("keep-child".into(), DelegateChildState::OtherProgress);
+        app.chat.activity = ActivityState::Thinking;
+
+        let remote_effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::SessionLoaded {
+                agent_id: "agent-remote".into(),
+                session_id: "remote-child".into(),
+                profile_id: None,
+            }),
+        );
+
+        assert_eq!(app.chat.activity, ActivityState::Idle);
+        assert_eq!(
+            app.delegates.parent_session_id.as_deref(),
+            Some("staged-parent")
+        );
+        assert_eq!(app.delegates.pending_parent_session_id, None);
+        assert!(
+            app.delegates
+                .pending_delegate_child_states
+                .contains_key("keep-child")
+        );
+        assert_eq!(app.navigation.screen, Screen::Delegate);
+        assert!(app.profiles.session_profile_id("remote-child").is_none());
+        assert_eq!(
+            remote_effects,
+            vec![Effect::Command(Command::SetAgentMode {
+                mode: "build".into(),
+            })]
+        );
+    }
+
+    #[test]
+    fn session_agent_mode_acp_route_is_owner_bounded_and_release_safe() {
+        let mut app = App::new();
+        app.sessions.agent_mode = "review".into();
+        app.sessions.mode_before_review = Some("plan".into());
+        app.auth.filter = "preserved auth".into();
+        app.mesh.mesh_invite_name = "preserved mesh".into();
+        app.chat
+            .messages
+            .push(ChatEntry::Error("preserved chat".into()));
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::AgentMode {
+                mode: "build".into(),
+            }),
+        );
+
+        assert!(effects.is_empty());
+        assert_eq!(app.sessions.agent_mode, "build");
+        assert_eq!(app.sessions.mode_before_review, None);
+        assert_eq!(app.auth.filter, "preserved auth");
+        assert_eq!(app.mesh.mesh_invite_name, "preserved mesh");
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::Error(message)] if message == "preserved chat"
+        ));
     }
 
     #[test]

--- a/src/application.rs
+++ b/src/application.rs
@@ -820,6 +820,7 @@ mod tests {
         app.chat.messages.push(ChatEntry::Error("preserved".into()));
         app.chat.streaming_content = "active stream".into();
         app.chat.activity = ActivityState::Streaming;
+        app.chat.apply_usage(900, 9_000, Some(9.0));
         app.render.card_cache.processed_messages = 6;
 
         let effects = update(
@@ -851,6 +852,33 @@ mod tests {
             1
         );
 
+        let log_count_before_usage = app.diagnostics.logs.len();
+        for (used, size, cost_usd) in [(100, 1_000, Some(1.5)), (250, 2_000, Some(0.25))] {
+            let effects = update(
+                &mut app,
+                AppEvent::Acp(AcpAppEvent::SessionUpdate {
+                    session_id: "child-1".into(),
+                    update: crate::acp_state::AcpSessionUpdate::UsageUpdate {
+                        used,
+                        size,
+                        cost_usd,
+                    },
+                    is_replay: false,
+                }),
+            );
+            assert!(effects.is_empty());
+        }
+        let child_stats = &app.delegates.pending_delegate_child_stats["child-1"];
+        assert_eq!(child_stats.messages, 1);
+        assert_eq!(child_stats.context_tokens, 250);
+        assert_eq!(child_stats.context_limit, 2_000);
+        assert_eq!(child_stats.cost_usd, 0.25);
+        assert_eq!(app.chat.session_stats.latest_context_tokens, Some(900));
+        assert_eq!(app.chat.context_limit, 9_000);
+        assert_eq!(app.chat.cumulative_cost, Some(9.0));
+        assert_eq!(app.diagnostics.logs.len(), log_count_before_usage);
+        assert_eq!(app.render.card_cache.processed_messages, 6);
+
         let effects = update(
             &mut app,
             AppEvent::Acp(AcpAppEvent::DelegationUpdate(delegation_update(
@@ -863,6 +891,9 @@ mod tests {
         let entry = &app.delegates.delegate_entries[0];
         assert_eq!(entry.child_session_id.as_deref(), Some("child-1"));
         assert_eq!(entry.stats.messages, 1);
+        assert_eq!(entry.stats.context_tokens, 250);
+        assert_eq!(entry.stats.context_limit, 2_000);
+        assert_eq!(entry.stats.cost_usd, 0.25);
         assert_eq!(entry.child_state, DelegateChildState::AssistantMessage);
         assert!(
             !app.delegates
@@ -876,6 +907,135 @@ mod tests {
         ));
         assert_eq!(app.chat.streaming_content, "active stream");
         assert_eq!(app.chat.activity, ActivityState::Streaming);
+    }
+
+    #[test]
+    fn chat_usage_and_timing_acp_route_is_owner_bounded_and_release_safe() {
+        let mut app = App::new();
+        app.sessions.session_id = Some("active".into());
+        app.chat.apply_usage(128, 4_096, Some(1.5));
+        app.chat.add_active_llm_duration(Duration::from_secs(2));
+        app.render.streaming_cache.store(5, Vec::new());
+        app.render.streaming_thinking_cache.store(6, Vec::new());
+        app.render.card_cache.processed_messages = 7;
+        app.diagnostics.status = "preserved status".into();
+        app.push_log(LogLevel::Debug, "test", "before usage");
+        let log_count_before = app.diagnostics.logs.len();
+
+        let effects = apply_session_update(
+            &mut app,
+            AcpSessionUpdate::UsageUpdate {
+                used: 2_048,
+                size: 8_192,
+                cost_usd: Some(0.0123),
+            },
+        );
+        assert!(effects.is_empty());
+        assert!(app.sessions.session_activity.contains_key("active"));
+        assert_eq!(app.chat.session_stats.latest_context_tokens, Some(2_048));
+        assert_eq!(app.chat.context_limit, 8_192);
+        assert_eq!(app.chat.cumulative_cost, Some(0.0123));
+
+        let effects = apply_session_update(
+            &mut app,
+            AcpSessionUpdate::UsageUpdate {
+                used: 512,
+                size: 0,
+                cost_usd: None,
+            },
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.chat.session_stats.latest_context_tokens, Some(512));
+        assert_eq!(app.chat.context_limit, 8_192);
+        assert_eq!(app.chat.cumulative_cost, Some(0.0123));
+
+        app.sessions.session_activity.remove("active");
+        let effects = apply_session_update(
+            &mut app,
+            AcpSessionUpdate::TimingUpdate { duration_secs: 3 },
+        );
+        assert!(effects.is_empty());
+        assert!(app.sessions.session_activity.contains_key("active"));
+        assert_eq!(app.chat.llm_request_elapsed(), Some(Duration::from_secs(5)));
+
+        app.sessions.session_activity.remove("active");
+        let log_count_before_zero = app.diagnostics.logs.len();
+        let effects = apply_session_update(
+            &mut app,
+            AcpSessionUpdate::TimingUpdate { duration_secs: 0 },
+        );
+        assert!(effects.is_empty());
+        assert!(app.sessions.session_activity.contains_key("active"));
+        assert_eq!(app.chat.llm_request_elapsed(), Some(Duration::from_secs(5)));
+        assert_eq!(app.diagnostics.logs.len(), log_count_before_zero);
+
+        assert_eq!(app.diagnostics.status, "preserved status");
+        let diagnostics = &app.diagnostics.logs[log_count_before..];
+        assert_eq!(diagnostics.len(), 3);
+        assert_eq!(diagnostics[0].level, LogLevel::Info);
+        assert_eq!(diagnostics[0].target, "usage");
+        assert_eq!(
+            diagnostics[0].message,
+            "usage: context 2048/8192 tokens (25%), cost $0.0123"
+        );
+        assert_eq!(diagnostics[1].level, LogLevel::Info);
+        assert_eq!(diagnostics[1].target, "usage");
+        assert_eq!(diagnostics[1].message, "usage: context 512/0 tokens");
+        assert_eq!(diagnostics[2].level, LogLevel::Info);
+        assert_eq!(diagnostics[2].target, "usage");
+        assert_eq!(diagnostics[2].message, "usage: active time 3s");
+        assert!(app.render.streaming_cache.get(5).is_some());
+        assert!(app.render.streaming_thinking_cache.get(6).is_some());
+        assert_eq!(app.render.card_cache.processed_messages, 7);
+    }
+
+    #[test]
+    fn chat_usage_timing_replay_preserves_summary_and_diagnostic_order() {
+        let mut app = App::new();
+        app.sessions.session_id = Some("active".into());
+        app.render.streaming_cache.store(8, Vec::new());
+        app.render.streaming_thinking_cache.store(9, Vec::new());
+        app.render.card_cache.processed_messages = 10;
+        let log_count_before = app.diagnostics.logs.len();
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::SessionReplay {
+                session_id: "active".into(),
+                updates: vec![
+                    AcpSessionUpdate::TimingUpdate { duration_secs: 4 },
+                    AcpSessionUpdate::UsageUpdate {
+                        used: 30,
+                        size: 120,
+                        cost_usd: Some(0.5),
+                    },
+                ],
+            }),
+        );
+
+        assert!(effects.is_empty());
+        assert!(app.sessions.session_activity.contains_key("active"));
+        assert_eq!(app.chat.llm_request_elapsed(), Some(Duration::from_secs(4)));
+        assert_eq!(app.chat.session_stats.latest_context_tokens, Some(30));
+        assert_eq!(app.chat.context_limit, 120);
+        assert_eq!(app.chat.cumulative_cost, Some(0.5));
+        let diagnostics = &app.diagnostics.logs[log_count_before..];
+        assert_eq!(diagnostics.len(), 3);
+        assert_eq!(diagnostics[0].level, LogLevel::Info);
+        assert_eq!(diagnostics[0].target, "session");
+        assert_eq!(diagnostics[0].message, "session replay: 2 update(s)");
+        assert_eq!(diagnostics[1].level, LogLevel::Info);
+        assert_eq!(diagnostics[1].target, "usage");
+        assert_eq!(diagnostics[1].message, "usage: active time 4s");
+        assert_eq!(diagnostics[2].level, LogLevel::Info);
+        assert_eq!(diagnostics[2].target, "usage");
+        assert_eq!(
+            diagnostics[2].message,
+            "usage: context 30/120 tokens (25%), cost $0.5000"
+        );
+        assert!(app.render.streaming_cache.get(8).is_some());
+        assert!(app.render.streaming_thinking_cache.get(9).is_some());
+        assert_eq!(app.render.card_cache.processed_messages, 10);
     }
 
     #[test]

--- a/src/application.rs
+++ b/src/application.rs
@@ -4,6 +4,7 @@ use crate::{
     acp_state::AcpAppEvent,
     app::{App, ConnectionEvent},
     auth_state::AuthAction,
+    chat_state::ChatAction,
     command::Command,
     connection_state::ConnState,
     diagnostics::LogLevel,
@@ -252,12 +253,13 @@ fn handle_runtime_event(app: &mut App, event: RuntimeEvent) -> Vec<Effect> {
             Vec::new()
         }
         RuntimeEvent::CommandFailed { command, message } => {
-            if let Command::Prompt { local_id, .. } = command {
-                app.chat.rollback_pending_prompt(&local_id);
-                app.render.invalidate_card_cache();
-            }
+            let effects = if let Command::Prompt { local_id, .. } = command {
+                app.apply_chat_action(ChatAction::RuntimePromptDispatchFailed { local_id })
+            } else {
+                Vec::new()
+            };
             app.set_status(LogLevel::Error, "command", message);
-            Vec::new()
+            effects
         }
     }
 }
@@ -1261,6 +1263,123 @@ mod tests {
         assert_eq!(diagnostic.level, LogLevel::Debug);
         assert_eq!(diagnostic.target, "activity");
         assert_eq!(diagnostic.message, "finished: EndTurn");
+    }
+
+    #[test]
+    fn chat_acp_error_route_is_unscoped_deduplicated_and_release_safe() {
+        let mut app = App::new();
+        app.chat.activity = ActivityState::Streaming;
+        app.chat.recent_prompt_text = Some("preserved prompt".into());
+        app.chat.messages.push(ChatEntry::Error("preserved".into()));
+        app.chat.session_stats.open_llm_request_instant =
+            Some(Instant::now() - Duration::from_secs(2));
+        app.render.streaming_cache.store(5, Vec::new());
+        app.render.streaming_thinking_cache.store(6, Vec::new());
+        app.render.card_cache.processed_messages = 7;
+        app.composer.input = "preserved input".into();
+        app.mesh.mesh_invite_name = "preserved invite".into();
+        let log_count_before = app.diagnostics.logs.len();
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::Error {
+                message: "connection lost".into(),
+            }),
+        );
+
+        assert!(effects.is_empty());
+        assert!(app.sessions.session_id.is_none());
+        assert_eq!(app.chat.activity, ActivityState::Streaming);
+        assert!(app.chat.session_stats.open_llm_request_instant.is_none());
+        assert!(app.chat.session_stats.active_llm_duration >= Duration::from_secs(2));
+        assert_eq!(
+            app.chat.recent_prompt_text.as_deref(),
+            Some("preserved prompt")
+        );
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::Error(preserved), ChatEntry::Error(inserted)]
+                if preserved == "preserved" && inserted == "connection lost"
+        ));
+        assert!(app.render.streaming_cache.get(5).is_some());
+        assert!(app.render.streaming_thinking_cache.get(6).is_some());
+        assert_eq!(app.render.card_cache.processed_messages, 7);
+        assert_eq!(app.diagnostics.status, "error: connection lost");
+        let diagnostics = &app.diagnostics.logs[log_count_before..];
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].level, LogLevel::Error);
+        assert_eq!(diagnostics[0].target, "acp");
+        assert_eq!(diagnostics[0].message, "error: connection lost");
+        assert_eq!(app.composer.input, "preserved input");
+        assert_eq!(app.mesh.mesh_invite_name, "preserved invite");
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::Error {
+                message: "connection lost".into(),
+            }),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.chat.messages.len(), 2);
+        assert_eq!(app.render.card_cache.processed_messages, 7);
+        assert_eq!(app.diagnostics.logs.len(), log_count_before + 1);
+    }
+
+    #[test]
+    fn chat_backend_prompt_failure_route_is_owner_bounded_and_release_safe() {
+        let mut app = App::new();
+        let failed_id = app.chat.push_pending_prompt("failed".into());
+        let retained_id = app.chat.push_pending_prompt("retained".into());
+        app.chat.activity = ActivityState::Thinking;
+        app.chat.recent_prompt_text = Some("preserved prompt".into());
+        app.chat.session_stats.open_llm_request_instant =
+            Some(Instant::now() - Duration::from_secs(2));
+        app.render.streaming_cache.store(8, Vec::new());
+        app.render.streaming_thinking_cache.store(9, Vec::new());
+        app.render.card_cache.processed_messages = 10;
+        app.composer.input = "preserved input".into();
+        app.mesh.mesh_invite_name = "preserved invite".into();
+        let log_count_before = app.diagnostics.logs.len();
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::PromptFailed {
+                local_id: failed_id.clone(),
+                message: "backend rejected prompt".into(),
+            }),
+        );
+
+        assert!(effects.is_empty());
+        assert_eq!(app.chat.activity, ActivityState::Thinking);
+        assert!(app.chat.session_stats.open_llm_request_instant.is_none());
+        assert!(app.chat.session_stats.active_llm_duration >= Duration::from_secs(2));
+        assert_eq!(
+            app.chat.recent_prompt_text.as_deref(),
+            Some("preserved prompt")
+        );
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [
+                ChatEntry::User { text, message_id: Some(message_id) },
+                ChatEntry::Error(message),
+            ] if text == "retained"
+                && message_id == &retained_id
+                && message == "backend rejected prompt"
+        ));
+        assert!(app.chat.messages.iter().all(|entry| {
+            !matches!(entry, ChatEntry::User { message_id: Some(id), .. } if id == &failed_id)
+        }));
+        assert!(app.render.streaming_cache.get(8).is_some());
+        assert!(app.render.streaming_thinking_cache.get(9).is_some());
+        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert_eq!(app.diagnostics.status, "error: backend rejected prompt");
+        let diagnostics = &app.diagnostics.logs[log_count_before..];
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].level, LogLevel::Error);
+        assert_eq!(diagnostics[0].target, "acp");
+        assert_eq!(diagnostics[0].message, "error: backend rejected prompt");
+        assert_eq!(app.composer.input, "preserved input");
+        assert_eq!(app.mesh.mesh_invite_name, "preserved invite");
     }
 
     #[test]
@@ -2491,7 +2610,13 @@ mod tests {
         let mut app = App::new();
         let failed_id = app.chat.push_pending_prompt("failed".into());
         let retained_id = app.chat.push_pending_prompt("retained".into());
+        app.chat.recent_prompt_text = Some("preserved prompt".into());
+        app.chat.session_stats.open_llm_request_instant = Some(Instant::now());
+        let open_timing = app.chat.session_stats.open_llm_request_instant;
+        app.render.streaming_cache.store(3, Vec::new());
+        app.render.streaming_thinking_cache.store(4, Vec::new());
         app.render.card_cache.processed_messages = 2;
+        let log_count_before = app.diagnostics.logs.len();
 
         let effects = update(
             &mut app,
@@ -2511,7 +2636,115 @@ mod tests {
         assert!(app.chat.messages.iter().any(|entry| {
             matches!(entry, ChatEntry::User { message_id: Some(id), .. } if id == &retained_id)
         }));
+        assert!(
+            app.chat
+                .messages
+                .iter()
+                .all(|entry| !matches!(entry, ChatEntry::Error(_)))
+        );
+        assert_eq!(
+            app.chat.recent_prompt_text.as_deref(),
+            Some("preserved prompt")
+        );
+        assert_eq!(app.chat.session_stats.open_llm_request_instant, open_timing);
+        assert_eq!(app.chat.session_stats.active_llm_duration, Duration::ZERO);
+        assert!(app.render.streaming_cache.get(3).is_some());
+        assert!(app.render.streaming_thinking_cache.get(4).is_some());
         assert_eq!(app.render.card_cache.processed_messages, 0);
         assert_eq!(app.diagnostics.status, "channel closed");
+        let diagnostics = &app.diagnostics.logs[log_count_before..];
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].level, LogLevel::Error);
+        assert_eq!(diagnostics[0].target, "command");
+        assert_eq!(diagnostics[0].message, "channel closed");
+    }
+
+    #[test]
+    fn unmatched_prompt_command_failure_is_diagnostic_only_and_release_safe() {
+        let mut app = App::new();
+        let retained_id = app.chat.push_pending_prompt("retained".into());
+        app.chat.recent_prompt_text = Some("preserved prompt".into());
+        app.chat.session_stats.open_llm_request_instant = Some(Instant::now());
+        let open_timing = app.chat.session_stats.open_llm_request_instant;
+        app.render.streaming_cache.store(5, Vec::new());
+        app.render.streaming_thinking_cache.store(6, Vec::new());
+        app.render.card_cache.processed_messages = 7;
+        let log_count_before = app.diagnostics.logs.len();
+
+        let effects = update(
+            &mut app,
+            AppEvent::Runtime(RuntimeEvent::CommandFailed {
+                command: Command::Prompt {
+                    prompt: vec![],
+                    local_id: "missing".into(),
+                },
+                message: "unknown prompt failed".into(),
+            }),
+        );
+
+        assert!(effects.is_empty());
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::User { text, message_id: Some(message_id) }]
+                if text == "retained" && message_id == &retained_id
+        ));
+        assert_eq!(
+            app.chat.recent_prompt_text.as_deref(),
+            Some("preserved prompt")
+        );
+        assert_eq!(app.chat.session_stats.open_llm_request_instant, open_timing);
+        assert_eq!(app.chat.session_stats.active_llm_duration, Duration::ZERO);
+        assert!(app.render.streaming_cache.get(5).is_some());
+        assert!(app.render.streaming_thinking_cache.get(6).is_some());
+        assert_eq!(app.render.card_cache.processed_messages, 7);
+        assert_eq!(app.diagnostics.status, "unknown prompt failed");
+        let diagnostics = &app.diagnostics.logs[log_count_before..];
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].level, LogLevel::Error);
+        assert_eq!(diagnostics[0].target, "command");
+        assert_eq!(diagnostics[0].message, "unknown prompt failed");
+    }
+
+    #[test]
+    fn non_prompt_command_failure_is_diagnostic_only_and_release_safe() {
+        let mut app = App::new();
+        let retained_id = app.chat.push_pending_prompt("retained".into());
+        app.chat.recent_prompt_text = Some("preserved prompt".into());
+        app.chat.session_stats.open_llm_request_instant = Some(Instant::now());
+        let open_timing = app.chat.session_stats.open_llm_request_instant;
+        app.render.streaming_cache.store(8, Vec::new());
+        app.render.streaming_thinking_cache.store(9, Vec::new());
+        app.render.card_cache.processed_messages = 10;
+        let log_count_before = app.diagnostics.logs.len();
+
+        let effects = update(
+            &mut app,
+            AppEvent::Runtime(RuntimeEvent::CommandFailed {
+                command: Command::CancelSession,
+                message: "cancel channel closed".into(),
+            }),
+        );
+
+        assert!(effects.is_empty());
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::User { text, message_id: Some(message_id) }]
+                if text == "retained" && message_id == &retained_id
+        ));
+        assert_eq!(
+            app.chat.recent_prompt_text.as_deref(),
+            Some("preserved prompt")
+        );
+        assert_eq!(app.chat.session_stats.open_llm_request_instant, open_timing);
+        assert_eq!(app.chat.session_stats.active_llm_duration, Duration::ZERO);
+        assert!(app.render.streaming_cache.get(8).is_some());
+        assert!(app.render.streaming_thinking_cache.get(9).is_some());
+        assert_eq!(app.render.card_cache.processed_messages, 10);
+        assert_eq!(app.diagnostics.status, "cancel channel closed");
+        let diagnostics = &app.diagnostics.logs[log_count_before..];
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].level, LogLevel::Error);
+        assert_eq!(diagnostics[0].target, "command");
+        assert_eq!(diagnostics[0].message, "cancel channel closed");
     }
 }

--- a/src/application.rs
+++ b/src/application.rs
@@ -278,7 +278,8 @@ mod tests {
             chat::ChatEntry,
             elicitation::ElicitationState,
             mesh::{MeshInviteCreatedInfo, MeshNodesInfo, RemoteNodeInfo},
-            profile::ProfileInfo,
+            model::DelegateModelPreference,
+            profile::{AgentInfo, ProfileInfo},
             session::{SessionGroup, SessionSummary},
         },
         navigation_state::Screen,
@@ -297,6 +298,23 @@ mod tests {
             state.message = format!("Question {elicitation_id}");
             app.chat.elicitation = Some(state);
             app.chat.elicitation_ui = Some(ElicitationUiState::default());
+        }
+    }
+
+    fn profile(id: &str) -> ProfileInfo {
+        ProfileInfo {
+            id: id.into(),
+            name: id.into(),
+            ..Default::default()
+        }
+    }
+
+    fn agent(id: &str) -> AgentInfo {
+        AgentInfo {
+            id: id.into(),
+            name: id.into(),
+            description: None,
+            capabilities: Vec::new(),
         }
     }
 
@@ -360,6 +378,380 @@ mod tests {
                 profile_id: "fast".into(),
             })]
         );
+    }
+
+    #[test]
+    fn profile_acp_route_preserves_selection_and_applies_refresh_conditions() {
+        let mut app = App::new();
+        app.profiles.active_profile_id = Some("deep".into());
+        app.models.agents_profile_id = Some("deep".into());
+        app.models.agents = vec![agent("primary"), agent("coder")];
+        app.auth.filter = "preserved auth".into();
+        app.mesh.mesh_invite_name = "preserved mesh".into();
+        app.chat
+            .messages
+            .push(ChatEntry::Error("preserved chat".into()));
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::Profiles {
+                profiles: vec![profile("fast"), profile("deep")],
+                active_profile_id: Some("fast".into()),
+            }),
+        );
+
+        assert!(effects.is_empty());
+        assert_eq!(app.profiles.active_profile_id.as_deref(), Some("deep"));
+        assert_eq!(app.models.agents_profile_id.as_deref(), Some("deep"));
+        assert_eq!(app.models.agents.len(), 2);
+
+        app.sessions.session_id = Some("session-1".into());
+        app.profiles
+            .bind_session_profile("session-1".into(), "fast".into());
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::Profiles {
+                profiles: vec![profile("fast"), profile("deep")],
+                active_profile_id: Some("deep".into()),
+            }),
+        );
+        assert!(app.models.agents.is_empty());
+        assert_eq!(app.models.agents_profile_id, None);
+        assert_eq!(
+            effects,
+            vec![Effect::Command(Command::ListProfileAgents {
+                profile_id: "fast".into(),
+            })]
+        );
+
+        app.sessions.session_id = None;
+        app.profiles.active_profile_id = Some("removed".into());
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::Profiles {
+                profiles: vec![profile("fast"), profile("deep")],
+                active_profile_id: Some("fast".into()),
+            }),
+        );
+
+        assert_eq!(app.profiles.active_profile_id.as_deref(), Some("fast"));
+        assert!(app.models.agents.is_empty());
+        assert_eq!(app.models.agents_profile_id, None);
+        assert_eq!(
+            effects,
+            vec![Effect::Command(Command::ListProfileAgents {
+                profile_id: "fast".into(),
+            })]
+        );
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::Profiles {
+                profiles: Vec::new(),
+                active_profile_id: None,
+            }),
+        );
+        assert!(effects.is_empty());
+        assert!(app.profiles.active_profile_id.is_none());
+        assert!(app.profiles.profiles.is_empty());
+        assert_eq!(app.auth.filter, "preserved auth");
+        assert_eq!(app.mesh.mesh_invite_name, "preserved mesh");
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::Error(message)] if message == "preserved chat"
+        ));
+    }
+
+    #[test]
+    fn profile_agents_acp_route_ignores_stale_and_reapplies_root_preferences() {
+        let mut app = App::new();
+        app.sessions.session_id = Some("parent".into());
+        app.profiles
+            .bind_session_profile("parent".into(), "quorum".into());
+        app.models.agents_profile_id = Some("quorum".into());
+        app.models.agents = vec![agent("sentinel"), agent("old")];
+        app.models.delegate_model_preferences.insert(
+            "quorum".into(),
+            [(
+                "coder".into(),
+                DelegateModelPreference {
+                    model_id: "openai/gpt-5".into(),
+                    provider: "openai".into(),
+                    model: "gpt-5".into(),
+                    node_id: Some("node-1".into()),
+                },
+            )]
+            .into_iter()
+            .collect(),
+        );
+        app.auth.filter = "preserved auth".into();
+        app.chat.context_limit = 4_096;
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::ProfileAgents {
+                profile_id: "stale".into(),
+                agents: vec![agent("stale")],
+            }),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.models.agents[0].id, "sentinel");
+        assert_eq!(app.models.agents_profile_id.as_deref(), Some("quorum"));
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::ProfileAgents {
+                profile_id: "quorum".into(),
+                agents: vec![agent("primary"), agent("coder")],
+            }),
+        );
+        assert_eq!(app.models.agents[1].id, "coder");
+        assert_eq!(app.models.agents_profile_id.as_deref(), Some("quorum"));
+        assert_eq!(
+            effects,
+            vec![Effect::Command(Command::SetDelegateModel {
+                session_id: "parent".into(),
+                agent_id: "coder".into(),
+                model_id: Some("openai/gpt-5".into()),
+                node_id: Some("node-1".into()),
+            })]
+        );
+
+        app.delegates.parent_session_id = Some("root".into());
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::ProfileAgents {
+                profile_id: "quorum".into(),
+                agents: vec![agent("primary"), agent("reviewer")],
+            }),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.models.agents[1].id, "reviewer");
+        assert_eq!(app.auth.filter, "preserved auth");
+        assert_eq!(app.chat.context_limit, 4_096);
+    }
+
+    #[test]
+    fn model_acp_route_preserves_ui_state_and_logs_exact_inventory_diagnostics() {
+        let mut app = App::new();
+        app.models.current_provider = Some("old-provider".into());
+        app.models.current_model = Some("old-model".into());
+        app.models.current_model_node_id = Some("old-node".into());
+        app.models.model_filter = "keep".into();
+        app.models.model_cursor = 7;
+        app.models.model_popup_agent_tab = 2;
+        app.models.reasoning_effort = Some("high".into());
+        app.auth.filter = "preserved auth".into();
+        app.sessions.session_id = Some("preserved session".into());
+        app.chat
+            .messages
+            .push(ChatEntry::Error("preserved chat".into()));
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::Models {
+                models: vec![
+                    crate::models_state::ModelsState::test_model_entry(
+                        "local", "provider", "local", None, None,
+                    ),
+                    crate::models_state::ModelsState::test_model_entry(
+                        "remote",
+                        "provider",
+                        "remote",
+                        Some("node-1"),
+                        Some("peer"),
+                    ),
+                ],
+                meta: Some(crate::acp_state::AcpModelsMetaInfo {
+                    remote_node_count: 2,
+                    remote_timeout_count: 1,
+                }),
+            }),
+        );
+
+        assert!(effects.is_empty());
+        assert_eq!(app.models.models.len(), 2);
+        assert_eq!(app.models.current_provider.as_deref(), Some("old-provider"));
+        assert_eq!(app.models.current_model.as_deref(), Some("old-model"));
+        assert_eq!(
+            app.models.current_model_node_id.as_deref(),
+            Some("old-node")
+        );
+        assert_eq!(app.models.model_filter, "keep");
+        assert_eq!(app.models.model_cursor, 7);
+        assert_eq!(app.models.model_popup_agent_tab, 2);
+        assert_eq!(app.models.reasoning_effort.as_deref(), Some("high"));
+        let diagnostic = app.diagnostics.logs.last().expect("model diagnostic");
+        assert_eq!(diagnostic.level, LogLevel::Info);
+        assert_eq!(diagnostic.target, "models");
+        assert_eq!(
+            diagnostic.message,
+            "models: 2 total, 1 remote (inventory nodes=2, timeouts=1)"
+        );
+        assert_eq!(app.auth.filter, "preserved auth");
+        assert_eq!(
+            app.sessions.session_id.as_deref(),
+            Some("preserved session")
+        );
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::Error(message)] if message == "preserved chat"
+        ));
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::DelegateModelSet {
+                session_id: "preserved session".into(),
+                agent_id: "coder".into(),
+                model: None,
+            }),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(
+            app.diagnostics.status,
+            "delegate model reset for coder in preserved session"
+        );
+        let diagnostic = app.diagnostics.logs.last().expect("delegate diagnostic");
+        assert_eq!(diagnostic.level, LogLevel::Info);
+        assert_eq!(diagnostic.target, "model");
+        assert_eq!(
+            diagnostic.message,
+            "delegate model reset for coder in preserved session"
+        );
+    }
+
+    #[test]
+    fn provider_and_effort_acp_routes_apply_release_sensitive_coordination() {
+        let mut app = App::new();
+        app.chat.context_limit = 4_096;
+        app.auth.filter = "preserved auth".into();
+        app.mesh.mesh_invite_name = "preserved mesh".into();
+        app.sessions.session_id = Some("preserved session".into());
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::ProviderChanged {
+                provider: "remote-provider".into(),
+                model: "model-1".into(),
+                context_limit: Some(128_000),
+                provider_node_id: Some("node-1".into()),
+            }),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(
+            app.models.current_provider.as_deref(),
+            Some("remote-provider")
+        );
+        assert_eq!(app.models.current_model.as_deref(), Some("model-1"));
+        assert_eq!(app.models.current_model_node_id.as_deref(), Some("node-1"));
+        assert_eq!(app.chat.context_limit, 128_000);
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::ProviderChanged {
+                provider: "local-provider".into(),
+                model: "model-2".into(),
+                context_limit: None,
+                provider_node_id: None,
+            }),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(
+            app.models.current_provider.as_deref(),
+            Some("local-provider")
+        );
+        assert_eq!(app.models.current_model.as_deref(), Some("model-2"));
+        assert_eq!(app.models.current_model_node_id, None);
+        assert_eq!(app.chat.context_limit, 128_000);
+
+        assert!(
+            update(
+                &mut app,
+                AppEvent::Acp(AcpAppEvent::ReasoningEffort {
+                    reasoning_effort: Some("med".into()),
+                }),
+            )
+            .is_empty()
+        );
+        assert_eq!(app.models.reasoning_effort.as_deref(), Some("medium"));
+        assert!(
+            update(
+                &mut app,
+                AppEvent::Acp(AcpAppEvent::ReasoningEffort {
+                    reasoning_effort: Some("invalid".into()),
+                }),
+            )
+            .is_empty()
+        );
+        assert_eq!(app.models.reasoning_effort.as_deref(), Some("medium"));
+        assert_eq!(app.auth.filter, "preserved auth");
+        assert_eq!(app.mesh.mesh_invite_name, "preserved mesh");
+        assert_eq!(
+            app.sessions.session_id.as_deref(),
+            Some("preserved session")
+        );
+    }
+
+    #[test]
+    fn initialized_acp_route_preserves_placeholder_and_discards_profile_effects() {
+        let mut app = App::new();
+        app.profiles.profiles = vec![profile("deep")];
+        app.profiles.active_profile_id = Some("deep".into());
+        app.models.model_popup_agent_tab = 3;
+        app.models.model_filter = "keep".into();
+        app.auth.ui_notice = Some(AuthUiNotice {
+            provider: Some("openai".into()),
+            success: false,
+            message: "stale".into(),
+        });
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::Initialized {
+                agent_id: "agent-1".into(),
+                agent_name: "Agent".into(),
+                profiles: Vec::new(),
+                active_profile_id: None,
+                agent_mode: Some("plan".into()),
+                reasoning_effort: Some(Some("high".into())),
+            }),
+        );
+
+        assert!(effects.is_empty());
+        assert_eq!(app.profiles.profiles[0].id, "deep");
+        assert_eq!(app.profiles.active_profile_id.as_deref(), Some("deep"));
+        assert_eq!(app.sessions.agent_id.as_deref(), Some("agent-1"));
+        assert_eq!(app.sessions.agent_mode, "plan");
+        assert_eq!(app.models.agents[0].id, "agent-1");
+        assert_eq!(app.models.agents_profile_id, None);
+        assert_eq!(app.models.model_popup_agent_tab, 3);
+        assert_eq!(app.models.model_filter, "keep");
+        assert_eq!(app.models.reasoning_effort.as_deref(), Some("high"));
+        assert!(app.auth.ui_notice.is_none());
+        assert_eq!(app.diagnostics.status, "connected");
+        let diagnostic = app.diagnostics.logs.last().expect("connection diagnostic");
+        assert_eq!(diagnostic.level, LogLevel::Info);
+        assert_eq!(diagnostic.target, "connection");
+        assert_eq!(diagnostic.message, "connected");
+
+        let mut app = App::new();
+        app.models.model_popup_agent_tab = 3;
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::Initialized {
+                agent_id: "agent-2".into(),
+                agent_name: "Agent Two".into(),
+                profiles: vec![profile("fast")],
+                active_profile_id: Some("fast".into()),
+                agent_mode: None,
+                reasoning_effort: None,
+            }),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.profiles.active_profile_id.as_deref(), Some("fast"));
+        assert_eq!(app.models.agents[0].id, "agent-2");
+        assert_eq!(app.models.agents_profile_id, None);
+        assert_eq!(app.models.model_popup_agent_tab, 0);
     }
 
     #[test]

--- a/src/application.rs
+++ b/src/application.rs
@@ -605,6 +605,231 @@ mod tests {
     }
 
     #[test]
+    fn chat_turn_and_user_routes_apply_release_sensitive_coordination() {
+        let mut app = App::new();
+        app.sessions.session_id = Some("active".into());
+        app.chat.streaming_content = "discarded".into();
+        app.chat.streaming_thinking = "discarded thinking".into();
+        app.render.streaming_cache.store(9, Vec::new());
+        app.render.streaming_thinking_cache.store(8, Vec::new());
+        app.render.card_cache.processed_messages = 7;
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::SessionUpdate {
+                session_id: "active".into(),
+                update: crate::acp_state::AcpSessionUpdate::TurnStarted,
+                is_replay: false,
+            }),
+        );
+        assert!(effects.is_empty());
+        assert!(app.sessions.session_activity.contains_key("active"));
+        assert_eq!(app.chat.activity, ActivityState::Thinking);
+        assert!(app.chat.streaming_content.is_empty());
+        assert!(app.chat.streaming_thinking.is_empty());
+        assert!(app.chat.session_stats.open_llm_request_instant.is_some());
+        assert!(app.render.streaming_cache.get(9).is_none());
+        assert!(app.render.streaming_thinking_cache.get(8).is_none());
+        assert_eq!(app.render.card_cache.processed_messages, 7);
+        assert_eq!(app.diagnostics.status, "thinking...");
+        let diagnostic = app.diagnostics.logs.last().expect("turn diagnostic");
+        assert_eq!(diagnostic.level, LogLevel::Debug);
+        assert_eq!(diagnostic.target, "activity");
+        assert_eq!(diagnostic.message, "thinking...");
+
+        let local_id = app.chat.push_pending_prompt("  repeat\n".into());
+        app.render.card_cache.processed_messages = 8;
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::SessionUpdate {
+                session_id: "active".into(),
+                update: crate::acp_state::AcpSessionUpdate::UserMessage {
+                    content: serde_json::json!({ "text": "repeat" }),
+                    message_id: Some("server-user".into()),
+                },
+                is_replay: false,
+            }),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::User { text, message_id: Some(id) }]
+                if text == "repeat" && id == "server-user" && id != &local_id
+        ));
+        assert_eq!(app.chat.undoable_turns[0].message_id, "server-user");
+
+        app.sessions.session_activity.remove("active");
+        app.render.card_cache.processed_messages = 9;
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::SessionUpdate {
+                session_id: "active".into(),
+                update: crate::acp_state::AcpSessionUpdate::UserMessage {
+                    content: serde_json::json!({ "text": "repeat" }),
+                    message_id: Some("server-user".into()),
+                },
+                is_replay: false,
+            }),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.render.card_cache.processed_messages, 9);
+        assert_eq!(app.chat.messages.len(), 1);
+    }
+
+    #[test]
+    fn chat_stream_and_final_routes_preserve_boundaries_and_invalidation_scope() {
+        let mut app = App::new();
+        app.sessions.session_id = Some("active".into());
+        app.chat.activity = ActivityState::Thinking;
+        app.render.streaming_cache.store(5, Vec::new());
+        app.render.streaming_thinking_cache.store(6, Vec::new());
+        app.render.card_cache.processed_messages = 7;
+
+        for update_value in [
+            crate::acp_state::AcpSessionUpdate::AssistantThinkingDelta {
+                content: "plan".into(),
+                message_id: Some("assistant-1".into()),
+            },
+            crate::acp_state::AcpSessionUpdate::AssistantContentDelta {
+                content: "first".into(),
+                message_id: Some("assistant-1".into()),
+            },
+        ] {
+            let effects = update(
+                &mut app,
+                AppEvent::Acp(AcpAppEvent::SessionUpdate {
+                    session_id: "active".into(),
+                    update: update_value,
+                    is_replay: false,
+                }),
+            );
+            assert!(effects.is_empty());
+        }
+        assert!(app.render.streaming_cache.get(5).is_some());
+        assert!(app.render.streaming_thinking_cache.get(6).is_some());
+        assert_eq!(app.render.card_cache.processed_messages, 7);
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::SessionUpdate {
+                session_id: "active".into(),
+                update: crate::acp_state::AcpSessionUpdate::AssistantThinkingDelta {
+                    content: "second plan".into(),
+                    message_id: Some("assistant-2".into()),
+                },
+                is_replay: false,
+            }),
+        );
+        assert!(effects.is_empty());
+        assert!(app.render.streaming_cache.get(5).is_none());
+        assert!(app.render.streaming_thinking_cache.get(6).is_none());
+        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::Assistant { content, thinking: Some(thinking), message_id: Some(id) }]
+                if content == "first" && thinking == "plan" && id == "assistant-1"
+        ));
+        assert_eq!(app.chat.streaming_thinking, "second plan");
+
+        app.render.streaming_cache.store(10, Vec::new());
+        app.render.streaming_thinking_cache.store(11, Vec::new());
+        app.render.card_cache.processed_messages = 12;
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::SessionUpdate {
+                session_id: "active".into(),
+                update: crate::acp_state::AcpSessionUpdate::AssistantMessage {
+                    content: "final".into(),
+                    thinking: None,
+                    message_id: Some("assistant-2".into()),
+                },
+                is_replay: false,
+            }),
+        );
+        assert!(effects.is_empty());
+        assert!(app.render.streaming_cache.get(10).is_none());
+        assert!(app.render.streaming_thinking_cache.get(11).is_none());
+        assert_eq!(app.render.card_cache.processed_messages, 12);
+        assert!(matches!(
+            &app.chat.messages[1],
+            ChatEntry::Assistant { content, thinking: Some(thinking), message_id: Some(id) }
+                if content == "final" && thinking == "second plan" && id == "assistant-2"
+        ));
+    }
+
+    #[test]
+    fn chat_cancel_and_finish_routes_discard_streams_and_emit_exact_diagnostics() {
+        let mut app = App::new();
+        app.sessions.session_id = Some("active".into());
+        update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::SessionUpdate {
+                session_id: "active".into(),
+                update: crate::acp_state::AcpSessionUpdate::TurnStarted,
+                is_replay: false,
+            }),
+        );
+        app.chat.streaming_content = "discarded".into();
+        app.chat.streaming_thinking = "discarded thinking".into();
+        app.render.streaming_cache.store(9, Vec::new());
+        app.render.streaming_thinking_cache.store(8, Vec::new());
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::SessionUpdate {
+                session_id: "active".into(),
+                update: crate::acp_state::AcpSessionUpdate::Cancelled,
+                is_replay: false,
+            }),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.chat.activity, ActivityState::Idle);
+        assert!(app.chat.session_stats.open_llm_request_instant.is_none());
+        assert!(app.chat.streaming_content.is_empty());
+        assert!(app.chat.streaming_thinking.is_empty());
+        assert!(app.chat.messages.is_empty());
+        assert!(app.render.streaming_cache.get(9).is_none());
+        assert!(app.render.streaming_thinking_cache.get(8).is_none());
+        assert_eq!(app.diagnostics.status, "cancelled");
+        let diagnostic = app.diagnostics.logs.last().expect("cancel diagnostic");
+        assert_eq!(diagnostic.level, LogLevel::Warn);
+        assert_eq!(diagnostic.target, "activity");
+        assert_eq!(diagnostic.message, "cancelled");
+
+        update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::SessionUpdate {
+                session_id: "active".into(),
+                update: crate::acp_state::AcpSessionUpdate::TurnStarted,
+                is_replay: false,
+            }),
+        );
+        app.chat.streaming_content = "discarded final".into();
+        app.chat.streaming_thinking = "discarded final thinking".into();
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::SessionUpdate {
+                session_id: "active".into(),
+                update: crate::acp_state::AcpSessionUpdate::Finished {
+                    finish_reason: "EndTurn".into(),
+                },
+                is_replay: false,
+            }),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.chat.activity, ActivityState::Idle);
+        assert!(app.chat.session_stats.open_llm_request_instant.is_none());
+        assert!(app.chat.streaming_content.is_empty());
+        assert!(app.chat.streaming_thinking.is_empty());
+        assert!(app.chat.messages.is_empty());
+        assert_eq!(app.diagnostics.status, "finished: EndTurn");
+        let diagnostic = app.diagnostics.logs.last().expect("finish diagnostic");
+        assert_eq!(diagnostic.level, LogLevel::Debug);
+        assert_eq!(diagnostic.target, "activity");
+        assert_eq!(diagnostic.message, "finished: EndTurn");
+    }
+
+    #[test]
     fn profile_acp_route_preserves_selection_and_applies_refresh_conditions() {
         let mut app = App::new();
         app.profiles.active_profile_id = Some("deep".into());

--- a/src/application.rs
+++ b/src/application.rs
@@ -260,7 +260,7 @@ mod tests {
         domain::{
             activity::{
                 ActivityState, DelegateChildState, DelegateStatus, DelegationState,
-                DelegationUpdate,
+                DelegationUpdate, SessionOp,
             },
             auth::{OAuthFlow, OAuthFlowKind, OAuthResult, OAuthResultStatus},
             chat::ChatEntry,
@@ -268,9 +268,12 @@ mod tests {
             mesh::{MeshInviteCreatedInfo, MeshNodesInfo, RemoteNodeInfo},
             model::DelegateModelPreference,
             profile::{AgentInfo, ProfileInfo},
-            session::{SessionGroup, SessionListPage, SessionSummary},
+            session::{
+                ForkResult, RedoResult, SessionGroup, SessionListPage, SessionSummary, UndoResult,
+                UndoStackSnapshot, UndoableTurn,
+            },
         },
-        navigation_state::Screen,
+        navigation_state::{Popup, Screen},
     };
 
     fn add_elicitation(app: &mut App, elicitation_id: &str, active: bool) {
@@ -1564,6 +1567,447 @@ mod tests {
         assert_eq!(diagnostics[0].message, "error: backend rejected prompt");
         assert_eq!(app.composer.input, "preserved input");
         assert_eq!(app.mesh.mesh_invite_name, "preserved invite");
+    }
+
+    #[test]
+    fn chat_history_stack_route_replaces_only_undo_state() {
+        let mut app = App::new();
+        app.chat.activity = ActivityState::SessionOp(SessionOp::Undo);
+        app.chat.streaming_content = "content".into();
+        app.chat.streaming_content_message_id = Some("content-id".into());
+        app.chat.streaming_thinking = "thinking".into();
+        app.chat.streaming_thinking_message_id = Some("thinking-id".into());
+        app.chat.recent_prompt_text = Some("prompt".into());
+        app.chat.pending_fork_message_id = Some("fork-target".into());
+        app.render.streaming_cache.store(7, Vec::new());
+        app.render.streaming_thinking_cache.store(8, Vec::new());
+        app.render.card_cache.processed_messages = 9;
+        let log_count = app.diagnostics.logs.len();
+        let status = app.diagnostics.status.clone();
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::UndoStack(UndoStackSnapshot {
+                message_ids: vec!["one".into()],
+            })),
+        );
+
+        assert!(effects.is_empty());
+        assert_eq!(app.chat.activity, ActivityState::SessionOp(SessionOp::Undo));
+        assert_eq!(app.chat.streaming_content, "content");
+        assert_eq!(
+            app.chat.streaming_content_message_id.as_deref(),
+            Some("content-id")
+        );
+        assert_eq!(app.chat.streaming_thinking, "thinking");
+        assert_eq!(
+            app.chat.streaming_thinking_message_id.as_deref(),
+            Some("thinking-id")
+        );
+        assert_eq!(app.chat.recent_prompt_text.as_deref(), Some("prompt"));
+        assert_eq!(
+            app.chat.pending_fork_message_id.as_deref(),
+            Some("fork-target")
+        );
+        assert_eq!(
+            app.chat
+                .undo_state
+                .as_ref()
+                .and_then(|state| state.frontier_message_id.as_deref()),
+            Some("one")
+        );
+        assert!(app.render.streaming_cache.get(7).is_some());
+        assert!(app.render.streaming_thinking_cache.get(8).is_some());
+        assert_eq!(app.render.card_cache.processed_messages, 9);
+        assert_eq!(app.diagnostics.logs.len(), log_count);
+        assert_eq!(app.diagnostics.status, status);
+    }
+
+    #[test]
+    fn chat_history_undo_routes_apply_release_sensitive_asymmetry_and_reload_context() {
+        let mut app = App::new();
+        app.sessions.session_id = Some("active".into());
+        app.sessions.agent_id = Some("agent-current".into());
+        app.sessions.session_groups = vec![SessionGroup {
+            cwd: Some("/group".into()),
+            sessions: vec![SessionSummary {
+                session_id: "active".into(),
+                cwd: Some("/active-session".into()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }];
+        app.connection.launch_cwd = Some("/launch".into());
+        app.chat.activity = ActivityState::SessionOp(SessionOp::Undo);
+        app.chat.undoable_turns = vec![
+            UndoableTurn {
+                turn_id: "turn-one".into(),
+                message_id: "one".into(),
+                text: "first".into(),
+            },
+            UndoableTurn {
+                turn_id: "turn-two".into(),
+                message_id: "two".into(),
+                text: "second".into(),
+            },
+        ];
+        app.chat.streaming_content = "discard content".into();
+        app.chat.streaming_content_message_id = Some("content-id".into());
+        app.chat.streaming_thinking = "keep thinking".into();
+        app.chat.streaming_thinking_message_id = Some("thinking-id".into());
+        app.chat.recent_prompt_text = Some("discard prompt".into());
+        app.render.streaming_cache.store(15, Vec::new());
+        app.render.streaming_thinking_cache.store(13, Vec::new());
+        app.render.card_cache.processed_messages = 7;
+        let log_count = app.diagnostics.logs.len();
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::UndoResult(UndoResult::Applied {
+                target_message_id: None,
+                reverted_files: vec!["src/main.rs".into()],
+                message: Some("ignored success".into()),
+                stack: UndoStackSnapshot {
+                    message_ids: vec!["one".into(), "two".into()],
+                },
+            })),
+        );
+
+        assert_eq!(app.chat.activity, ActivityState::Idle);
+        assert!(app.chat.streaming_content.is_empty());
+        assert!(app.chat.streaming_content_message_id.is_none());
+        assert_eq!(app.chat.streaming_thinking, "keep thinking");
+        assert_eq!(
+            app.chat.streaming_thinking_message_id.as_deref(),
+            Some("thinking-id")
+        );
+        assert!(app.chat.recent_prompt_text.is_none());
+        let state = app.chat.undo_state.as_ref().expect("undo state");
+        assert_eq!(state.frontier_message_id.as_deref(), Some("two"));
+        assert!(state.stack[0].reverted_files.is_empty());
+        assert_eq!(state.stack[1].reverted_files, ["src/main.rs"]);
+        assert!(app.render.streaming_cache.get(15).is_none());
+        assert!(app.render.streaming_thinking_cache.get(13).is_some());
+        assert_eq!(app.render.card_cache.processed_messages, 7);
+        assert_eq!(app.diagnostics.status, "undone - reloading session");
+        let diagnostics = &app.diagnostics.logs[log_count..];
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].level, LogLevel::Info);
+        assert_eq!(diagnostics[0].target, "session");
+        assert_eq!(diagnostics[0].message, "undone - reloading session");
+        assert_eq!(
+            effects,
+            vec![
+                Effect::Command(Command::LoadSession {
+                    session_id: "active".into(),
+                    cwd: Some("/active-session".into()),
+                }),
+                Effect::Command(Command::SubscribeSession {
+                    session_id: "active".into(),
+                    agent_id: Some("agent-current".into()),
+                }),
+            ]
+        );
+
+        app.chat.activity = ActivityState::SessionOp(SessionOp::Undo);
+        app.chat.streaming_content = "preserve content".into();
+        app.chat.streaming_content_message_id = Some("preserve-content-id".into());
+        app.chat.streaming_thinking = "preserve thinking".into();
+        app.chat.streaming_thinking_message_id = Some("preserve-thinking-id".into());
+        app.chat.recent_prompt_text = Some("preserve prompt".into());
+        app.render.streaming_cache.store(16, Vec::new());
+        app.render.streaming_thinking_cache.store(17, Vec::new());
+        app.render.card_cache.processed_messages = 8;
+        let log_count = app.diagnostics.logs.len();
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::UndoResult(UndoResult::Rejected {
+                target_message_id: Some("one".into()),
+                message: None,
+                stack: UndoStackSnapshot {
+                    message_ids: vec!["one".into(), "two".into()],
+                },
+            })),
+        );
+
+        assert!(effects.is_empty());
+        assert_eq!(app.chat.activity, ActivityState::Idle);
+        assert_eq!(app.chat.streaming_content, "preserve content");
+        assert_eq!(
+            app.chat.streaming_content_message_id.as_deref(),
+            Some("preserve-content-id")
+        );
+        assert_eq!(app.chat.streaming_thinking, "preserve thinking");
+        assert_eq!(
+            app.chat.streaming_thinking_message_id.as_deref(),
+            Some("preserve-thinking-id")
+        );
+        assert_eq!(
+            app.chat.recent_prompt_text.as_deref(),
+            Some("preserve prompt")
+        );
+        assert_eq!(
+            app.chat
+                .undo_state
+                .as_ref()
+                .and_then(|state| state.frontier_message_id.as_deref()),
+            Some("one")
+        );
+        assert!(app.render.streaming_cache.get(16).is_some());
+        assert!(app.render.streaming_thinking_cache.get(17).is_some());
+        assert_eq!(app.render.card_cache.processed_messages, 8);
+        assert_eq!(app.diagnostics.status, "undo failed");
+        let diagnostics = &app.diagnostics.logs[log_count..];
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].level, LogLevel::Warn);
+        assert_eq!(diagnostics[0].target, "session");
+        assert_eq!(diagnostics[0].message, "undo failed");
+    }
+
+    #[test]
+    fn chat_history_redo_routes_preserve_streams_and_reload_only_when_applied() {
+        let mut app = App::new();
+        app.sessions.session_id = Some("active".into());
+        app.sessions.agent_id = Some("agent-current".into());
+        app.sessions.session_groups = vec![SessionGroup {
+            cwd: Some("/group-cwd".into()),
+            sessions: vec![SessionSummary {
+                session_id: "active".into(),
+                cwd: None,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }];
+        app.connection.launch_cwd = Some("/launch".into());
+        app.chat.activity = ActivityState::SessionOp(SessionOp::Redo);
+        app.chat.streaming_content = "keep content".into();
+        app.chat.streaming_content_message_id = Some("content-id".into());
+        app.chat.streaming_thinking = "keep thinking".into();
+        app.chat.streaming_thinking_message_id = Some("thinking-id".into());
+        app.chat.recent_prompt_text = Some("keep prompt".into());
+        app.render.streaming_cache.store(12, Vec::new());
+        app.render.streaming_thinking_cache.store(13, Vec::new());
+        app.render.card_cache.processed_messages = 14;
+        let log_count = app.diagnostics.logs.len();
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::RedoResult(RedoResult::Applied {
+                message: Some("ignored success".into()),
+                stack: UndoStackSnapshot {
+                    message_ids: vec!["one".into()],
+                },
+            })),
+        );
+
+        assert_eq!(app.chat.activity, ActivityState::Idle);
+        assert_eq!(app.chat.streaming_content, "keep content");
+        assert_eq!(
+            app.chat.streaming_content_message_id.as_deref(),
+            Some("content-id")
+        );
+        assert_eq!(app.chat.streaming_thinking, "keep thinking");
+        assert_eq!(
+            app.chat.streaming_thinking_message_id.as_deref(),
+            Some("thinking-id")
+        );
+        assert_eq!(app.chat.recent_prompt_text.as_deref(), Some("keep prompt"));
+        assert!(app.render.streaming_cache.get(12).is_some());
+        assert!(app.render.streaming_thinking_cache.get(13).is_some());
+        assert_eq!(app.render.card_cache.processed_messages, 14);
+        assert_eq!(app.diagnostics.status, "redone - reloading session");
+        let diagnostics = &app.diagnostics.logs[log_count..];
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].level, LogLevel::Info);
+        assert_eq!(diagnostics[0].target, "session");
+        assert_eq!(diagnostics[0].message, "redone - reloading session");
+        assert_eq!(
+            effects,
+            vec![
+                Effect::Command(Command::LoadSession {
+                    session_id: "active".into(),
+                    cwd: Some("/group-cwd".into()),
+                }),
+                Effect::Command(Command::SubscribeSession {
+                    session_id: "active".into(),
+                    agent_id: Some("agent-current".into()),
+                }),
+            ]
+        );
+
+        app.chat.activity = ActivityState::SessionOp(SessionOp::Redo);
+        let log_count = app.diagnostics.logs.len();
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::RedoResult(RedoResult::Rejected {
+                message: None,
+                stack: UndoStackSnapshot {
+                    message_ids: vec!["one".into(), "two".into()],
+                },
+            })),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.chat.activity, ActivityState::Idle);
+        assert_eq!(app.diagnostics.status, "redo failed");
+        assert_eq!(
+            app.chat
+                .undo_state
+                .as_ref()
+                .and_then(|state| state.frontier_message_id.as_deref()),
+            Some("one")
+        );
+        let diagnostics = &app.diagnostics.logs[log_count..];
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].level, LogLevel::Warn);
+        assert_eq!(diagnostics[0].target, "session");
+        assert_eq!(diagnostics[0].message, "redo failed");
+    }
+
+    #[test]
+    fn chat_history_fork_routes_apply_popup_diagnostics_and_load_context_exactly() {
+        let mut app = App::new();
+        app.sessions.agent_id = Some("agent-current".into());
+        app.connection.launch_cwd = Some("/launch-cwd".into());
+        app.navigation.popup = Popup::ForkTurnSelect;
+        app.chat.pending_fork_message_id = Some("fork-target".into());
+        let log_count = app.diagnostics.logs.len();
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::ForkResult(ForkResult::Succeeded {
+                source_session_id: Some("ignored-source".into()),
+                forked_session_id: Some("forked".into()),
+                message: Some("ignored success".into()),
+            })),
+        );
+
+        assert!(app.chat.pending_fork_message_id.is_none());
+        assert_eq!(app.navigation.popup, Popup::None);
+        assert_eq!(app.diagnostics.status, "forked - loading session");
+        let diagnostics = &app.diagnostics.logs[log_count..];
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].level, LogLevel::Info);
+        assert_eq!(diagnostics[0].target, "fork");
+        assert_eq!(diagnostics[0].message, "forked - loading session");
+        assert_eq!(
+            effects,
+            vec![
+                Effect::Command(Command::LoadSession {
+                    session_id: "forked".into(),
+                    cwd: Some("/launch-cwd".into()),
+                }),
+                Effect::Command(Command::SubscribeSession {
+                    session_id: "forked".into(),
+                    agent_id: Some("agent-current".into()),
+                }),
+            ]
+        );
+
+        app.navigation.popup = Popup::ForkTurnSelect;
+        app.chat.pending_fork_message_id = Some("fork-target".into());
+        let log_count = app.diagnostics.logs.len();
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::ForkResult(ForkResult::Succeeded {
+                source_session_id: Some("ignored-source".into()),
+                forked_session_id: None,
+                message: None,
+            })),
+        );
+        assert!(effects.is_empty());
+        assert!(app.chat.pending_fork_message_id.is_none());
+        assert_eq!(app.navigation.popup, Popup::ForkTurnSelect);
+        assert_eq!(app.diagnostics.status, "fork succeeded without session id");
+        let diagnostics = &app.diagnostics.logs[log_count..];
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].level, LogLevel::Warn);
+        assert_eq!(diagnostics[0].target, "fork");
+        assert_eq!(diagnostics[0].message, "fork succeeded without session id");
+
+        app.chat.pending_fork_message_id = Some("fork-target".into());
+        let log_count = app.diagnostics.logs.len();
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::ForkResult(ForkResult::Failed {
+                source_session_id: Some("ignored-source".into()),
+                message: None,
+            })),
+        );
+        assert!(effects.is_empty());
+        assert!(app.chat.pending_fork_message_id.is_none());
+        assert_eq!(app.navigation.popup, Popup::ForkTurnSelect);
+        assert_eq!(app.diagnostics.status, "fork failed");
+        let diagnostics = &app.diagnostics.logs[log_count..];
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].level, LogLevel::Warn);
+        assert_eq!(diagnostics[0].target, "fork");
+        assert_eq!(diagnostics[0].message, "fork failed");
+    }
+
+    #[test]
+    fn chat_history_applied_results_without_active_session_still_coordinate_in_release() {
+        let mut app = App::new();
+        app.sessions.agent_id = Some("unused-agent".into());
+        app.connection.launch_cwd = Some("/unused-cwd".into());
+        app.chat.activity = ActivityState::SessionOp(SessionOp::Undo);
+        app.chat.streaming_content = "discard".into();
+        app.chat.streaming_content_message_id = Some("content-id".into());
+        app.chat.streaming_thinking = "keep thinking".into();
+        app.chat.streaming_thinking_message_id = Some("thinking-id".into());
+        app.chat.recent_prompt_text = Some("discard prompt".into());
+        app.render.streaming_cache.store(7, Vec::new());
+        app.render.streaming_thinking_cache.store(8, Vec::new());
+        let log_count = app.diagnostics.logs.len();
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::UndoResult(UndoResult::Applied {
+                target_message_id: None,
+                reverted_files: Vec::new(),
+                message: None,
+                stack: UndoStackSnapshot {
+                    message_ids: vec!["one".into()],
+                },
+            })),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.chat.activity, ActivityState::Idle);
+        assert!(app.chat.streaming_content.is_empty());
+        assert!(app.chat.streaming_content_message_id.is_none());
+        assert_eq!(app.chat.streaming_thinking, "keep thinking");
+        assert!(app.chat.recent_prompt_text.is_none());
+        assert!(app.render.streaming_cache.get(7).is_none());
+        assert!(app.render.streaming_thinking_cache.get(8).is_some());
+        assert_eq!(app.diagnostics.status, "undone - reloading session");
+        assert_eq!(app.diagnostics.logs.len(), log_count + 1);
+
+        app.chat.activity = ActivityState::SessionOp(SessionOp::Redo);
+        app.chat.streaming_content = "keep redo content".into();
+        app.chat.streaming_content_message_id = Some("redo-content-id".into());
+        app.chat.recent_prompt_text = Some("keep redo prompt".into());
+        let log_count = app.diagnostics.logs.len();
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::RedoResult(RedoResult::Applied {
+                message: None,
+                stack: UndoStackSnapshot {
+                    message_ids: vec!["one".into()],
+                },
+            })),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.chat.activity, ActivityState::Idle);
+        assert_eq!(app.chat.streaming_content, "keep redo content");
+        assert_eq!(
+            app.chat.streaming_content_message_id.as_deref(),
+            Some("redo-content-id")
+        );
+        assert_eq!(
+            app.chat.recent_prompt_text.as_deref(),
+            Some("keep redo prompt")
+        );
+        assert_eq!(app.diagnostics.status, "redone - reloading session");
+        assert_eq!(app.diagnostics.logs.len(), log_count + 1);
     }
 
     #[test]

--- a/src/application.rs
+++ b/src/application.rs
@@ -275,8 +275,12 @@ mod tests {
         command::SessionListRequest,
         composer_state::FileIndexEntryLite,
         connection_state::ServerState,
+        domain::tool::ToolDetail,
         domain::{
-            activity::{ActivityState, DelegateChildState},
+            activity::{
+                ActivityState, DelegateChildState, DelegateStatus, DelegationState,
+                DelegationUpdate,
+            },
             auth::{OAuthFlow, OAuthFlowKind, OAuthResult, OAuthResultStatus},
             chat::ChatEntry,
             elicitation::ElicitationState,
@@ -318,6 +322,32 @@ mod tests {
             name: id.into(),
             description: None,
             capabilities: Vec::new(),
+        }
+    }
+
+    fn delegation_update(
+        session_id: &str,
+        state: DelegationState,
+        updated_at: i64,
+    ) -> DelegationUpdate {
+        DelegationUpdate {
+            session_id: session_id.into(),
+            delegation_id: "delegation-1".into(),
+            tool_call_id: Some("delegate-call".into()),
+            state,
+            target_agent_id: "coder".into(),
+            objective: "Implement the feature".into(),
+            child_session_id: (state != DelegationState::Requested).then(|| "child-1".into()),
+            requested_at: 100,
+            forked_at: (state != DelegationState::Requested).then_some(110),
+            finished_at: matches!(
+                state,
+                DelegationState::Completed | DelegationState::Failed | DelegationState::Cancelled
+            )
+            .then_some(120),
+            updated_at,
+            result_summary: (state == DelegationState::Completed).then(|| "done".into()),
+            error: (state == DelegationState::Failed).then(|| "boom".into()),
         }
     }
 
@@ -381,6 +411,197 @@ mod tests {
                 profile_id: "fast".into(),
             })]
         );
+    }
+
+    #[test]
+    fn delegation_lifecycle_acp_route_is_filtered_ranked_and_release_safe() {
+        let mut app = App::new();
+        app.sessions.session_id = Some("parent".into());
+        app.render.card_cache.processed_messages = 7;
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::DelegationUpdate(delegation_update(
+                "parent",
+                DelegationState::Completed,
+                120,
+            ))),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert_eq!(app.delegates.delegate_entries.len(), 1);
+        assert_eq!(
+            app.delegates.delegate_entries[0].status,
+            DelegateStatus::Completed
+        );
+        assert_eq!(
+            app.delegates.delegation_result_summaries["delegation-1"],
+            "done"
+        );
+
+        app.render.card_cache.processed_messages = 8;
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::DelegationUpdate(delegation_update(
+                "parent",
+                DelegationState::Forked,
+                120,
+            ))),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.render.card_cache.processed_messages, 8);
+        assert_eq!(
+            app.delegates.delegate_entries[0].status,
+            DelegateStatus::Completed
+        );
+
+        app.render.card_cache.processed_messages = 9;
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::DelegationUpdate(delegation_update(
+                "other-parent",
+                DelegationState::Failed,
+                130,
+            ))),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.render.card_cache.processed_messages, 9);
+        assert_eq!(app.delegates.delegate_entries.len(), 1);
+    }
+
+    #[test]
+    fn provisional_delegate_acp_route_reconciles_without_reordering_chat_tool_state() {
+        let mut app = App::new();
+        app.sessions.session_id = Some("parent".into());
+        app.chat.messages.push(ChatEntry::Assistant {
+            content: "before delegate".into(),
+            thinking: None,
+            message_id: Some("assistant-1".into()),
+        });
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::SessionUpdate {
+                session_id: "parent".into(),
+                update: crate::acp_state::AcpSessionUpdate::ToolCallStart {
+                    tool_call_id: Some("delegate-call".into()),
+                    name: "delegate".into(),
+                    arguments: Some(serde_json::json!({
+                        "target_agent_id": "coder",
+                        "objective": "Implement the feature"
+                    })),
+                },
+                is_replay: false,
+            }),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.delegates.delegate_entries.len(), 1);
+        assert_eq!(
+            app.delegates.delegate_entries[0].delegation_id,
+            "tool:delegate-call"
+        );
+        assert_eq!(app.delegates.pending_delegate_tool_calls.len(), 1);
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [
+                ChatEntry::Assistant { content, .. },
+                ChatEntry::ToolCall {
+                    tool_call_id: Some(tool_call_id),
+                    name,
+                    is_error: false,
+                    detail: ToolDetail::Summary(summary),
+                },
+            ] if content == "before delegate"
+                && tool_call_id == "delegate-call"
+                && name == "delegate"
+                && summary == "(coder) Implement the feature"
+        ));
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::DelegationUpdate(delegation_update(
+                "parent",
+                DelegationState::Forked,
+                110,
+            ))),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.delegates.delegate_entries.len(), 1);
+        let entry = &app.delegates.delegate_entries[0];
+        assert_eq!(entry.delegation_id, "delegation-1");
+        assert_eq!(
+            entry.delegate_tool_call_id.as_deref(),
+            Some("delegate-call")
+        );
+        assert_eq!(entry.child_session_id.as_deref(), Some("child-1"));
+        assert_eq!(entry.target_agent_id.as_deref(), Some("coder"));
+        assert_eq!(entry.objective, "Implement the feature");
+        assert!(app.delegates.pending_delegate_tool_calls.is_empty());
+    }
+
+    #[test]
+    fn inactive_child_acp_route_marks_activity_without_mutating_active_chat() {
+        let mut app = App::new();
+        app.sessions.session_id = Some("parent".into());
+        app.chat.messages.push(ChatEntry::Error("preserved".into()));
+        app.chat.streaming_content = "active stream".into();
+        app.chat.activity = ActivityState::Streaming;
+        app.render.card_cache.processed_messages = 6;
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::SessionUpdate {
+                session_id: "child-1".into(),
+                update: crate::acp_state::AcpSessionUpdate::AssistantContentDelta {
+                    content: "child content".into(),
+                    message_id: Some("child-message".into()),
+                },
+                is_replay: false,
+            }),
+        );
+        assert!(effects.is_empty());
+        assert!(app.sessions.session_activity.contains_key("child-1"));
+        assert_eq!(app.render.card_cache.processed_messages, 6);
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::Error(message)] if message == "preserved"
+        ));
+        assert_eq!(app.chat.streaming_content, "active stream");
+        assert_eq!(app.chat.activity, ActivityState::Streaming);
+        assert_eq!(
+            app.delegates.pending_delegate_child_states["child-1"],
+            DelegateChildState::AssistantMessage
+        );
+        assert_eq!(
+            app.delegates.pending_delegate_child_stats["child-1"].messages,
+            1
+        );
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::DelegationUpdate(delegation_update(
+                "parent",
+                DelegationState::Forked,
+                110,
+            ))),
+        );
+        assert!(effects.is_empty());
+        let entry = &app.delegates.delegate_entries[0];
+        assert_eq!(entry.child_session_id.as_deref(), Some("child-1"));
+        assert_eq!(entry.stats.messages, 1);
+        assert_eq!(entry.child_state, DelegateChildState::AssistantMessage);
+        assert!(
+            !app.delegates
+                .pending_delegate_child_states
+                .contains_key("child-1")
+        );
+        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::Error(message)] if message == "preserved"
+        ));
+        assert_eq!(app.chat.streaming_content, "active stream");
+        assert_eq!(app.chat.activity, ActivityState::Streaming);
     }
 
     #[test]

--- a/src/application.rs
+++ b/src/application.rs
@@ -3,7 +3,7 @@ use crossterm::event::{KeyEvent, MouseEvent};
 use crate::{
     acp_state::AcpAppEvent,
     app::{App, ConnectionEvent},
-    auth_state::AuthUiNotice,
+    auth_state::AuthAction,
     command::Command,
     connection_state::ConnState,
     diagnostics::LogLevel,
@@ -192,35 +192,12 @@ fn handle_supervisor_event(app: &mut App, event: ServerEvent) -> Vec<Effect> {
 
 fn handle_runtime_event(app: &mut App, event: RuntimeEvent) -> Vec<Effect> {
     match event {
-        RuntimeEvent::ClipboardFinished { target, success } => {
-            match target {
-                ClipboardTarget::Auth { provider } => {
-                    if success {
-                        app.auth.ui_notice = Some(AuthUiNotice {
-                            provider: Some(provider),
-                            success: true,
-                            message: "Copied to clipboard".into(),
-                        });
-                        app.auth.clipboard_fallback = None;
-                    } else {
-                        app.auth.ui_notice = None;
-                        app.auth.clipboard_fallback = app
-                            .auth
-                            .oauth_flow
-                            .as_ref()
-                            .map(|flow| flow.authorization_url.clone());
-                    }
-                }
-                ClipboardTarget::MeshInvite => {
-                    if success {
-                        app.set_status(LogLevel::Info, "mesh", "invite URL copied");
-                    } else if let Some(url) = app.mesh.invite_url().map(str::to_string) {
-                        app.mesh.set_clipboard_fallback(url);
-                    }
-                }
+        RuntimeEvent::ClipboardFinished { target, success } => match target {
+            ClipboardTarget::Auth { provider } => {
+                app.apply_auth_action(AuthAction::ClipboardFinished { provider, success })
             }
-            Vec::new()
-        }
+            ClipboardTarget::MeshInvite => app.apply_mesh_clipboard_result(success),
+        },
         RuntimeEvent::ExternalEditorFinished { outcome } => {
             app.render.invalidate_card_cache();
             app.render.invalidate_content_cache();
@@ -292,14 +269,15 @@ mod tests {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEventKind};
 
     use super::*;
+    use crate::auth_state::AuthUiNotice;
     use crate::{
         chat_state::ElicitationUiState,
         connection_state::ServerState,
         domain::{
-            auth::{OAuthFlow, OAuthFlowKind},
+            auth::{OAuthFlow, OAuthFlowKind, OAuthResult, OAuthResultStatus},
             chat::ChatEntry,
             elicitation::ElicitationState,
-            mesh::MeshInviteCreatedInfo,
+            mesh::{MeshInviteCreatedInfo, MeshNodesInfo, RemoteNodeInfo},
             profile::ProfileInfo,
             session::{SessionGroup, SessionSummary},
         },
@@ -381,6 +359,88 @@ mod tests {
             vec![Effect::Command(Command::ListProfileAgents {
                 profile_id: "fast".into(),
             })]
+        );
+    }
+
+    #[test]
+    fn mesh_acp_route_mutates_only_mesh_and_explicit_coordination_targets() {
+        let mut app = App::new();
+        app.auth.filter = "preserved auth".into();
+        app.chat
+            .messages
+            .push(ChatEntry::Error("preserved chat".into()));
+        app.models.reasoning_effort = Some("high".into());
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::MeshNodes(MeshNodesInfo {
+                nodes: vec![RemoteNodeInfo {
+                    id: "node-1".into(),
+                    label: "Remote".into(),
+                    ..Default::default()
+                }],
+            })),
+        );
+
+        assert_eq!(app.mesh.selected_mesh_node_id(), Some("node-1"));
+        assert_eq!(
+            effects,
+            vec![Effect::Command(Command::ListRemoteSessions {
+                node_id: "node-1".into(),
+                offset: 0,
+                limit: 50,
+            })]
+        );
+        assert_eq!(app.auth.filter, "preserved auth");
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::Error(message)] if message == "preserved chat"
+        ));
+        assert_eq!(app.models.reasoning_effort.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn auth_acp_route_mutates_only_auth_and_explicit_diagnostic_effect_targets() {
+        let mut app = App::new();
+        app.mesh.mesh_nodes = vec![RemoteNodeInfo {
+            id: "node-1".into(),
+            label: "Remote".into(),
+            ..Default::default()
+        }];
+        app.chat
+            .messages
+            .push(ChatEntry::Error("preserved chat".into()));
+        app.sessions.session_id = Some("session-1".into());
+        app.auth.oauth_flow = Some(OAuthFlow {
+            flow_id: "flow-1".into(),
+            provider: "openai".into(),
+            authorization_url: "https://example.com/authorize".into(),
+            flow_kind: OAuthFlowKind::RedirectCode,
+        });
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::OAuthResult(OAuthResult {
+                provider: "openai".into(),
+                status: OAuthResultStatus::Success,
+                message: "connected".into(),
+            })),
+        );
+
+        assert!(app.auth.oauth_flow.is_none());
+        assert_eq!(effects, vec![Effect::Command(Command::ListAuthProviders)]);
+        assert_eq!(app.mesh.selected_mesh_node_id(), Some("node-1"));
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::Error(message)] if message == "preserved chat"
+        ));
+        assert_eq!(app.sessions.session_id.as_deref(), Some("session-1"));
+        assert_eq!(
+            app.diagnostics
+                .logs
+                .last()
+                .map(|entry| entry.message.as_str()),
+            Some("connected")
         );
     }
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -4,11 +4,10 @@ use crate::{
     acp_state::AcpAppEvent,
     app::{App, ConnectionEvent},
     auth_state::AuthAction,
-    chat_state::ChatAction,
+    chat_state::{ChatAction, ElicitationAction},
     command::Command,
     connection_state::ConnState,
     diagnostics::LogLevel,
-    domain::chat::ChatEntry,
     handlers,
     server_manager::ServerEvent,
 };
@@ -227,31 +226,10 @@ fn handle_runtime_event(app: &mut App, event: RuntimeEvent) -> Vec<Effect> {
         RuntimeEvent::ElicitationResponseSent {
             elicitation_id,
             outcome,
-        } => {
-            let is_active = app
-                .chat
-                .elicitation
-                .as_ref()
-                .is_some_and(|state| state.elicitation_id == elicitation_id);
-            if is_active {
-                app.resolve_elicitation(&elicitation_id, &outcome);
-            } else if let Some(ChatEntry::Elicitation {
-                outcome: card_outcome,
-                ..
-            }) = app.chat.messages.iter_mut().find(|entry| {
-                matches!(
-                    entry,
-                    ChatEntry::Elicitation {
-                        elicitation_id: existing_id,
-                        ..
-                    } if existing_id == &elicitation_id
-                )
-            }) {
-                *card_outcome = Some(outcome);
-                app.render.invalidate_card_cache();
-            }
-            Vec::new()
-        }
+        } => app.apply_chat_elicitation_action(ElicitationAction::ResponseAcknowledged {
+            elicitation_id,
+            outcome,
+        }),
         RuntimeEvent::CommandFailed { command, message } => {
             let effects = if let Command::Prompt { local_id, .. } = command {
                 app.apply_chat_action(ChatAction::RuntimePromptDispatchFailed { local_id })
@@ -337,6 +315,30 @@ mod tests {
                 is_replay: false,
             }),
         )
+    }
+
+    fn supported_elicitation(elicitation_id: &str) -> AcpSessionUpdate {
+        AcpSessionUpdate::ElicitationRequested {
+            elicitation_id: elicitation_id.into(),
+            message: format!("Question {elicitation_id}"),
+            requested_schema: serde_json::json!({
+                "type": "object",
+                "properties": { "target": { "type": "string", "enum": ["staging"] } },
+                "required": ["target"]
+            }),
+            source: "builtin:question".into(),
+            allow_custom: true,
+        }
+    }
+
+    fn unsupported_elicitation(elicitation_id: &str) -> AcpSessionUpdate {
+        AcpSessionUpdate::ElicitationRequested {
+            elicitation_id: elicitation_id.into(),
+            message: format!("Question {elicitation_id}"),
+            requested_schema: serde_json::json!({ "type": "array" }),
+            source: "extension:file-picker".into(),
+            allow_custom: false,
+        }
     }
 
     fn delegation_update(
@@ -909,6 +911,188 @@ mod tests {
         ));
         assert_eq!(app.chat.streaming_content, "active stream");
         assert_eq!(app.chat.activity, ActivityState::Streaming);
+    }
+
+    #[test]
+    fn chat_elicitation_acp_route_is_owner_bounded_and_release_safe() {
+        let mut app = App::new();
+        app.sessions.session_id = Some("active".into());
+        app.chat.streaming_thinking = "plan".into();
+        app.chat.streaming_thinking_message_id = Some("assistant-1".into());
+        app.chat.streaming_content = "answer".into();
+        app.chat.streaming_content_message_id = Some("assistant-1".into());
+        app.chat.scroll_offset = 8;
+        app.render.streaming_cache.store(6, Vec::new());
+        app.render.streaming_thinking_cache.store(4, Vec::new());
+        app.render.card_cache.processed_messages = 7;
+        let log_count_before = app.diagnostics.logs.len();
+
+        let effects = apply_session_update(&mut app, supported_elicitation("elic-live"));
+        assert!(effects.is_empty());
+        assert_eq!(
+            app.chat
+                .elicitation
+                .as_ref()
+                .map(|state| state.elicitation_id.as_str()),
+            Some("elic-live")
+        );
+        assert!(app.chat.elicitation_ui.is_some());
+        assert_eq!(app.chat.scroll_offset, 0);
+        assert!(app.chat.streaming_content.is_empty());
+        assert!(app.chat.streaming_thinking.is_empty());
+        assert!(app.render.streaming_cache.get(6).is_none());
+        assert!(app.render.streaming_thinking_cache.get(4).is_none());
+        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [
+                ChatEntry::Assistant { content, thinking: Some(thinking), message_id: Some(message_id) },
+                ChatEntry::Elicitation { elicitation_id, outcome: None, .. },
+            ] if content == "answer"
+                && thinking == "plan"
+                && message_id == "assistant-1"
+                && elicitation_id == "elic-live"
+        ));
+        assert_eq!(
+            app.diagnostics.status,
+            "question - answer in the panel above input"
+        );
+        let diagnostics = &app.diagnostics.logs[log_count_before..];
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].level, LogLevel::Info);
+        assert_eq!(diagnostics[0].target, "elicitation");
+        assert_eq!(
+            diagnostics[0].message,
+            "question - answer in the panel above input"
+        );
+
+        app.render.streaming_cache.store(9, Vec::new());
+        app.render.streaming_thinking_cache.store(10, Vec::new());
+        app.render.card_cache.processed_messages = 2;
+        let log_count_before_duplicate = app.diagnostics.logs.len();
+        let effects = apply_session_update(&mut app, supported_elicitation("elic-live"));
+        assert!(effects.is_empty());
+        assert_eq!(app.chat.messages.len(), 2);
+        assert!(app.render.streaming_cache.get(9).is_some());
+        assert!(app.render.streaming_thinking_cache.get(10).is_some());
+        assert_eq!(app.render.card_cache.processed_messages, 2);
+        assert_eq!(app.diagnostics.logs.len(), log_count_before_duplicate);
+    }
+
+    #[test]
+    fn chat_elicitation_replay_and_unsupported_routes_preserve_exact_behavior() {
+        let mut app = App::new();
+        app.sessions.session_id = Some("active".into());
+        app.render.streaming_cache.store(5, Vec::new());
+        app.render.streaming_thinking_cache.store(6, Vec::new());
+        app.render.card_cache.processed_messages = 7;
+        let log_count_before_replay = app.diagnostics.logs.len();
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::SessionReplay {
+                session_id: "active".into(),
+                updates: vec![supported_elicitation("elic-replay")],
+            }),
+        );
+        assert!(effects.is_empty());
+        assert!(app.chat.elicitation.is_none());
+        assert!(app.chat.elicitation_ui.is_none());
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::Elicitation { elicitation_id, outcome: None, .. }]
+                if elicitation_id == "elic-replay"
+        ));
+        assert!(app.render.streaming_cache.get(5).is_some());
+        assert!(app.render.streaming_thinking_cache.get(6).is_some());
+        assert_eq!(app.render.card_cache.processed_messages, 7);
+        assert_eq!(
+            app.diagnostics.status,
+            "question - answer in the panel above input"
+        );
+        let replay_diagnostics = &app.diagnostics.logs[log_count_before_replay..];
+        assert_eq!(replay_diagnostics.len(), 2);
+        assert_eq!(replay_diagnostics[0].level, LogLevel::Info);
+        assert_eq!(replay_diagnostics[0].target, "session");
+        assert_eq!(replay_diagnostics[0].message, "session replay: 1 update(s)");
+        assert_eq!(replay_diagnostics[1].level, LogLevel::Info);
+        assert_eq!(replay_diagnostics[1].target, "elicitation");
+        assert_eq!(
+            replay_diagnostics[1].message,
+            "question - answer in the panel above input"
+        );
+
+        let log_count_before_unsupported = app.diagnostics.logs.len();
+        let effects = apply_session_update(&mut app, unsupported_elicitation("elic-unsupported"));
+        assert!(effects.is_empty());
+        assert!(app.chat.elicitation.is_none());
+        assert!(app.chat.elicitation_ui.is_none());
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [
+                ChatEntry::Elicitation { elicitation_id: replay, outcome: None, .. },
+                ChatEntry::Elicitation { elicitation_id: unsupported, outcome: Some(outcome), .. },
+            ] if replay == "elic-replay"
+                && unsupported == "elic-unsupported"
+                && outcome == "unsupported schema - cannot answer in TUI"
+        ));
+        assert_eq!(app.render.card_cache.processed_messages, 7);
+        assert_eq!(
+            app.diagnostics.status,
+            "question skipped - unsupported schema"
+        );
+        let unsupported_diagnostic = app
+            .diagnostics
+            .logs
+            .get(log_count_before_unsupported)
+            .expect("unsupported diagnostic");
+        assert_eq!(unsupported_diagnostic.level, LogLevel::Warn);
+        assert_eq!(unsupported_diagnostic.target, "elicitation");
+        assert_eq!(
+            unsupported_diagnostic.message,
+            "question skipped - unsupported schema"
+        );
+    }
+
+    #[test]
+    fn inactive_child_elicitation_stays_in_delegate_state_without_chat_mutation() {
+        let mut app = App::new();
+        app.sessions.session_id = Some("parent".into());
+        add_elicitation(&mut app, "active-elicitation", true);
+        app.chat.streaming_content = "active stream".into();
+        app.render.card_cache.processed_messages = 6;
+        app.diagnostics.status = "preserved status".into();
+        let log_count_before = app.diagnostics.logs.len();
+
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::SessionUpdate {
+                session_id: "child-1".into(),
+                update: supported_elicitation("child-elicitation"),
+                is_replay: false,
+            }),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(
+            app.chat
+                .elicitation
+                .as_ref()
+                .map(|state| state.elicitation_id.as_str()),
+            Some("active-elicitation")
+        );
+        assert!(app.chat.elicitation_ui.is_some());
+        assert_eq!(app.chat.streaming_content, "active stream");
+        assert_eq!(app.chat.messages.len(), 1);
+        assert_eq!(app.render.card_cache.processed_messages, 6);
+        assert_eq!(app.diagnostics.status, "preserved status");
+        assert_eq!(app.diagnostics.logs.len(), log_count_before);
+        assert!(matches!(
+            &app.delegates.pending_delegate_child_states["child-1"],
+            DelegateChildState::PendingElicitation { elicitation_id, message, source, .. }
+                if elicitation_id == "child-elicitation"
+                    && message == "Question child-elicitation"
+                    && source == "builtin:question"
+        ));
     }
 
     #[test]
@@ -2518,6 +2702,12 @@ mod tests {
     fn elicitation_response_ack_resolves_the_matching_active_card() {
         let mut app = App::new();
         add_elicitation(&mut app, "elic-1", true);
+        app.connection.conn = ConnState::Connected;
+        app.render.streaming_cache.store(3, Vec::new());
+        app.render.streaming_thinking_cache.store(4, Vec::new());
+        app.render.card_cache.processed_messages = 5;
+        app.diagnostics.status = "question pending".into();
+        let log_count_before = app.diagnostics.logs.len();
 
         let effects = update(
             &mut app,
@@ -2535,12 +2725,25 @@ mod tests {
             [ChatEntry::Elicitation { elicitation_id, outcome: Some(outcome), .. }]
                 if elicitation_id == "elic-1" && outcome == "accepted"
         ));
+        assert!(app.render.streaming_cache.get(3).is_some());
+        assert!(app.render.streaming_thinking_cache.get(4).is_some());
+        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert_eq!(app.diagnostics.status, "ready");
+        let diagnostics = &app.diagnostics.logs[log_count_before..];
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].level, LogLevel::Debug);
+        assert_eq!(diagnostics[0].target, "activity");
+        assert_eq!(diagnostics[0].message, "ready");
     }
 
     #[test]
     fn elicitation_command_failure_leaves_active_card_pending() {
         let mut app = App::new();
         add_elicitation(&mut app, "elic-1", true);
+        app.render.streaming_cache.store(3, Vec::new());
+        app.render.streaming_thinking_cache.store(4, Vec::new());
+        app.render.card_cache.processed_messages = 5;
+        let log_count_before = app.diagnostics.logs.len();
 
         let effects = update(
             &mut app,
@@ -2568,7 +2771,15 @@ mod tests {
             [ChatEntry::Elicitation { elicitation_id, outcome: None, .. }]
                 if elicitation_id == "elic-1"
         ));
+        assert!(app.render.streaming_cache.get(3).is_some());
+        assert!(app.render.streaming_thinking_cache.get(4).is_some());
+        assert_eq!(app.render.card_cache.processed_messages, 5);
         assert_eq!(app.diagnostics.status, "channel closed");
+        let diagnostics = &app.diagnostics.logs[log_count_before..];
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].level, LogLevel::Error);
+        assert_eq!(diagnostics[0].target, "command");
+        assert_eq!(diagnostics[0].message, "channel closed");
     }
 
     #[test]
@@ -2576,7 +2787,11 @@ mod tests {
         let mut app = App::new();
         add_elicitation(&mut app, "elic-old", false);
         add_elicitation(&mut app, "elic-new", true);
+        app.render.streaming_cache.store(3, Vec::new());
+        app.render.streaming_thinking_cache.store(4, Vec::new());
         app.render.card_cache.processed_messages = 2;
+        app.diagnostics.status = "newer question pending".into();
+        let log_count_before = app.diagnostics.logs.len();
 
         let effects = update(
             &mut app,
@@ -2595,7 +2810,11 @@ mod tests {
             Some("elic-new")
         );
         assert!(app.chat.elicitation_ui.is_some());
+        assert!(app.render.streaming_cache.get(3).is_some());
+        assert!(app.render.streaming_thinking_cache.get(4).is_some());
         assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert_eq!(app.diagnostics.status, "newer question pending");
+        assert_eq!(app.diagnostics.logs.len(), log_count_before);
         assert!(matches!(
             app.chat.messages.as_slice(),
             [
@@ -2603,6 +2822,82 @@ mod tests {
                 ChatEntry::Elicitation { elicitation_id: new_id, outcome: None, .. },
             ] if old_id == "elic-old" && outcome == "accepted" && new_id == "elic-new"
         ));
+    }
+
+    #[test]
+    fn unknown_elicitation_ack_is_a_complete_noop() {
+        let mut app = App::new();
+        add_elicitation(&mut app, "elic-active", true);
+        app.render.streaming_cache.store(3, Vec::new());
+        app.render.streaming_thinking_cache.store(4, Vec::new());
+        app.render.card_cache.processed_messages = 5;
+        app.diagnostics.status = "question pending".into();
+        let log_count_before = app.diagnostics.logs.len();
+
+        let effects = update(
+            &mut app,
+            AppEvent::Runtime(RuntimeEvent::ElicitationResponseSent {
+                elicitation_id: "missing".into(),
+                outcome: "accepted".into(),
+            }),
+        );
+
+        assert!(effects.is_empty());
+        assert_eq!(
+            app.chat
+                .elicitation
+                .as_ref()
+                .map(|state| state.elicitation_id.as_str()),
+            Some("elic-active")
+        );
+        assert!(app.chat.elicitation_ui.is_some());
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::Elicitation { elicitation_id, outcome: None, .. }]
+                if elicitation_id == "elic-active"
+        ));
+        assert!(app.render.streaming_cache.get(3).is_some());
+        assert!(app.render.streaming_thinking_cache.get(4).is_some());
+        assert_eq!(app.render.card_cache.processed_messages, 5);
+        assert_eq!(app.diagnostics.status, "question pending");
+        assert_eq!(app.diagnostics.logs.len(), log_count_before);
+    }
+
+    #[test]
+    fn duplicate_elicitation_ack_rewrites_and_invalidates_again_without_status_refresh() {
+        let mut app = App::new();
+        add_elicitation(&mut app, "elic-1", false);
+        app.render.card_cache.processed_messages = 5;
+        app.diagnostics.status = "preserved status".into();
+        let log_count_before = app.diagnostics.logs.len();
+
+        let first_effects = update(
+            &mut app,
+            AppEvent::Runtime(RuntimeEvent::ElicitationResponseSent {
+                elicitation_id: "elic-1".into(),
+                outcome: "accepted".into(),
+            }),
+        );
+        assert!(first_effects.is_empty());
+        assert_eq!(app.render.card_cache.processed_messages, 0);
+        app.render.card_cache.processed_messages = 6;
+
+        let duplicate_effects = update(
+            &mut app,
+            AppEvent::Runtime(RuntimeEvent::ElicitationResponseSent {
+                elicitation_id: "elic-1".into(),
+                outcome: "declined".into(),
+            }),
+        );
+        assert!(duplicate_effects.is_empty());
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::Elicitation { elicitation_id, outcome: Some(outcome), .. }]
+                if elicitation_id == "elic-1" && outcome == "declined"
+        ));
+        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert_eq!(app.diagnostics.status, "preserved status");
+        assert_eq!(app.diagnostics.logs.len(), log_count_before);
     }
 
     #[test]

--- a/src/application.rs
+++ b/src/application.rs
@@ -271,6 +271,7 @@ mod tests {
     use super::*;
     use crate::auth_state::AuthUiNotice;
     use crate::{
+        acp_state::AcpSessionUpdate,
         chat_state::ElicitationUiState,
         command::SessionListRequest,
         composer_state::FileIndexEntryLite,
@@ -323,6 +324,17 @@ mod tests {
             description: None,
             capabilities: Vec::new(),
         }
+    }
+
+    fn apply_session_update(app: &mut App, update_value: AcpSessionUpdate) -> Vec<Effect> {
+        update(
+            app,
+            AppEvent::Acp(AcpAppEvent::SessionUpdate {
+                session_id: "active".into(),
+                update: update_value,
+                is_replay: false,
+            }),
+        )
     }
 
     fn delegation_update(
@@ -473,11 +485,13 @@ mod tests {
     fn provisional_delegate_acp_route_reconciles_without_reordering_chat_tool_state() {
         let mut app = App::new();
         app.sessions.session_id = Some("parent".into());
-        app.chat.messages.push(ChatEntry::Assistant {
-            content: "before delegate".into(),
-            thinking: None,
-            message_id: Some("assistant-1".into()),
-        });
+        app.chat.streaming_content = "before delegate".into();
+        app.chat.streaming_content_message_id = Some("assistant-1".into());
+        app.chat.streaming_thinking = "delegate plan".into();
+        app.chat.streaming_thinking_message_id = Some("assistant-1".into());
+        app.render.streaming_cache.store(15, Vec::new());
+        app.render.streaming_thinking_cache.store(13, Vec::new());
+        app.render.card_cache.processed_messages = 7;
 
         let effects = update(
             &mut app,
@@ -495,6 +509,24 @@ mod tests {
             }),
         );
         assert!(effects.is_empty());
+        assert!(app.sessions.session_activity.contains_key("parent"));
+        assert_eq!(
+            app.chat.activity,
+            ActivityState::RunningTool {
+                name: "delegate".into()
+            }
+        );
+        assert_eq!(app.chat.session_stats.total_tool_calls, 1);
+        assert!(app.chat.streaming_content.is_empty());
+        assert!(app.chat.streaming_thinking.is_empty());
+        assert!(app.render.streaming_cache.get(15).is_none());
+        assert!(app.render.streaming_thinking_cache.get(13).is_none());
+        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert_eq!(app.diagnostics.status, "tool: delegate");
+        let diagnostic = app.diagnostics.logs.last().expect("delegate tool status");
+        assert_eq!(diagnostic.level, LogLevel::Debug);
+        assert_eq!(diagnostic.target, "tool");
+        assert_eq!(diagnostic.message, "tool: delegate");
         assert_eq!(app.delegates.delegate_entries.len(), 1);
         assert_eq!(
             app.delegates.delegate_entries[0].delegation_id,
@@ -504,7 +536,7 @@ mod tests {
         assert!(matches!(
             app.chat.messages.as_slice(),
             [
-                ChatEntry::Assistant { content, .. },
+                ChatEntry::Assistant { content, thinking: Some(thinking), message_id: Some(message_id) },
                 ChatEntry::ToolCall {
                     tool_call_id: Some(tool_call_id),
                     name,
@@ -512,6 +544,8 @@ mod tests {
                     detail: ToolDetail::Summary(summary),
                 },
             ] if content == "before delegate"
+                && thinking == "delegate plan"
+                && message_id == "assistant-1"
                 && tool_call_id == "delegate-call"
                 && name == "delegate"
                 && summary == "(coder) Implement the feature"
@@ -537,6 +571,246 @@ mod tests {
         assert_eq!(entry.target_agent_id.as_deref(), Some("coder"));
         assert_eq!(entry.objective, "Implement the feature");
         assert!(app.delegates.pending_delegate_tool_calls.is_empty());
+    }
+
+    #[test]
+    fn chat_tool_start_acp_route_is_owner_bounded_and_release_safe() {
+        let mut app = App::new();
+        app.sessions.session_id = Some("active".into());
+        app.chat.suppress_turn_output = true;
+        app.chat.activity = ActivityState::Thinking;
+        app.chat.streaming_content = "preserved while suppressed".into();
+        app.chat.streaming_content_message_id = Some("assistant-suppressed".into());
+        app.render.streaming_cache.store(26, Vec::new());
+        app.render.streaming_thinking_cache.store(9, Vec::new());
+        app.render.card_cache.processed_messages = 8;
+        let status_before = app.diagnostics.status.clone();
+        let log_count_before = app.diagnostics.logs.len();
+
+        let effects = apply_session_update(
+            &mut app,
+            AcpSessionUpdate::ToolCallStart {
+                tool_call_id: Some("shell-1".into()),
+                name: "shell".into(),
+                arguments: Some(serde_json::json!({ "command": "cargo check" })),
+            },
+        );
+        assert!(effects.is_empty());
+        assert!(app.sessions.session_activity.contains_key("active"));
+        assert_eq!(app.chat.activity, ActivityState::Thinking);
+        assert_eq!(app.chat.streaming_content, "preserved while suppressed");
+        assert!(app.chat.messages.is_empty());
+        assert_eq!(app.chat.session_stats.total_tool_calls, 0);
+        assert_eq!(app.diagnostics.status, status_before);
+        assert_eq!(app.diagnostics.logs.len(), log_count_before);
+        assert!(app.render.streaming_cache.get(26).is_some());
+        assert!(app.render.streaming_thinking_cache.get(9).is_some());
+        assert_eq!(app.render.card_cache.processed_messages, 8);
+
+        app.chat.suppress_turn_output = false;
+        app.chat.streaming_thinking = "plan".into();
+        app.chat.streaming_thinking_message_id = Some("assistant-suppressed".into());
+        let effects = apply_session_update(
+            &mut app,
+            AcpSessionUpdate::ToolCallStart {
+                tool_call_id: Some("shell-1".into()),
+                name: "shell".into(),
+                arguments: Some(serde_json::json!({ "command": "cargo check" })),
+            },
+        );
+        assert!(effects.is_empty());
+        assert_eq!(
+            app.chat.activity,
+            ActivityState::RunningTool {
+                name: "shell".into()
+            }
+        );
+        assert_eq!(app.chat.session_stats.total_tool_calls, 1);
+        assert!(app.chat.streaming_content.is_empty());
+        assert!(app.chat.streaming_thinking.is_empty());
+        assert!(app.render.streaming_cache.get(26).is_none());
+        assert!(app.render.streaming_thinking_cache.get(9).is_none());
+        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert_eq!(app.diagnostics.status, "tool: shell");
+        let diagnostic = app.diagnostics.logs.last().expect("shell tool status");
+        assert_eq!(diagnostic.level, LogLevel::Debug);
+        assert_eq!(diagnostic.target, "tool");
+        assert_eq!(diagnostic.message, "tool: shell");
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [
+                ChatEntry::Assistant { content, thinking: Some(thinking), message_id: Some(message_id) },
+                ChatEntry::ToolCall { tool_call_id: Some(tool_call_id), name, is_error: false, detail: ToolDetail::Shell { command, .. } },
+            ] if content == "preserved while suppressed"
+                && thinking == "plan"
+                && message_id == "assistant-suppressed"
+                && tool_call_id == "shell-1"
+                && name == "shell"
+                && command == "cargo check"
+        ));
+
+        app.render.streaming_cache.store(15, Vec::new());
+        app.render.streaming_thinking_cache.store(16, Vec::new());
+        app.render.card_cache.processed_messages = 9;
+        let effects = apply_session_update(
+            &mut app,
+            AcpSessionUpdate::ToolCallStart {
+                tool_call_id: Some("question-1".into()),
+                name: "question".into(),
+                arguments: Some(serde_json::json!({ "prompt": "Continue?" })),
+            },
+        );
+        assert!(effects.is_empty());
+        assert_eq!(
+            app.chat.activity,
+            ActivityState::RunningTool {
+                name: "question".into()
+            }
+        );
+        assert_eq!(app.chat.session_stats.total_tool_calls, 1);
+        assert_eq!(app.chat.messages.len(), 2);
+        assert!(app.render.streaming_cache.get(15).is_some());
+        assert!(app.render.streaming_thinking_cache.get(16).is_some());
+        assert_eq!(app.render.card_cache.processed_messages, 9);
+        assert_eq!(app.diagnostics.status, "tool: question");
+        let diagnostic = app.diagnostics.logs.last().expect("question tool status");
+        assert_eq!(diagnostic.level, LogLevel::Debug);
+        assert_eq!(diagnostic.target, "tool");
+        assert_eq!(diagnostic.message, "tool: question");
+
+        app.render.streaming_cache.store(17, Vec::new());
+        app.render.streaming_thinking_cache.store(18, Vec::new());
+        app.render.card_cache.processed_messages = 10;
+        let effects = apply_session_update(
+            &mut app,
+            AcpSessionUpdate::ToolCallStart {
+                tool_call_id: Some("shell-1".into()),
+                name: "shell".into(),
+                arguments: Some(serde_json::json!({ "command": "ignored duplicate args" })),
+            },
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.chat.session_stats.total_tool_calls, 1);
+        assert_eq!(app.chat.messages.len(), 2);
+        assert!(app.chat.streaming_thinking.is_empty());
+        assert!(app.render.streaming_cache.get(17).is_some());
+        assert!(app.render.streaming_thinking_cache.get(18).is_none());
+        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert!(matches!(
+            &app.chat.messages[1],
+            ChatEntry::ToolCall { detail: ToolDetail::Shell { command, .. }, .. }
+                if command == "cargo check"
+        ));
+    }
+
+    #[test]
+    fn chat_tool_end_acp_route_is_idempotent_and_release_safe() {
+        let mut app = App::new();
+        app.sessions.session_id = Some("active".into());
+        app.render.streaming_cache.store(11, Vec::new());
+        app.render.streaming_thinking_cache.store(12, Vec::new());
+        app.render.card_cache.processed_messages = 7;
+
+        let effects = apply_session_update(
+            &mut app,
+            AcpSessionUpdate::ToolCallEnd {
+                tool_call_id: Some("tool-1".into()),
+                name: "shell".into(),
+                is_error: false,
+                result: Some("successful before start".into()),
+            },
+        );
+        assert!(effects.is_empty());
+        assert!(app.sessions.session_activity.contains_key("active"));
+        assert!(app.chat.messages.is_empty());
+        assert!(app.render.streaming_cache.get(11).is_some());
+        assert!(app.render.streaming_thinking_cache.get(12).is_some());
+        assert_eq!(app.render.card_cache.processed_messages, 7);
+
+        let failed_end = AcpSessionUpdate::ToolCallEnd {
+            tool_call_id: Some("tool-1".into()),
+            name: "shell".into(),
+            is_error: true,
+            result: Some("failed before start".into()),
+        };
+        let effects = apply_session_update(&mut app, failed_end.clone());
+        assert!(effects.is_empty());
+        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::ToolCall { tool_call_id: Some(id), name, is_error: true, detail: ToolDetail::Summary(detail) }]
+                if id == "tool-1" && name == "shell (failed)" && detail == "failed before start"
+        ));
+
+        app.render.card_cache.processed_messages = 8;
+        let effects = apply_session_update(&mut app, failed_end);
+        assert!(effects.is_empty());
+        assert_eq!(app.chat.messages.len(), 1);
+        assert_eq!(app.render.card_cache.processed_messages, 8);
+
+        app.render.streaming_cache.store(13, Vec::new());
+        app.render.streaming_thinking_cache.store(14, Vec::new());
+        app.render.card_cache.processed_messages = 9;
+        let effects = apply_session_update(
+            &mut app,
+            AcpSessionUpdate::ToolCallStart {
+                tool_call_id: Some("tool-1".into()),
+                name: "shell".into(),
+                arguments: Some(serde_json::json!({ "command": "echo late" })),
+            },
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.chat.session_stats.total_tool_calls, 0);
+        assert_eq!(app.chat.messages.len(), 1);
+        assert!(app.render.streaming_cache.get(13).is_some());
+        assert!(app.render.streaming_thinking_cache.get(14).is_none());
+        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert_eq!(app.diagnostics.status, "tool: shell");
+        let diagnostic = app.diagnostics.logs.last().expect("late shell status");
+        assert_eq!(diagnostic.level, LogLevel::Debug);
+        assert_eq!(diagnostic.target, "tool");
+        assert_eq!(diagnostic.message, "tool: shell");
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::ToolCall { tool_call_id: Some(id), name, is_error: true, detail: ToolDetail::Shell { command, output_tail: None, .. } }]
+                if id == "tool-1" && name == "shell" && command == "echo late"
+        ));
+
+        app.render.streaming_cache.store(15, Vec::new());
+        app.render.streaming_thinking_cache.store(16, Vec::new());
+        app.render.card_cache.processed_messages = 10;
+        let effects = apply_session_update(
+            &mut app,
+            AcpSessionUpdate::ToolCallEnd {
+                tool_call_id: Some("tool-1".into()),
+                name: "shell".into(),
+                is_error: true,
+                result: Some("line one\nline two".into()),
+            },
+        );
+        assert!(effects.is_empty());
+        assert!(app.render.streaming_cache.get(15).is_some());
+        assert!(app.render.streaming_thinking_cache.get(16).is_some());
+        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::ToolCall { is_error: true, detail: ToolDetail::Shell { output_tail: Some(tail), .. }, .. }]
+                if tail.lines == ["line one", "line two"]
+        ));
+
+        app.render.card_cache.processed_messages = 11;
+        let effects = apply_session_update(
+            &mut app,
+            AcpSessionUpdate::ToolCallEnd {
+                tool_call_id: Some("tool-1".into()),
+                name: "shell".into(),
+                is_error: true,
+                result: Some("line one\nline two".into()),
+            },
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.chat.messages.len(), 1);
+        assert_eq!(app.render.card_cache.processed_messages, 11);
     }
 
     #[test]

--- a/src/auth_state.rs
+++ b/src/auth_state.rs
@@ -1,3 +1,6 @@
+use crate::application::Effect;
+use crate::command::Command;
+use crate::diagnostics::LogLevel;
 use crate::domain::auth::{AuthProviderEntry, OAuthFlow, OAuthResult};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -5,6 +8,26 @@ pub(crate) struct AuthUiNotice {
     pub(crate) provider: Option<String>,
     pub(crate) success: bool,
     pub(crate) message: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum AuthAction {
+    Providers(Vec<AuthProviderEntry>),
+    OAuthFlowStarted(OAuthFlow),
+    OAuthResult(OAuthResult),
+    ClipboardFinished { provider: String, success: bool },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AuthCoordination {
+    pub(crate) level: LogLevel,
+    pub(crate) message: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct AuthOutcome {
+    pub(crate) diagnostics: Vec<AuthCoordination>,
+    pub(crate) effects: Vec<Effect>,
 }
 
 /// Which sub-panel is active in the provider auth popup.
@@ -37,6 +60,64 @@ pub(crate) struct AuthState {
 }
 
 impl AuthState {
+    pub(crate) fn reduce(&mut self, action: AuthAction) -> AuthOutcome {
+        match action {
+            AuthAction::Providers(providers) => {
+                self.providers = providers;
+                AuthOutcome {
+                    diagnostics: vec![AuthCoordination {
+                        level: LogLevel::Debug,
+                        message: format!("{} auth provider(s)", self.providers.len()),
+                    }],
+                    effects: Vec::new(),
+                }
+            }
+            AuthAction::OAuthFlowStarted(flow) => {
+                let provider = flow.provider.clone();
+                self.begin_oauth_flow(flow);
+                AuthOutcome {
+                    diagnostics: vec![AuthCoordination {
+                        level: LogLevel::Info,
+                        message: format!("OAuth flow started for {provider}"),
+                    }],
+                    effects: Vec::new(),
+                }
+            }
+            AuthAction::OAuthResult(result) => {
+                let is_success = result.is_success();
+                let level = if is_success {
+                    LogLevel::Info
+                } else {
+                    LogLevel::Warn
+                };
+                let message = result.message.clone();
+                let applied_success = self.apply_oauth_result(result);
+                debug_assert_eq!(applied_success, is_success);
+                AuthOutcome {
+                    diagnostics: vec![AuthCoordination { level, message }],
+                    effects: vec![Effect::Command(Command::ListAuthProviders)],
+                }
+            }
+            AuthAction::ClipboardFinished { provider, success } => {
+                if success {
+                    self.ui_notice = Some(AuthUiNotice {
+                        provider: Some(provider),
+                        success: true,
+                        message: "Copied to clipboard".into(),
+                    });
+                    self.clipboard_fallback = None;
+                } else {
+                    self.ui_notice = None;
+                    self.clipboard_fallback = self
+                        .oauth_flow
+                        .as_ref()
+                        .map(|flow| flow.authorization_url.clone());
+                }
+                AuthOutcome::default()
+            }
+        }
+    }
+
     pub(crate) fn new() -> Self {
         Self {
             providers: Vec::new(),
@@ -171,6 +252,145 @@ mod tests {
             status,
             message: message.into(),
         }
+    }
+
+    #[test]
+    fn reducer_replaces_provider_catalog_and_reports_exact_count() {
+        let mut auth = AuthState::new();
+        auth.providers = vec![provider("stale", "Stale")];
+
+        let outcome = auth.reduce(AuthAction::Providers(vec![
+            provider("openai", "OpenAI"),
+            provider("anthropic", "Anthropic"),
+        ]));
+
+        assert_eq!(auth.providers.len(), 2);
+        assert_eq!(auth.providers[0].provider, "openai");
+        assert_eq!(
+            outcome,
+            AuthOutcome {
+                diagnostics: vec![AuthCoordination {
+                    level: LogLevel::Debug,
+                    message: "2 auth provider(s)".into(),
+                }],
+                effects: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn reducer_begins_oauth_flow_with_exact_state_and_diagnostic() {
+        let mut auth = AuthState::new();
+        auth.oauth_response = "stale response".into();
+        auth.oauth_response_cursor = auth.oauth_response.len();
+        auth.last_result = Some(oauth_result(
+            "openai",
+            OAuthResultStatus::Failure,
+            "old result",
+        ));
+        let flow = oauth_flow("openai");
+
+        let outcome = auth.reduce(AuthAction::OAuthFlowStarted(flow.clone()));
+
+        assert_eq!(auth.oauth_flow, Some(flow));
+        assert_eq!(auth.panel, AuthPanel::OAuthFlow);
+        assert!(auth.oauth_response.is_empty());
+        assert_eq!(auth.oauth_response_cursor, 0);
+        assert!(auth.last_result.is_none());
+        assert_eq!(
+            outcome,
+            AuthOutcome {
+                diagnostics: vec![AuthCoordination {
+                    level: LogLevel::Info,
+                    message: "OAuth flow started for openai".into(),
+                }],
+                effects: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn reducer_oauth_results_always_refresh_providers_and_preserve_failure_flow() {
+        let mut auth = AuthState::new();
+        let flow = oauth_flow("openai");
+        auth.oauth_flow = Some(flow.clone());
+        auth.panel = AuthPanel::OAuthFlow;
+
+        let failed = auth.reduce(AuthAction::OAuthResult(oauth_result(
+            "openai",
+            OAuthResultStatus::Failure,
+            "authorization denied",
+        )));
+
+        assert_eq!(auth.oauth_flow, Some(flow));
+        assert_eq!(auth.panel, AuthPanel::OAuthFlow);
+        assert_eq!(
+            failed,
+            AuthOutcome {
+                diagnostics: vec![AuthCoordination {
+                    level: LogLevel::Warn,
+                    message: "authorization denied".into(),
+                }],
+                effects: vec![Effect::Command(Command::ListAuthProviders)],
+            }
+        );
+
+        let succeeded = auth.reduce(AuthAction::OAuthResult(oauth_result(
+            "openai",
+            OAuthResultStatus::Success,
+            "connected",
+        )));
+
+        assert!(auth.oauth_flow.is_none());
+        assert_eq!(auth.panel, AuthPanel::List);
+        assert_eq!(
+            succeeded,
+            AuthOutcome {
+                diagnostics: vec![AuthCoordination {
+                    level: LogLevel::Info,
+                    message: "connected".into(),
+                }],
+                effects: vec![Effect::Command(Command::ListAuthProviders)],
+            }
+        );
+    }
+
+    #[test]
+    fn reducer_clipboard_results_preserve_exact_feedback_and_fallback() {
+        let mut auth = AuthState::new();
+        auth.oauth_flow = Some(oauth_flow("openai"));
+        auth.ui_notice = Some(AuthUiNotice {
+            provider: None,
+            success: false,
+            message: "old notice".into(),
+        });
+
+        let failed = auth.reduce(AuthAction::ClipboardFinished {
+            provider: "openai".into(),
+            success: false,
+        });
+
+        assert_eq!(failed, AuthOutcome::default());
+        assert!(auth.ui_notice.is_none());
+        assert_eq!(
+            auth.clipboard_fallback.as_deref(),
+            Some("https://example.com/authorize")
+        );
+
+        let succeeded = auth.reduce(AuthAction::ClipboardFinished {
+            provider: "openai".into(),
+            success: true,
+        });
+
+        assert_eq!(succeeded, AuthOutcome::default());
+        assert!(matches!(
+            auth.ui_notice.as_ref(),
+            Some(notice)
+                if notice.provider.as_deref() == Some("openai")
+                    && notice.success
+                    && notice.message == "Copied to clipboard"
+        ));
+        assert!(auth.clipboard_fallback.is_none());
     }
 
     #[test]

--- a/src/auth_state.rs
+++ b/src/auth_state.rs
@@ -16,6 +16,7 @@ pub(crate) enum AuthAction {
     OAuthFlowStarted(OAuthFlow),
     OAuthResult(OAuthResult),
     ClipboardFinished { provider: String, success: bool },
+    ClearUiNotice,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -113,6 +114,10 @@ impl AuthState {
                         .as_ref()
                         .map(|flow| flow.authorization_url.clone());
                 }
+                AuthOutcome::default()
+            }
+            AuthAction::ClearUiNotice => {
+                self.ui_notice = None;
                 AuthOutcome::default()
             }
         }
@@ -391,6 +396,61 @@ mod tests {
                     && notice.message == "Copied to clipboard"
         ));
         assert!(auth.clipboard_fallback.is_none());
+    }
+
+    #[test]
+    fn reducer_notice_clear_preserves_all_other_auth_state_with_empty_outcome() {
+        let mut auth = AuthState::new();
+        auth.providers = vec![provider("openai", "OpenAI")];
+        auth.cursor = 4;
+        auth.filter = "keep".into();
+        auth.selected = Some(0);
+        auth.panel = AuthPanel::OAuthFlow;
+        auth.api_key_input = "secret".into();
+        auth.api_key_cursor = 3;
+        auth.api_key_masked = false;
+        auth.oauth_flow = Some(oauth_flow("openai"));
+        auth.oauth_response = "response".into();
+        auth.oauth_response_cursor = 5;
+        auth.last_result = Some(oauth_result(
+            "openai",
+            OAuthResultStatus::Failure,
+            "old result",
+        ));
+        auth.ui_notice = Some(AuthUiNotice {
+            provider: Some("openai".into()),
+            success: false,
+            message: "old notice".into(),
+        });
+        auth.clipboard_fallback = Some("https://example.com/fallback".into());
+
+        let outcome = auth.reduce(AuthAction::ClearUiNotice);
+
+        assert_eq!(outcome, AuthOutcome::default());
+        assert!(auth.ui_notice.is_none());
+        assert_eq!(auth.providers, vec![provider("openai", "OpenAI")]);
+        assert_eq!(auth.cursor, 4);
+        assert_eq!(auth.filter, "keep");
+        assert_eq!(auth.selected, Some(0));
+        assert_eq!(auth.panel, AuthPanel::OAuthFlow);
+        assert_eq!(auth.api_key_input, "secret");
+        assert_eq!(auth.api_key_cursor, 3);
+        assert!(!auth.api_key_masked);
+        assert_eq!(auth.oauth_flow, Some(oauth_flow("openai")));
+        assert_eq!(auth.oauth_response, "response");
+        assert_eq!(auth.oauth_response_cursor, 5);
+        assert_eq!(
+            auth.last_result,
+            Some(oauth_result(
+                "openai",
+                OAuthResultStatus::Failure,
+                "old result",
+            ))
+        );
+        assert_eq!(
+            auth.clipboard_fallback.as_deref(),
+            Some("https://example.com/fallback")
+        );
     }
 
     #[test]

--- a/src/chat_state.rs
+++ b/src/chat_state.rs
@@ -118,10 +118,36 @@ pub(crate) struct StreamingDeltaTransition {
     pub(crate) ignored_duplicate: bool,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(crate) struct ElicitationTransition {
-    pub(crate) inserted: bool,
-    pub(crate) finalized_streaming: bool,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ElicitationAction {
+    Requested {
+        elicitation_id: String,
+        message: String,
+        source: String,
+        requested_schema: serde_json::Value,
+        allow_custom: bool,
+        is_replay: bool,
+    },
+    ResponseAcknowledged {
+        elicitation_id: String,
+        outcome: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ElicitationTransition {
+    InsertedSupported {
+        is_replay: bool,
+        finalized_streaming: bool,
+    },
+    InsertedUnsupported {
+        is_replay: bool,
+        finalized_streaming: bool,
+    },
+    Duplicate,
+    ResolvedActive,
+    ResolvedStale,
+    UnknownAcknowledgement,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -287,6 +313,7 @@ pub(crate) enum ChatCoordination {
         target: &'static str,
         message: String,
     },
+    RefreshTransientStatus,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -306,6 +333,13 @@ pub(crate) struct ChatToolOutcome {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ChatUsageOutcome {
     pub(crate) transition: ChatUsageTransition,
+    pub(crate) coordination: Vec<ChatCoordination>,
+    pub(crate) effects: Vec<Effect>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ElicitationOutcome {
+    pub(crate) transition: ElicitationTransition,
     pub(crate) coordination: Vec<ChatCoordination>,
     pub(crate) effects: Vec<Effect>,
 }
@@ -654,6 +688,143 @@ impl ChatState {
             ChatUsageAction::TimingUpdated { .. } => (ChatUsageTransition::NoOp, Vec::new()),
         };
         ChatUsageOutcome {
+            transition,
+            coordination,
+            effects: Vec::new(),
+        }
+    }
+
+    pub(crate) fn reduce_elicitation(&mut self, action: ElicitationAction) -> ElicitationOutcome {
+        let (transition, coordination) = match action {
+            ElicitationAction::Requested {
+                elicitation_id,
+                message,
+                source,
+                requested_schema,
+                allow_custom,
+                is_replay,
+            } => {
+                if self.messages.iter().any(|entry| {
+                    matches!(
+                        entry,
+                        ChatEntry::Elicitation {
+                            elicitation_id: existing_id,
+                            ..
+                        } if existing_id == &elicitation_id
+                    )
+                }) {
+                    return ElicitationOutcome {
+                        transition: ElicitationTransition::Duplicate,
+                        coordination: Vec::new(),
+                        effects: Vec::new(),
+                    };
+                }
+
+                let fields = ElicitationState::parse_schema(&requested_schema);
+                let supported = !fields.is_empty();
+                let finalized_streaming = self.finalize_streaming_segment();
+                if supported && !is_replay {
+                    self.elicitation = Some(ElicitationState {
+                        elicitation_id: elicitation_id.clone(),
+                        message: message.clone(),
+                        source: source.clone(),
+                        fields,
+                        selected: std::collections::HashMap::new(),
+                        text_input: String::new(),
+                        custom_input: String::new(),
+                        allow_custom,
+                    });
+                    self.elicitation_ui = Some(ElicitationUiState::default());
+                }
+                self.messages.push(ChatEntry::Elicitation {
+                    elicitation_id,
+                    message,
+                    source,
+                    outcome: (!supported)
+                        .then(|| "unsupported schema - cannot answer in TUI".into()),
+                });
+                self.scroll_offset = 0;
+
+                let mut coordination = if finalized_streaming {
+                    vec![
+                        ChatCoordination::InvalidateContentCache,
+                        ChatCoordination::InvalidateThinkingCache,
+                        ChatCoordination::InvalidateCardCache,
+                    ]
+                } else {
+                    Vec::new()
+                };
+                let (transition, status) = if supported {
+                    (
+                        ElicitationTransition::InsertedSupported {
+                            is_replay,
+                            finalized_streaming,
+                        },
+                        ChatCoordination::Status {
+                            level: LogLevel::Info,
+                            target: "elicitation",
+                            message: "question - answer in the panel above input".into(),
+                        },
+                    )
+                } else {
+                    (
+                        ElicitationTransition::InsertedUnsupported {
+                            is_replay,
+                            finalized_streaming,
+                        },
+                        ChatCoordination::Status {
+                            level: LogLevel::Warn,
+                            target: "elicitation",
+                            message: "question skipped - unsupported schema".into(),
+                        },
+                    )
+                };
+                coordination.push(status);
+                (transition, coordination)
+            }
+            ElicitationAction::ResponseAcknowledged {
+                elicitation_id,
+                outcome,
+            } => {
+                let is_active = self
+                    .elicitation
+                    .as_ref()
+                    .is_some_and(|state| state.elicitation_id == elicitation_id);
+                let Some(card_outcome) = self.messages.iter_mut().find_map(|entry| match entry {
+                    ChatEntry::Elicitation {
+                        elicitation_id: existing_id,
+                        outcome,
+                        ..
+                    } if existing_id == &elicitation_id => Some(outcome),
+                    _ => None,
+                }) else {
+                    return ElicitationOutcome {
+                        transition: ElicitationTransition::UnknownAcknowledgement,
+                        coordination: Vec::new(),
+                        effects: Vec::new(),
+                    };
+                };
+                *card_outcome = Some(outcome);
+
+                if is_active {
+                    self.elicitation = None;
+                    self.elicitation_ui = None;
+                    (
+                        ElicitationTransition::ResolvedActive,
+                        vec![
+                            ChatCoordination::InvalidateCardCache,
+                            ChatCoordination::RefreshTransientStatus,
+                        ],
+                    )
+                } else {
+                    (
+                        ElicitationTransition::ResolvedStale,
+                        vec![ChatCoordination::InvalidateCardCache],
+                    )
+                }
+            }
+        };
+        ElicitationOutcome {
             transition,
             coordination,
             effects: Vec::new(),
@@ -1540,64 +1711,6 @@ impl ChatState {
         }
     }
 
-    pub(crate) fn push_elicitation(
-        &mut self,
-        active: Option<ElicitationState>,
-        elicitation_id: String,
-        message: String,
-        source: String,
-        outcome: Option<String>,
-    ) -> ElicitationTransition {
-        if self.messages.iter().any(|entry| {
-            matches!(
-                entry,
-                ChatEntry::Elicitation {
-                    elicitation_id: existing_id,
-                    ..
-                } if existing_id == &elicitation_id
-            )
-        }) {
-            return ElicitationTransition::default();
-        }
-
-        let finalized_streaming = self.finalize_streaming_segment();
-        if let Some(active) = active {
-            self.elicitation = Some(active);
-            self.elicitation_ui = Some(ElicitationUiState::default());
-        }
-        self.messages.push(ChatEntry::Elicitation {
-            elicitation_id,
-            message,
-            source,
-            outcome,
-        });
-        self.scroll_offset = 0;
-        ElicitationTransition {
-            inserted: true,
-            finalized_streaming,
-        }
-    }
-
-    pub(crate) fn resolve_elicitation(&mut self, elicitation_id: &str, outcome: &str) -> bool {
-        let mut resolved = false;
-        for entry in &mut self.messages {
-            if let ChatEntry::Elicitation {
-                elicitation_id: existing_id,
-                outcome: existing_outcome,
-                ..
-            } = entry
-                && existing_id == elicitation_id
-            {
-                *existing_outcome = Some(outcome.to_string());
-                resolved = true;
-                break;
-            }
-        }
-        self.elicitation = None;
-        self.elicitation_ui = None;
-        resolved
-    }
-
     pub(crate) fn backfill_elicitation_outcomes(&mut self, result_str: &str) {
         let Ok(value) = serde_json::from_str::<serde_json::Value>(result_str) else {
             return;
@@ -1984,17 +2097,22 @@ mod tests {
     #[test]
     fn elicitation_resolution_and_backfill_update_durable_cards() {
         let mut chat = ChatState::new();
-        let state = ElicitationState::new_for_test(Vec::new());
-        let transition = chat.push_elicitation(
-            Some(state),
-            "elic-1".into(),
-            "Pick".into(),
-            "question".into(),
-            None,
-        );
-        assert!(transition.inserted);
-        assert!(chat.elicitation.is_some());
-        assert!(chat.resolve_elicitation("elic-1", "responded"));
+        chat.messages.push(ChatEntry::Elicitation {
+            elicitation_id: "elic-1".into(),
+            message: "Pick".into(),
+            source: "question".into(),
+            outcome: None,
+        });
+        let mut active = ElicitationState::new_for_test(Vec::new());
+        active.elicitation_id = "elic-1".into();
+        chat.elicitation = Some(active);
+        chat.elicitation_ui = Some(ElicitationUiState::default());
+
+        let outcome = chat.reduce_elicitation(ElicitationAction::ResponseAcknowledged {
+            elicitation_id: "elic-1".into(),
+            outcome: "responded".into(),
+        });
+        assert_eq!(outcome.transition, ElicitationTransition::ResolvedActive);
         assert!(chat.elicitation.is_none());
         chat.backfill_elicitation_outcomes(
             r#"{"answers":[{"question":"Pick","answers":["Alpha","Beta"]}]}"#,
@@ -2009,25 +2127,327 @@ mod tests {
     #[test]
     fn elicitation_live_replay_duplicate_identity_is_idempotent() {
         let mut chat = ChatState::new();
-        let replay = chat.push_elicitation(
-            None,
-            "elic-1".into(),
-            "Question".into(),
-            "source".into(),
-            None,
+        let request = |is_replay| ElicitationAction::Requested {
+            elicitation_id: "elic-1".into(),
+            message: "Question".into(),
+            source: "source".into(),
+            requested_schema: serde_json::json!({
+                "type": "object",
+                "properties": { "answer": { "type": "string" } }
+            }),
+            allow_custom: false,
+            is_replay,
+        };
+        let replay = chat.reduce_elicitation(request(true));
+        assert_eq!(
+            replay.transition,
+            ElicitationTransition::InsertedSupported {
+                is_replay: true,
+                finalized_streaming: false,
+            }
         );
-        assert!(replay.inserted);
         assert!(chat.elicitation.is_none());
-        let duplicate = chat.push_elicitation(
-            Some(ElicitationState::new_for_test(Vec::new())),
-            "elic-1".into(),
-            "Question".into(),
-            "source".into(),
-            None,
-        );
-        assert_eq!(duplicate, ElicitationTransition::default());
+        let duplicate = chat.reduce_elicitation(request(false));
+        assert_eq!(duplicate.transition, ElicitationTransition::Duplicate);
+        assert!(duplicate.coordination.is_empty());
         assert_eq!(chat.messages.len(), 1);
         assert!(chat.elicitation.is_none());
+    }
+
+    #[test]
+    fn elicitation_supported_live_and_replay_have_exact_state_and_coordination() {
+        let request = |is_replay| ElicitationAction::Requested {
+            elicitation_id: "elic-1".into(),
+            message: "Choose a target".into(),
+            source: "builtin:question".into(),
+            requested_schema: serde_json::json!({
+                "type": "object",
+                "properties": { "target": { "type": "string", "enum": ["staging"] } },
+                "required": ["target"]
+            }),
+            allow_custom: true,
+            is_replay,
+        };
+
+        let mut live = ChatState::new();
+        live.scroll_offset = 9;
+        let live_outcome = live.reduce_elicitation(request(false));
+        assert_eq!(
+            live_outcome,
+            ElicitationOutcome {
+                transition: ElicitationTransition::InsertedSupported {
+                    is_replay: false,
+                    finalized_streaming: false,
+                },
+                coordination: vec![ChatCoordination::Status {
+                    level: LogLevel::Info,
+                    target: "elicitation",
+                    message: "question - answer in the panel above input".into(),
+                }],
+                effects: Vec::new(),
+            }
+        );
+        let active = live.elicitation.as_ref().expect("live active elicitation");
+        assert_eq!(active.elicitation_id, "elic-1");
+        assert_eq!(active.message, "Choose a target");
+        assert_eq!(active.source, "builtin:question");
+        assert_eq!(active.fields.len(), 1);
+        assert!(active.allow_custom);
+        assert!(live.elicitation_ui.is_some());
+        assert_eq!(live.scroll_offset, 0);
+        assert!(matches!(
+            live.messages.as_slice(),
+            [ChatEntry::Elicitation { elicitation_id, message, source, outcome: None }]
+                if elicitation_id == "elic-1"
+                    && message == "Choose a target"
+                    && source == "builtin:question"
+        ));
+
+        let mut replay = ChatState::new();
+        let replay_outcome = replay.reduce_elicitation(request(true));
+        assert_eq!(
+            replay_outcome,
+            ElicitationOutcome {
+                transition: ElicitationTransition::InsertedSupported {
+                    is_replay: true,
+                    finalized_streaming: false,
+                },
+                coordination: vec![ChatCoordination::Status {
+                    level: LogLevel::Info,
+                    target: "elicitation",
+                    message: "question - answer in the panel above input".into(),
+                }],
+                effects: Vec::new(),
+            }
+        );
+        assert!(replay.elicitation.is_none());
+        assert!(replay.elicitation_ui.is_none());
+        assert!(matches!(
+            replay.messages.as_slice(),
+            [ChatEntry::Elicitation { elicitation_id, outcome: None, .. }]
+                if elicitation_id == "elic-1"
+        ));
+    }
+
+    #[test]
+    fn elicitation_unsupported_live_and_replay_insert_outcome_without_active_state() {
+        for is_replay in [false, true] {
+            let mut chat = ChatState::new();
+            let outcome = chat.reduce_elicitation(ElicitationAction::Requested {
+                elicitation_id: format!("unsupported-{is_replay}"),
+                message: "Upload a file".into(),
+                source: "extension:file-picker".into(),
+                requested_schema: serde_json::json!({ "type": "array" }),
+                allow_custom: false,
+                is_replay,
+            });
+
+            assert_eq!(
+                outcome,
+                ElicitationOutcome {
+                    transition: ElicitationTransition::InsertedUnsupported {
+                        is_replay,
+                        finalized_streaming: false,
+                    },
+                    coordination: vec![ChatCoordination::Status {
+                        level: LogLevel::Warn,
+                        target: "elicitation",
+                        message: "question skipped - unsupported schema".into(),
+                    }],
+                    effects: Vec::new(),
+                }
+            );
+            assert!(chat.elicitation.is_none());
+            assert!(chat.elicitation_ui.is_none());
+            assert!(matches!(
+                chat.messages.as_slice(),
+                [ChatEntry::Elicitation { outcome: Some(outcome), .. }]
+                    if outcome == "unsupported schema - cannot answer in TUI"
+            ));
+        }
+    }
+
+    #[test]
+    fn elicitation_request_finalizes_stream_before_card_and_distinct_live_replaces_active() {
+        let request = |id: &str| ElicitationAction::Requested {
+            elicitation_id: id.into(),
+            message: format!("Question {id}"),
+            source: "builtin:question".into(),
+            requested_schema: serde_json::json!({
+                "type": "object",
+                "properties": { "answer": { "type": "string" } }
+            }),
+            allow_custom: false,
+            is_replay: false,
+        };
+        let mut chat = ChatState::new();
+        chat.streaming_thinking = "plan".into();
+        chat.streaming_thinking_message_id = Some("assistant-1".into());
+        chat.streaming_content = "answer".into();
+        chat.streaming_content_message_id = Some("assistant-1".into());
+
+        let first = chat.reduce_elicitation(request("elic-1"));
+        assert_eq!(
+            first.transition,
+            ElicitationTransition::InsertedSupported {
+                is_replay: false,
+                finalized_streaming: true,
+            }
+        );
+        assert_eq!(
+            first.coordination,
+            vec![
+                ChatCoordination::InvalidateContentCache,
+                ChatCoordination::InvalidateThinkingCache,
+                ChatCoordination::InvalidateCardCache,
+                ChatCoordination::Status {
+                    level: LogLevel::Info,
+                    target: "elicitation",
+                    message: "question - answer in the panel above input".into(),
+                },
+            ]
+        );
+        assert!(first.effects.is_empty());
+        assert!(matches!(
+            chat.messages.as_slice(),
+            [
+                ChatEntry::Assistant { content, thinking: Some(thinking), message_id: Some(message_id) },
+                ChatEntry::Elicitation { elicitation_id, outcome: None, .. },
+            ] if content == "answer"
+                && thinking == "plan"
+                && message_id == "assistant-1"
+                && elicitation_id == "elic-1"
+        ));
+
+        chat.streaming_content = "must remain pending".into();
+        let duplicate = chat.reduce_elicitation(request("elic-1"));
+        assert_eq!(duplicate.transition, ElicitationTransition::Duplicate);
+        assert!(duplicate.coordination.is_empty());
+        assert!(duplicate.effects.is_empty());
+        assert_eq!(chat.streaming_content, "must remain pending");
+        assert_eq!(chat.messages.len(), 2);
+        assert_eq!(
+            chat.elicitation
+                .as_ref()
+                .map(|state| state.elicitation_id.as_str()),
+            Some("elic-1")
+        );
+
+        chat.streaming_content.clear();
+        let second = chat.reduce_elicitation(request("elic-2"));
+        assert_eq!(
+            second.transition,
+            ElicitationTransition::InsertedSupported {
+                is_replay: false,
+                finalized_streaming: false,
+            }
+        );
+        assert_eq!(
+            chat.elicitation
+                .as_ref()
+                .map(|state| state.elicitation_id.as_str()),
+            Some("elic-2")
+        );
+        assert!(chat.elicitation_ui.is_some());
+        assert!(matches!(
+            chat.messages.as_slice(),
+            [
+                ChatEntry::Assistant { .. },
+                ChatEntry::Elicitation { elicitation_id: first, outcome: None, .. },
+                ChatEntry::Elicitation { elicitation_id: second, outcome: None, .. },
+            ] if first == "elic-1" && second == "elic-2"
+        ));
+    }
+
+    #[test]
+    fn elicitation_acknowledgements_type_unknown_stale_active_and_duplicate_behavior() {
+        let mut chat = ChatState::new();
+        for id in ["elic-old", "elic-new"] {
+            chat.messages.push(ChatEntry::Elicitation {
+                elicitation_id: id.into(),
+                message: format!("Question {id}"),
+                source: "builtin:question".into(),
+                outcome: None,
+            });
+        }
+        let mut active = ElicitationState::new_for_test(Vec::new());
+        active.elicitation_id = "elic-new".into();
+        chat.elicitation = Some(active);
+        chat.elicitation_ui = Some(ElicitationUiState::default());
+
+        let unknown = chat.reduce_elicitation(ElicitationAction::ResponseAcknowledged {
+            elicitation_id: "missing".into(),
+            outcome: "accepted".into(),
+        });
+        assert_eq!(
+            unknown,
+            ElicitationOutcome {
+                transition: ElicitationTransition::UnknownAcknowledgement,
+                coordination: Vec::new(),
+                effects: Vec::new(),
+            }
+        );
+        assert_eq!(
+            chat.elicitation
+                .as_ref()
+                .map(|state| state.elicitation_id.as_str()),
+            Some("elic-new")
+        );
+
+        let stale = chat.reduce_elicitation(ElicitationAction::ResponseAcknowledged {
+            elicitation_id: "elic-old".into(),
+            outcome: "declined".into(),
+        });
+        assert_eq!(stale.transition, ElicitationTransition::ResolvedStale);
+        assert_eq!(
+            stale.coordination,
+            vec![ChatCoordination::InvalidateCardCache]
+        );
+        assert!(stale.effects.is_empty());
+        assert_eq!(
+            chat.elicitation
+                .as_ref()
+                .map(|state| state.elicitation_id.as_str()),
+            Some("elic-new")
+        );
+        assert!(chat.elicitation_ui.is_some());
+
+        let active = chat.reduce_elicitation(ElicitationAction::ResponseAcknowledged {
+            elicitation_id: "elic-new".into(),
+            outcome: "accepted".into(),
+        });
+        assert_eq!(active.transition, ElicitationTransition::ResolvedActive);
+        assert_eq!(
+            active.coordination,
+            vec![
+                ChatCoordination::InvalidateCardCache,
+                ChatCoordination::RefreshTransientStatus,
+            ]
+        );
+        assert!(active.effects.is_empty());
+        assert!(chat.elicitation.is_none());
+        assert!(chat.elicitation_ui.is_none());
+
+        let duplicate = chat.reduce_elicitation(ElicitationAction::ResponseAcknowledged {
+            elicitation_id: "elic-new".into(),
+            outcome: "accepted".into(),
+        });
+        assert_eq!(duplicate.transition, ElicitationTransition::ResolvedStale);
+        assert_eq!(
+            duplicate.coordination,
+            vec![ChatCoordination::InvalidateCardCache]
+        );
+        assert!(duplicate.effects.is_empty());
+        assert!(matches!(
+            chat.messages.as_slice(),
+            [
+                ChatEntry::Elicitation { elicitation_id: old, outcome: Some(old_outcome), .. },
+                ChatEntry::Elicitation { elicitation_id: new, outcome: Some(new_outcome), .. },
+            ] if old == "elic-old"
+                && old_outcome == "declined"
+                && new == "elic-new"
+                && new_outcome == "accepted"
+        ));
     }
 
     #[test]

--- a/src/chat_state.rs
+++ b/src/chat_state.rs
@@ -11,6 +11,7 @@ use crate::domain::session::{
     UndoableTurn,
 };
 use crate::domain::tool::ToolDetail;
+use crate::tool_detail;
 
 const CANCEL_CONFIRM_TIMEOUT: Duration = Duration::from_millis(1000);
 
@@ -131,6 +132,63 @@ pub(crate) enum AssistantMessageTransition {
     Appended,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) enum ChatToolAction {
+    PrepareToolStart {
+        name: String,
+    },
+    InsertOrReconcileToolStart {
+        tool_call_id: Option<String>,
+        name: String,
+        detail: ToolDetail,
+    },
+    ToolCallEnd {
+        tool_call_id: Option<String>,
+        name: String,
+        is_error: bool,
+        result: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolStartPreparationTransition {
+    Suppressed,
+    Prepared { finalized_streaming: bool },
+    QuestionOnly { finalized_streaming: bool },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolStartInsertionTransition {
+    Reconciled,
+    Inserted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolEndTransition {
+    Updated {
+        detail_updated: bool,
+        marked_failed: bool,
+    },
+    FallbackInserted,
+    NoOp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ToolResultDetailState {
+    Shell(Option<(Vec<String>, usize)>),
+    ReadTool(Option<u64>, Option<u64>),
+    Edit(Option<usize>),
+    MultiEdit(Vec<Option<usize>>),
+    Unchanged,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ChatToolTransition {
+    StartPrepared(ToolStartPreparationTransition),
+    StartInserted(ToolStartInsertionTransition),
+    Ended(ToolEndTransition),
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ChatAction {
     TurnStarted {
@@ -190,6 +248,13 @@ pub(crate) enum ChatCoordination {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ChatOutcome {
     pub(crate) transition: ChatTransition,
+    pub(crate) coordination: Vec<ChatCoordination>,
+    pub(crate) effects: Vec<Effect>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ChatToolOutcome {
+    pub(crate) transition: ChatToolTransition,
     pub(crate) coordination: Vec<ChatCoordination>,
     pub(crate) effects: Vec<Effect>,
 }
@@ -323,6 +388,135 @@ impl ChatState {
             }
         };
         ChatOutcome {
+            transition,
+            coordination,
+            effects: Vec::new(),
+        }
+    }
+
+    pub(crate) fn reduce_tool(&mut self, action: ChatToolAction) -> ChatToolOutcome {
+        let (transition, coordination) = match action {
+            ChatToolAction::PrepareToolStart { name } => {
+                if self.suppress_turn_output {
+                    return ChatToolOutcome {
+                        transition: ChatToolTransition::StartPrepared(
+                            ToolStartPreparationTransition::Suppressed,
+                        ),
+                        coordination: Vec::new(),
+                        effects: Vec::new(),
+                    };
+                }
+
+                self.activity = ActivityState::RunningTool { name: name.clone() };
+                let finalized_streaming = self.finalize_streaming_segment();
+                let mut coordination = vec![ChatCoordination::Status {
+                    level: LogLevel::Debug,
+                    target: "tool",
+                    message: format!("tool: {name}"),
+                }];
+                if finalized_streaming {
+                    coordination.extend([
+                        ChatCoordination::InvalidateContentCache,
+                        ChatCoordination::InvalidateThinkingCache,
+                        ChatCoordination::InvalidateCardCache,
+                    ]);
+                }
+                let preparation = if name == "question" {
+                    ToolStartPreparationTransition::QuestionOnly {
+                        finalized_streaming,
+                    }
+                } else {
+                    ToolStartPreparationTransition::Prepared {
+                        finalized_streaming,
+                    }
+                };
+                (ChatToolTransition::StartPrepared(preparation), coordination)
+            }
+            ChatToolAction::InsertOrReconcileToolStart {
+                tool_call_id,
+                name,
+                detail,
+            } => {
+                if self.reconcile_tool_call_start(tool_call_id.as_deref(), &name, detail.clone()) {
+                    self.clear_streaming_thinking();
+                    (
+                        ChatToolTransition::StartInserted(ToolStartInsertionTransition::Reconciled),
+                        vec![
+                            ChatCoordination::InvalidateThinkingCache,
+                            ChatCoordination::InvalidateCardCache,
+                        ],
+                    )
+                } else {
+                    self.record_tool_call();
+                    let moved_thinking = self.push_streaming_thinking_entry();
+                    self.push_tool_call(tool_call_id, name, false, detail);
+                    (
+                        ChatToolTransition::StartInserted(ToolStartInsertionTransition::Inserted),
+                        moved_thinking
+                            .then_some(ChatCoordination::InvalidateThinkingCache)
+                            .into_iter()
+                            .collect(),
+                    )
+                }
+            }
+            ChatToolAction::ToolCallEnd {
+                tool_call_id,
+                name,
+                is_error,
+                result,
+            } => {
+                let detail_before = self
+                    .tool_call_detail(tool_call_id.as_deref())
+                    .map(tool_result_detail_state);
+                let detail_updated = result.as_deref().is_some_and(|result| {
+                    let found = tool_detail::update_tool_detail(
+                        &mut self.messages,
+                        tool_call_id.as_deref(),
+                        result,
+                    );
+                    found
+                        && detail_before.as_ref().is_some_and(|before| {
+                            self.tool_call_detail(tool_call_id.as_deref())
+                                .is_some_and(|after| before != &tool_result_detail_state(after))
+                        })
+                });
+                let failure_before = is_error
+                    .then(|| self.tool_call_error_state(tool_call_id.as_deref(), &name))
+                    .flatten();
+                let marked_failed = if failure_before.is_some() {
+                    self.mark_tool_call_failed(tool_call_id.as_deref(), &name);
+                    failure_before == Some(false)
+                } else {
+                    false
+                };
+                if is_error && failure_before.is_none() {
+                    self.push_tool_call(
+                        tool_call_id,
+                        format!("{name} (failed)"),
+                        true,
+                        result.map(ToolDetail::Summary).unwrap_or(ToolDetail::None),
+                    );
+                    (
+                        ChatToolTransition::Ended(ToolEndTransition::FallbackInserted),
+                        vec![ChatCoordination::InvalidateCardCache],
+                    )
+                } else if detail_updated || marked_failed {
+                    (
+                        ChatToolTransition::Ended(ToolEndTransition::Updated {
+                            detail_updated,
+                            marked_failed,
+                        }),
+                        vec![ChatCoordination::InvalidateCardCache],
+                    )
+                } else {
+                    (
+                        ChatToolTransition::Ended(ToolEndTransition::NoOp),
+                        Vec::new(),
+                    )
+                }
+            }
+        };
+        ChatToolOutcome {
             transition,
             coordination,
             effects: Vec::new(),
@@ -1127,6 +1321,34 @@ impl ChatState {
         false
     }
 
+    fn tool_call_detail(&self, tool_call_id: Option<&str>) -> Option<&ToolDetail> {
+        let tool_call_id = tool_call_id?;
+        self.messages.iter().rev().find_map(|entry| match entry {
+            ChatEntry::ToolCall {
+                tool_call_id: Some(existing),
+                detail,
+                ..
+            } if existing == tool_call_id => Some(detail),
+            _ => None,
+        })
+    }
+
+    fn tool_call_error_state(&self, tool_call_id: Option<&str>, tool_name: &str) -> Option<bool> {
+        let tool_call_id = tool_call_id?;
+        let fallback_name = format!("{tool_name} (failed)");
+        self.messages.iter().rev().find_map(|entry| match entry {
+            ChatEntry::ToolCall {
+                tool_call_id: Some(existing),
+                name,
+                is_error,
+                ..
+            } if existing == tool_call_id && (name == tool_name || name == &fallback_name) => {
+                Some(*is_error)
+            }
+            _ => None,
+        })
+    }
+
     pub(crate) fn mark_tool_call_failed(
         &mut self,
         tool_call_id: Option<&str>,
@@ -1266,6 +1488,26 @@ impl ChatState {
                 .flatten();
             *outcome = Some(format_outcome_labels(labels));
         }
+    }
+}
+
+fn tool_result_detail_state(detail: &ToolDetail) -> ToolResultDetailState {
+    match detail {
+        ToolDetail::Shell { output_tail, .. } => ToolResultDetailState::Shell(
+            output_tail
+                .as_ref()
+                .map(|tail| (tail.lines.clone(), tail.hidden_line_count)),
+        ),
+        ToolDetail::ReadTool {
+            start_line,
+            end_line,
+            ..
+        } => ToolResultDetailState::ReadTool(*start_line, *end_line),
+        ToolDetail::Edit { start_line, .. } => ToolResultDetailState::Edit(*start_line),
+        ToolDetail::MultiEdit { sections, .. } => ToolResultDetailState::MultiEdit(
+            sections.iter().map(|section| section.start_line).collect(),
+        ),
+        _ => ToolResultDetailState::Unchanged,
     }
 }
 
@@ -1604,6 +1846,336 @@ mod tests {
                 if id == "assistant-1" && call_id == "call-1"
         ));
         assert_eq!(chat.session_stats.total_tool_calls, 1);
+    }
+
+    #[test]
+    fn tool_reducer_suppression_is_a_typed_noop() {
+        let mut chat = ChatState::new();
+        chat.suppress_turn_output = true;
+        chat.activity = ActivityState::Thinking;
+        chat.streaming_content = "preserved".into();
+        chat.streaming_content_message_id = Some("assistant-1".into());
+        chat.session_stats.total_tool_calls = 4;
+
+        let outcome = chat.reduce_tool(ChatToolAction::PrepareToolStart {
+            name: "shell".into(),
+        });
+
+        assert_eq!(
+            outcome,
+            ChatToolOutcome {
+                transition: ChatToolTransition::StartPrepared(
+                    ToolStartPreparationTransition::Suppressed,
+                ),
+                coordination: Vec::new(),
+                effects: Vec::new(),
+            }
+        );
+        assert_eq!(chat.activity, ActivityState::Thinking);
+        assert_eq!(chat.streaming_content, "preserved");
+        assert_eq!(
+            chat.streaming_content_message_id.as_deref(),
+            Some("assistant-1")
+        );
+        assert!(chat.messages.is_empty());
+        assert_eq!(chat.session_stats.total_tool_calls, 4);
+    }
+
+    #[test]
+    fn tool_reducer_prepare_sets_status_and_finalizes_stream_in_exact_order() {
+        let mut chat = ChatState::new();
+        chat.streaming_content = "answer".into();
+        chat.streaming_content_message_id = Some("assistant-1".into());
+        chat.streaming_thinking = "plan".into();
+        chat.streaming_thinking_message_id = Some("assistant-1".into());
+
+        let outcome = chat.reduce_tool(ChatToolAction::PrepareToolStart {
+            name: "shell".into(),
+        });
+
+        assert_eq!(
+            outcome,
+            ChatToolOutcome {
+                transition: ChatToolTransition::StartPrepared(
+                    ToolStartPreparationTransition::Prepared {
+                        finalized_streaming: true,
+                    },
+                ),
+                coordination: vec![
+                    ChatCoordination::Status {
+                        level: LogLevel::Debug,
+                        target: "tool",
+                        message: "tool: shell".into(),
+                    },
+                    ChatCoordination::InvalidateContentCache,
+                    ChatCoordination::InvalidateThinkingCache,
+                    ChatCoordination::InvalidateCardCache,
+                ],
+                effects: Vec::new(),
+            }
+        );
+        assert_eq!(
+            chat.activity,
+            ActivityState::RunningTool {
+                name: "shell".into()
+            }
+        );
+        assert!(chat.streaming_content.is_empty());
+        assert!(chat.streaming_thinking.is_empty());
+        assert!(matches!(
+            chat.messages.as_slice(),
+            [ChatEntry::Assistant { content, thinking: Some(thinking), message_id: Some(id) }]
+                if content == "answer" && thinking == "plan" && id == "assistant-1"
+        ));
+    }
+
+    #[test]
+    fn tool_reducer_question_prepare_excludes_card_and_count() {
+        let mut chat = ChatState::new();
+
+        let outcome = chat.reduce_tool(ChatToolAction::PrepareToolStart {
+            name: "question".into(),
+        });
+
+        assert_eq!(
+            outcome.transition,
+            ChatToolTransition::StartPrepared(ToolStartPreparationTransition::QuestionOnly {
+                finalized_streaming: false,
+            })
+        );
+        assert_eq!(
+            outcome.coordination,
+            vec![ChatCoordination::Status {
+                level: LogLevel::Debug,
+                target: "tool",
+                message: "tool: question".into(),
+            }]
+        );
+        assert!(outcome.effects.is_empty());
+        assert_eq!(
+            chat.activity,
+            ActivityState::RunningTool {
+                name: "question".into()
+            }
+        );
+        assert!(chat.messages.is_empty());
+        assert_eq!(chat.session_stats.total_tool_calls, 0);
+    }
+
+    #[test]
+    fn tool_reducer_inserts_after_pending_thinking_and_counts_once() {
+        let mut chat = ChatState::new();
+        chat.streaming_thinking = "inspect".into();
+        chat.streaming_thinking_message_id = Some("assistant-1".into());
+        chat.session_stats.total_tool_calls = 7;
+
+        let outcome = chat.reduce_tool(ChatToolAction::InsertOrReconcileToolStart {
+            tool_call_id: Some("tool-1".into()),
+            name: "read_tool".into(),
+            detail: ToolDetail::ReadTool {
+                path: "src/lib.rs".into(),
+                start_line: Some(1),
+                end_line: Some(5),
+            },
+        });
+
+        assert_eq!(
+            outcome.transition,
+            ChatToolTransition::StartInserted(ToolStartInsertionTransition::Inserted)
+        );
+        assert_eq!(
+            outcome.coordination,
+            vec![ChatCoordination::InvalidateThinkingCache]
+        );
+        assert!(outcome.effects.is_empty());
+        assert_eq!(chat.session_stats.total_tool_calls, 8);
+        assert!(matches!(
+            chat.messages.as_slice(),
+            [
+                ChatEntry::Thinking { content, message_id: Some(message_id) },
+                ChatEntry::ToolCall { tool_call_id: Some(tool_call_id), name, is_error: false, .. },
+            ] if content == "inspect"
+                && message_id == "assistant-1"
+                && tool_call_id == "tool-1"
+                && name == "read_tool"
+        ));
+
+        chat.session_stats.total_tool_calls = u32::MAX;
+        let saturated = chat.reduce_tool(ChatToolAction::InsertOrReconcileToolStart {
+            tool_call_id: None,
+            name: "shell".into(),
+            detail: ToolDetail::None,
+        });
+        assert_eq!(
+            saturated.transition,
+            ChatToolTransition::StartInserted(ToolStartInsertionTransition::Inserted)
+        );
+        assert_eq!(chat.session_stats.total_tool_calls, u32::MAX);
+    }
+
+    #[test]
+    fn tool_reducer_reconciles_failed_start_without_append_or_count() {
+        let mut chat = ChatState::new();
+        chat.session_stats.total_tool_calls = 7;
+        chat.streaming_thinking = "discard duplicate thinking".into();
+        chat.push_tool_call(
+            Some("tool-1".into()),
+            "shell (failed)".into(),
+            true,
+            ToolDetail::Summary("failed".into()),
+        );
+
+        let outcome = chat.reduce_tool(ChatToolAction::InsertOrReconcileToolStart {
+            tool_call_id: Some("tool-1".into()),
+            name: "shell".into(),
+            detail: ToolDetail::Shell {
+                command: "echo late".into(),
+                workdir: None,
+                output_tail: None,
+            },
+        });
+
+        assert_eq!(
+            outcome.transition,
+            ChatToolTransition::StartInserted(ToolStartInsertionTransition::Reconciled)
+        );
+        assert_eq!(
+            outcome.coordination,
+            vec![
+                ChatCoordination::InvalidateThinkingCache,
+                ChatCoordination::InvalidateCardCache,
+            ]
+        );
+        assert!(outcome.effects.is_empty());
+        assert_eq!(chat.messages.len(), 1);
+        assert_eq!(chat.session_stats.total_tool_calls, 7);
+        assert!(chat.streaming_thinking.is_empty());
+        assert!(matches!(
+            chat.messages.as_slice(),
+            [ChatEntry::ToolCall { tool_call_id: Some(id), name, is_error: true, detail: ToolDetail::Shell { command, .. } }]
+                if id == "tool-1" && name == "shell" && command == "echo late"
+        ));
+    }
+
+    #[test]
+    fn tool_reducer_failed_fallback_dedupes_and_late_start_restores() {
+        let mut chat = ChatState::new();
+        let failed = ChatToolAction::ToolCallEnd {
+            tool_call_id: Some("tool-1".into()),
+            name: "shell".into(),
+            is_error: true,
+            result: Some("failed".into()),
+        };
+
+        let inserted = chat.reduce_tool(failed.clone());
+        assert_eq!(
+            inserted.transition,
+            ChatToolTransition::Ended(ToolEndTransition::FallbackInserted)
+        );
+        assert_eq!(
+            inserted.coordination,
+            vec![ChatCoordination::InvalidateCardCache]
+        );
+        assert!(inserted.effects.is_empty());
+
+        let repeated = chat.reduce_tool(failed);
+        assert_eq!(
+            repeated.transition,
+            ChatToolTransition::Ended(ToolEndTransition::NoOp)
+        );
+        assert!(repeated.coordination.is_empty());
+        assert_eq!(chat.messages.len(), 1);
+        assert_eq!(chat.session_stats.total_tool_calls, 0);
+
+        let reconciled = chat.reduce_tool(ChatToolAction::InsertOrReconcileToolStart {
+            tool_call_id: Some("tool-1".into()),
+            name: "shell".into(),
+            detail: ToolDetail::Shell {
+                command: "echo late".into(),
+                workdir: None,
+                output_tail: None,
+            },
+        });
+        assert_eq!(
+            reconciled.transition,
+            ChatToolTransition::StartInserted(ToolStartInsertionTransition::Reconciled)
+        );
+        assert_eq!(chat.messages.len(), 1);
+        assert_eq!(chat.session_stats.total_tool_calls, 0);
+        assert!(matches!(
+            chat.messages.as_slice(),
+            [ChatEntry::ToolCall { name, is_error: true, detail: ToolDetail::Shell { command, .. }, .. }]
+                if name == "shell" && command == "echo late"
+        ));
+    }
+
+    #[test]
+    fn tool_reducer_success_before_start_is_a_typed_noop() {
+        let mut chat = ChatState::new();
+
+        let outcome = chat.reduce_tool(ChatToolAction::ToolCallEnd {
+            tool_call_id: Some("missing".into()),
+            name: "shell".into(),
+            is_error: false,
+            result: Some("done".into()),
+        });
+
+        assert_eq!(
+            outcome,
+            ChatToolOutcome {
+                transition: ChatToolTransition::Ended(ToolEndTransition::NoOp),
+                coordination: Vec::new(),
+                effects: Vec::new(),
+            }
+        );
+        assert!(chat.messages.is_empty());
+    }
+
+    #[test]
+    fn tool_reducer_existing_end_updates_detail_then_failure_once() {
+        let mut chat = ChatState::new();
+        chat.push_tool_call(
+            Some("tool-1".into()),
+            "shell".into(),
+            false,
+            ToolDetail::Shell {
+                command: "cargo check".into(),
+                workdir: Some("/repo".into()),
+                output_tail: None,
+            },
+        );
+        let end = ChatToolAction::ToolCallEnd {
+            tool_call_id: Some("tool-1".into()),
+            name: "shell".into(),
+            is_error: true,
+            result: Some("line one\nline two".into()),
+        };
+
+        let updated = chat.reduce_tool(end.clone());
+        assert_eq!(
+            updated.transition,
+            ChatToolTransition::Ended(ToolEndTransition::Updated {
+                detail_updated: true,
+                marked_failed: true,
+            })
+        );
+        assert_eq!(
+            updated.coordination,
+            vec![ChatCoordination::InvalidateCardCache]
+        );
+        assert!(updated.effects.is_empty());
+        assert!(matches!(
+            chat.messages.as_slice(),
+            [ChatEntry::ToolCall { is_error: true, detail: ToolDetail::Shell { output_tail: Some(tail), .. }, .. }]
+                if tail.lines == ["line one", "line two"]
+        ));
+
+        let repeated = chat.reduce_tool(end);
+        assert_eq!(
+            repeated.transition,
+            ChatToolTransition::Ended(ToolEndTransition::NoOp)
+        );
+        assert!(repeated.coordination.is_empty());
     }
 
     #[test]

--- a/src/chat_state.rs
+++ b/src/chat_state.rs
@@ -150,6 +150,25 @@ pub(crate) enum ChatToolAction {
     },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum ChatUsageAction {
+    UsageUpdated {
+        used: u64,
+        size: u64,
+        cost_usd: Option<f64>,
+    },
+    TimingUpdated {
+        duration_secs: u64,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ChatUsageTransition {
+    UsageUpdated,
+    TimingUpdated,
+    NoOp,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ToolStartPreparationTransition {
     Suppressed,
@@ -238,6 +257,11 @@ pub(crate) enum ChatCoordination {
     InvalidateContentCache,
     InvalidateThinkingCache,
     InvalidateCardCache,
+    Log {
+        level: LogLevel,
+        target: &'static str,
+        message: String,
+    },
     Status {
         level: LogLevel,
         target: &'static str,
@@ -255,6 +279,13 @@ pub(crate) struct ChatOutcome {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ChatToolOutcome {
     pub(crate) transition: ChatToolTransition,
+    pub(crate) coordination: Vec<ChatCoordination>,
+    pub(crate) effects: Vec<Effect>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ChatUsageOutcome {
+    pub(crate) transition: ChatUsageTransition,
     pub(crate) coordination: Vec<ChatCoordination>,
     pub(crate) effects: Vec<Effect>,
 }
@@ -517,6 +548,51 @@ impl ChatState {
             }
         };
         ChatToolOutcome {
+            transition,
+            coordination,
+            effects: Vec::new(),
+        }
+    }
+
+    pub(crate) fn reduce_usage(&mut self, action: ChatUsageAction) -> ChatUsageOutcome {
+        let (transition, coordination) = match action {
+            ChatUsageAction::UsageUpdated {
+                used,
+                size,
+                cost_usd,
+            } => {
+                self.apply_usage(used, size, cost_usd);
+                let percentage = if used > 0 && size > 0 {
+                    format!(" ({}%)", (used as f64 / size as f64 * 100.0) as u32)
+                } else {
+                    String::new()
+                };
+                let cost = cost_usd
+                    .map(|amount| format!(", cost ${amount:.4}"))
+                    .unwrap_or_default();
+                (
+                    ChatUsageTransition::UsageUpdated,
+                    vec![ChatCoordination::Log {
+                        level: LogLevel::Info,
+                        target: "usage",
+                        message: format!("usage: context {used}/{size} tokens{percentage}{cost}"),
+                    }],
+                )
+            }
+            ChatUsageAction::TimingUpdated { duration_secs } if duration_secs > 0 => {
+                self.add_active_llm_duration(Duration::from_secs(duration_secs));
+                (
+                    ChatUsageTransition::TimingUpdated,
+                    vec![ChatCoordination::Log {
+                        level: LogLevel::Info,
+                        target: "usage",
+                        message: format!("usage: active time {duration_secs}s"),
+                    }],
+                )
+            }
+            ChatUsageAction::TimingUpdated { .. } => (ChatUsageTransition::NoOp, Vec::new()),
+        };
+        ChatUsageOutcome {
             transition,
             coordination,
             effects: Vec::new(),
@@ -1718,6 +1794,105 @@ mod tests {
         assert_eq!(chat.session_stats.total_tool_calls, 1);
         assert_eq!(chat.context_limit, 8192);
         assert_eq!(chat.cumulative_cost, Some(0.0123));
+    }
+
+    #[test]
+    fn usage_reducer_replaces_metrics_and_emits_exact_log_intent() {
+        let mut chat = ChatState::new();
+        chat.apply_usage(1024, 4096, Some(1.25));
+
+        let outcome = chat.reduce_usage(ChatUsageAction::UsageUpdated {
+            used: 2048,
+            size: 8192,
+            cost_usd: Some(0.0123),
+        });
+
+        assert_eq!(chat.session_stats.latest_context_tokens, Some(2048));
+        assert_eq!(chat.context_limit, 8192);
+        assert_eq!(chat.cumulative_cost, Some(0.0123));
+        assert_eq!(
+            outcome,
+            ChatUsageOutcome {
+                transition: ChatUsageTransition::UsageUpdated,
+                coordination: vec![ChatCoordination::Log {
+                    level: LogLevel::Info,
+                    target: "usage",
+                    message: "usage: context 2048/8192 tokens (25%), cost $0.0123".into(),
+                }],
+                effects: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn usage_reducer_preserves_absent_values_and_omits_zero_size_percentage() {
+        let mut chat = ChatState::new();
+        chat.apply_usage(128, 8192, Some(1.25));
+
+        let outcome = chat.reduce_usage(ChatUsageAction::UsageUpdated {
+            used: 512,
+            size: 0,
+            cost_usd: None,
+        });
+
+        assert_eq!(chat.session_stats.latest_context_tokens, Some(512));
+        assert_eq!(chat.context_limit, 8192);
+        assert_eq!(chat.cumulative_cost, Some(1.25));
+        assert_eq!(
+            outcome,
+            ChatUsageOutcome {
+                transition: ChatUsageTransition::UsageUpdated,
+                coordination: vec![ChatCoordination::Log {
+                    level: LogLevel::Info,
+                    target: "usage",
+                    message: "usage: context 512/0 tokens".into(),
+                }],
+                effects: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn timing_reducer_adds_repeated_durations_and_types_zero_as_noop() {
+        let mut chat = ChatState::new();
+        chat.add_active_llm_duration(Duration::from_secs(2));
+
+        let first = chat.reduce_usage(ChatUsageAction::TimingUpdated { duration_secs: 3 });
+        assert_eq!(
+            first,
+            ChatUsageOutcome {
+                transition: ChatUsageTransition::TimingUpdated,
+                coordination: vec![ChatCoordination::Log {
+                    level: LogLevel::Info,
+                    target: "usage",
+                    message: "usage: active time 3s".into(),
+                }],
+                effects: Vec::new(),
+            }
+        );
+        let second = chat.reduce_usage(ChatUsageAction::TimingUpdated { duration_secs: 4 });
+        assert_eq!(second.transition, ChatUsageTransition::TimingUpdated);
+        assert_eq!(
+            second.coordination,
+            vec![ChatCoordination::Log {
+                level: LogLevel::Info,
+                target: "usage",
+                message: "usage: active time 4s".into(),
+            }]
+        );
+        assert!(second.effects.is_empty());
+        assert_eq!(chat.llm_request_elapsed(), Some(Duration::from_secs(9)));
+
+        let zero = chat.reduce_usage(ChatUsageAction::TimingUpdated { duration_secs: 0 });
+        assert_eq!(
+            zero,
+            ChatUsageOutcome {
+                transition: ChatUsageTransition::NoOp,
+                coordination: Vec::new(),
+                effects: Vec::new(),
+            }
+        );
+        assert_eq!(chat.llm_request_elapsed(), Some(Duration::from_secs(9)));
     }
 
     #[test]

--- a/src/chat_state.rs
+++ b/src/chat_state.rs
@@ -1,6 +1,8 @@
 use std::time::{Duration, Instant};
 
+use crate::application::Effect;
 use crate::composer_state::build_input_visual_layout;
+use crate::diagnostics::LogLevel;
 use crate::domain::activity::{ActivityState, SessionOp, SessionStatsLite};
 use crate::domain::chat::{ChatEntry, format_outcome_labels};
 use crate::domain::elicitation::ElicitationState;
@@ -121,6 +123,77 @@ pub(crate) struct ElicitationTransition {
     pub(crate) finalized_streaming: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AssistantMessageTransition {
+    Ignored,
+    Duplicate,
+    ReplacedThinking,
+    Appended,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ChatAction {
+    TurnStarted {
+        is_replay: bool,
+    },
+    UserMessage {
+        text: String,
+        message_id: Option<String>,
+        is_replay: bool,
+    },
+    AssistantContentDelta {
+        content: String,
+        message_id: Option<String>,
+    },
+    AssistantThinkingDelta {
+        content: String,
+        message_id: Option<String>,
+        is_replay: bool,
+    },
+    AssistantMessage {
+        content: String,
+        thinking: Option<String>,
+        message_id: Option<String>,
+    },
+    Cancelled {
+        is_replay: bool,
+    },
+    Finished {
+        finish_reason: String,
+        is_replay: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ChatTransition {
+    TurnStarted,
+    UserMessage(UserMessageTransition),
+    AssistantContentDelta(StreamingDeltaTransition),
+    AssistantThinkingDelta(StreamingDeltaTransition),
+    AssistantMessage(AssistantMessageTransition),
+    Cancelled,
+    Finished,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ChatCoordination {
+    InvalidateContentCache,
+    InvalidateThinkingCache,
+    InvalidateCardCache,
+    Status {
+        level: LogLevel,
+        target: &'static str,
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ChatOutcome {
+    pub(crate) transition: ChatTransition,
+    pub(crate) coordination: Vec<ChatCoordination>,
+    pub(crate) effects: Vec<Effect>,
+}
+
 pub(crate) struct ChatState {
     pub(crate) messages: Vec<ChatEntry>,
     pub(crate) pending_prompt_seq: u64,
@@ -148,6 +221,126 @@ pub(crate) struct ChatState {
 }
 
 impl ChatState {
+    pub(crate) fn reduce(&mut self, action: ChatAction) -> ChatOutcome {
+        let (transition, coordination) = match action {
+            ChatAction::TurnStarted { is_replay } => {
+                self.begin_turn(is_replay);
+                (
+                    ChatTransition::TurnStarted,
+                    vec![
+                        ChatCoordination::InvalidateContentCache,
+                        ChatCoordination::InvalidateThinkingCache,
+                        ChatCoordination::Status {
+                            level: LogLevel::Debug,
+                            target: "activity",
+                            message: "thinking...".into(),
+                        },
+                    ],
+                )
+            }
+            ChatAction::UserMessage {
+                text,
+                message_id,
+                is_replay,
+            } => {
+                let transition = self.push_user_message(text, message_id, is_replay);
+                let coordination = matches!(transition, UserMessageTransition::Reconciled)
+                    .then_some(ChatCoordination::InvalidateCardCache)
+                    .into_iter()
+                    .collect();
+                (ChatTransition::UserMessage(transition), coordination)
+            }
+            ChatAction::AssistantContentDelta {
+                content,
+                message_id,
+            } => {
+                let transition = self.append_streaming_content(&content, message_id);
+                let coordination = Self::stream_boundary_coordination(transition);
+                (
+                    ChatTransition::AssistantContentDelta(transition),
+                    coordination,
+                )
+            }
+            ChatAction::AssistantThinkingDelta {
+                content,
+                message_id,
+                is_replay,
+            } => {
+                let transition = self.append_streaming_thinking(&content, message_id, is_replay);
+                let coordination = Self::stream_boundary_coordination(transition);
+                (
+                    ChatTransition::AssistantThinkingDelta(transition),
+                    coordination,
+                )
+            }
+            ChatAction::AssistantMessage {
+                content,
+                thinking,
+                message_id,
+            } => {
+                let transition = self.push_assistant_message(content, thinking, message_id);
+                let mut coordination = vec![
+                    ChatCoordination::InvalidateContentCache,
+                    ChatCoordination::InvalidateThinkingCache,
+                ];
+                if transition == AssistantMessageTransition::ReplacedThinking {
+                    coordination.push(ChatCoordination::InvalidateCardCache);
+                }
+                (ChatTransition::AssistantMessage(transition), coordination)
+            }
+            ChatAction::Cancelled { is_replay } => {
+                self.cancel_turn(is_replay);
+                (
+                    ChatTransition::Cancelled,
+                    vec![
+                        ChatCoordination::InvalidateContentCache,
+                        ChatCoordination::InvalidateThinkingCache,
+                        ChatCoordination::Status {
+                            level: LogLevel::Warn,
+                            target: "activity",
+                            message: "cancelled".into(),
+                        },
+                    ],
+                )
+            }
+            ChatAction::Finished {
+                finish_reason,
+                is_replay,
+            } => {
+                self.finish_turn(is_replay);
+                (
+                    ChatTransition::Finished,
+                    vec![
+                        ChatCoordination::InvalidateContentCache,
+                        ChatCoordination::InvalidateThinkingCache,
+                        ChatCoordination::Status {
+                            level: LogLevel::Debug,
+                            target: "activity",
+                            message: format!("finished: {finish_reason}"),
+                        },
+                    ],
+                )
+            }
+        };
+        ChatOutcome {
+            transition,
+            coordination,
+            effects: Vec::new(),
+        }
+    }
+
+    fn stream_boundary_coordination(transition: StreamingDeltaTransition) -> Vec<ChatCoordination> {
+        if transition.finalized_previous {
+            vec![
+                ChatCoordination::InvalidateContentCache,
+                ChatCoordination::InvalidateThinkingCache,
+                ChatCoordination::InvalidateCardCache,
+            ]
+        } else {
+            Vec::new()
+        }
+    }
+
     pub(crate) fn new() -> Self {
         Self {
             messages: Vec::new(),
@@ -420,7 +613,9 @@ impl ChatState {
     }
 
     pub(crate) fn begin_llm_request_span(&mut self, timestamp: Option<i64>) {
-        if self.session_stats.open_llm_request_ts.is_none() {
+        if self.session_stats.open_llm_request_ts.is_none()
+            && self.session_stats.open_llm_request_instant.is_none()
+        {
             self.session_stats.open_llm_request_ts = timestamp;
             self.session_stats.open_llm_request_instant = Some(Instant::now());
         }
@@ -821,7 +1016,7 @@ impl ChatState {
         content: String,
         thinking: Option<String>,
         message_id: Option<String>,
-    ) -> bool {
+    ) -> AssistantMessageTransition {
         let explicit_thinking = thinking.filter(|text| !text.is_empty());
         let thinking_message_id = message_id
             .clone()
@@ -833,12 +1028,12 @@ impl ChatState {
         }
         if content.is_empty() && explicit_thinking.is_none() && self.streaming_thinking.is_empty() {
             self.streaming_thinking_message_id = None;
-            return false;
+            return AssistantMessageTransition::Ignored;
         }
         self.recent_prompt_text = None;
         if self.suppress_turn_output {
             self.clear_streaming_thinking();
-            return false;
+            return AssistantMessageTransition::Ignored;
         }
 
         if let Some(message_id) = message_id.as_deref() {
@@ -846,7 +1041,7 @@ impl ChatState {
                 matches!(entry, ChatEntry::Assistant { message_id: Some(mid), .. } if mid == message_id)
             }) {
                 self.clear_streaming_thinking();
-                return false;
+                return AssistantMessageTransition::Duplicate;
             }
 
             if let Some(index) = self.messages.iter().position(|entry| {
@@ -854,7 +1049,7 @@ impl ChatState {
             }) {
                 if content.is_empty() {
                     self.clear_streaming_thinking();
-                    return false;
+                    return AssistantMessageTransition::Duplicate;
                 }
                 let existing_thinking = match &self.messages[index] {
                     ChatEntry::Thinking { content, .. } => content.clone(),
@@ -871,7 +1066,7 @@ impl ChatState {
                     thinking: thinking_text,
                     message_id: Some(message_id.to_string()),
                 };
-                return true;
+                return AssistantMessageTransition::ReplacedThinking;
             }
         }
 
@@ -893,7 +1088,7 @@ impl ChatState {
                 message_id,
             });
         }
-        false
+        AssistantMessageTransition::Appended
     }
 
     pub(crate) fn reconcile_tool_call_start(
@@ -1429,6 +1624,314 @@ mod tests {
             ChatEntry::User { message_id: Some(id), .. } if id == &second
         ));
         assert_ne!(first, second);
+    }
+
+    #[test]
+    fn reducer_turn_start_preserves_live_replay_timing_and_exact_coordination() {
+        let mut live = ChatState::new();
+        live.streaming_content = "discarded".into();
+        live.streaming_thinking = "discarded thinking".into();
+        live.arm_cancel_confirm();
+        let outcome = live.reduce(ChatAction::TurnStarted { is_replay: false });
+        assert_eq!(outcome.transition, ChatTransition::TurnStarted);
+        assert_eq!(
+            outcome.coordination,
+            vec![
+                ChatCoordination::InvalidateContentCache,
+                ChatCoordination::InvalidateThinkingCache,
+                ChatCoordination::Status {
+                    level: LogLevel::Debug,
+                    target: "activity",
+                    message: "thinking...".into(),
+                },
+            ]
+        );
+        assert!(outcome.effects.is_empty());
+        assert_eq!(live.activity, ActivityState::Thinking);
+        assert!(live.streaming_content.is_empty());
+        assert!(live.streaming_thinking.is_empty());
+        assert!(live.pending_cancel_confirm_until.is_none());
+        let opened = live.session_stats.open_llm_request_instant;
+        assert!(opened.is_some());
+        live.reduce(ChatAction::TurnStarted { is_replay: false });
+        assert_eq!(live.session_stats.open_llm_request_instant, opened);
+
+        let mut replay = ChatState::new();
+        replay.reduce(ChatAction::TurnStarted { is_replay: true });
+        assert_eq!(replay.activity, ActivityState::Thinking);
+        assert!(replay.session_stats.open_llm_request_instant.is_none());
+    }
+
+    #[test]
+    fn reducer_user_message_reports_noops_and_reconciles_in_submission_order() {
+        let mut chat = ChatState::new();
+        let ignored = chat.reduce(ChatAction::UserMessage {
+            text: String::new(),
+            message_id: Some("empty".into()),
+            is_replay: false,
+        });
+        assert_eq!(
+            ignored,
+            ChatOutcome {
+                transition: ChatTransition::UserMessage(UserMessageTransition::Ignored),
+                coordination: Vec::new(),
+                effects: Vec::new(),
+            }
+        );
+
+        let first = chat.push_pending_prompt("  repeat\n".into());
+        let second = chat.push_pending_prompt("repeat".into());
+        let reconciled = chat.reduce(ChatAction::UserMessage {
+            text: "repeat".into(),
+            message_id: Some("server-1".into()),
+            is_replay: false,
+        });
+        assert_eq!(
+            reconciled.transition,
+            ChatTransition::UserMessage(UserMessageTransition::Reconciled)
+        );
+        assert_eq!(
+            reconciled.coordination,
+            vec![ChatCoordination::InvalidateCardCache]
+        );
+        assert!(matches!(
+            &chat.messages[0],
+            ChatEntry::User { message_id: Some(id), .. } if id == "server-1"
+        ));
+        assert!(matches!(
+            &chat.messages[1],
+            ChatEntry::User { message_id: Some(id), .. } if id == &second
+        ));
+        assert_ne!(first, second);
+        assert_eq!(chat.undoable_turns[0].message_id, "server-1");
+
+        let duplicate = chat.reduce(ChatAction::UserMessage {
+            text: "repeat".into(),
+            message_id: Some("server-1".into()),
+            is_replay: false,
+        });
+        assert_eq!(
+            duplicate.transition,
+            ChatTransition::UserMessage(UserMessageTransition::Duplicate)
+        );
+        assert!(duplicate.coordination.is_empty());
+
+        chat.undo_state = Some(UndoState {
+            stack: Vec::new(),
+            frontier_message_id: None,
+        });
+        chat.suppress_turn_output = true;
+        let replay = chat.reduce(ChatAction::UserMessage {
+            text: "replayed".into(),
+            message_id: Some("server-2".into()),
+            is_replay: true,
+        });
+        assert_eq!(
+            replay.transition,
+            ChatTransition::UserMessage(UserMessageTransition::Appended)
+        );
+        assert!(replay.coordination.is_empty());
+    }
+
+    #[test]
+    fn reducer_stream_deltas_preserve_boundaries_and_replay_suppression() {
+        let mut chat = ChatState::new();
+        chat.activity = ActivityState::Thinking;
+        let thinking = chat.reduce(ChatAction::AssistantThinkingDelta {
+            content: "plan".into(),
+            message_id: Some("one".into()),
+            is_replay: true,
+        });
+        assert_eq!(
+            thinking.transition,
+            ChatTransition::AssistantThinkingDelta(StreamingDeltaTransition::default())
+        );
+        assert!(thinking.coordination.is_empty());
+
+        let duplicate = chat.reduce(ChatAction::AssistantThinkingDelta {
+            content: "plan".into(),
+            message_id: Some("one".into()),
+            is_replay: true,
+        });
+        assert_eq!(
+            duplicate.transition,
+            ChatTransition::AssistantThinkingDelta(StreamingDeltaTransition {
+                finalized_previous: false,
+                ignored_duplicate: true,
+            })
+        );
+        assert!(duplicate.coordination.is_empty());
+        assert_eq!(chat.streaming_thinking, "plan");
+
+        let content = chat.reduce(ChatAction::AssistantContentDelta {
+            content: "answer".into(),
+            message_id: Some("one".into()),
+        });
+        assert_eq!(
+            content.transition,
+            ChatTransition::AssistantContentDelta(StreamingDeltaTransition::default())
+        );
+        assert_eq!(chat.activity, ActivityState::Streaming);
+
+        let boundary = chat.reduce(ChatAction::AssistantContentDelta {
+            content: "second".into(),
+            message_id: Some("two".into()),
+        });
+        assert_eq!(
+            boundary.transition,
+            ChatTransition::AssistantContentDelta(StreamingDeltaTransition {
+                finalized_previous: true,
+                ignored_duplicate: false,
+            })
+        );
+        assert_eq!(
+            boundary.coordination,
+            vec![
+                ChatCoordination::InvalidateContentCache,
+                ChatCoordination::InvalidateThinkingCache,
+                ChatCoordination::InvalidateCardCache,
+            ]
+        );
+        assert!(matches!(
+            chat.messages.as_slice(),
+            [ChatEntry::Assistant { content, thinking: Some(thinking), message_id: Some(id) }]
+                if content == "answer" && thinking == "plan" && id == "one"
+        ));
+        assert_eq!(chat.streaming_content, "second");
+        assert_eq!(chat.streaming_content_message_id.as_deref(), Some("two"));
+    }
+
+    #[test]
+    fn reducer_final_assistant_merges_replaces_and_deduplicates_exactly() {
+        let expected_base_coordination = vec![
+            ChatCoordination::InvalidateContentCache,
+            ChatCoordination::InvalidateThinkingCache,
+        ];
+        let mut chat = ChatState::new();
+        chat.streaming_content = "partial".into();
+        chat.streaming_content_message_id = Some("assistant-1".into());
+        chat.streaming_thinking = "streamed thinking".into();
+        chat.streaming_thinking_message_id = Some("assistant-1".into());
+        let appended = chat.reduce(ChatAction::AssistantMessage {
+            content: "final".into(),
+            thinking: None,
+            message_id: Some("assistant-1".into()),
+        });
+        assert_eq!(
+            appended.transition,
+            ChatTransition::AssistantMessage(AssistantMessageTransition::Appended)
+        );
+        assert_eq!(appended.coordination, expected_base_coordination);
+        assert!(chat.streaming_content.is_empty());
+        assert!(chat.streaming_thinking.is_empty());
+        assert!(matches!(
+            chat.messages.as_slice(),
+            [ChatEntry::Assistant { content, thinking: Some(thinking), message_id: Some(id) }]
+                if content == "final" && thinking == "streamed thinking" && id == "assistant-1"
+        ));
+
+        let duplicate = chat.reduce(ChatAction::AssistantMessage {
+            content: "duplicate".into(),
+            thinking: Some("duplicate thinking".into()),
+            message_id: Some("assistant-1".into()),
+        });
+        assert_eq!(
+            duplicate.transition,
+            ChatTransition::AssistantMessage(AssistantMessageTransition::Duplicate)
+        );
+        assert_eq!(duplicate.coordination, expected_base_coordination);
+        assert_eq!(chat.messages.len(), 1);
+
+        chat.messages.push(ChatEntry::Thinking {
+            content: "old thinking".into(),
+            message_id: Some("assistant-2".into()),
+        });
+        let replaced = chat.reduce(ChatAction::AssistantMessage {
+            content: "replacement".into(),
+            thinking: Some("explicit thinking".into()),
+            message_id: Some("assistant-2".into()),
+        });
+        assert_eq!(
+            replaced.transition,
+            ChatTransition::AssistantMessage(AssistantMessageTransition::ReplacedThinking)
+        );
+        assert_eq!(
+            replaced.coordination,
+            vec![
+                ChatCoordination::InvalidateContentCache,
+                ChatCoordination::InvalidateThinkingCache,
+                ChatCoordination::InvalidateCardCache,
+            ]
+        );
+        assert!(matches!(
+            &chat.messages[1],
+            ChatEntry::Assistant { content, thinking: Some(thinking), message_id: Some(id) }
+                if content == "replacement" && thinking == "explicit thinking" && id == "assistant-2"
+        ));
+    }
+
+    #[test]
+    fn reducer_cancel_and_finish_discard_streams_close_live_timing_and_report_status() {
+        let mut cancelled = ChatState::new();
+        cancelled.begin_llm_request_span(None);
+        cancelled.activity = ActivityState::Streaming;
+        cancelled.streaming_content = "discard content".into();
+        cancelled.streaming_thinking = "discard thinking".into();
+        let outcome = cancelled.reduce(ChatAction::Cancelled { is_replay: false });
+        assert_eq!(outcome.transition, ChatTransition::Cancelled);
+        assert_eq!(
+            outcome.coordination,
+            vec![
+                ChatCoordination::InvalidateContentCache,
+                ChatCoordination::InvalidateThinkingCache,
+                ChatCoordination::Status {
+                    level: LogLevel::Warn,
+                    target: "activity",
+                    message: "cancelled".into(),
+                },
+            ]
+        );
+        assert_eq!(cancelled.activity, ActivityState::Idle);
+        assert!(cancelled.session_stats.open_llm_request_instant.is_none());
+        assert!(cancelled.streaming_content.is_empty());
+        assert!(cancelled.streaming_thinking.is_empty());
+        assert!(cancelled.messages.is_empty());
+
+        let mut finished = ChatState::new();
+        finished.begin_llm_request_span(None);
+        finished.streaming_content = "discard content".into();
+        finished.streaming_thinking = "discard thinking".into();
+        let outcome = finished.reduce(ChatAction::Finished {
+            finish_reason: "EndTurn".into(),
+            is_replay: false,
+        });
+        assert_eq!(outcome.transition, ChatTransition::Finished);
+        assert_eq!(
+            outcome.coordination,
+            vec![
+                ChatCoordination::InvalidateContentCache,
+                ChatCoordination::InvalidateThinkingCache,
+                ChatCoordination::Status {
+                    level: LogLevel::Debug,
+                    target: "activity",
+                    message: "finished: EndTurn".into(),
+                },
+            ]
+        );
+        assert_eq!(finished.activity, ActivityState::Idle);
+        assert!(finished.session_stats.open_llm_request_instant.is_none());
+        assert!(finished.streaming_content.is_empty());
+        assert!(finished.streaming_thinking.is_empty());
+        assert!(finished.messages.is_empty());
+
+        let mut replay = ChatState::new();
+        replay.begin_llm_request_span(None);
+        let opened = replay.session_stats.open_llm_request_instant;
+        replay.reduce(ChatAction::Finished {
+            finish_reason: "Replay".into(),
+            is_replay: true,
+        });
+        assert_eq!(replay.session_stats.open_llm_request_instant, opened);
     }
 
     #[test]

--- a/src/chat_state.rs
+++ b/src/chat_state.rs
@@ -232,6 +232,16 @@ pub(crate) enum ChatAction {
         thinking: Option<String>,
         message_id: Option<String>,
     },
+    AcpError {
+        message: String,
+    },
+    BackendPromptFailed {
+        local_id: String,
+        message: String,
+    },
+    RuntimePromptDispatchFailed {
+        local_id: String,
+    },
     Cancelled {
         is_replay: bool,
     },
@@ -248,6 +258,16 @@ pub(crate) enum ChatTransition {
     AssistantContentDelta(StreamingDeltaTransition),
     AssistantThinkingDelta(StreamingDeltaTransition),
     AssistantMessage(AssistantMessageTransition),
+    AcpError {
+        error_inserted: bool,
+    },
+    BackendPromptFailed {
+        prompt_rolled_back: bool,
+        error_inserted: bool,
+    },
+    RuntimePromptDispatchFailed {
+        prompt_rolled_back: bool,
+    },
     Cancelled,
     Finished,
 }
@@ -383,6 +403,47 @@ impl ChatState {
                     coordination.push(ChatCoordination::InvalidateCardCache);
                 }
                 (ChatTransition::AssistantMessage(transition), coordination)
+            }
+            ChatAction::AcpError { message } => {
+                self.end_llm_request_span(None);
+                let error_inserted = self.push_error(&message);
+                (
+                    ChatTransition::AcpError { error_inserted },
+                    vec![ChatCoordination::Status {
+                        level: LogLevel::Error,
+                        target: "acp",
+                        message: format!("error: {message}"),
+                    }],
+                )
+            }
+            ChatAction::BackendPromptFailed { local_id, message } => {
+                self.end_llm_request_span(None);
+                let prompt_rolled_back = self.rollback_pending_prompt(&local_id);
+                let error_inserted = self.push_error(&message);
+                (
+                    ChatTransition::BackendPromptFailed {
+                        prompt_rolled_back,
+                        error_inserted,
+                    },
+                    vec![
+                        ChatCoordination::InvalidateCardCache,
+                        ChatCoordination::Status {
+                            level: LogLevel::Error,
+                            target: "acp",
+                            message: format!("error: {message}"),
+                        },
+                    ],
+                )
+            }
+            ChatAction::RuntimePromptDispatchFailed { local_id } => {
+                let prompt_rolled_back = self.rollback_pending_prompt(&local_id);
+                (
+                    ChatTransition::RuntimePromptDispatchFailed { prompt_rolled_back },
+                    prompt_rolled_back
+                        .then_some(ChatCoordination::InvalidateCardCache)
+                        .into_iter()
+                        .collect(),
+                )
             }
             ChatAction::Cancelled { is_replay } => {
                 self.cancel_turn(is_replay);
@@ -2371,6 +2432,172 @@ mod tests {
             ChatEntry::User { message_id: Some(id), .. } if id == &second
         ));
         assert_ne!(first, second);
+    }
+
+    #[test]
+    fn error_reducer_closes_live_timing_and_types_error_deduplication() {
+        let mut chat = ChatState::new();
+        chat.recent_prompt_text = Some("preserved prompt".into());
+        chat.session_stats.open_llm_request_instant = Some(Instant::now() - Duration::from_secs(2));
+
+        let inserted = chat.reduce(ChatAction::AcpError {
+            message: "connection lost".into(),
+        });
+
+        assert_eq!(
+            inserted,
+            ChatOutcome {
+                transition: ChatTransition::AcpError {
+                    error_inserted: true,
+                },
+                coordination: vec![ChatCoordination::Status {
+                    level: LogLevel::Error,
+                    target: "acp",
+                    message: "error: connection lost".into(),
+                }],
+                effects: Vec::new(),
+            }
+        );
+        assert!(chat.session_stats.open_llm_request_instant.is_none());
+        assert!(chat.session_stats.active_llm_duration >= Duration::from_secs(2));
+        assert_eq!(chat.recent_prompt_text.as_deref(), Some("preserved prompt"));
+        assert!(matches!(
+            chat.messages.as_slice(),
+            [ChatEntry::Error(message)] if message == "connection lost"
+        ));
+
+        chat.session_stats.open_llm_request_instant = Some(Instant::now());
+        let duplicate = chat.reduce(ChatAction::AcpError {
+            message: "connection lost".into(),
+        });
+        assert_eq!(
+            duplicate.transition,
+            ChatTransition::AcpError {
+                error_inserted: false,
+            }
+        );
+        assert_eq!(duplicate.coordination, inserted.coordination);
+        assert!(duplicate.effects.is_empty());
+        assert!(chat.session_stats.open_llm_request_instant.is_none());
+        assert_eq!(chat.messages.len(), 1);
+    }
+
+    #[test]
+    fn backend_prompt_failure_reducer_preserves_matching_and_dedupe_semantics() {
+        let mut chat = ChatState::new();
+        let failed_id = chat.push_pending_prompt("failed".into());
+        let retained_id = chat.push_pending_prompt("retained".into());
+        chat.recent_prompt_text = Some("preserved prompt".into());
+        chat.session_stats.open_llm_request_instant = Some(Instant::now() - Duration::from_secs(2));
+
+        let failed = chat.reduce(ChatAction::BackendPromptFailed {
+            local_id: failed_id.clone(),
+            message: "backend rejected prompt".into(),
+        });
+
+        assert_eq!(
+            failed,
+            ChatOutcome {
+                transition: ChatTransition::BackendPromptFailed {
+                    prompt_rolled_back: true,
+                    error_inserted: true,
+                },
+                coordination: vec![
+                    ChatCoordination::InvalidateCardCache,
+                    ChatCoordination::Status {
+                        level: LogLevel::Error,
+                        target: "acp",
+                        message: "error: backend rejected prompt".into(),
+                    },
+                ],
+                effects: Vec::new(),
+            }
+        );
+        assert!(chat.session_stats.open_llm_request_instant.is_none());
+        assert!(chat.session_stats.active_llm_duration >= Duration::from_secs(2));
+        assert_eq!(chat.recent_prompt_text.as_deref(), Some("preserved prompt"));
+        assert!(matches!(
+            chat.messages.as_slice(),
+            [
+                ChatEntry::User { text, message_id: Some(message_id) },
+                ChatEntry::Error(message),
+            ] if text == "retained"
+                && message_id == &retained_id
+                && message == "backend rejected prompt"
+        ));
+
+        chat.session_stats.open_llm_request_instant = Some(Instant::now());
+        let nonmatching = chat.reduce(ChatAction::BackendPromptFailed {
+            local_id: "missing".into(),
+            message: "backend rejected prompt".into(),
+        });
+        assert_eq!(
+            nonmatching.transition,
+            ChatTransition::BackendPromptFailed {
+                prompt_rolled_back: false,
+                error_inserted: false,
+            }
+        );
+        assert_eq!(nonmatching.coordination, failed.coordination);
+        assert!(nonmatching.effects.is_empty());
+        assert!(chat.session_stats.open_llm_request_instant.is_none());
+        assert_eq!(chat.messages.len(), 2);
+        assert_eq!(chat.recent_prompt_text.as_deref(), Some("preserved prompt"));
+    }
+
+    #[test]
+    fn runtime_prompt_dispatch_failure_reducer_only_coordinates_matching_rollback() {
+        let mut chat = ChatState::new();
+        let failed_id = chat.push_pending_prompt("failed".into());
+        let retained_id = chat.push_pending_prompt("retained".into());
+        chat.recent_prompt_text = Some("preserved prompt".into());
+        chat.session_stats.open_llm_request_instant = Some(Instant::now());
+        let open_timing = chat.session_stats.open_llm_request_instant;
+
+        let failed = chat.reduce(ChatAction::RuntimePromptDispatchFailed {
+            local_id: failed_id,
+        });
+
+        assert_eq!(
+            failed,
+            ChatOutcome {
+                transition: ChatTransition::RuntimePromptDispatchFailed {
+                    prompt_rolled_back: true,
+                },
+                coordination: vec![ChatCoordination::InvalidateCardCache],
+                effects: Vec::new(),
+            }
+        );
+        assert_eq!(chat.session_stats.open_llm_request_instant, open_timing);
+        assert_eq!(chat.session_stats.active_llm_duration, Duration::ZERO);
+        assert_eq!(chat.recent_prompt_text.as_deref(), Some("preserved prompt"));
+        assert!(matches!(
+            chat.messages.as_slice(),
+            [ChatEntry::User { text, message_id: Some(message_id) }]
+                if text == "retained" && message_id == &retained_id
+        ));
+
+        let nonmatching = chat.reduce(ChatAction::RuntimePromptDispatchFailed {
+            local_id: "missing".into(),
+        });
+        assert_eq!(
+            nonmatching,
+            ChatOutcome {
+                transition: ChatTransition::RuntimePromptDispatchFailed {
+                    prompt_rolled_back: false,
+                },
+                coordination: Vec::new(),
+                effects: Vec::new(),
+            }
+        );
+        assert_eq!(chat.session_stats.open_llm_request_instant, open_timing);
+        assert_eq!(chat.session_stats.active_llm_duration, Duration::ZERO);
+        assert_eq!(chat.recent_prompt_text.as_deref(), Some("preserved prompt"));
+        assert!(
+            chat.messages
+                .iter()
+                .all(|entry| !matches!(entry, ChatEntry::Error(_)))
+        );
     }
 
     #[test]

--- a/src/chat_state.rs
+++ b/src/chat_state.rs
@@ -7,8 +7,8 @@ use crate::domain::activity::{ActivityState, SessionOp, SessionStatsLite};
 use crate::domain::chat::{ChatEntry, format_outcome_labels};
 use crate::domain::elicitation::ElicitationState;
 use crate::domain::session::{
-    ForkBoundaryKind, ForkTurnItem, UndoFrame, UndoFrameStatus, UndoStackSnapshot, UndoState,
-    UndoableTurn,
+    ForkBoundaryKind, ForkResult, ForkTurnItem, RedoResult, UndoFrame, UndoFrameStatus, UndoResult,
+    UndoStackSnapshot, UndoState, UndoableTurn,
 };
 use crate::domain::tool::ToolDetail;
 use crate::tool_detail;
@@ -299,6 +299,41 @@ pub(crate) enum ChatTransition {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HistoryAction {
+    ReplaceStack(UndoStackSnapshot),
+    UndoCompleted(UndoResult),
+    RedoCompleted(RedoResult),
+    ForkCompleted(ForkResult),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HistoryTransition {
+    StackReplaced,
+    UndoApplied,
+    UndoRejected,
+    RedoApplied,
+    RedoRejected,
+    ForkLoaded,
+    ForkMissingSessionId,
+    ForkFailed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HistoryCoordination {
+    InvalidateContentCache,
+    Status {
+        level: LogLevel,
+        target: &'static str,
+        message: String,
+    },
+    ClosePopup,
+    ReloadActiveSession,
+    LoadForkedSession {
+        session_id: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ChatCoordination {
     InvalidateContentCache,
     InvalidateThinkingCache,
@@ -341,6 +376,13 @@ pub(crate) struct ChatUsageOutcome {
 pub(crate) struct ElicitationOutcome {
     pub(crate) transition: ElicitationTransition,
     pub(crate) coordination: Vec<ChatCoordination>,
+    pub(crate) effects: Vec<Effect>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HistoryOutcome {
+    pub(crate) transition: HistoryTransition,
+    pub(crate) coordination: Vec<HistoryCoordination>,
     pub(crate) effects: Vec<Effect>,
 }
 
@@ -514,6 +556,152 @@ impl ChatState {
             }
         };
         ChatOutcome {
+            transition,
+            coordination,
+            effects: Vec::new(),
+        }
+    }
+
+    pub(crate) fn reduce_history(&mut self, action: HistoryAction) -> HistoryOutcome {
+        let (transition, coordination) = match action {
+            HistoryAction::ReplaceStack(stack) => {
+                self.undo_state = self.build_undo_state_from_server_stack(&stack, None, None);
+                (HistoryTransition::StackReplaced, Vec::new())
+            }
+            HistoryAction::UndoCompleted(result) => {
+                self.activity = ActivityState::Idle;
+                match result {
+                    UndoResult::Applied {
+                        target_message_id,
+                        reverted_files,
+                        message: _,
+                        stack,
+                    } => {
+                        let preferred =
+                            target_message_id.or_else(|| stack.message_ids.last().cloned());
+                        self.undo_state = self.build_undo_state_from_server_stack(
+                            &stack,
+                            preferred.as_deref(),
+                            Some(&reverted_files),
+                        );
+                        self.recent_prompt_text = None;
+                        self.streaming_content.clear();
+                        self.streaming_content_message_id = None;
+                        (
+                            HistoryTransition::UndoApplied,
+                            vec![
+                                HistoryCoordination::InvalidateContentCache,
+                                HistoryCoordination::Status {
+                                    level: LogLevel::Info,
+                                    target: "session",
+                                    message: "undone - reloading session".into(),
+                                },
+                                HistoryCoordination::ReloadActiveSession,
+                            ],
+                        )
+                    }
+                    UndoResult::Rejected {
+                        target_message_id,
+                        message,
+                        stack,
+                    } => {
+                        let preferred =
+                            target_message_id.or_else(|| stack.message_ids.last().cloned());
+                        self.undo_state = self.build_undo_state_from_server_stack(
+                            &stack,
+                            preferred.as_deref(),
+                            None,
+                        );
+                        (
+                            HistoryTransition::UndoRejected,
+                            vec![HistoryCoordination::Status {
+                                level: LogLevel::Warn,
+                                target: "session",
+                                message: message.unwrap_or_else(|| "undo failed".into()),
+                            }],
+                        )
+                    }
+                }
+            }
+            HistoryAction::RedoCompleted(result) => {
+                self.activity = ActivityState::Idle;
+                match result {
+                    RedoResult::Applied { message: _, stack } => {
+                        self.undo_state =
+                            self.build_undo_state_from_server_stack(&stack, None, None);
+                        (
+                            HistoryTransition::RedoApplied,
+                            vec![
+                                HistoryCoordination::Status {
+                                    level: LogLevel::Info,
+                                    target: "session",
+                                    message: "redone - reloading session".into(),
+                                },
+                                HistoryCoordination::ReloadActiveSession,
+                            ],
+                        )
+                    }
+                    RedoResult::Rejected { message, stack } => {
+                        self.undo_state =
+                            self.build_undo_state_from_server_stack(&stack, None, None);
+                        (
+                            HistoryTransition::RedoRejected,
+                            vec![HistoryCoordination::Status {
+                                level: LogLevel::Warn,
+                                target: "session",
+                                message: message.unwrap_or_else(|| "redo failed".into()),
+                            }],
+                        )
+                    }
+                }
+            }
+            HistoryAction::ForkCompleted(result) => {
+                self.pending_fork_message_id = None;
+                match result {
+                    ForkResult::Succeeded {
+                        source_session_id: _,
+                        forked_session_id: Some(session_id),
+                        message: _,
+                    } => (
+                        HistoryTransition::ForkLoaded,
+                        vec![
+                            HistoryCoordination::ClosePopup,
+                            HistoryCoordination::Status {
+                                level: LogLevel::Info,
+                                target: "fork",
+                                message: "forked - loading session".into(),
+                            },
+                            HistoryCoordination::LoadForkedSession { session_id },
+                        ],
+                    ),
+                    ForkResult::Succeeded {
+                        source_session_id: _,
+                        forked_session_id: None,
+                        message,
+                    } => (
+                        HistoryTransition::ForkMissingSessionId,
+                        vec![HistoryCoordination::Status {
+                            level: LogLevel::Warn,
+                            target: "fork",
+                            message: message
+                                .unwrap_or_else(|| "fork succeeded without session id".into()),
+                        }],
+                    ),
+                    ForkResult::Failed {
+                        source_session_id: _,
+                        message,
+                    } => (
+                        HistoryTransition::ForkFailed,
+                        vec![HistoryCoordination::Status {
+                            level: LogLevel::Warn,
+                            target: "fork",
+                            message: message.unwrap_or_else(|| "fork failed".into()),
+                        }],
+                    ),
+                }
+            }
+        };
+        HistoryOutcome {
             transition,
             coordination,
             effects: Vec::new(),
@@ -2092,6 +2280,395 @@ mod tests {
         assert_eq!(state.stack[0].turn_id, "turn-three");
         assert_eq!(state.stack[1].turn_id, "unknown");
         assert_eq!(state.stack[1].reverted_files, ["src/lib.rs"]);
+    }
+
+    #[test]
+    fn history_stack_replacement_rebuilds_only_undo_state() {
+        let mut chat = ChatState::new();
+        chat.activity = ActivityState::SessionOp(SessionOp::Undo);
+        chat.streaming_content = "content".into();
+        chat.streaming_content_message_id = Some("content-id".into());
+        chat.streaming_thinking = "thinking".into();
+        chat.streaming_thinking_message_id = Some("thinking-id".into());
+        chat.recent_prompt_text = Some("prompt".into());
+        chat.pending_fork_message_id = Some("fork-target".into());
+        chat.undoable_turns = vec![turn("one")];
+
+        let outcome = chat.reduce_history(HistoryAction::ReplaceStack(UndoStackSnapshot {
+            message_ids: vec!["one".into()],
+        }));
+
+        assert_eq!(
+            outcome,
+            HistoryOutcome {
+                transition: HistoryTransition::StackReplaced,
+                coordination: Vec::new(),
+                effects: Vec::new(),
+            }
+        );
+        assert_eq!(chat.activity, ActivityState::SessionOp(SessionOp::Undo));
+        assert_eq!(chat.streaming_content, "content");
+        assert_eq!(
+            chat.streaming_content_message_id.as_deref(),
+            Some("content-id")
+        );
+        assert_eq!(chat.streaming_thinking, "thinking");
+        assert_eq!(
+            chat.streaming_thinking_message_id.as_deref(),
+            Some("thinking-id")
+        );
+        assert_eq!(chat.recent_prompt_text.as_deref(), Some("prompt"));
+        assert_eq!(chat.pending_fork_message_id.as_deref(), Some("fork-target"));
+        let state = chat.undo_state.as_ref().expect("rebuilt undo state");
+        assert_eq!(state.frontier_message_id.as_deref(), Some("one"));
+        assert_eq!(state.stack[0].turn_id, "turn-one");
+    }
+
+    #[test]
+    fn history_applied_undo_prefers_explicit_target_and_clears_only_undo_stream_scope() {
+        let mut chat = ChatState::new();
+        chat.activity = ActivityState::SessionOp(SessionOp::Undo);
+        chat.undoable_turns = vec![turn("one"), turn("two")];
+        chat.streaming_content = "discard content".into();
+        chat.streaming_content_message_id = Some("content-id".into());
+        chat.streaming_thinking = "keep thinking".into();
+        chat.streaming_thinking_message_id = Some("thinking-id".into());
+        chat.recent_prompt_text = Some("discard prompt".into());
+
+        let outcome = chat.reduce_history(HistoryAction::UndoCompleted(UndoResult::Applied {
+            target_message_id: Some("one".into()),
+            reverted_files: vec!["src/lib.rs".into()],
+            message: Some("ignored success".into()),
+            stack: UndoStackSnapshot {
+                message_ids: vec!["one".into(), "two".into()],
+            },
+        }));
+
+        assert_eq!(chat.activity, ActivityState::Idle);
+        assert!(chat.streaming_content.is_empty());
+        assert!(chat.streaming_content_message_id.is_none());
+        assert_eq!(chat.streaming_thinking, "keep thinking");
+        assert_eq!(
+            chat.streaming_thinking_message_id.as_deref(),
+            Some("thinking-id")
+        );
+        assert!(chat.recent_prompt_text.is_none());
+        let state = chat.undo_state.as_ref().expect("rebuilt undo state");
+        assert_eq!(state.frontier_message_id.as_deref(), Some("one"));
+        assert_eq!(state.stack[0].reverted_files, ["src/lib.rs"]);
+        assert!(state.stack[1].reverted_files.is_empty());
+        assert_eq!(
+            outcome,
+            HistoryOutcome {
+                transition: HistoryTransition::UndoApplied,
+                coordination: vec![
+                    HistoryCoordination::InvalidateContentCache,
+                    HistoryCoordination::Status {
+                        level: LogLevel::Info,
+                        target: "session",
+                        message: "undone - reloading session".into(),
+                    },
+                    HistoryCoordination::ReloadActiveSession,
+                ],
+                effects: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn history_applied_undo_uses_stack_tail_for_reverted_file_attribution() {
+        let mut chat = ChatState::new();
+        chat.undoable_turns = vec![turn("one"), turn("two")];
+
+        chat.reduce_history(HistoryAction::UndoCompleted(UndoResult::Applied {
+            target_message_id: None,
+            reverted_files: vec!["src/main.rs".into()],
+            message: None,
+            stack: UndoStackSnapshot {
+                message_ids: vec!["one".into(), "two".into()],
+            },
+        }));
+
+        let state = chat.undo_state.as_ref().expect("rebuilt undo state");
+        assert_eq!(state.frontier_message_id.as_deref(), Some("two"));
+        assert!(state.stack[0].reverted_files.is_empty());
+        assert_eq!(state.stack[1].reverted_files, ["src/main.rs"]);
+    }
+
+    #[test]
+    fn history_rejected_undo_uses_fallback_frontier_and_preserves_live_state() {
+        let mut chat = ChatState::new();
+        chat.activity = ActivityState::SessionOp(SessionOp::Undo);
+        chat.undoable_turns = vec![turn("one"), turn("two")];
+        chat.streaming_content = "keep content".into();
+        chat.streaming_content_message_id = Some("content-id".into());
+        chat.streaming_thinking = "keep thinking".into();
+        chat.streaming_thinking_message_id = Some("thinking-id".into());
+        chat.recent_prompt_text = Some("keep prompt".into());
+
+        let outcome = chat.reduce_history(HistoryAction::UndoCompleted(UndoResult::Rejected {
+            target_message_id: None,
+            message: None,
+            stack: UndoStackSnapshot {
+                message_ids: vec!["one".into(), "two".into()],
+            },
+        }));
+
+        assert_eq!(chat.activity, ActivityState::Idle);
+        assert_eq!(chat.streaming_content, "keep content");
+        assert_eq!(
+            chat.streaming_content_message_id.as_deref(),
+            Some("content-id")
+        );
+        assert_eq!(chat.streaming_thinking, "keep thinking");
+        assert_eq!(
+            chat.streaming_thinking_message_id.as_deref(),
+            Some("thinking-id")
+        );
+        assert_eq!(chat.recent_prompt_text.as_deref(), Some("keep prompt"));
+        assert_eq!(
+            chat.undo_state
+                .as_ref()
+                .and_then(|state| state.frontier_message_id.as_deref()),
+            Some("two")
+        );
+        assert_eq!(
+            outcome,
+            HistoryOutcome {
+                transition: HistoryTransition::UndoRejected,
+                coordination: vec![HistoryCoordination::Status {
+                    level: LogLevel::Warn,
+                    target: "session",
+                    message: "undo failed".into(),
+                }],
+                effects: Vec::new(),
+            }
+        );
+
+        let outcome = chat.reduce_history(HistoryAction::UndoCompleted(UndoResult::Rejected {
+            target_message_id: Some("one".into()),
+            message: Some("explicit rejection".into()),
+            stack: UndoStackSnapshot {
+                message_ids: vec!["one".into(), "two".into()],
+            },
+        }));
+        assert_eq!(
+            chat.undo_state
+                .as_ref()
+                .and_then(|state| state.frontier_message_id.as_deref()),
+            Some("one")
+        );
+        assert_eq!(
+            outcome.coordination,
+            vec![HistoryCoordination::Status {
+                level: LogLevel::Warn,
+                target: "session",
+                message: "explicit rejection".into(),
+            }]
+        );
+    }
+
+    #[test]
+    fn history_redo_results_rebuild_without_undo_cleanup_and_coordinate_exactly() {
+        let mut chat = ChatState::new();
+        chat.activity = ActivityState::SessionOp(SessionOp::Redo);
+        chat.streaming_content = "keep content".into();
+        chat.streaming_content_message_id = Some("content-id".into());
+        chat.streaming_thinking = "keep thinking".into();
+        chat.streaming_thinking_message_id = Some("thinking-id".into());
+        chat.recent_prompt_text = Some("keep prompt".into());
+
+        let applied = chat.reduce_history(HistoryAction::RedoCompleted(RedoResult::Applied {
+            message: Some("ignored success".into()),
+            stack: UndoStackSnapshot {
+                message_ids: vec!["one".into()],
+            },
+        }));
+
+        assert_eq!(chat.activity, ActivityState::Idle);
+        assert_eq!(chat.streaming_content, "keep content");
+        assert_eq!(
+            chat.streaming_content_message_id.as_deref(),
+            Some("content-id")
+        );
+        assert_eq!(chat.streaming_thinking, "keep thinking");
+        assert_eq!(
+            chat.streaming_thinking_message_id.as_deref(),
+            Some("thinking-id")
+        );
+        assert_eq!(chat.recent_prompt_text.as_deref(), Some("keep prompt"));
+        assert_eq!(
+            applied,
+            HistoryOutcome {
+                transition: HistoryTransition::RedoApplied,
+                coordination: vec![
+                    HistoryCoordination::Status {
+                        level: LogLevel::Info,
+                        target: "session",
+                        message: "redone - reloading session".into(),
+                    },
+                    HistoryCoordination::ReloadActiveSession,
+                ],
+                effects: Vec::new(),
+            }
+        );
+
+        chat.activity = ActivityState::SessionOp(SessionOp::Redo);
+        let rejected = chat.reduce_history(HistoryAction::RedoCompleted(RedoResult::Rejected {
+            message: None,
+            stack: UndoStackSnapshot {
+                message_ids: vec!["one".into(), "two".into()],
+            },
+        }));
+        assert_eq!(chat.activity, ActivityState::Idle);
+        assert_eq!(
+            chat.undo_state
+                .as_ref()
+                .and_then(|state| state.frontier_message_id.as_deref()),
+            Some("one")
+        );
+        assert_eq!(
+            rejected,
+            HistoryOutcome {
+                transition: HistoryTransition::RedoRejected,
+                coordination: vec![HistoryCoordination::Status {
+                    level: LogLevel::Warn,
+                    target: "session",
+                    message: "redo failed".into(),
+                }],
+                effects: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn history_fork_results_clear_pending_and_preserve_ignored_success_fields() {
+        let mut chat = ChatState::new();
+        chat.pending_fork_message_id = Some("fork-target".into());
+
+        let loaded = chat.reduce_history(HistoryAction::ForkCompleted(ForkResult::Succeeded {
+            source_session_id: Some("ignored-source".into()),
+            forked_session_id: Some("forked".into()),
+            message: Some("ignored success".into()),
+        }));
+        assert!(chat.pending_fork_message_id.is_none());
+        assert_eq!(
+            loaded,
+            HistoryOutcome {
+                transition: HistoryTransition::ForkLoaded,
+                coordination: vec![
+                    HistoryCoordination::ClosePopup,
+                    HistoryCoordination::Status {
+                        level: LogLevel::Info,
+                        target: "fork",
+                        message: "forked - loading session".into(),
+                    },
+                    HistoryCoordination::LoadForkedSession {
+                        session_id: "forked".into(),
+                    },
+                ],
+                effects: Vec::new(),
+            }
+        );
+
+        chat.pending_fork_message_id = Some("fork-target".into());
+        let missing_id = chat.reduce_history(HistoryAction::ForkCompleted(ForkResult::Succeeded {
+            source_session_id: Some("ignored-source".into()),
+            forked_session_id: None,
+            message: None,
+        }));
+        assert!(chat.pending_fork_message_id.is_none());
+        assert_eq!(
+            missing_id,
+            HistoryOutcome {
+                transition: HistoryTransition::ForkMissingSessionId,
+                coordination: vec![HistoryCoordination::Status {
+                    level: LogLevel::Warn,
+                    target: "fork",
+                    message: "fork succeeded without session id".into(),
+                }],
+                effects: Vec::new(),
+            }
+        );
+
+        chat.pending_fork_message_id = Some("fork-target".into());
+        let failed = chat.reduce_history(HistoryAction::ForkCompleted(ForkResult::Failed {
+            source_session_id: Some("ignored-source".into()),
+            message: None,
+        }));
+        assert!(chat.pending_fork_message_id.is_none());
+        assert_eq!(
+            failed,
+            HistoryOutcome {
+                transition: HistoryTransition::ForkFailed,
+                coordination: vec![HistoryCoordination::Status {
+                    level: LogLevel::Warn,
+                    target: "fork",
+                    message: "fork failed".into(),
+                }],
+                effects: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn history_rejections_preserve_supplied_diagnostic_messages() {
+        let mut chat = ChatState::new();
+
+        let undo = chat.reduce_history(HistoryAction::UndoCompleted(UndoResult::Rejected {
+            target_message_id: None,
+            message: Some("undo rejected by server".into()),
+            stack: UndoStackSnapshot::default(),
+        }));
+        assert_eq!(
+            undo.coordination,
+            vec![HistoryCoordination::Status {
+                level: LogLevel::Warn,
+                target: "session",
+                message: "undo rejected by server".into(),
+            }]
+        );
+
+        let redo = chat.reduce_history(HistoryAction::RedoCompleted(RedoResult::Rejected {
+            message: Some("redo rejected by server".into()),
+            stack: UndoStackSnapshot::default(),
+        }));
+        assert_eq!(
+            redo.coordination,
+            vec![HistoryCoordination::Status {
+                level: LogLevel::Warn,
+                target: "session",
+                message: "redo rejected by server".into(),
+            }]
+        );
+
+        let missing_fork =
+            chat.reduce_history(HistoryAction::ForkCompleted(ForkResult::Succeeded {
+                source_session_id: None,
+                forked_session_id: None,
+                message: Some("fork response omitted an id".into()),
+            }));
+        assert_eq!(
+            missing_fork.coordination,
+            vec![HistoryCoordination::Status {
+                level: LogLevel::Warn,
+                target: "fork",
+                message: "fork response omitted an id".into(),
+            }]
+        );
+
+        let failed = chat.reduce_history(HistoryAction::ForkCompleted(ForkResult::Failed {
+            source_session_id: None,
+            message: Some("fork rejected by server".into()),
+        }));
+        assert_eq!(
+            failed.coordination,
+            vec![HistoryCoordination::Status {
+                level: LogLevel::Warn,
+                target: "fork",
+                message: "fork rejected by server".into(),
+            }]
+        );
     }
 
     #[test]

--- a/src/delegates_state.rs
+++ b/src/delegates_state.rs
@@ -2,12 +2,75 @@ use std::collections::{HashMap, HashSet};
 
 use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
+use serde_json::Value;
 
+use crate::application::Effect;
 use crate::domain::activity::{
-    DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus, PendingDelegateToolCall,
+    DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus, DelegationState,
+    DelegationUpdate, PendingDelegateToolCall,
 };
 
-pub(crate) struct DelegateLifecycleUpdate {
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum DelegateChildActivity {
+    ToolCallStarted,
+    AssistantMessage {
+        message_id: Option<String>,
+    },
+    AssistantContent {
+        message_id: Option<String>,
+    },
+    Progress,
+    UserMessage,
+    Usage {
+        used: u64,
+        size: u64,
+        cost_usd: Option<f64>,
+    },
+    PendingElicitation {
+        elicitation_id: String,
+        message: String,
+        requested_schema: Value,
+        source: String,
+    },
+    QuestionToolFinished,
+    Unchanged,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum DelegateAction {
+    LifecycleUpdate(DelegationUpdate),
+    ProvisionalToolDelegate {
+        tool_call_id: Option<String>,
+        arguments: Option<Value>,
+    },
+    InactiveChildActivity {
+        session_id: String,
+        activity: DelegateChildActivity,
+    },
+    ResolveLoadedSessionParent(Option<String>),
+    ClearNewRootParent,
+    ClearRootSessionState,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct DelegateContext {
+    pub(crate) active_session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DelegateCoordination {
+    NoteSessionActivity(String),
+    InvalidateCardCache,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct DelegateOutcome {
+    pub(crate) changed: bool,
+    pub(crate) coordination: Vec<DelegateCoordination>,
+    pub(crate) effects: Vec<Effect>,
+}
+
+struct DelegateLifecycleUpdate {
     pub(crate) delegation_id: String,
     pub(crate) tool_call_id: Option<String>,
     pub(crate) target_agent_id: String,
@@ -22,6 +85,7 @@ pub(crate) struct DelegateLifecycleUpdate {
     pub(crate) error: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct DelegatesState {
     pub(crate) delegate_popup_visible_rows: usize,
     pub(crate) delegate_entries: Vec<DelegateEntry>,
@@ -40,6 +104,179 @@ pub(crate) struct DelegatesState {
 }
 
 impl DelegatesState {
+    pub(crate) fn reduce(
+        &mut self,
+        action: DelegateAction,
+        context: DelegateContext,
+    ) -> DelegateOutcome {
+        match action {
+            DelegateAction::LifecycleUpdate(update) => {
+                if context.active_session_id.as_deref() != Some(update.session_id.as_str()) {
+                    return DelegateOutcome::default();
+                }
+                let status = match update.state {
+                    DelegationState::Requested | DelegationState::Forked => {
+                        DelegateStatus::InProgress
+                    }
+                    DelegationState::Completed => DelegateStatus::Completed,
+                    DelegationState::Failed => DelegateStatus::Failed,
+                    DelegationState::Cancelled => DelegateStatus::Cancelled,
+                };
+                let lifecycle_rank = delegation_state_rank(update.state);
+                let before = self.clone();
+                let accepted = self.apply_lifecycle_update(DelegateLifecycleUpdate {
+                    delegation_id: update.delegation_id,
+                    tool_call_id: update.tool_call_id,
+                    target_agent_id: update.target_agent_id,
+                    objective: update.objective,
+                    child_session_id: update.child_session_id,
+                    status,
+                    lifecycle_rank,
+                    requested_at: update.requested_at,
+                    finished_at: update.finished_at,
+                    updated_at: update.updated_at,
+                    result_summary: update.result_summary,
+                    error: update.error,
+                });
+                Self::outcome_with_card_invalidation(accepted && *self != before)
+            }
+            DelegateAction::ProvisionalToolDelegate {
+                tool_call_id,
+                arguments,
+            } => {
+                let Some(tool_call_id) = tool_call_id else {
+                    return DelegateOutcome::default();
+                };
+                let target_agent_id = arguments
+                    .as_ref()
+                    .and_then(|value| value.get("target_agent_id"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+                let objective = arguments
+                    .as_ref()
+                    .and_then(|value| value.get("objective"))
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+                let changed =
+                    self.upsert_provisional_delegate(&tool_call_id, target_agent_id, objective);
+                Self::outcome_with_card_invalidation(changed)
+            }
+            DelegateAction::InactiveChildActivity {
+                session_id,
+                activity,
+            } => {
+                let changed = self.apply_child_activity(&session_id, activity);
+                let mut coordination = vec![DelegateCoordination::NoteSessionActivity(session_id)];
+                if changed {
+                    coordination.push(DelegateCoordination::InvalidateCardCache);
+                }
+                DelegateOutcome {
+                    changed,
+                    coordination,
+                    effects: Vec::new(),
+                }
+            }
+            DelegateAction::ResolveLoadedSessionParent(discovered_parent) => {
+                let parent_before = self.parent_session_id.clone();
+                let pending_before = self.pending_parent_session_id.clone();
+                self.resolve_parent_session_id(discovered_parent);
+                DelegateOutcome {
+                    changed: self.parent_session_id != parent_before
+                        || self.pending_parent_session_id != pending_before,
+                    ..DelegateOutcome::default()
+                }
+            }
+            DelegateAction::ClearNewRootParent => {
+                let changed = self.parent_session_id.take().is_some()
+                    | self.pending_parent_session_id.take().is_some();
+                DelegateOutcome {
+                    changed,
+                    ..DelegateOutcome::default()
+                }
+            }
+            DelegateAction::ClearRootSessionState => {
+                if self.parent_session_id.is_some() {
+                    return DelegateOutcome::default();
+                }
+                let before = self.clone();
+                self.clear_for_root_session();
+                DelegateOutcome {
+                    changed: *self != before,
+                    ..DelegateOutcome::default()
+                }
+            }
+        }
+    }
+
+    fn outcome_with_card_invalidation(changed: bool) -> DelegateOutcome {
+        DelegateOutcome {
+            changed,
+            coordination: changed
+                .then_some(DelegateCoordination::InvalidateCardCache)
+                .into_iter()
+                .collect(),
+            effects: Vec::new(),
+        }
+    }
+
+    fn apply_child_activity(&mut self, session_id: &str, activity: DelegateChildActivity) -> bool {
+        let (mut state, mut stats) = self.child_snapshot(session_id);
+        match activity {
+            DelegateChildActivity::ToolCallStarted => {
+                stats.tool_calls = stats.tool_calls.saturating_add(1);
+                state = DelegateChildState::OtherProgress;
+            }
+            DelegateChildActivity::AssistantMessage { message_id } => {
+                if self.record_child_message_id(session_id, message_id.as_deref(), true) {
+                    stats.messages = stats.messages.saturating_add(1);
+                }
+                state = DelegateChildState::AssistantMessage;
+            }
+            DelegateChildActivity::AssistantContent { message_id } => {
+                if self.record_child_message_id(session_id, message_id.as_deref(), false) {
+                    stats.messages = stats.messages.saturating_add(1);
+                }
+                state = DelegateChildState::AssistantMessage;
+            }
+            DelegateChildActivity::Progress => state = DelegateChildState::OtherProgress,
+            DelegateChildActivity::UserMessage => state = DelegateChildState::UserMessage,
+            DelegateChildActivity::Usage {
+                used,
+                size,
+                cost_usd,
+            } => {
+                if used > 0 {
+                    stats.context_tokens = used;
+                }
+                if size > 0 {
+                    stats.context_limit = size;
+                }
+                if let Some(cost) = cost_usd {
+                    stats.cost_usd = cost;
+                }
+            }
+            DelegateChildActivity::PendingElicitation {
+                elicitation_id,
+                message,
+                requested_schema,
+                source,
+            } => {
+                state = DelegateChildState::PendingElicitation {
+                    elicitation_id,
+                    message,
+                    requested_schema,
+                    source,
+                };
+            }
+            DelegateChildActivity::QuestionToolFinished => {
+                state = DelegateChildState::QuestionToolFinished;
+            }
+            DelegateChildActivity::Unchanged => {}
+        }
+        self.apply_child_snapshot(session_id, state, stats)
+    }
+
     pub(crate) fn new() -> Self {
         Self {
             delegate_popup_visible_rows: 0,
@@ -156,7 +393,7 @@ impl DelegatesState {
         true
     }
 
-    pub(crate) fn apply_lifecycle_update(&mut self, update: DelegateLifecycleUpdate) -> bool {
+    fn apply_lifecycle_update(&mut self, update: DelegateLifecycleUpdate) -> bool {
         let DelegateLifecycleUpdate {
             delegation_id,
             mut tool_call_id,
@@ -376,6 +613,14 @@ fn lifecycle_rank(status: DelegateStatus, child_session_id: Option<&str>) -> u8 
 
 fn entry_lifecycle_rank(entry: &DelegateEntry) -> u8 {
     lifecycle_rank(entry.status, entry.child_session_id.as_deref())
+}
+
+fn delegation_state_rank(state: DelegationState) -> u8 {
+    match state {
+        DelegationState::Requested => 1,
+        DelegationState::Forked => 2,
+        DelegationState::Completed | DelegationState::Failed | DelegationState::Cancelled => 3,
+    }
 }
 
 #[cfg(test)]
@@ -719,6 +964,285 @@ mod tests {
         assert_eq!(state.delegate_filter, "stale");
         assert_eq!(state.delegate_cursor, 3);
         assert_eq!(state.delegate_popup_visible_rows, 5);
+    }
+
+    #[test]
+    fn reducer_lifecycle_filters_and_preserves_timestamp_rank_and_tie_semantics() {
+        let mut state = DelegatesState::new();
+        let update = |session_id: &str, lifecycle, updated_at| DelegationUpdate {
+            session_id: session_id.into(),
+            delegation_id: "d1".into(),
+            tool_call_id: Some("tool-1".into()),
+            state: lifecycle,
+            target_agent_id: "coder".into(),
+            objective: "build feature".into(),
+            child_session_id: (lifecycle != DelegationState::Requested).then(|| "child".into()),
+            requested_at: 10,
+            forked_at: (lifecycle != DelegationState::Requested).then_some(15),
+            finished_at: matches!(
+                lifecycle,
+                DelegationState::Completed | DelegationState::Failed | DelegationState::Cancelled
+            )
+            .then_some(20),
+            updated_at,
+            result_summary: (lifecycle == DelegationState::Completed).then(|| "done".into()),
+            error: (lifecycle == DelegationState::Failed).then(|| "boom".into()),
+        };
+        let context = DelegateContext {
+            active_session_id: Some("parent".into()),
+        };
+
+        let filtered = state.reduce(
+            DelegateAction::LifecycleUpdate(update("other-parent", DelegationState::Requested, 10)),
+            context.clone(),
+        );
+        assert_eq!(filtered, DelegateOutcome::default());
+        assert!(state.delegate_entries.is_empty());
+
+        let accepted = state.reduce(
+            DelegateAction::LifecycleUpdate(update("parent", DelegationState::Completed, 20)),
+            context.clone(),
+        );
+        assert!(accepted.changed);
+        assert_eq!(
+            accepted.coordination,
+            vec![DelegateCoordination::InvalidateCardCache]
+        );
+        assert!(accepted.effects.is_empty());
+
+        let stale = state.reduce(
+            DelegateAction::LifecycleUpdate(update("parent", DelegationState::Forked, 19)),
+            context.clone(),
+        );
+        assert_eq!(stale, DelegateOutcome::default());
+        let equal_lower_rank = state.reduce(
+            DelegateAction::LifecycleUpdate(update("parent", DelegationState::Forked, 20)),
+            context.clone(),
+        );
+        assert_eq!(equal_lower_rank, DelegateOutcome::default());
+
+        let equal_rank_tie = state.reduce(
+            DelegateAction::LifecycleUpdate(update("parent", DelegationState::Failed, 20)),
+            context.clone(),
+        );
+        assert!(equal_rank_tie.changed);
+        assert_eq!(state.delegate_entries[0].status, DelegateStatus::Failed);
+        assert_eq!(state.delegation_errors["d1"], "boom");
+        assert!(!state.delegation_result_summaries.contains_key("d1"));
+
+        let repeated = state.reduce(
+            DelegateAction::LifecycleUpdate(update("parent", DelegationState::Failed, 20)),
+            context,
+        );
+        assert_eq!(repeated, DelegateOutcome::default());
+    }
+
+    #[test]
+    fn reducer_provisional_action_reconciles_authoritative_metadata_without_duplicates() {
+        let mut state = DelegatesState::new();
+        let action = DelegateAction::ProvisionalToolDelegate {
+            tool_call_id: Some("tool-1".into()),
+            arguments: Some(serde_json::json!({
+                "target_agent_id": "coder",
+                "objective": "build feature"
+            })),
+        };
+
+        let inserted = state.reduce(action.clone(), DelegateContext::default());
+        assert!(inserted.changed);
+        assert_eq!(
+            inserted.coordination,
+            vec![DelegateCoordination::InvalidateCardCache]
+        );
+        assert!(inserted.effects.is_empty());
+        assert_eq!(
+            state.reduce(action, DelegateContext::default()),
+            DelegateOutcome::default()
+        );
+        assert_eq!(
+            state.reduce(
+                DelegateAction::ProvisionalToolDelegate {
+                    tool_call_id: None,
+                    arguments: None,
+                },
+                DelegateContext::default(),
+            ),
+            DelegateOutcome::default()
+        );
+
+        let authoritative = state.reduce(
+            DelegateAction::LifecycleUpdate(DelegationUpdate {
+                session_id: "parent".into(),
+                delegation_id: "d1".into(),
+                tool_call_id: Some("tool-1".into()),
+                state: DelegationState::Forked,
+                target_agent_id: "reviewer".into(),
+                objective: "review feature".into(),
+                child_session_id: Some("child".into()),
+                requested_at: 10,
+                forked_at: Some(11),
+                finished_at: None,
+                updated_at: 11,
+                result_summary: None,
+                error: None,
+            }),
+            DelegateContext {
+                active_session_id: Some("parent".into()),
+            },
+        );
+        assert!(authoritative.changed);
+        assert_eq!(state.delegate_entries.len(), 1);
+        let entry = &state.delegate_entries[0];
+        assert_eq!(entry.delegation_id, "d1");
+        assert_eq!(entry.delegate_tool_call_id.as_deref(), Some("tool-1"));
+        assert_eq!(entry.target_agent_id.as_deref(), Some("reviewer"));
+        assert_eq!(entry.objective, "review feature");
+        assert_eq!(entry.child_session_id.as_deref(), Some("child"));
+        assert!(state.pending_delegate_tool_calls.is_empty());
+    }
+
+    #[test]
+    fn reducer_inactive_activity_stages_then_attaches_and_orders_coordination() {
+        let mut state = DelegatesState::new();
+        let context = DelegateContext {
+            active_session_id: Some("parent".into()),
+        };
+        let staged = state.reduce(
+            DelegateAction::InactiveChildActivity {
+                session_id: "child".into(),
+                activity: DelegateChildActivity::AssistantContent {
+                    message_id: Some("m1".into()),
+                },
+            },
+            context.clone(),
+        );
+        assert!(!staged.changed);
+        assert_eq!(
+            staged.coordination,
+            vec![DelegateCoordination::NoteSessionActivity("child".into())]
+        );
+        assert!(staged.effects.is_empty());
+        assert_eq!(
+            state.pending_delegate_child_states["child"],
+            DelegateChildState::AssistantMessage
+        );
+        assert_eq!(state.pending_delegate_child_stats["child"].messages, 1);
+
+        let linked = state.reduce(
+            DelegateAction::LifecycleUpdate(DelegationUpdate {
+                session_id: "parent".into(),
+                delegation_id: "d1".into(),
+                tool_call_id: None,
+                state: DelegationState::Forked,
+                target_agent_id: "coder".into(),
+                objective: "build feature".into(),
+                child_session_id: Some("child".into()),
+                requested_at: 10,
+                forked_at: Some(11),
+                finished_at: None,
+                updated_at: 11,
+                result_summary: None,
+                error: None,
+            }),
+            context.clone(),
+        );
+        assert!(linked.changed);
+        assert_eq!(state.delegate_entries[0].stats.messages, 1);
+        assert_eq!(
+            state.delegate_entries[0].child_state,
+            DelegateChildState::AssistantMessage
+        );
+        assert!(!state.pending_delegate_child_states.contains_key("child"));
+        assert!(!state.pending_delegate_child_stats.contains_key("child"));
+
+        let changed = state.reduce(
+            DelegateAction::InactiveChildActivity {
+                session_id: "child".into(),
+                activity: DelegateChildActivity::ToolCallStarted,
+            },
+            context.clone(),
+        );
+        assert!(changed.changed);
+        assert_eq!(
+            changed.coordination,
+            vec![
+                DelegateCoordination::NoteSessionActivity("child".into()),
+                DelegateCoordination::InvalidateCardCache,
+            ]
+        );
+        assert_eq!(state.delegate_entries[0].stats.tool_calls, 1);
+
+        let unchanged = state.reduce(
+            DelegateAction::InactiveChildActivity {
+                session_id: "child".into(),
+                activity: DelegateChildActivity::Unchanged,
+            },
+            context,
+        );
+        assert!(!unchanged.changed);
+        assert_eq!(
+            unchanged.coordination,
+            vec![DelegateCoordination::NoteSessionActivity("child".into())]
+        );
+    }
+
+    #[test]
+    fn reducer_resolve_and_clear_actions_report_exact_changes() {
+        let mut state = DelegatesState::new();
+        state.pending_parent_session_id = Some("staged-parent".into());
+        state
+            .delegate_entries
+            .push(entry("d1", "task", None, DelegateStatus::InProgress));
+
+        let resolved = state.reduce(
+            DelegateAction::ResolveLoadedSessionParent(Some("catalog-parent".into())),
+            DelegateContext::default(),
+        );
+        assert!(resolved.changed);
+        assert!(resolved.coordination.is_empty());
+        assert!(resolved.effects.is_empty());
+        assert_eq!(state.parent_session_id.as_deref(), Some("staged-parent"));
+        assert_eq!(state.pending_parent_session_id, None);
+        assert_eq!(
+            state.reduce(
+                DelegateAction::ResolveLoadedSessionParent(Some("staged-parent".into())),
+                DelegateContext::default(),
+            ),
+            DelegateOutcome::default()
+        );
+
+        let protected = state.reduce(
+            DelegateAction::ClearRootSessionState,
+            DelegateContext::default(),
+        );
+        assert_eq!(protected, DelegateOutcome::default());
+        assert_eq!(state.delegate_entries.len(), 1);
+
+        let cleared_parent = state.reduce(
+            DelegateAction::ClearNewRootParent,
+            DelegateContext::default(),
+        );
+        assert!(cleared_parent.changed);
+        assert_eq!(
+            state.reduce(
+                DelegateAction::ClearNewRootParent,
+                DelegateContext::default(),
+            ),
+            DelegateOutcome::default()
+        );
+        let cleared_root = state.reduce(
+            DelegateAction::ClearRootSessionState,
+            DelegateContext::default(),
+        );
+        assert!(cleared_root.changed);
+        assert!(state.delegate_entries.is_empty());
+        assert_eq!(
+            state.reduce(
+                DelegateAction::ClearRootSessionState,
+                DelegateContext::default(),
+            ),
+            DelegateOutcome::default()
+        );
     }
 
     #[test]

--- a/src/delegates_state.rs
+++ b/src/delegates_state.rs
@@ -55,11 +55,11 @@ pub(crate) enum DelegateAction {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct DelegateContext {
     pub(crate) active_session_id: Option<String>,
+    pub(crate) inactive_activity_session_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum DelegateCoordination {
-    NoteSessionActivity(String),
     InvalidateCardCache,
 }
 
@@ -166,14 +166,16 @@ impl DelegatesState {
                 session_id,
                 activity,
             } => {
-                let changed = self.apply_child_activity(&session_id, activity);
-                let mut coordination = vec![DelegateCoordination::NoteSessionActivity(session_id)];
-                if changed {
-                    coordination.push(DelegateCoordination::InvalidateCardCache);
+                if context.inactive_activity_session_id.as_deref() != Some(session_id.as_str()) {
+                    return DelegateOutcome::default();
                 }
+                let changed = self.apply_child_activity(&session_id, activity);
                 DelegateOutcome {
                     changed,
-                    coordination,
+                    coordination: changed
+                        .then_some(DelegateCoordination::InvalidateCardCache)
+                        .into_iter()
+                        .collect(),
                     effects: Vec::new(),
                 }
             }
@@ -990,6 +992,7 @@ mod tests {
         };
         let context = DelegateContext {
             active_session_id: Some("parent".into()),
+            inactive_activity_session_id: None,
         };
 
         let filtered = state.reduce(
@@ -1088,6 +1091,7 @@ mod tests {
             }),
             DelegateContext {
                 active_session_id: Some("parent".into()),
+                inactive_activity_session_id: None,
             },
         );
         assert!(authoritative.changed);
@@ -1106,7 +1110,25 @@ mod tests {
         let mut state = DelegatesState::new();
         let context = DelegateContext {
             active_session_id: Some("parent".into()),
+            inactive_activity_session_id: Some("child".into()),
         };
+        let rejected = state.reduce(
+            DelegateAction::InactiveChildActivity {
+                session_id: "child".into(),
+                activity: DelegateChildActivity::AssistantContent {
+                    message_id: Some("m1".into()),
+                },
+            },
+            DelegateContext {
+                active_session_id: Some("parent".into()),
+                inactive_activity_session_id: None,
+            },
+        );
+        assert!(!rejected.changed);
+        assert!(rejected.coordination.is_empty());
+        assert!(state.pending_delegate_child_states.is_empty());
+        assert!(state.pending_delegate_child_stats.is_empty());
+
         let staged = state.reduce(
             DelegateAction::InactiveChildActivity {
                 session_id: "child".into(),
@@ -1117,10 +1139,7 @@ mod tests {
             context.clone(),
         );
         assert!(!staged.changed);
-        assert_eq!(
-            staged.coordination,
-            vec![DelegateCoordination::NoteSessionActivity("child".into())]
-        );
+        assert!(staged.coordination.is_empty());
         assert!(staged.effects.is_empty());
         assert_eq!(
             state.pending_delegate_child_states["child"],
@@ -1165,10 +1184,7 @@ mod tests {
         assert!(changed.changed);
         assert_eq!(
             changed.coordination,
-            vec![
-                DelegateCoordination::NoteSessionActivity("child".into()),
-                DelegateCoordination::InvalidateCardCache,
-            ]
+            vec![DelegateCoordination::InvalidateCardCache]
         );
         assert_eq!(state.delegate_entries[0].stats.tool_calls, 1);
 
@@ -1180,10 +1196,7 @@ mod tests {
             context,
         );
         assert!(!unchanged.changed);
-        assert_eq!(
-            unchanged.coordination,
-            vec![DelegateCoordination::NoteSessionActivity("child".into())]
-        );
+        assert!(unchanged.coordination.is_empty());
     }
 
     #[test]

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -1,10 +1,12 @@
 use crate::app::App;
+use crate::application::Effect;
 use crate::command::Command;
 use crate::diagnostics::LogLevel;
 use crate::domain::mesh::{
     MeshInviteCreatedInfo, MeshNodesInfo, MeshStatusInfo, RemoteSessionAttachInfo,
     RemoteSessionListInfo,
 };
+use crate::mesh_state::{MeshAction, MeshContext, MeshCoordination, MeshOutcome};
 use crate::navigation_state::Popup;
 
 impl App {
@@ -20,10 +22,10 @@ impl App {
     }
 
     pub fn apply_mesh_invite_created(&mut self, invite: MeshInviteCreatedInfo) {
-        let url = self.mesh.store_invite(invite);
-        self.navigation.popup = Popup::MeshInviteQr;
-        self.set_status(LogLevel::Info, "mesh", "mesh invite created");
-        self.push_log(LogLevel::Info, "mesh", format!("mesh invite: {url}"));
+        let outcome = self
+            .mesh
+            .reduce(MeshAction::InviteCreated(invite), MeshContext::default());
+        debug_assert!(self.apply_mesh_outcome(outcome).is_empty());
     }
 
     pub fn mesh_invite_form_command(&mut self) -> Option<Command> {
@@ -36,69 +38,78 @@ impl App {
     }
 
     pub fn apply_mesh_status(&mut self, status: MeshStatusInfo) {
-        let (enabled, peer_count) = self.mesh.replace_status(status);
-        self.push_log(
-            LogLevel::Debug,
-            "mesh",
-            format!("mesh status: enabled={enabled}, peers={peer_count}"),
-        );
+        let outcome = self
+            .mesh
+            .reduce(MeshAction::Status(status), MeshContext::default());
+        debug_assert!(self.apply_mesh_outcome(outcome).is_empty());
     }
 
     pub fn apply_mesh_nodes(&mut self, nodes: MeshNodesInfo) -> Vec<Command> {
-        let (count, selected_node_id) = self.mesh.replace_nodes(nodes.nodes);
-        self.push_log(LogLevel::Info, "mesh", format!("mesh nodes: {count}"));
-        selected_node_id
-            .map(|node_id| Command::ListRemoteSessions {
-                node_id,
-                offset: 0,
-                limit: 50,
-            })
-            .into_iter()
-            .collect()
+        let outcome = self
+            .mesh
+            .reduce(MeshAction::Nodes(nodes), MeshContext::default());
+        self.apply_mesh_outcome(outcome)
     }
 
     pub fn apply_remote_sessions(&mut self, list: RemoteSessionListInfo) {
-        for session in &list.sessions {
-            self.sessions.remember_remote_session_location(
-                &session.id,
-                &session.node_id,
-                session.cwd.clone(),
-            );
-        }
-        let count = self
+        let outcome = self
             .mesh
-            .replace_remote_sessions(&list.node_id, list.sessions);
-        self.push_log(
-            LogLevel::Info,
-            "mesh",
-            format!("remote sessions: {count} for {}", list.node_id),
-        );
+            .reduce(MeshAction::RemoteSessions(list), MeshContext::default());
+        debug_assert!(self.apply_mesh_outcome(outcome).is_empty());
     }
 
     pub fn apply_remote_session_attached(
         &mut self,
         attached: RemoteSessionAttachInfo,
     ) -> Vec<Command> {
-        // ACP session/load is authoritative for history and typed config; applying this
-        // extension snapshot/config directly would duplicate replay or configuration.
-        self.sessions
-            .remember_remote_session_node(&attached.session_id, &attached.node_id);
-        if attached.attached {
-            self.navigation.popup = Popup::None;
-            self.set_status(LogLevel::Info, "mesh", "remote session attached");
-            Command::load_session_commands(
-                attached.session_id.clone(),
-                self.sessions.session_remote_cwd(&attached.session_id),
-                self.sessions.agent_id.clone(),
-            )
-            .into()
-        } else {
-            self.set_status(LogLevel::Info, "mesh", "remote session created");
-            vec![Command::ListRemoteSessions {
-                node_id: attached.node_id,
-                offset: 0,
-                limit: 50,
-            }]
+        // ACP session/load remains authoritative for history and typed config.
+        let context = MeshContext {
+            agent_id: self.sessions.agent_id.clone(),
+            remote_session_cwd: self.sessions.session_remote_cwd(&attached.session_id),
+        };
+        let outcome = self
+            .mesh
+            .reduce(MeshAction::RemoteSessionAttached(attached), context);
+        self.apply_mesh_outcome(outcome)
+    }
+
+    pub(crate) fn apply_mesh_clipboard_result(&mut self, success: bool) -> Vec<Effect> {
+        let outcome = self.mesh.reduce(
+            MeshAction::ClipboardFinished { success },
+            MeshContext::default(),
+        );
+        self.apply_mesh_outcome(outcome)
+            .into_iter()
+            .map(Effect::Command)
+            .collect()
+    }
+
+    fn apply_mesh_outcome(&mut self, outcome: MeshOutcome) -> Vec<Command> {
+        for coordination in outcome.coordination {
+            match coordination {
+                MeshCoordination::Log { level, message } => {
+                    self.push_log(level, "mesh", message);
+                }
+                MeshCoordination::Status { level, message } => {
+                    self.set_status(level, "mesh", message);
+                }
+                MeshCoordination::SetPopup(popup) => self.navigation.popup = popup,
+                MeshCoordination::RememberRemoteSession {
+                    session_id,
+                    node_id,
+                    cwd,
+                } => self
+                    .sessions
+                    .remember_remote_session_location(&session_id, &node_id, cwd),
+            }
         }
+        outcome
+            .effects
+            .into_iter()
+            .map(|effect| match effect {
+                Effect::Command(command) => command,
+                _ => unreachable!("mesh reducers only emit command effects"),
+            })
+            .collect()
     }
 }

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -25,7 +25,8 @@ impl App {
         let outcome = self
             .mesh
             .reduce(MeshAction::InviteCreated(invite), MeshContext::default());
-        debug_assert!(self.apply_mesh_outcome(outcome).is_empty());
+        let effects = self.apply_mesh_outcome(outcome);
+        debug_assert!(effects.is_empty());
     }
 
     pub fn mesh_invite_form_command(&mut self) -> Option<Command> {
@@ -41,7 +42,8 @@ impl App {
         let outcome = self
             .mesh
             .reduce(MeshAction::Status(status), MeshContext::default());
-        debug_assert!(self.apply_mesh_outcome(outcome).is_empty());
+        let effects = self.apply_mesh_outcome(outcome);
+        debug_assert!(effects.is_empty());
     }
 
     pub fn apply_mesh_nodes(&mut self, nodes: MeshNodesInfo) -> Vec<Command> {
@@ -55,7 +57,8 @@ impl App {
         let outcome = self
             .mesh
             .reduce(MeshAction::RemoteSessions(list), MeshContext::default());
-        debug_assert!(self.apply_mesh_outcome(outcome).is_empty());
+        let effects = self.apply_mesh_outcome(outcome);
+        debug_assert!(effects.is_empty());
     }
 
     pub fn apply_remote_session_attached(

--- a/src/mesh_state.rs
+++ b/src/mesh_state.rs
@@ -1,9 +1,14 @@
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
+use crate::application::Effect;
+use crate::command::Command;
+use crate::diagnostics::LogLevel;
 use crate::domain::mesh::{
-    MeshInviteCreatedInfo, MeshStatusInfo, RemoteNodeInfo, RemoteSessionInfo,
+    MeshInviteCreatedInfo, MeshNodesInfo, MeshStatusInfo, RemoteNodeInfo, RemoteSessionAttachInfo,
+    RemoteSessionInfo, RemoteSessionListInfo,
 };
+use crate::navigation_state::Popup;
 
 const INVITE_ERROR_TTL: Duration = Duration::from_secs(5);
 
@@ -20,6 +25,46 @@ pub(crate) enum MeshInviteFormField {
     MeshName,
     Ttl,
     MaxUses,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum MeshAction {
+    Status(MeshStatusInfo),
+    Nodes(MeshNodesInfo),
+    InviteCreated(MeshInviteCreatedInfo),
+    RemoteSessions(RemoteSessionListInfo),
+    RemoteSessionAttached(RemoteSessionAttachInfo),
+    ClipboardFinished { success: bool },
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct MeshContext {
+    pub(crate) agent_id: Option<String>,
+    pub(crate) remote_session_cwd: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum MeshCoordination {
+    Log {
+        level: LogLevel,
+        message: String,
+    },
+    Status {
+        level: LogLevel,
+        message: String,
+    },
+    SetPopup(Popup),
+    RememberRemoteSession {
+        session_id: String,
+        node_id: String,
+        cwd: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct MeshOutcome {
+    pub(crate) coordination: Vec<MeshCoordination>,
+    pub(crate) effects: Vec<Effect>,
 }
 
 pub(crate) struct MeshState {
@@ -41,6 +86,139 @@ pub(crate) struct MeshState {
 }
 
 impl MeshState {
+    pub(crate) fn reduce(&mut self, action: MeshAction, context: MeshContext) -> MeshOutcome {
+        match action {
+            MeshAction::Status(status) => {
+                let (enabled, peer_count) = self.replace_status(status);
+                MeshOutcome {
+                    coordination: vec![MeshCoordination::Log {
+                        level: LogLevel::Debug,
+                        message: format!("mesh status: enabled={enabled}, peers={peer_count}"),
+                    }],
+                    effects: Vec::new(),
+                }
+            }
+            MeshAction::Nodes(nodes) => {
+                let (count, selected_node_id) = self.replace_nodes(nodes.nodes);
+                MeshOutcome {
+                    coordination: vec![MeshCoordination::Log {
+                        level: LogLevel::Info,
+                        message: format!("mesh nodes: {count}"),
+                    }],
+                    effects: selected_node_id
+                        .map(|node_id| {
+                            Effect::Command(Command::ListRemoteSessions {
+                                node_id,
+                                offset: 0,
+                                limit: 50,
+                            })
+                        })
+                        .into_iter()
+                        .collect(),
+                }
+            }
+            MeshAction::InviteCreated(invite) => {
+                let url = self.store_invite(invite);
+                MeshOutcome {
+                    coordination: vec![
+                        MeshCoordination::SetPopup(Popup::MeshInviteQr),
+                        MeshCoordination::Status {
+                            level: LogLevel::Info,
+                            message: "mesh invite created".into(),
+                        },
+                        MeshCoordination::Log {
+                            level: LogLevel::Info,
+                            message: format!("mesh invite: {url}"),
+                        },
+                    ],
+                    effects: Vec::new(),
+                }
+            }
+            MeshAction::RemoteSessions(list) => {
+                let node_id = list.node_id;
+                let mut coordination = list
+                    .sessions
+                    .iter()
+                    .map(|session| MeshCoordination::RememberRemoteSession {
+                        session_id: session.id.clone(),
+                        node_id: session.node_id.clone(),
+                        cwd: session.cwd.clone(),
+                    })
+                    .collect::<Vec<_>>();
+                let count = self.replace_remote_sessions(&node_id, list.sessions);
+                coordination.push(MeshCoordination::Log {
+                    level: LogLevel::Info,
+                    message: format!("remote sessions: {count} for {node_id}"),
+                });
+                MeshOutcome {
+                    coordination,
+                    effects: Vec::new(),
+                }
+            }
+            MeshAction::RemoteSessionAttached(attached) => {
+                let RemoteSessionAttachInfo {
+                    session_id,
+                    node_id,
+                    attached,
+                    config_options: _,
+                    snapshot: _,
+                } = attached;
+                let mut coordination = vec![MeshCoordination::RememberRemoteSession {
+                    session_id: session_id.clone(),
+                    node_id: node_id.clone(),
+                    cwd: None,
+                }];
+                if attached {
+                    coordination.extend([
+                        MeshCoordination::SetPopup(Popup::None),
+                        MeshCoordination::Status {
+                            level: LogLevel::Info,
+                            message: "remote session attached".into(),
+                        },
+                    ]);
+                    MeshOutcome {
+                        coordination,
+                        effects: Command::load_session_commands(
+                            session_id,
+                            context.remote_session_cwd,
+                            context.agent_id,
+                        )
+                        .into_iter()
+                        .map(Effect::Command)
+                        .collect(),
+                    }
+                } else {
+                    coordination.push(MeshCoordination::Status {
+                        level: LogLevel::Info,
+                        message: "remote session created".into(),
+                    });
+                    MeshOutcome {
+                        coordination,
+                        effects: vec![Effect::Command(Command::ListRemoteSessions {
+                            node_id,
+                            offset: 0,
+                            limit: 50,
+                        })],
+                    }
+                }
+            }
+            MeshAction::ClipboardFinished { success } => {
+                if success {
+                    MeshOutcome {
+                        coordination: vec![MeshCoordination::Status {
+                            level: LogLevel::Info,
+                            message: "invite URL copied".into(),
+                        }],
+                        effects: Vec::new(),
+                    }
+                } else {
+                    self.show_invite_url_fallback();
+                    MeshOutcome::default()
+                }
+            }
+        }
+    }
+
     pub(crate) fn new() -> Self {
         Self {
             mesh_node_count: None,
@@ -342,6 +520,241 @@ mod tests {
             max_uses: 1,
             mesh_name: None,
         }
+    }
+
+    #[test]
+    fn reducer_owns_status_and_node_events_with_exact_outcomes() {
+        let mut state = MeshState::new();
+        let status = state.reduce(
+            MeshAction::Status(MeshStatusInfo {
+                enabled: true,
+                known_peer_count: 2,
+                ..Default::default()
+            }),
+            MeshContext::default(),
+        );
+
+        assert!(
+            state
+                .mesh_status
+                .as_ref()
+                .is_some_and(|status| { status.enabled && status.known_peer_count == 2 })
+        );
+        assert_eq!(
+            status,
+            MeshOutcome {
+                coordination: vec![MeshCoordination::Log {
+                    level: LogLevel::Debug,
+                    message: "mesh status: enabled=true, peers=2".into(),
+                }],
+                effects: Vec::new(),
+            }
+        );
+
+        state.mesh_node_cursor = 1;
+        let nodes = state.reduce(
+            MeshAction::Nodes(MeshNodesInfo {
+                nodes: vec![node("node-1"), node("node-2")],
+            }),
+            MeshContext::default(),
+        );
+
+        assert_eq!(state.mesh_node_count, Some(2));
+        assert_eq!(state.selected_mesh_node_id(), Some("node-2"));
+        assert_eq!(
+            nodes,
+            MeshOutcome {
+                coordination: vec![MeshCoordination::Log {
+                    level: LogLevel::Info,
+                    message: "mesh nodes: 2".into(),
+                }],
+                effects: vec![Effect::Command(Command::ListRemoteSessions {
+                    node_id: "node-2".into(),
+                    offset: 0,
+                    limit: 50,
+                })],
+            }
+        );
+    }
+
+    #[test]
+    fn reducer_owns_invite_and_remote_session_events_with_exact_outcomes() {
+        let mut state = MeshState::new();
+        state.set_error("stale");
+        state.set_clipboard_fallback("old".into());
+
+        let created = state.reduce(
+            MeshAction::InviteCreated(invite("qmt://mesh/join/token")),
+            MeshContext::default(),
+        );
+
+        assert_eq!(state.invite_url(), Some("qmt://mesh/join/token"));
+        assert!(state.mesh_error.is_none());
+        assert!(state.mesh_clipboard_fallback.is_none());
+        assert_eq!(
+            created,
+            MeshOutcome {
+                coordination: vec![
+                    MeshCoordination::SetPopup(Popup::MeshInviteQr),
+                    MeshCoordination::Status {
+                        level: LogLevel::Info,
+                        message: "mesh invite created".into(),
+                    },
+                    MeshCoordination::Log {
+                        level: LogLevel::Info,
+                        message: "mesh invite: qmt://mesh/join/token".into(),
+                    },
+                ],
+                effects: Vec::new(),
+            }
+        );
+
+        state.remote_session_cursor = 3;
+        let mut remote = session("session-1", "node-1");
+        remote.cwd = Some("/remote/repo".into());
+        let sessions = state.reduce(
+            MeshAction::RemoteSessions(RemoteSessionListInfo {
+                node_id: "node-1".into(),
+                sessions: vec![remote.clone()],
+                next_offset: Some(50),
+                total_count: 51,
+            }),
+            MeshContext::default(),
+        );
+
+        assert_eq!(state.remote_session_cursor, 0);
+        assert_eq!(state.remote_sessions_by_node["node-1"][0].id, "session-1");
+        assert_eq!(
+            sessions,
+            MeshOutcome {
+                coordination: vec![
+                    MeshCoordination::RememberRemoteSession {
+                        session_id: "session-1".into(),
+                        node_id: "node-1".into(),
+                        cwd: Some("/remote/repo".into()),
+                    },
+                    MeshCoordination::Log {
+                        level: LogLevel::Info,
+                        message: "remote sessions: 1 for node-1".into(),
+                    },
+                ],
+                effects: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn reducer_remote_attach_preserves_attached_and_detached_ordering() {
+        let mut state = MeshState::new();
+        let attached = state.reduce(
+            MeshAction::RemoteSessionAttached(RemoteSessionAttachInfo {
+                session_id: "session-1".into(),
+                node_id: "node-1".into(),
+                attached: true,
+                config_options: vec![serde_json::json!({ "retained": true })],
+                snapshot: Some(serde_json::json!({ "ignored": "authoritative replay" })),
+            }),
+            MeshContext {
+                agent_id: Some("agent-1".into()),
+                remote_session_cwd: Some("/remote/repo".into()),
+            },
+        );
+
+        assert_eq!(
+            attached,
+            MeshOutcome {
+                coordination: vec![
+                    MeshCoordination::RememberRemoteSession {
+                        session_id: "session-1".into(),
+                        node_id: "node-1".into(),
+                        cwd: None,
+                    },
+                    MeshCoordination::SetPopup(Popup::None),
+                    MeshCoordination::Status {
+                        level: LogLevel::Info,
+                        message: "remote session attached".into(),
+                    },
+                ],
+                effects: vec![
+                    Effect::Command(Command::LoadSession {
+                        session_id: "session-1".into(),
+                        cwd: Some("/remote/repo".into()),
+                    }),
+                    Effect::Command(Command::SubscribeSession {
+                        session_id: "session-1".into(),
+                        agent_id: Some("agent-1".into()),
+                    }),
+                ],
+            }
+        );
+
+        let detached = state.reduce(
+            MeshAction::RemoteSessionAttached(RemoteSessionAttachInfo {
+                session_id: "session-2".into(),
+                node_id: "node-2".into(),
+                attached: false,
+                config_options: Vec::new(),
+                snapshot: None,
+            }),
+            MeshContext::default(),
+        );
+
+        assert_eq!(
+            detached,
+            MeshOutcome {
+                coordination: vec![
+                    MeshCoordination::RememberRemoteSession {
+                        session_id: "session-2".into(),
+                        node_id: "node-2".into(),
+                        cwd: None,
+                    },
+                    MeshCoordination::Status {
+                        level: LogLevel::Info,
+                        message: "remote session created".into(),
+                    },
+                ],
+                effects: vec![Effect::Command(Command::ListRemoteSessions {
+                    node_id: "node-2".into(),
+                    offset: 0,
+                    limit: 50,
+                })],
+            }
+        );
+    }
+
+    #[test]
+    fn reducer_clipboard_results_preserve_status_and_fallback_contracts() {
+        let mut state = MeshState::new();
+        state.store_invite(invite("qmt://mesh/join/token"));
+
+        let failed = state.reduce(
+            MeshAction::ClipboardFinished { success: false },
+            MeshContext::default(),
+        );
+        assert_eq!(failed, MeshOutcome::default());
+        assert_eq!(
+            state.mesh_clipboard_fallback.as_deref(),
+            Some("qmt://mesh/join/token")
+        );
+
+        let succeeded = state.reduce(
+            MeshAction::ClipboardFinished { success: true },
+            MeshContext::default(),
+        );
+        assert_eq!(
+            succeeded,
+            MeshOutcome {
+                coordination: vec![MeshCoordination::Status {
+                    level: LogLevel::Info,
+                    message: "invite URL copied".into(),
+                }],
+                effects: Vec::new(),
+            }
+        );
+        assert_eq!(
+            state.mesh_clipboard_fallback.as_deref(),
+            Some("qmt://mesh/join/token")
+        );
     }
 
     #[test]

--- a/src/models_state.rs
+++ b/src/models_state.rs
@@ -1,10 +1,70 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
 
+use crate::application::Effect;
+use crate::command::Command;
+use crate::diagnostics::LogLevel;
 use crate::domain::model::{DelegateModelPreference, ModelEntry};
 use crate::domain::profile::AgentInfo;
+
+#[derive(Debug, Clone)]
+pub(crate) enum ModelAction {
+    InitializePrimaryAgent(AgentInfo),
+    InitializeReasoningEffort(Option<String>),
+    ReasoningEffort(Option<String>),
+    ReplaceCatalog {
+        models: Vec<ModelEntry>,
+        remote_node_count: u32,
+        remote_timeout_count: u32,
+    },
+    SynchronizeProfileCatalog {
+        active_profile_changed: bool,
+    },
+    ReplaceProfileAgents {
+        profile_id: String,
+        agents: Vec<AgentInfo>,
+    },
+    ProviderChanged {
+        provider: String,
+        model: String,
+        node_id: Option<String>,
+        context_limit: Option<u64>,
+    },
+    DelegateModelSet {
+        session_id: String,
+        agent_id: String,
+        model_id: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ModelContext {
+    pub(crate) desired_profile_id: Option<String>,
+    pub(crate) root_session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ModelCoordination {
+    Log {
+        level: LogLevel,
+        target: &'static str,
+        message: String,
+    },
+    Status {
+        level: LogLevel,
+        target: &'static str,
+        message: String,
+    },
+    SetContextLimit(u64),
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ModelOutcome {
+    pub(crate) coordination: Vec<ModelCoordination>,
+    pub(crate) effects: Vec<Effect>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ModelPopupItem {
@@ -49,6 +109,118 @@ pub(crate) fn validate_reasoning_effort(s: Option<&str>) -> Option<Option<String
 }
 
 impl ModelsState {
+    pub(crate) fn reduce(&mut self, action: ModelAction, context: ModelContext) -> ModelOutcome {
+        match action {
+            ModelAction::InitializePrimaryAgent(agent) => {
+                self.initialize_primary_agent(agent);
+                ModelOutcome::default()
+            }
+            ModelAction::InitializeReasoningEffort(reasoning_effort) => {
+                self.reasoning_effort = reasoning_effort;
+                ModelOutcome::default()
+            }
+            ModelAction::ReasoningEffort(reasoning_effort) => {
+                if let Some(validated) = validate_reasoning_effort(reasoning_effort.as_deref()) {
+                    self.reasoning_effort = validated;
+                }
+                ModelOutcome::default()
+            }
+            ModelAction::ReplaceCatalog {
+                models,
+                remote_node_count,
+                remote_timeout_count,
+            } => {
+                let (total_models, remote_models) = self.replace_catalog(models);
+                let mut message = format!("models: {total_models} total, {remote_models} remote");
+                if remote_node_count > 0 || remote_timeout_count > 0 {
+                    message.push_str(&format!(
+                        " (inventory nodes={remote_node_count}, timeouts={remote_timeout_count})"
+                    ));
+                }
+                ModelOutcome {
+                    coordination: vec![ModelCoordination::Log {
+                        level: LogLevel::Info,
+                        target: "models",
+                        message,
+                    }],
+                    effects: Vec::new(),
+                }
+            }
+            ModelAction::SynchronizeProfileCatalog {
+                active_profile_changed,
+            } => {
+                let desired_profile_id = context.desired_profile_id;
+                if active_profile_changed
+                    || self.agents_profile_id.as_deref() != desired_profile_id.as_deref()
+                    || self.agents.len() <= 1
+                {
+                    self.clear_profile_agents();
+                    ModelOutcome {
+                        coordination: Vec::new(),
+                        effects: desired_profile_id
+                            .map(|profile_id| {
+                                Effect::Command(Command::ListProfileAgents { profile_id })
+                            })
+                            .into_iter()
+                            .collect(),
+                    }
+                } else {
+                    ModelOutcome::default()
+                }
+            }
+            ModelAction::ReplaceProfileAgents { profile_id, agents } => {
+                if context.desired_profile_id.as_deref() != Some(profile_id.as_str()) {
+                    return ModelOutcome::default();
+                }
+                self.replace_profile_agents(profile_id.clone(), agents);
+                ModelOutcome {
+                    coordination: Vec::new(),
+                    effects: context
+                        .root_session_id
+                        .map(|session_id| {
+                            self.delegate_model_commands_for_session(&session_id, &profile_id)
+                        })
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(Effect::Command)
+                        .collect(),
+                }
+            }
+            ModelAction::ProviderChanged {
+                provider,
+                model,
+                node_id,
+                context_limit,
+            } => {
+                self.replace_live_selection(provider, model, node_id);
+                ModelOutcome {
+                    coordination: context_limit
+                        .map(ModelCoordination::SetContextLimit)
+                        .into_iter()
+                        .collect(),
+                    effects: Vec::new(),
+                }
+            }
+            ModelAction::DelegateModelSet {
+                session_id,
+                agent_id,
+                model_id,
+            } => ModelOutcome {
+                coordination: vec![ModelCoordination::Status {
+                    level: LogLevel::Info,
+                    target: "model",
+                    message: match model_id {
+                        Some(model_id) => {
+                            format!("delegate model set for {agent_id} in {session_id}: {model_id}")
+                        }
+                        None => format!("delegate model reset for {agent_id} in {session_id}"),
+                    },
+                }],
+                effects: Vec::new(),
+            },
+        }
+    }
+
     /// Valid explicit reasoning levels; automatic effort is represented by `None`.
     pub const EFFORT_LEVELS: &[&str] = &["low", "medium", "high", "max"];
 
@@ -373,6 +545,31 @@ impl ModelsState {
             .and_then(|preferences| preferences.get(agent_id))
     }
 
+    pub(crate) fn delegate_model_commands_for_session(
+        &self,
+        session_id: &str,
+        profile_id: &str,
+    ) -> Vec<Command> {
+        let known_agents: HashSet<&str> = self
+            .agents
+            .iter()
+            .skip(1)
+            .map(|agent| agent.id.as_str())
+            .collect();
+        self.delegate_model_preferences
+            .get(profile_id)
+            .into_iter()
+            .flat_map(|preferences| preferences.iter())
+            .filter(|(agent_id, _)| known_agents.contains(agent_id.as_str()))
+            .map(|(agent_id, preference)| Command::SetDelegateModel {
+                session_id: session_id.to_string(),
+                agent_id: agent_id.clone(),
+                model_id: Some(preference.model_id.clone()),
+                node_id: preference.node_id.clone(),
+            })
+            .collect()
+    }
+
     pub(crate) fn delegate_model_cursor(&self, profile_id: Option<&str>, agent_id: &str) -> usize {
         let items = self.visible_model_popup_items();
         let Some(profile_id) = profile_id else {
@@ -451,6 +648,217 @@ mod tests {
             description: None,
             capabilities: Vec::new(),
         }
+    }
+
+    #[test]
+    fn reducer_initialization_and_reasoning_effort_preserve_validation_contracts() {
+        let mut state = ModelsState::new();
+        state.model_popup_agent_tab = 3;
+        state.reasoning_effort = Some("low".into());
+
+        assert_eq!(
+            state.reduce(
+                ModelAction::InitializePrimaryAgent(agent("primary", "Primary")),
+                ModelContext::default(),
+            ),
+            ModelOutcome::default()
+        );
+        assert_eq!(state.agents[0].id, "primary");
+        assert_eq!(state.agents_profile_id, None);
+        assert_eq!(state.model_popup_agent_tab, 3);
+
+        state.reduce(
+            ModelAction::InitializeReasoningEffort(Some("backend-level".into())),
+            ModelContext::default(),
+        );
+        assert_eq!(state.reasoning_effort.as_deref(), Some("backend-level"));
+        state.reduce(
+            ModelAction::ReasoningEffort(Some("med".into())),
+            ModelContext::default(),
+        );
+        assert_eq!(state.reasoning_effort.as_deref(), Some("medium"));
+        state.reduce(
+            ModelAction::ReasoningEffort(Some("invalid".into())),
+            ModelContext::default(),
+        );
+        assert_eq!(state.reasoning_effort.as_deref(), Some("medium"));
+    }
+
+    #[test]
+    fn reducer_catalog_preserves_model_ui_state_and_reports_exact_diagnostics() {
+        let mut state = ModelsState::new();
+        state.current_model = Some("old-model".into());
+        state.current_provider = Some("old-provider".into());
+        state.current_model_node_id = Some("old-node".into());
+        state.model_cursor = 9;
+        state.model_filter = "old-filter".into();
+        state.model_popup_agent_tab = 3;
+        state.reasoning_effort = Some("high".into());
+
+        let outcome = state.reduce(
+            ModelAction::ReplaceCatalog {
+                models: vec![
+                    model("local", "local", "p", "m", None, None),
+                    model("remote", "remote", "p", "m", Some("node"), None),
+                ],
+                remote_node_count: 2,
+                remote_timeout_count: 1,
+            },
+            ModelContext::default(),
+        );
+
+        assert_eq!(state.models.len(), 2);
+        assert_eq!(state.current_model.as_deref(), Some("old-model"));
+        assert_eq!(state.current_provider.as_deref(), Some("old-provider"));
+        assert_eq!(state.current_model_node_id.as_deref(), Some("old-node"));
+        assert_eq!(state.model_cursor, 9);
+        assert_eq!(state.model_filter, "old-filter");
+        assert_eq!(state.model_popup_agent_tab, 3);
+        assert_eq!(state.reasoning_effort.as_deref(), Some("high"));
+        assert_eq!(
+            outcome,
+            ModelOutcome {
+                coordination: vec![ModelCoordination::Log {
+                    level: LogLevel::Info,
+                    target: "models",
+                    message: "models: 2 total, 1 remote (inventory nodes=2, timeouts=1)".into(),
+                }],
+                effects: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn reducer_profile_synchronization_preserves_refresh_and_stale_response_contracts() {
+        let mut state = ModelsState::new();
+        state.agents_profile_id = Some("quorum".into());
+        state.agents = vec![agent("primary", "Primary"), agent("coder", "Coder")];
+        state.model_popup_agent_tab = 1;
+
+        let outcome = state.reduce(
+            ModelAction::SynchronizeProfileCatalog {
+                active_profile_changed: false,
+            },
+            ModelContext {
+                desired_profile_id: Some("quorum".into()),
+                root_session_id: None,
+            },
+        );
+        assert_eq!(outcome, ModelOutcome::default());
+        assert_eq!(state.agents.len(), 2);
+
+        let outcome = state.reduce(
+            ModelAction::SynchronizeProfileCatalog {
+                active_profile_changed: true,
+            },
+            ModelContext {
+                desired_profile_id: Some("fast".into()),
+                root_session_id: None,
+            },
+        );
+        assert!(state.agents.is_empty());
+        assert_eq!(state.agents_profile_id, None);
+        assert_eq!(state.model_popup_agent_tab, 0);
+        assert_eq!(
+            outcome.effects,
+            vec![Effect::Command(Command::ListProfileAgents {
+                profile_id: "fast".into(),
+            })]
+        );
+
+        state.agents = vec![agent("sentinel", "Sentinel")];
+        let outcome = state.reduce(
+            ModelAction::ReplaceProfileAgents {
+                profile_id: "stale".into(),
+                agents: vec![agent("stale", "Stale")],
+            },
+            ModelContext {
+                desired_profile_id: Some("fast".into()),
+                root_session_id: Some("session".into()),
+            },
+        );
+        assert_eq!(outcome, ModelOutcome::default());
+        assert_eq!(state.agents[0].id, "sentinel");
+    }
+
+    #[test]
+    fn reducer_current_profile_agents_update_tabs_before_reapplying_root_preferences() {
+        let mut state = ModelsState::new();
+        state.delegate_model_preferences.insert(
+            "quorum".into(),
+            [(
+                "coder".into(),
+                DelegateModelPreference {
+                    model_id: "openai/gpt-5".into(),
+                    provider: "openai".into(),
+                    model: "gpt-5".into(),
+                    node_id: Some("node-1".into()),
+                },
+            )]
+            .into_iter()
+            .collect(),
+        );
+
+        let outcome = state.reduce(
+            ModelAction::ReplaceProfileAgents {
+                profile_id: "quorum".into(),
+                agents: vec![agent("primary", "Primary"), agent("coder", "Coder")],
+            },
+            ModelContext {
+                desired_profile_id: Some("quorum".into()),
+                root_session_id: Some("parent".into()),
+            },
+        );
+
+        assert_eq!(state.agents_profile_id.as_deref(), Some("quorum"));
+        assert_eq!(state.model_popup_tab_agent_id(1), Some("coder"));
+        assert_eq!(
+            outcome.effects,
+            vec![Effect::Command(Command::SetDelegateModel {
+                session_id: "parent".into(),
+                agent_id: "coder".into(),
+                model_id: Some("openai/gpt-5".into()),
+                node_id: Some("node-1".into()),
+            })]
+        );
+    }
+
+    #[test]
+    fn reducer_provider_and_delegate_events_return_ordered_coordination() {
+        let mut state = ModelsState::new();
+        let outcome = state.reduce(
+            ModelAction::ProviderChanged {
+                provider: "provider".into(),
+                model: "model".into(),
+                node_id: Some("node".into()),
+                context_limit: Some(128_000),
+            },
+            ModelContext::default(),
+        );
+        assert_eq!(state.current_provider.as_deref(), Some("provider"));
+        assert_eq!(state.current_model.as_deref(), Some("model"));
+        assert_eq!(state.current_model_node_id.as_deref(), Some("node"));
+        assert_eq!(
+            outcome.coordination,
+            vec![ModelCoordination::SetContextLimit(128_000)]
+        );
+
+        let outcome = state.reduce(
+            ModelAction::DelegateModelSet {
+                session_id: "session".into(),
+                agent_id: "coder".into(),
+                model_id: Some("openai/gpt-5".into()),
+            },
+            ModelContext::default(),
+        );
+        assert_eq!(
+            outcome.coordination,
+            vec![ModelCoordination::Status {
+                level: LogLevel::Info,
+                target: "model",
+                message: "delegate model set for coder in session: openai/gpt-5".into(),
+            }]
+        );
     }
 
     #[test]

--- a/src/profiles_state.rs
+++ b/src/profiles_state.rs
@@ -5,6 +5,19 @@ use fuzzy_matcher::skim::SkimMatcherV2;
 
 use crate::domain::profile::ProfileInfo;
 
+#[derive(Debug, Clone)]
+pub(crate) enum ProfileAction {
+    ReplaceCatalog {
+        profiles: Vec<ProfileInfo>,
+        backend_active_profile_id: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ProfileOutcome {
+    pub(crate) active_profile_changed: bool,
+}
+
 pub(crate) struct ProfilesState {
     pub(crate) profiles: Vec<ProfileInfo>,
     pub(crate) active_profile_id: Option<String>,
@@ -14,6 +27,17 @@ pub(crate) struct ProfilesState {
 }
 
 impl ProfilesState {
+    pub(crate) fn reduce(&mut self, action: ProfileAction) -> ProfileOutcome {
+        match action {
+            ProfileAction::ReplaceCatalog {
+                profiles,
+                backend_active_profile_id,
+            } => ProfileOutcome {
+                active_profile_changed: self.apply_catalog(profiles, backend_active_profile_id),
+            },
+        }
+    }
+
     pub(crate) fn new() -> Self {
         Self {
             profiles: Vec::new(),
@@ -184,6 +208,54 @@ mod tests {
             .into_iter()
             .map(|profile| profile.id.as_str())
             .collect()
+    }
+
+    #[test]
+    fn reducer_catalog_preserves_selection_precedence_and_reports_change() {
+        let mut state = ProfilesState::new();
+        state.active_profile_id = Some("deep".into());
+
+        let outcome = state.reduce(ProfileAction::ReplaceCatalog {
+            profiles: vec![profile("fast", "Fast", None), profile("deep", "Deep", None)],
+            backend_active_profile_id: Some("fast".into()),
+        });
+        assert_eq!(outcome, ProfileOutcome::default());
+        assert_eq!(state.active_profile_id.as_deref(), Some("deep"));
+
+        state.active_profile_id = Some("removed".into());
+        let outcome = state.reduce(ProfileAction::ReplaceCatalog {
+            profiles: vec![profile("fast", "Fast", None), profile("deep", "Deep", None)],
+            backend_active_profile_id: Some("deep".into()),
+        });
+        assert_eq!(
+            outcome,
+            ProfileOutcome {
+                active_profile_changed: true,
+            }
+        );
+        assert_eq!(state.active_profile_id.as_deref(), Some("deep"));
+    }
+
+    #[test]
+    fn reducer_empty_catalog_clears_selection_without_unowned_normalization() {
+        let mut state = ProfilesState::new();
+        state.profiles = vec![profile("old", "Old", None)];
+        state.active_profile_id = Some("old".into());
+        state.profile_cursor = 4;
+        state.profile_filter = "keep".into();
+        state.bind_session_profile("session".into(), "old".into());
+
+        let outcome = state.reduce(ProfileAction::ReplaceCatalog {
+            profiles: Vec::new(),
+            backend_active_profile_id: None,
+        });
+
+        assert!(outcome.active_profile_changed);
+        assert!(state.profiles.is_empty());
+        assert!(state.active_profile_id.is_none());
+        assert_eq!(state.profile_cursor, 0);
+        assert_eq!(state.profile_filter, "keep");
+        assert_eq!(state.session_profile_id("session"), Some("old"));
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -8,15 +8,6 @@ use crate::composer_state::FileIndexEntryLite;
 use crate::navigation_state::Popup;
 
 impl App {
-    pub fn apply_session_profile_binding(&mut self, session_id: &str, profile_id: Option<String>) {
-        if let Some(profile_id) = profile_id {
-            self.profiles
-                .bind_session_profile(session_id.to_string(), profile_id);
-        } else if self.sessions.is_remote_session_id(session_id) {
-            self.profiles.remove_session_profile(session_id);
-        }
-    }
-
     pub fn resolve_new_session_default_cwd(&self) -> Option<String> {
         if let Some(active_session_id) = self.sessions.session_id.as_deref() {
             for group in &self.sessions.session_groups {
@@ -287,41 +278,6 @@ mod tests {
         app.sessions
             .remember_remote_session_node("remote", "node-1");
         assert_eq!(app.current_profile_label(), "remote");
-    }
-
-    #[test]
-    fn profile_binding_some_inserts_and_overwrites() {
-        let mut app = App::new();
-
-        app.apply_session_profile_binding("session", Some("fast".into()));
-        assert_eq!(app.profiles.session_profile_id("session"), Some("fast"));
-
-        app.apply_session_profile_binding("session", Some("deep".into()));
-        assert_eq!(app.profiles.session_profile_id("session"), Some("deep"));
-    }
-
-    #[test]
-    fn missing_local_profile_preserves_existing_binding() {
-        let mut app = App::new();
-        app.profiles
-            .bind_session_profile("local".into(), "fast".into());
-
-        app.apply_session_profile_binding("local", None);
-
-        assert_eq!(app.profiles.session_profile_id("local"), Some("fast"));
-    }
-
-    #[test]
-    fn missing_remote_profile_removes_existing_binding() {
-        let mut app = App::new();
-        app.sessions
-            .remember_remote_session_node("remote", "node-1");
-        app.profiles
-            .bind_session_profile("remote".into(), "fast".into());
-
-        app.apply_session_profile_binding("remote", None);
-
-        assert!(app.profiles.session_profile_id("remote").is_none());
     }
 
     #[test]

--- a/src/session_state.rs
+++ b/src/session_state.rs
@@ -4,10 +4,13 @@ use std::time::{Duration, Instant};
 use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
 
+use crate::application::Effect;
+use crate::command::{Command, SessionListRequest};
 use crate::composer_state::FileIndexEntryLite;
+use crate::diagnostics::LogLevel;
 use crate::domain::activity::SessionActivity;
 use crate::domain::mesh::RemoteSessionLocation;
-use crate::domain::session::{SessionChildrenPage, SessionGroup, SessionSummary};
+use crate::domain::session::{SessionChildrenPage, SessionGroup, SessionListPage, SessionSummary};
 
 /// Maximum number of recent sessions shown per group on the start page.
 pub(crate) const MAX_RECENT_SESSIONS: usize = 3;
@@ -71,6 +74,60 @@ pub(crate) fn session_group_count_text(session_count: usize, session_total: Opti
         .unwrap_or_else(|| session_count.to_string())
 }
 
+#[derive(Debug, Clone)]
+pub(crate) enum SessionAction {
+    CatalogPage {
+        request: SessionListRequest,
+        page: SessionListPage,
+    },
+    CatalogFailed {
+        request: SessionListRequest,
+        message: String,
+    },
+    Created {
+        agent_id: String,
+        session_id: String,
+        profile_id: Option<String>,
+    },
+    Loaded {
+        agent_id: String,
+        session_id: String,
+        profile_id: Option<String>,
+    },
+    ReplaceAgentMode(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SessionCoordination {
+    PushChatError(String),
+    ClearDelegateParent,
+    SetChatIdle,
+    ResolveDelegateParent(Option<String>),
+    ApplyProfileBinding {
+        session_id: String,
+        profile_id: Option<String>,
+        remove_if_missing: bool,
+    },
+    ResetActiveSessionView,
+    SelectChat,
+    SelectLoadedSessionScreen,
+    Status {
+        level: LogLevel,
+        target: &'static str,
+        message: String,
+    },
+    SynchronizeProfileCommands {
+        session_id: String,
+        root_only: bool,
+    },
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct SessionOutcome {
+    pub(crate) coordination: Vec<SessionCoordination>,
+    pub(crate) effects: Vec<Effect>,
+}
+
 pub(crate) struct SessionsState {
     pub(crate) session_groups: Vec<SessionGroup>,
     pub(crate) session_cursor: usize,
@@ -98,6 +155,139 @@ pub(crate) struct SessionsState {
 }
 
 impl SessionsState {
+    pub(crate) fn reduce(&mut self, action: SessionAction) -> SessionOutcome {
+        match action {
+            SessionAction::CatalogPage { request, page } => {
+                let SessionListPage {
+                    groups,
+                    next_cursor,
+                    total_count: _,
+                } = page;
+                let commands = match request {
+                    SessionListRequest::Discovery => {
+                        let (workspaces, next_discovery_cursor) =
+                            self.apply_discovery_page(groups, next_cursor);
+                        let mut commands = workspaces
+                            .into_iter()
+                            .map(Command::list_sessions_workspace)
+                            .collect::<Vec<_>>();
+                        if let Some(cursor) = next_discovery_cursor {
+                            commands.push(Command::list_sessions_discovery(Some(cursor)));
+                        }
+                        commands
+                    }
+                    SessionListRequest::WorkspaceFirstPage { cwd } => {
+                        self.apply_workspace_first_page(cwd, groups);
+                        Vec::new()
+                    }
+                    SessionListRequest::WorkspaceContinuation { cwd } => {
+                        self.apply_workspace_continuation(cwd, groups);
+                        Vec::new()
+                    }
+                };
+                SessionOutcome {
+                    coordination: Vec::new(),
+                    effects: commands.into_iter().map(Effect::Command).collect(),
+                }
+            }
+            SessionAction::CatalogFailed { request, message } => {
+                match request {
+                    SessionListRequest::Discovery => self.fail_discovery(),
+                    SessionListRequest::WorkspaceFirstPage { cwd }
+                    | SessionListRequest::WorkspaceContinuation { cwd } => {
+                        self.fail_workspace_request(&cwd);
+                    }
+                }
+                SessionOutcome {
+                    coordination: vec![
+                        SessionCoordination::PushChatError(message.clone()),
+                        SessionCoordination::Status {
+                            level: LogLevel::Error,
+                            target: "acp",
+                            message: format!("error: {message}"),
+                        },
+                    ],
+                    effects: Vec::new(),
+                }
+            }
+            SessionAction::Created {
+                agent_id,
+                session_id,
+                profile_id,
+            } => {
+                let remove_if_missing = self.is_remote_session_id(&session_id);
+                self.session_id = Some(session_id.clone());
+                self.agent_id = Some(agent_id);
+                self.mode_before_review = None;
+                SessionOutcome {
+                    coordination: vec![
+                        SessionCoordination::ClearDelegateParent,
+                        SessionCoordination::ApplyProfileBinding {
+                            session_id: session_id.clone(),
+                            profile_id,
+                            remove_if_missing,
+                        },
+                        SessionCoordination::ResetActiveSessionView,
+                        SessionCoordination::SelectChat,
+                        SessionCoordination::Status {
+                            level: LogLevel::Info,
+                            target: "session",
+                            message: "session created".into(),
+                        },
+                        SessionCoordination::SynchronizeProfileCommands {
+                            session_id: session_id.clone(),
+                            root_only: false,
+                        },
+                    ],
+                    effects: vec![Effect::Command(Command::SubscribeSession {
+                        session_id,
+                        agent_id: self.agent_id.clone(),
+                    })],
+                }
+            }
+            SessionAction::Loaded {
+                agent_id,
+                session_id,
+                profile_id,
+            } => {
+                let discovered_parent = self.session_parent_id(&session_id).map(str::to_owned);
+                let remove_if_missing = self.is_remote_session_id(&session_id);
+                self.session_id = Some(session_id.clone());
+                self.agent_id = Some(agent_id);
+                self.mode_before_review = None;
+                SessionOutcome {
+                    coordination: vec![
+                        SessionCoordination::SetChatIdle,
+                        SessionCoordination::ResolveDelegateParent(discovered_parent),
+                        SessionCoordination::ApplyProfileBinding {
+                            session_id: session_id.clone(),
+                            profile_id,
+                            remove_if_missing,
+                        },
+                        SessionCoordination::ResetActiveSessionView,
+                        SessionCoordination::SelectLoadedSessionScreen,
+                        SessionCoordination::Status {
+                            level: LogLevel::Debug,
+                            target: "activity",
+                            message: "ready".into(),
+                        },
+                        SessionCoordination::SynchronizeProfileCommands {
+                            session_id,
+                            root_only: true,
+                        },
+                    ],
+                    effects: vec![Effect::Command(Command::SetAgentMode {
+                        mode: self.agent_mode.clone(),
+                    })],
+                }
+            }
+            SessionAction::ReplaceAgentMode(mode) => {
+                self.replace_agent_mode(mode);
+                SessionOutcome::default()
+            }
+        }
+    }
+
     pub(crate) fn new() -> Self {
         Self {
             session_groups: Vec::new(),
@@ -1010,6 +1200,256 @@ mod tests {
             sessions: ids.iter().map(|id| session(id)).collect(),
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn reducer_catalog_pages_preserve_request_order_and_remote_locations() {
+        let mut state = SessionsState::new();
+        state.session_discovery_in_progress = true;
+        state.remember_remote_session_location("remote", "node-1", Some("/remote".into()));
+
+        let outcome = state.reduce(SessionAction::CatalogPage {
+            request: SessionListRequest::Discovery,
+            page: SessionListPage {
+                groups: vec![group("/first", &["remote"]), group("/second", &["local"])],
+                next_cursor: Some("discovery-2".into()),
+                total_count: Some(2),
+            },
+        });
+
+        assert_eq!(
+            outcome,
+            SessionOutcome {
+                coordination: Vec::new(),
+                effects: vec![
+                    Effect::Command(Command::list_sessions_workspace("/first".into())),
+                    Effect::Command(Command::list_sessions_workspace("/second".into())),
+                    Effect::Command(Command::list_sessions_discovery(Some("discovery-2".into()))),
+                ],
+            }
+        );
+        assert_eq!(state.remote_session_locations["remote"].node_id, "node-1");
+        assert_eq!(
+            state.remote_session_locations["remote"].cwd.as_deref(),
+            Some("/remote")
+        );
+
+        let first_page = state.reduce(SessionAction::CatalogPage {
+            request: SessionListRequest::WorkspaceFirstPage {
+                cwd: "/first".into(),
+            },
+            page: SessionListPage {
+                groups: vec![group("/first", &["first-page"])],
+                ..Default::default()
+            },
+        });
+        assert_eq!(first_page, SessionOutcome::default());
+        let continuation = state.reduce(SessionAction::CatalogPage {
+            request: SessionListRequest::WorkspaceContinuation {
+                cwd: "/first".into(),
+            },
+            page: SessionListPage {
+                groups: vec![group("/first", &["continued"])],
+                ..Default::default()
+            },
+        });
+        assert_eq!(continuation, SessionOutcome::default());
+        assert_eq!(
+            state.session_groups[0]
+                .sessions
+                .iter()
+                .map(|session| session.session_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["first-page", "continued"]
+        );
+    }
+
+    #[test]
+    fn reducer_catalog_failures_clear_only_the_requested_pending_state() {
+        let mut state = SessionsState::new();
+        state.session_discovery_in_progress = true;
+        state
+            .pending_session_group_loads
+            .insert(Some("/repo".into()));
+        state
+            .pending_session_group_loads
+            .insert(Some("/keep".into()));
+
+        let discovery = state.reduce(SessionAction::CatalogFailed {
+            request: SessionListRequest::Discovery,
+            message: "discovery failed".into(),
+        });
+        assert!(!state.session_discovery_in_progress);
+        assert_eq!(
+            discovery,
+            SessionOutcome {
+                coordination: vec![
+                    SessionCoordination::PushChatError("discovery failed".into()),
+                    SessionCoordination::Status {
+                        level: LogLevel::Error,
+                        target: "acp",
+                        message: "error: discovery failed".into(),
+                    },
+                ],
+                effects: Vec::new(),
+            }
+        );
+
+        let workspace = state.reduce(SessionAction::CatalogFailed {
+            request: SessionListRequest::WorkspaceContinuation {
+                cwd: "/repo".into(),
+            },
+            message: "workspace failed".into(),
+        });
+        assert!(
+            !state
+                .pending_session_group_loads
+                .contains(&Some("/repo".into()))
+        );
+        assert!(
+            state
+                .pending_session_group_loads
+                .contains(&Some("/keep".into()))
+        );
+        assert_eq!(workspace.coordination.len(), 2);
+        assert!(workspace.effects.is_empty());
+    }
+
+    #[test]
+    fn reducer_created_owns_active_ids_and_orders_external_coordination() {
+        let mut state = SessionsState::new();
+        state.mode_before_review = Some("plan".into());
+
+        let outcome = state.reduce(SessionAction::Created {
+            agent_id: "agent-1".into(),
+            session_id: "session-1".into(),
+            profile_id: Some("code".into()),
+        });
+
+        assert_eq!(state.session_id.as_deref(), Some("session-1"));
+        assert_eq!(state.agent_id.as_deref(), Some("agent-1"));
+        assert_eq!(state.mode_before_review, None);
+        assert_eq!(
+            outcome,
+            SessionOutcome {
+                coordination: vec![
+                    SessionCoordination::ClearDelegateParent,
+                    SessionCoordination::ApplyProfileBinding {
+                        session_id: "session-1".into(),
+                        profile_id: Some("code".into()),
+                        remove_if_missing: false,
+                    },
+                    SessionCoordination::ResetActiveSessionView,
+                    SessionCoordination::SelectChat,
+                    SessionCoordination::Status {
+                        level: LogLevel::Info,
+                        target: "session",
+                        message: "session created".into(),
+                    },
+                    SessionCoordination::SynchronizeProfileCommands {
+                        session_id: "session-1".into(),
+                        root_only: false,
+                    },
+                ],
+                effects: vec![Effect::Command(Command::SubscribeSession {
+                    session_id: "session-1".into(),
+                    agent_id: Some("agent-1".into()),
+                })],
+            }
+        );
+    }
+
+    #[test]
+    fn reducer_loaded_reports_parent_remote_binding_and_mode_prefix() {
+        let mut child = session("child");
+        child.parent_session_id = Some("parent".into());
+        let mut state = SessionsState::new();
+        state.agent_mode = "plan".into();
+        state.mode_before_review = Some("build".into());
+        state.session_groups = vec![SessionGroup {
+            sessions: vec![child],
+            ..Default::default()
+        }];
+        state.remember_remote_session_location("child", "node-1", Some("/remote".into()));
+
+        let outcome = state.reduce(SessionAction::Loaded {
+            agent_id: "agent-1".into(),
+            session_id: "child".into(),
+            profile_id: None,
+        });
+
+        assert_eq!(state.session_id.as_deref(), Some("child"));
+        assert_eq!(state.agent_id.as_deref(), Some("agent-1"));
+        assert_eq!(state.mode_before_review, None);
+        assert_eq!(
+            outcome.coordination,
+            vec![
+                SessionCoordination::SetChatIdle,
+                SessionCoordination::ResolveDelegateParent(Some("parent".into())),
+                SessionCoordination::ApplyProfileBinding {
+                    session_id: "child".into(),
+                    profile_id: None,
+                    remove_if_missing: true,
+                },
+                SessionCoordination::ResetActiveSessionView,
+                SessionCoordination::SelectLoadedSessionScreen,
+                SessionCoordination::Status {
+                    level: LogLevel::Debug,
+                    target: "activity",
+                    message: "ready".into(),
+                },
+                SessionCoordination::SynchronizeProfileCommands {
+                    session_id: "child".into(),
+                    root_only: true,
+                },
+            ]
+        );
+        assert_eq!(
+            outcome.effects,
+            vec![Effect::Command(Command::SetAgentMode {
+                mode: "plan".into(),
+            })]
+        );
+    }
+
+    #[test]
+    fn reducer_loaded_marks_missing_local_profile_as_non_removing() {
+        let mut state = SessionsState::new();
+        let outcome = state.reduce(SessionAction::Loaded {
+            agent_id: "agent-1".into(),
+            session_id: "local".into(),
+            profile_id: None,
+        });
+        assert!(matches!(
+            outcome.coordination.get(2),
+            Some(SessionCoordination::ApplyProfileBinding {
+                session_id,
+                profile_id: None,
+                remove_if_missing: false,
+            }) if session_id == "local"
+        ));
+    }
+
+    #[test]
+    fn reducer_agent_mode_replacement_preserves_review_return_semantics() {
+        let mut state = SessionsState::new();
+        state.agent_mode = "review".into();
+        state.mode_before_review = Some("plan".into());
+
+        assert_eq!(
+            state.reduce(SessionAction::ReplaceAgentMode("build".into())),
+            SessionOutcome::default()
+        );
+        assert_eq!(state.agent_mode, "build");
+        assert_eq!(state.mode_before_review, None);
+
+        state.mode_before_review = Some("plan".into());
+        assert_eq!(
+            state.reduce(SessionAction::ReplaceAgentMode("review".into())),
+            SessionOutcome::default()
+        );
+        assert_eq!(state.agent_mode, "review");
+        assert_eq!(state.mode_before_review.as_deref(), Some("plan"));
     }
 
     #[test]

--- a/src/session_state.rs
+++ b/src/session_state.rs
@@ -94,6 +94,7 @@ pub(crate) enum SessionAction {
         session_id: String,
         profile_id: Option<String>,
     },
+    InitializeAgentId(String),
     ReplaceAgentMode(String),
 }
 
@@ -280,6 +281,10 @@ impl SessionsState {
                         mode: self.agent_mode.clone(),
                     })],
                 }
+            }
+            SessionAction::InitializeAgentId(agent_id) => {
+                self.agent_id = Some(agent_id);
+                SessionOutcome::default()
             }
             SessionAction::ReplaceAgentMode(mode) => {
                 self.replace_agent_mode(mode);
@@ -1428,6 +1433,41 @@ mod tests {
                 remove_if_missing: false,
             }) if session_id == "local"
         ));
+    }
+
+    #[test]
+    fn reducer_agent_initialization_changes_only_identity_with_empty_outcome() {
+        let mut state = SessionsState::new();
+        state.session_id = Some("session-1".into());
+        state.agent_id = Some("old-agent".into());
+        state.agent_mode = "review".into();
+        state.mode_before_review = Some("plan".into());
+        state.session_filter = "keep".into();
+        state.session_cursor = 4;
+        state.new_session_path = "/keep".into();
+        state.note_session_activity("session-1");
+        state.remember_remote_session_location("remote-1", "node-1", Some("/remote/repo".into()));
+        let activity_at = state.session_activity["session-1"].last_event_at;
+
+        let outcome = state.reduce(SessionAction::InitializeAgentId("agent-1".into()));
+
+        assert_eq!(outcome, SessionOutcome::default());
+        assert_eq!(state.agent_id.as_deref(), Some("agent-1"));
+        assert_eq!(state.session_id.as_deref(), Some("session-1"));
+        assert_eq!(state.agent_mode, "review");
+        assert_eq!(state.mode_before_review.as_deref(), Some("plan"));
+        assert_eq!(state.session_filter, "keep");
+        assert_eq!(state.session_cursor, 4);
+        assert_eq!(state.new_session_path, "/keep");
+        assert_eq!(
+            state.session_activity["session-1"].last_event_at,
+            activity_at
+        );
+        assert_eq!(state.session_remote_node_id("remote-1"), Some("node-1"));
+        assert_eq!(
+            state.session_remote_cwd("remote-1"),
+            Some("/remote/repo".into())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Scope
- Extract bounded reducers, actions, and outcomes for mesh/auth, models/profiles, sessions, delegation, and chat stream/tool/usage/error/elicitation/history behavior.
- Make ordered coordination and effects explicit while keeping application composition shallow.
- Include the release coordination fix and the `SessionNotification -> AppEvent -> reducer` acceptance bridge.
- Exclude Phase 8+ work.

## Validation
- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --all-targets --all-features`
- Debug all-target/all-feature tests: 999 passed, 0 failed/ignored.
- Release all-target/all-feature tests: 999 passed, 0 failed/ignored.
- Exact approved head: `d97bf1b2d5c4bed656431bb039d6ca6a2c52e6cd`.
- Independent aggregate review approved with no actionable findings.

## Residual
- No live ACP/UI smoke was available.
