### PR TITLE
refactor: separate domain and rendering

### DIFF
--- a/src/acp/contract_tests.rs
+++ b/src/acp/contract_tests.rs
@@ -367,7 +367,7 @@ async fn session_notification_reaches_application_reducer_coordination() {
     let mut app = App::new();
     app.sessions.session_id = Some("session".into());
     let local_id = app.push_pending_prompt("hello".into());
-    app.render.card_cache.processed_messages = 7;
+    app.render.test_seed_card_cache(7);
     let original_logs = app.diagnostics.logs.clone();
     let original_log_cursor = app.diagnostics.log_cursor;
     let original_log_filter = app.diagnostics.log_filter.clone();
@@ -402,7 +402,7 @@ async fn session_notification_reaches_application_reducer_coordination() {
     ));
     assert_eq!(app.chat.undoable_turns.len(), 1);
     assert_eq!(app.chat.undoable_turns[0].message_id, "u1");
-    assert_eq!(app.render.card_cache.processed_messages, 0);
+    assert_eq!(app.render.test_card_source_entry_count(), 0);
     assert_eq!(app.diagnostics.logs, original_logs);
     assert_eq!(app.diagnostics.log_cursor, original_log_cursor);
     assert_eq!(app.diagnostics.log_filter, original_log_filter);

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -803,6 +803,13 @@ impl crate::app::App {
             coordination,
             effects,
         } = self.chat.reduce_elicitation(action);
+        if matches!(
+            transition,
+            ElicitationTransition::InsertedSupported { .. }
+                | ElicitationTransition::InsertedUnsupported { .. }
+        ) {
+            self.render.scroll_chat_to_bottom();
+        }
         self.apply_render_changes(elicitation_render_changes(&transition));
         self.apply_chat_coordination(coordination);
         effects
@@ -2580,7 +2587,7 @@ mod tests {
             ended_at: None,
             child_state: DelegateChildState::None,
         });
-        app.chat.scroll_offset = 3;
+        app.render.test_seed_chat_viewport(3, 24);
         app.composer.input = "/mo".into();
         app.composer.input_cursor = 3;
         app.composer.input_scroll = 2;
@@ -2631,7 +2638,8 @@ mod tests {
         assert!(app.delegates.delegate_entries.is_empty());
         assert!(app.chat.messages.is_empty());
         assert!(app.chat.streaming_content.is_empty());
-        assert_eq!(app.chat.scroll_offset, 0);
+        assert_eq!(app.render.chat_scroll_offset(), 0);
+        assert_eq!(app.render.test_chat_previous_total_height(), 0);
         assert_eq!(app.composer.input, "/mo");
         assert_eq!(app.composer.input_cursor, 3);
         assert_eq!(app.composer.input_scroll, 2);
@@ -2676,6 +2684,7 @@ mod tests {
             profile_id: None,
         });
         let first_epoch = app.render.test_session_epoch();
+        app.render.test_seed_chat_viewport(9, 42);
 
         app.handle_acp_event(AcpAppEvent::SessionLoaded {
             agent_id: "agent-1".into(),
@@ -2684,6 +2693,8 @@ mod tests {
         });
 
         assert!(app.render.test_session_epoch() > first_epoch);
+        assert_eq!(app.render.chat_scroll_offset(), 0);
+        assert_eq!(app.render.test_chat_previous_total_height(), 0);
     }
 
     #[test]
@@ -2715,7 +2726,7 @@ mod tests {
         app.chat.streaming_content_message_id = Some("stream-1".into());
         app.chat.streaming_thinking = "stale thinking".into();
         app.chat.streaming_thinking_message_id = Some("thinking-1".into());
-        app.chat.scroll_offset = 4;
+        app.render.test_seed_chat_viewport(4, 31);
         app.chat.undo_state = Some(UndoState {
             stack: Vec::new(),
             frontier_message_id: Some("undo-1".into()),
@@ -2754,7 +2765,8 @@ mod tests {
         assert_eq!(app.chat.streaming_content_message_id, None);
         assert!(app.chat.streaming_thinking.is_empty());
         assert_eq!(app.chat.streaming_thinking_message_id, None);
-        assert_eq!(app.chat.scroll_offset, 0);
+        assert_eq!(app.render.chat_scroll_offset(), 0);
+        assert_eq!(app.render.test_chat_previous_total_height(), 0);
         assert!(app.chat.undo_state.is_none());
         assert!(app.chat.undoable_turns.is_empty());
         assert!(app.chat.recent_prompt_text.is_none());
@@ -4113,6 +4125,7 @@ mod tests {
     #[test]
     fn native_live_elicitation_creates_card_and_active_state() {
         let mut app = app_with_active_session();
+        app.render.set_chat_scroll_offset(8);
 
         apply_live_update(
             &mut app,
@@ -4129,6 +4142,7 @@ mod tests {
             },
         );
 
+        assert_eq!(app.render.chat_scroll_offset(), 0);
         assert_eq!(
             app.chat
                 .elicitation
@@ -4146,6 +4160,7 @@ mod tests {
     #[test]
     fn native_replay_elicitation_creates_card_without_active_state() {
         let mut app = app_with_active_session();
+        app.render.set_chat_scroll_offset(8);
 
         app.handle_acp_event(AcpAppEvent::SessionReplay {
             session_id: TEST_SESSION_ID.into(),
@@ -4162,6 +4177,7 @@ mod tests {
             }],
         });
 
+        assert_eq!(app.render.chat_scroll_offset(), 0);
         assert!(app.chat.elicitation.is_none());
         assert!(matches!(
             app.chat.messages.as_slice(),
@@ -4185,16 +4201,21 @@ mod tests {
             allow_custom: true,
         }];
 
-        for _ in 0..2 {
-            app.handle_acp_event(AcpAppEvent::SessionReplay {
-                session_id: TEST_SESSION_ID.into(),
-                updates: updates.clone(),
-            });
-        }
+        app.handle_acp_event(AcpAppEvent::SessionReplay {
+            session_id: TEST_SESSION_ID.into(),
+            updates: updates.clone(),
+        });
+        app.render.set_chat_scroll_offset(6);
+        app.handle_acp_event(AcpAppEvent::SessionReplay {
+            session_id: TEST_SESSION_ID.into(),
+            updates: updates.clone(),
+        });
+        assert_eq!(app.render.chat_scroll_offset(), 6);
         app.apply_chat_elicitation_action(ElicitationAction::ResponseAcknowledged {
             elicitation_id: "elic-1".into(),
             outcome: ElicitationResponseOutcome::Text("staging".into()),
         });
+        assert_eq!(app.render.chat_scroll_offset(), 6);
         app.handle_acp_event(AcpAppEvent::SessionReplay {
             session_id: TEST_SESSION_ID.into(),
             updates,
@@ -4249,6 +4270,7 @@ mod tests {
     #[test]
     fn native_unsupported_replay_elicitation_is_idempotent() {
         let mut app = app_with_active_session();
+        app.render.set_chat_scroll_offset(8);
         let updates = vec![AcpSessionUpdate::ElicitationRequested {
             elicitation_id: "elic-unsupported".into(),
             message: "Upload a file".into(),
@@ -4257,13 +4279,18 @@ mod tests {
             allow_custom: false,
         }];
 
-        for _ in 0..2 {
-            app.handle_acp_event(AcpAppEvent::SessionReplay {
-                session_id: TEST_SESSION_ID.into(),
-                updates: updates.clone(),
-            });
-        }
+        app.handle_acp_event(AcpAppEvent::SessionReplay {
+            session_id: TEST_SESSION_ID.into(),
+            updates: updates.clone(),
+        });
+        assert_eq!(app.render.chat_scroll_offset(), 0);
+        app.render.set_chat_scroll_offset(5);
+        app.handle_acp_event(AcpAppEvent::SessionReplay {
+            session_id: TEST_SESSION_ID.into(),
+            updates,
+        });
 
+        assert_eq!(app.render.chat_scroll_offset(), 5);
         assert!(matches!(
             app.chat.messages.as_slice(),
             [ChatEntry::Elicitation { elicitation_id, outcome: Some(outcome), .. }]

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -28,6 +28,7 @@ use crate::domain::session::{
 use crate::models_state::{ModelAction, ModelContext, ModelCoordination, ModelOutcome};
 use crate::navigation_state::{Popup, Screen};
 use crate::profiles_state::{ProfileAction, ProfileOutcome};
+use crate::render_state::SessionIdentity;
 use crate::session_state::{SessionAction, SessionCoordination, SessionOutcome};
 use crate::tool_detail;
 
@@ -719,6 +720,19 @@ impl crate::app::App {
 
     fn reset_active_session_view(&mut self) {
         self.chat.reset_for_session_switch();
+        let session_id = self.sessions.session_id.clone();
+        let remote_node_id = session_id
+            .as_deref()
+            .and_then(|id| self.sessions.session_remote_node_id(id))
+            .map(str::to_string);
+        let is_remote = session_id
+            .as_deref()
+            .is_some_and(|id| self.sessions.is_remote_session_id(id));
+        self.render.advance_session_epoch(SessionIdentity::new(
+            session_id,
+            remote_node_id,
+            is_remote,
+        ));
         self.render.invalidate_content_cache();
         self.render.invalidate_thinking_cache();
         self.render.invalidate_card_cache();
@@ -2538,6 +2552,26 @@ mod tests {
                 && agent_id.as_deref() == Some("agent-1")
                 && profile_id == "code"
         ));
+    }
+
+    #[test]
+    fn same_id_session_reload_advances_render_epoch() {
+        let mut app = App::new();
+
+        app.handle_acp_event(AcpAppEvent::SessionLoaded {
+            agent_id: "agent-1".into(),
+            session_id: "same-session".into(),
+            profile_id: None,
+        });
+        let first_epoch = app.render.test_session_epoch();
+
+        app.handle_acp_event(AcpAppEvent::SessionLoaded {
+            agent_id: "agent-1".into(),
+            session_id: "same-session".into(),
+            profile_id: None,
+        });
+
+        assert!(app.render.test_session_epoch() > first_epoch);
     }
 
     #[test]

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -810,6 +810,15 @@ impl crate::app::App {
         ) {
             self.render.scroll_chat_to_bottom();
         }
+        match transition {
+            ElicitationTransition::InsertedSupported {
+                is_replay: false, ..
+            }
+            | ElicitationTransition::ResolvedActive => {
+                self.render.reset_elicitation_custom_geometry();
+            }
+            _ => {}
+        }
         self.apply_render_changes(elicitation_render_changes(&transition));
         self.apply_chat_coordination(coordination);
         effects
@@ -855,6 +864,8 @@ impl crate::app::App {
                 remote_node_id,
                 is_remote,
             )));
+        self.render.reset_composer_input_geometry();
+        self.render.reset_elicitation_custom_geometry();
         let effects = self.apply_delegate_action(DelegateAction::ClearRootSessionState);
         self.composer.reset_for_session_switch();
         effects
@@ -2588,10 +2599,10 @@ mod tests {
             child_state: DelegateChildState::None,
         });
         app.render.test_seed_chat_viewport(3, 24);
+        app.render.test_seed_composer_input_geometry(40, 2);
+        app.render.test_seed_elicitation_custom_geometry(30, 1);
         app.composer.input = "/mo".into();
         app.composer.input_cursor = 3;
-        app.composer.input_scroll = 2;
-        app.composer.input_line_width = 40;
         app.composer.input_preferred_col = Some(4);
         app.composer.refresh_slash_state();
         app.composer.file_index = vec![FileIndexEntryLite {
@@ -2642,9 +2653,9 @@ mod tests {
         assert_eq!(app.render.test_chat_previous_total_height(), 0);
         assert_eq!(app.composer.input, "/mo");
         assert_eq!(app.composer.input_cursor, 3);
-        assert_eq!(app.composer.input_scroll, 2);
-        assert_eq!(app.composer.input_line_width, 40);
         assert_eq!(app.composer.input_preferred_col, Some(4));
+        assert_eq!(app.render.test_composer_input_geometry(), (1, 0, false));
+        assert_eq!(app.render.test_elicitation_custom_geometry(), (1, 0, false));
         assert!(app.composer.file_index.is_empty());
         assert_eq!(app.composer.file_index_generated_at, None);
         assert!(!app.composer.file_index_loading);

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -5,13 +5,15 @@ use serde_json::Value;
 use crate::application::Effect;
 use crate::auth_state::{AuthAction, AuthOutcome};
 use crate::chat_state::{
-    ChatAction, ChatCoordination, ChatOutcome, ChatToolAction, ChatToolOutcome, ChatToolTransition,
-    ChatUsageAction, ChatUsageOutcome, ElicitationAction, ElicitationOutcome, HistoryAction,
-    HistoryCoordination, HistoryOutcome, ToolStartPreparationTransition,
+    AssistantMessageTransition, ChatAction, ChatCoordination, ChatOutcome, ChatToolAction,
+    ChatToolOutcome, ChatToolTransition, ChatTransition, ChatUsageAction, ChatUsageOutcome,
+    ElicitationAction, ElicitationOutcome, ElicitationTransition, HistoryAction,
+    HistoryCoordination, HistoryOutcome, HistoryTransition, ToolEndTransition,
+    ToolStartInsertionTransition, ToolStartPreparationTransition, UserMessageTransition,
 };
 use crate::command::{Command, SessionListRequest};
 use crate::delegates_state::{
-    DelegateAction, DelegateChildActivity, DelegateContext, DelegateCoordination, DelegateOutcome,
+    DelegateAction, DelegateChildActivity, DelegateContext, DelegateOutcome,
 };
 use crate::diagnostics::LogLevel;
 use crate::domain::activity::{ActivityState, DelegationUpdate};
@@ -28,7 +30,7 @@ use crate::domain::session::{
 use crate::models_state::{ModelAction, ModelContext, ModelCoordination, ModelOutcome};
 use crate::navigation_state::{Popup, Screen};
 use crate::profiles_state::{ProfileAction, ProfileOutcome};
-use crate::render_state::SessionIdentity;
+use crate::render_state::{RenderChange, SessionIdentity};
 use crate::session_state::{SessionAction, SessionCoordination, SessionOutcome};
 use crate::tool_detail;
 
@@ -36,6 +38,121 @@ use crate::tool_detail;
 pub(crate) struct AcpModelsMetaInfo {
     pub remote_node_count: u32,
     pub remote_timeout_count: u32,
+}
+
+fn chat_render_changes(transition: &ChatTransition) -> Vec<RenderChange> {
+    match transition {
+        ChatTransition::TurnStarted | ChatTransition::Cancelled | ChatTransition::Finished => vec![
+            RenderChange::StreamingContentChanged,
+            RenderChange::StreamingThinkingChanged,
+        ],
+        ChatTransition::UserMessage(UserMessageTransition::Reconciled) => {
+            vec![RenderChange::FinalizedMessagesChanged]
+        }
+        ChatTransition::UserMessage(_) => Vec::new(),
+        ChatTransition::AssistantContentDelta(transition)
+        | ChatTransition::AssistantThinkingDelta(transition)
+            if transition.finalized_previous =>
+        {
+            vec![
+                RenderChange::StreamingContentChanged,
+                RenderChange::StreamingThinkingChanged,
+                RenderChange::FinalizedMessagesChanged,
+            ]
+        }
+        ChatTransition::AssistantContentDelta(_) | ChatTransition::AssistantThinkingDelta(_) => {
+            Vec::new()
+        }
+        ChatTransition::AssistantMessage(transition) => {
+            let mut changes = vec![
+                RenderChange::StreamingContentChanged,
+                RenderChange::StreamingThinkingChanged,
+            ];
+            if *transition == AssistantMessageTransition::ReplacedThinking {
+                changes.push(RenderChange::FinalizedMessagesChanged);
+            }
+            changes
+        }
+        ChatTransition::BackendPromptFailed { .. } => {
+            vec![RenderChange::FinalizedMessagesChanged]
+        }
+        ChatTransition::RuntimePromptDispatchFailed {
+            prompt_rolled_back: true,
+        } => vec![RenderChange::FinalizedMessagesChanged],
+        ChatTransition::RuntimePromptDispatchFailed {
+            prompt_rolled_back: false,
+        }
+        | ChatTransition::AcpError { .. } => Vec::new(),
+    }
+}
+
+fn tool_render_changes(transition: &ChatToolTransition) -> Vec<RenderChange> {
+    match transition {
+        ChatToolTransition::StartPrepared(
+            ToolStartPreparationTransition::Prepared {
+                finalized_streaming: true,
+            }
+            | ToolStartPreparationTransition::QuestionOnly {
+                finalized_streaming: true,
+            },
+        ) => vec![
+            RenderChange::StreamingContentChanged,
+            RenderChange::StreamingThinkingChanged,
+            RenderChange::FinalizedMessagesChanged,
+        ],
+        ChatToolTransition::StartPrepared(_) => Vec::new(),
+        ChatToolTransition::StartInserted(ToolStartInsertionTransition::Reconciled) => vec![
+            RenderChange::StreamingThinkingChanged,
+            RenderChange::FinalizedMessagesChanged,
+        ],
+        ChatToolTransition::StartInserted(ToolStartInsertionTransition::Inserted {
+            moved_thinking: true,
+        }) => vec![RenderChange::StreamingThinkingChanged],
+        ChatToolTransition::StartInserted(ToolStartInsertionTransition::Inserted {
+            moved_thinking: false,
+        }) => Vec::new(),
+        ChatToolTransition::Ended(
+            ToolEndTransition::Updated { .. } | ToolEndTransition::FallbackInserted,
+        ) => vec![RenderChange::FinalizedMessagesChanged],
+        ChatToolTransition::Ended(ToolEndTransition::NoOp) => Vec::new(),
+    }
+}
+
+fn elicitation_render_changes(transition: &ElicitationTransition) -> Vec<RenderChange> {
+    match transition {
+        ElicitationTransition::InsertedSupported {
+            finalized_streaming: true,
+            ..
+        }
+        | ElicitationTransition::InsertedUnsupported {
+            finalized_streaming: true,
+            ..
+        } => vec![
+            RenderChange::StreamingContentChanged,
+            RenderChange::StreamingThinkingChanged,
+            RenderChange::FinalizedMessagesChanged,
+        ],
+        ElicitationTransition::ResolvedActive | ElicitationTransition::ResolvedStale => {
+            vec![RenderChange::FinalizedMessagesChanged]
+        }
+        ElicitationTransition::InsertedSupported { .. }
+        | ElicitationTransition::InsertedUnsupported { .. }
+        | ElicitationTransition::Duplicate
+        | ElicitationTransition::UnknownAcknowledgement => Vec::new(),
+    }
+}
+
+fn history_render_changes(transition: HistoryTransition) -> Vec<RenderChange> {
+    match transition {
+        HistoryTransition::UndoApplied => vec![RenderChange::StreamingContentChanged],
+        HistoryTransition::StackReplaced
+        | HistoryTransition::UndoRejected
+        | HistoryTransition::RedoApplied
+        | HistoryTransition::RedoRejected
+        | HistoryTransition::ForkLoaded
+        | HistoryTransition::ForkMissingSessionId
+        | HistoryTransition::ForkFailed => Vec::new(),
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -509,7 +626,9 @@ impl crate::app::App {
                         self.profiles.remove_session_profile(&session_id);
                     }
                 }
-                SessionCoordination::ResetActiveSessionView => self.reset_active_session_view(),
+                SessionCoordination::ResetActiveSessionView => {
+                    effects.extend(self.reset_active_session_view());
+                }
                 SessionCoordination::SelectChat => self.navigation.screen = Screen::Chat,
                 SessionCoordination::SelectLoadedSessionScreen => {
                     self.navigation.screen = if self.delegates.parent_session_id.is_some() {
@@ -586,40 +705,36 @@ impl crate::app::App {
     fn apply_delegate_outcome(&mut self, outcome: DelegateOutcome) -> Vec<Effect> {
         let DelegateOutcome {
             changed: _,
-            coordination,
+            presentation_changed,
             effects,
         } = outcome;
-        for coordination in coordination {
-            match coordination {
-                DelegateCoordination::InvalidateCardCache => {
-                    self.render.invalidate_card_cache();
-                }
-            }
+        if presentation_changed {
+            self.render
+                .apply_change(RenderChange::DelegatePresentationChanged);
         }
         effects
     }
 
     pub(crate) fn apply_chat_action(&mut self, action: ChatAction) -> Vec<Effect> {
         let ChatOutcome {
-            transition: _,
+            transition,
             coordination,
             effects,
         } = self.chat.reduce(action);
+        self.apply_render_changes(chat_render_changes(&transition));
         self.apply_chat_coordination(coordination);
         effects
     }
 
     fn apply_chat_history_action(&mut self, action: HistoryAction) -> Vec<Effect> {
         let HistoryOutcome {
-            transition: _,
+            transition,
             coordination,
             mut effects,
         } = self.chat.reduce_history(action);
+        self.apply_render_changes(history_render_changes(transition));
         for coordination in coordination {
             match coordination {
-                HistoryCoordination::InvalidateContentCache => {
-                    self.render.invalidate_content_cache();
-                }
                 HistoryCoordination::Status {
                     level,
                     target,
@@ -665,6 +780,7 @@ impl crate::app::App {
             effects,
         } = self.chat.reduce_tool(action);
         self.apply_chat_coordination(coordination);
+        self.apply_render_changes(tool_render_changes(&transition));
         (transition, effects)
     }
 
@@ -683,26 +799,24 @@ impl crate::app::App {
         action: ElicitationAction,
     ) -> Vec<Effect> {
         let ElicitationOutcome {
-            transition: _,
+            transition,
             coordination,
             effects,
         } = self.chat.reduce_elicitation(action);
+        self.apply_render_changes(elicitation_render_changes(&transition));
         self.apply_chat_coordination(coordination);
         effects
+    }
+
+    fn apply_render_changes(&mut self, changes: Vec<RenderChange>) {
+        for change in changes {
+            self.render.apply_change(change);
+        }
     }
 
     fn apply_chat_coordination(&mut self, coordination: Vec<ChatCoordination>) {
         for coordination in coordination {
             match coordination {
-                ChatCoordination::InvalidateContentCache => {
-                    self.render.invalidate_content_cache();
-                }
-                ChatCoordination::InvalidateThinkingCache => {
-                    self.render.invalidate_thinking_cache();
-                }
-                ChatCoordination::InvalidateCardCache => {
-                    self.render.invalidate_card_cache();
-                }
                 ChatCoordination::Log {
                     level,
                     target,
@@ -718,7 +832,7 @@ impl crate::app::App {
         }
     }
 
-    fn reset_active_session_view(&mut self) {
+    fn reset_active_session_view(&mut self) -> Vec<Effect> {
         self.chat.reset_for_session_switch();
         let session_id = self.sessions.session_id.clone();
         let remote_node_id = session_id
@@ -728,17 +842,15 @@ impl crate::app::App {
         let is_remote = session_id
             .as_deref()
             .is_some_and(|id| self.sessions.is_remote_session_id(id));
-        self.render.advance_session_epoch(SessionIdentity::new(
-            session_id,
-            remote_node_id,
-            is_remote,
-        ));
-        self.render.invalidate_content_cache();
-        self.render.invalidate_thinking_cache();
-        self.render.invalidate_card_cache();
+        self.render
+            .apply_change(RenderChange::SessionChanged(SessionIdentity::new(
+                session_id,
+                remote_node_id,
+                is_remote,
+            )));
         let effects = self.apply_delegate_action(DelegateAction::ClearRootSessionState);
-        debug_assert!(effects.is_empty());
         self.composer.reset_for_session_switch();
+        effects
     }
 
     fn apply_acp_delegation_update(&mut self, update: DelegationUpdate) -> Vec<Effect> {

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -1371,7 +1371,7 @@ mod tests {
         DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus, DelegationState,
         PendingDelegateToolCall, SessionOp,
     };
-    use crate::domain::chat::ChatEntry;
+    use crate::domain::chat::{ChatEntry, ElicitationResponseOutcome};
     use crate::domain::elicitation::ElicitationState;
     use crate::domain::mesh::{RemoteNodeInfo, RemoteSessionInfo};
     use crate::domain::model::DelegateModelPreference;
@@ -4047,7 +4047,7 @@ mod tests {
         }
         app.apply_chat_elicitation_action(ElicitationAction::ResponseAcknowledged {
             elicitation_id: "elic-1".into(),
-            outcome: "staging".into(),
+            outcome: ElicitationResponseOutcome::Text("staging".into()),
         });
         app.handle_acp_event(AcpAppEvent::SessionReplay {
             session_id: TEST_SESSION_ID.into(),
@@ -4058,7 +4058,8 @@ mod tests {
         assert!(matches!(
             app.chat.messages.as_slice(),
             [ChatEntry::Elicitation { elicitation_id, outcome: Some(outcome), .. }]
-                if elicitation_id == "elic-1" && outcome == "staging"
+                if elicitation_id == "elic-1"
+                    && outcome == &ElicitationResponseOutcome::Text("staging".into())
         ));
     }
 
@@ -4121,7 +4122,7 @@ mod tests {
             app.chat.messages.as_slice(),
             [ChatEntry::Elicitation { elicitation_id, outcome: Some(outcome), .. }]
                 if elicitation_id == "elic-unsupported"
-                    && outcome == "unsupported schema - cannot answer in TUI"
+                    && outcome == &ElicitationResponseOutcome::UnsupportedSchema
         ));
     }
 

--- a/src/acp_state.rs
+++ b/src/acp_state.rs
@@ -862,9 +862,7 @@ impl crate::app::App {
                     ));
                 }
 
-                let cwd = self.current_session_cwd();
-                let detail =
-                    tool_detail::parse_tool_detail(&name, arguments.as_ref(), cwd.as_deref());
+                let detail = tool_detail::parse_tool_detail(&name, arguments.as_ref());
                 let (_, insertion_effects) =
                     self.apply_chat_tool_action(ChatToolAction::InsertOrReconcileToolStart {
                         tool_call_id,
@@ -3418,9 +3416,9 @@ mod tests {
         assert!(matches!(
             app.chat.messages.as_slice(),
             [ChatEntry::ToolCall {
-                detail: ToolDetail::Shell { output_tail: Some(tail), .. },
+                detail: ToolDetail::Shell { output: Some(output), .. },
                 ..
-            }] if tail.lines.iter().any(|line| line.contains("Finished dev profile"))
+            }] if output.stdout.contains("Finished dev profile")
         ));
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -101,8 +101,8 @@ impl App {
 
     pub fn take_input(&mut self) -> String {
         self.composer.input_cursor = 0;
-        self.composer.input_scroll = 0;
         self.composer.input_preferred_col = None;
+        self.render.reset_composer_input_geometry();
         self.render.scroll_chat_to_bottom();
         self.composer.mention_state = None;
         self.composer.slash_state = None;

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,7 +9,7 @@ use crate::mesh_state::MeshState;
 use crate::models_state::ModelsState;
 use crate::navigation_state::{NavigationState, Popup};
 use crate::profiles_state::ProfilesState;
-use crate::render_state::RenderState;
+use crate::render_state::{RenderChange, RenderState};
 use crate::session_state::SessionsState;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -198,7 +198,8 @@ impl App {
 
     pub fn push_pending_prompt(&mut self, text: String) -> String {
         let local_id = self.chat.push_pending_prompt(text);
-        self.render.invalidate_card_cache();
+        self.render
+            .apply_change(RenderChange::FinalizedMessagesChanged);
         local_id
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -103,7 +103,7 @@ impl App {
         self.composer.input_cursor = 0;
         self.composer.input_scroll = 0;
         self.composer.input_preferred_col = None;
-        self.chat.scroll_offset = 0;
+        self.render.scroll_chat_to_bottom();
         self.composer.mention_state = None;
         self.composer.slash_state = None;
         std::mem::take(&mut self.composer.input)
@@ -198,6 +198,7 @@ impl App {
 
     pub fn push_pending_prompt(&mut self, text: String) -> String {
         let local_id = self.chat.push_pending_prompt(text);
+        self.render.scroll_chat_to_bottom();
         self.render
             .apply_change(RenderChange::FinalizedMessagesChanged);
         local_id

--- a/src/app.rs
+++ b/src/app.rs
@@ -806,7 +806,7 @@ mod tests {
     use super::*;
     use crate::connection_state::ServerState;
     use crate::domain::activity::{ActivityState, SessionOp};
-    use crate::domain::chat::{ChatEntry, OUTCOME_BULLET};
+    use crate::domain::chat::{ChatEntry, ElicitationResponseOutcome};
     use crate::domain::session::{
         ForkBoundaryKind, UndoFrame, UndoFrameStatus, UndoStackSnapshot, UndoState, UndoableTurn,
     };
@@ -1264,7 +1264,7 @@ mod tests {
             elicitation_id: "e1".into(),
             message: "Pick one".into(),
             source: "builtin:question".into(),
-            outcome: Some("responded".into()),
+            outcome: Some(ElicitationResponseOutcome::Responded),
         }];
         let result = r#"{"answers":[{"question":"Pick one","answers":["Beta"]}]}"#;
         let mut chat = ChatState::new();
@@ -1272,7 +1272,8 @@ mod tests {
         chat.backfill_elicitation_outcomes(result);
         messages = chat.messages;
         assert!(matches!(&messages[0],
-            ChatEntry::Elicitation { outcome: Some(o), .. } if *o == format!("{OUTCOME_BULLET}Beta")
+            ChatEntry::Elicitation { outcome: Some(o), .. }
+                if o == &ElicitationResponseOutcome::Selected(vec!["Beta".into()])
         ));
     }
 
@@ -1282,7 +1283,7 @@ mod tests {
             elicitation_id: "e1".into(),
             message: "Pick many".into(),
             source: "builtin:question".into(),
-            outcome: Some("responded".into()),
+            outcome: Some(ElicitationResponseOutcome::Responded),
         }];
         let result = r#"{"answers":[{"question":"Pick many","answers":["X","Z"]}]}"#;
         let mut chat = ChatState::new();
@@ -1290,7 +1291,8 @@ mod tests {
         chat.backfill_elicitation_outcomes(result);
         messages = chat.messages;
         assert!(matches!(&messages[0],
-            ChatEntry::Elicitation { outcome: Some(o), .. } if *o == format!("{OUTCOME_BULLET}X\n{OUTCOME_BULLET}Z")
+            ChatEntry::Elicitation { outcome: Some(o), .. }
+                if o == &ElicitationResponseOutcome::Selected(vec!["X".into(), "Z".into()])
         ));
     }
 
@@ -1301,13 +1303,13 @@ mod tests {
                 elicitation_id: "e1".into(),
                 message: "Q1".into(),
                 source: "builtin:question".into(),
-                outcome: Some("responded".into()),
+                outcome: Some(ElicitationResponseOutcome::Responded),
             },
             ChatEntry::Elicitation {
                 elicitation_id: "e2".into(),
                 message: "Q2".into(),
                 source: "builtin:question".into(),
-                outcome: Some("responded".into()),
+                outcome: Some(ElicitationResponseOutcome::Responded),
             },
         ];
         let result = r#"{"answers":[{"question":"Q1","answers":["Alpha"]},{"question":"Q2","answers":["Yes"]}]}"#;
@@ -1316,10 +1318,12 @@ mod tests {
         chat.backfill_elicitation_outcomes(result);
         messages = chat.messages;
         assert!(matches!(&messages[0],
-            ChatEntry::Elicitation { outcome: Some(o), .. } if *o == format!("{OUTCOME_BULLET}Alpha")
+            ChatEntry::Elicitation { outcome: Some(o), .. }
+                if o == &ElicitationResponseOutcome::Selected(vec!["Alpha".into()])
         ));
         assert!(matches!(&messages[1],
-            ChatEntry::Elicitation { outcome: Some(o), .. } if *o == format!("{OUTCOME_BULLET}Yes")
+            ChatEntry::Elicitation { outcome: Some(o), .. }
+                if o == &ElicitationResponseOutcome::Selected(vec!["Yes".into()])
         ));
     }
 
@@ -1330,13 +1334,15 @@ mod tests {
                 elicitation_id: "e1".into(),
                 message: "Q1".into(),
                 source: "builtin:question".into(),
-                outcome: Some(format!("{OUTCOME_BULLET}AlreadySet")),
+                outcome: Some(ElicitationResponseOutcome::Selected(vec![
+                    "AlreadySet".into(),
+                ])),
             },
             ChatEntry::Elicitation {
                 elicitation_id: "e2".into(),
                 message: "Q2".into(),
                 source: "builtin:question".into(),
-                outcome: Some("responded".into()),
+                outcome: Some(ElicitationResponseOutcome::Responded),
             },
         ];
         let result = r#"{"answers":[{"question":"Q2","answers":["Beta"]}]}"#;
@@ -1346,11 +1352,13 @@ mod tests {
         messages = chat.messages;
         // First card unchanged
         assert!(matches!(&messages[0],
-            ChatEntry::Elicitation { outcome: Some(o), .. } if *o == format!("{OUTCOME_BULLET}AlreadySet")
+            ChatEntry::Elicitation { outcome: Some(o), .. }
+                if o == &ElicitationResponseOutcome::Selected(vec!["AlreadySet".into()])
         ));
         // Second card updated
         assert!(matches!(&messages[1],
-            ChatEntry::Elicitation { outcome: Some(o), .. } if *o == format!("{OUTCOME_BULLET}Beta")
+            ChatEntry::Elicitation { outcome: Some(o), .. }
+                if o == &ElicitationResponseOutcome::Selected(vec!["Beta".into()])
         ));
     }
 }

--- a/src/application.rs
+++ b/src/application.rs
@@ -205,6 +205,7 @@ fn handle_runtime_event(app: &mut App, event: RuntimeEvent) -> Vec<Effect> {
             match outcome {
                 ExternalEditorOutcome::Completed(updated_input) => {
                     app.composer.replace_input_from_editor(updated_input);
+                    app.render.reset_composer_input_geometry();
                     app.set_status(
                         LogLevel::Info,
                         "editor",
@@ -403,6 +404,7 @@ mod tests {
     fn key_and_mouse_events_dispatch_through_update() {
         let mut app = App::new();
         app.composer.input = "draft".into();
+        app.render.test_seed_composer_input_geometry(24, 2);
 
         let effects = update(
             &mut app,
@@ -410,6 +412,7 @@ mod tests {
         );
         assert!(effects.is_empty());
         assert!(app.composer.input.is_empty());
+        assert_eq!(app.render.test_composer_input_geometry(), (1, 0, false));
 
         app.navigation.screen = Screen::Chat;
         app.render.set_chat_scroll_offset(2);
@@ -1012,6 +1015,7 @@ mod tests {
         seed_content_cache(&mut app);
         seed_thinking_cache(&mut app);
         seed_card_cache(&mut app, 7);
+        app.render.test_seed_elicitation_custom_geometry(24, 3);
         let log_count_before = app.diagnostics.logs.len();
 
         let effects = apply_session_update(&mut app, supported_elicitation("elic-live"));
@@ -1024,6 +1028,7 @@ mod tests {
             Some("elic-live")
         );
         assert!(app.chat.elicitation_ui.is_some());
+        assert_eq!(app.render.test_elicitation_custom_geometry(), (1, 0, false));
         assert_eq!(app.render.chat_scroll_offset(), 0);
         assert!(app.chat.streaming_content.is_empty());
         assert!(app.chat.streaming_thinking.is_empty());
@@ -1057,10 +1062,12 @@ mod tests {
         seed_thinking_cache(&mut app);
         seed_card_cache(&mut app, 2);
         app.render.set_chat_scroll_offset(6);
+        app.render.test_seed_elicitation_custom_geometry(18, 2);
         let log_count_before_duplicate = app.diagnostics.logs.len();
         let effects = apply_session_update(&mut app, supported_elicitation("elic-live"));
         assert!(effects.is_empty());
         assert_eq!(app.render.chat_scroll_offset(), 6);
+        assert_eq!(app.render.test_elicitation_custom_geometry(), (18, 2, true));
         assert_eq!(app.chat.messages.len(), 2);
         assert!(content_cache_populated(&app));
         assert!(thinking_cache_populated(&app));
@@ -1076,6 +1083,7 @@ mod tests {
         seed_thinking_cache(&mut app);
         seed_card_cache(&mut app, 7);
         app.render.set_chat_scroll_offset(7);
+        app.render.test_seed_elicitation_custom_geometry(22, 2);
         let log_count_before_replay = app.diagnostics.logs.len();
 
         let effects = update(
@@ -1087,6 +1095,7 @@ mod tests {
         );
         assert!(effects.is_empty());
         assert_eq!(app.render.chat_scroll_offset(), 0);
+        assert_eq!(app.render.test_elicitation_custom_geometry(), (22, 2, true));
         assert!(app.chat.elicitation.is_none());
         assert!(app.chat.elicitation_ui.is_none());
         assert!(matches!(
@@ -1118,6 +1127,7 @@ mod tests {
         let effects = apply_session_update(&mut app, unsupported_elicitation("elic-unsupported"));
         assert!(effects.is_empty());
         assert_eq!(app.render.chat_scroll_offset(), 0);
+        assert_eq!(app.render.test_elicitation_custom_geometry(), (22, 2, true));
         assert!(app.chat.elicitation.is_none());
         assert!(app.chat.elicitation_ui.is_none());
         assert!(matches!(
@@ -3232,6 +3242,7 @@ mod tests {
     fn editor_results_apply_state_then_request_redraw() {
         let mut app = App::new();
         app.composer.input = "draft".into();
+        app.render.test_seed_composer_input_geometry(30, 2);
         seed_card_cache(&mut app, 2);
         seed_content_cache(&mut app);
         seed_thinking_cache(&mut app);
@@ -3245,6 +3256,7 @@ mod tests {
 
         assert_eq!(app.composer.input, "revised");
         assert_eq!(app.composer.input_cursor, "revised".len());
+        assert_eq!(app.render.test_composer_input_geometry(), (1, 0, false));
         assert_eq!(card_cache_count(&app), 0);
         assert!(!content_cache_populated(&app));
         assert!(thinking_cache_populated(&app));
@@ -3256,6 +3268,7 @@ mod tests {
     fn editor_cancel_and_failure_preserve_input_and_request_redraw() {
         let mut app = App::new();
         app.composer.input = "draft".into();
+        app.render.test_seed_composer_input_geometry(30, 2);
         seed_card_cache(&mut app, 2);
         seed_content_cache(&mut app);
         seed_thinking_cache(&mut app);
@@ -3267,6 +3280,7 @@ mod tests {
             }),
         );
         assert_eq!(app.composer.input, "draft");
+        assert_eq!(app.render.test_composer_input_geometry(), (30, 2, true));
         assert_eq!(card_cache_count(&app), 0);
         assert!(!content_cache_populated(&app));
         assert!(thinking_cache_populated(&app));
@@ -3283,6 +3297,7 @@ mod tests {
             }),
         );
         assert_eq!(app.composer.input, "draft");
+        assert_eq!(app.render.test_composer_input_geometry(), (30, 2, true));
         assert_eq!(card_cache_count(&app), 0);
         assert!(!content_cache_populated(&app));
         assert!(thinking_cache_populated(&app));
@@ -3302,6 +3317,7 @@ mod tests {
         seed_thinking_cache(&mut app);
         seed_card_cache(&mut app, 5);
         app.render.set_chat_scroll_offset(6);
+        app.render.test_seed_elicitation_custom_geometry(26, 2);
         app.diagnostics.status = "question pending".into();
         let log_count_before = app.diagnostics.logs.len();
 
@@ -3315,6 +3331,7 @@ mod tests {
 
         assert!(effects.is_empty());
         assert_eq!(app.render.chat_scroll_offset(), 6);
+        assert_eq!(app.render.test_elicitation_custom_geometry(), (1, 0, false));
         assert!(app.chat.elicitation.is_none());
         assert!(app.chat.elicitation_ui.is_none());
         assert!(matches!(
@@ -3388,6 +3405,7 @@ mod tests {
         seed_content_cache(&mut app);
         seed_thinking_cache(&mut app);
         seed_card_cache(&mut app, 2);
+        app.render.test_seed_elicitation_custom_geometry(28, 3);
         app.diagnostics.status = "newer question pending".into();
         let log_count_before = app.diagnostics.logs.len();
 
@@ -3408,6 +3426,7 @@ mod tests {
             Some("elic-new")
         );
         assert!(app.chat.elicitation_ui.is_some());
+        assert_eq!(app.render.test_elicitation_custom_geometry(), (28, 3, true));
         assert!(content_cache_populated(&app));
         assert!(thinking_cache_populated(&app));
         assert_eq!(card_cache_count(&app), 0);
@@ -3432,6 +3451,7 @@ mod tests {
         seed_thinking_cache(&mut app);
         seed_card_cache(&mut app, 5);
         app.render.set_chat_scroll_offset(7);
+        app.render.test_seed_elicitation_custom_geometry(32, 1);
         app.diagnostics.status = "question pending".into();
         let log_count_before = app.diagnostics.logs.len();
 
@@ -3453,6 +3473,7 @@ mod tests {
             Some("elic-active")
         );
         assert!(app.chat.elicitation_ui.is_some());
+        assert_eq!(app.render.test_elicitation_custom_geometry(), (32, 1, true));
         assert!(matches!(
             app.chat.messages.as_slice(),
             [ChatEntry::Elicitation { elicitation_id, outcome: None, .. }]
@@ -3470,6 +3491,7 @@ mod tests {
         let mut app = App::new();
         add_elicitation(&mut app, "elic-1", false);
         seed_card_cache(&mut app, 5);
+        app.render.test_seed_elicitation_custom_geometry(34, 2);
         app.diagnostics.status = "preserved status".into();
         let log_count_before = app.diagnostics.logs.len();
 
@@ -3499,6 +3521,7 @@ mod tests {
                     && outcome == &ElicitationResponseOutcome::Declined
         ));
         assert_eq!(card_cache_count(&app), 0);
+        assert_eq!(app.render.test_elicitation_custom_geometry(), (34, 2, true));
         assert_eq!(app.diagnostics.status, "preserved status");
         assert_eq!(app.diagnostics.logs.len(), log_count_before);
     }

--- a/src/application.rs
+++ b/src/application.rs
@@ -548,14 +548,18 @@ mod tests {
                     tool_call_id: Some(tool_call_id),
                     name,
                     is_error: false,
-                    detail: ToolDetail::Summary(summary),
+                    detail: ToolDetail::Delegate {
+                        target_agent_id,
+                        objective,
+                    },
                 },
             ] if content == "before delegate"
                 && thinking == "delegate plan"
                 && message_id == "assistant-1"
                 && tool_call_id == "delegate-call"
                 && name == "delegate"
-                && summary == "(coder) Implement the feature"
+                && target_agent_id == "coder"
+                && objective == "Implement the feature"
         ));
 
         let effects = update(
@@ -745,8 +749,8 @@ mod tests {
         assert_eq!(app.render.card_cache.processed_messages, 0);
         assert!(matches!(
             app.chat.messages.as_slice(),
-            [ChatEntry::ToolCall { tool_call_id: Some(id), name, is_error: true, detail: ToolDetail::Summary(detail) }]
-                if id == "tool-1" && name == "shell (failed)" && detail == "failed before start"
+            [ChatEntry::ToolCall { tool_call_id: Some(id), name, is_error: true, detail: ToolDetail::Generic { input: None, result: Some(result) } }]
+                if id == "tool-1" && name == "shell (failed)" && result == "failed before start"
         ));
 
         app.render.card_cache.processed_messages = 8;
@@ -779,7 +783,7 @@ mod tests {
         assert_eq!(diagnostic.message, "tool: shell");
         assert!(matches!(
             app.chat.messages.as_slice(),
-            [ChatEntry::ToolCall { tool_call_id: Some(id), name, is_error: true, detail: ToolDetail::Shell { command, output_tail: None, .. } }]
+            [ChatEntry::ToolCall { tool_call_id: Some(id), name, is_error: true, detail: ToolDetail::Shell { command, output: None, .. } }]
                 if id == "tool-1" && name == "shell" && command == "echo late"
         ));
 
@@ -801,8 +805,8 @@ mod tests {
         assert_eq!(app.render.card_cache.processed_messages, 0);
         assert!(matches!(
             app.chat.messages.as_slice(),
-            [ChatEntry::ToolCall { is_error: true, detail: ToolDetail::Shell { output_tail: Some(tail), .. }, .. }]
-                if tail.lines == ["line one", "line two"]
+            [ChatEntry::ToolCall { is_error: true, detail: ToolDetail::Shell { output: Some(output), .. }, .. }]
+                if output.stdout == "line one\nline two" && output.stderr.is_empty()
         ));
 
         app.render.card_cache.processed_messages = 11;

--- a/src/application.rs
+++ b/src/application.rs
@@ -412,7 +412,7 @@ mod tests {
         assert!(app.composer.input.is_empty());
 
         app.navigation.screen = Screen::Chat;
-        app.chat.scroll_offset = 2;
+        app.render.set_chat_scroll_offset(2);
         let effects = update(
             &mut app,
             AppEvent::Mouse(MouseEvent {
@@ -423,7 +423,32 @@ mod tests {
             }),
         );
         assert!(effects.is_empty());
-        assert_eq!(app.chat.scroll_offset, 5);
+        assert_eq!(app.render.chat_scroll_offset(), 5);
+
+        let effects = update(
+            &mut app,
+            AppEvent::Mouse(MouseEvent {
+                kind: MouseEventKind::ScrollDown,
+                column: 0,
+                row: 0,
+                modifiers: KeyModifiers::NONE,
+            }),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.render.chat_scroll_offset(), 2);
+
+        app.render.set_chat_scroll_offset(1);
+        let effects = update(
+            &mut app,
+            AppEvent::Mouse(MouseEvent {
+                kind: MouseEventKind::ScrollDown,
+                column: 0,
+                row: 0,
+                modifiers: KeyModifiers::NONE,
+            }),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.render.chat_scroll_offset(), 0);
 
         let effects = update(
             &mut app,
@@ -435,6 +460,32 @@ mod tests {
             }),
         );
         assert!(effects.is_empty());
+    }
+
+    #[test]
+    fn mouse_chat_viewport_respects_screen_and_popup_gating() {
+        let mut app = App::new();
+        app.render.set_chat_scroll_offset(4);
+        let scroll_up = || MouseEvent {
+            kind: MouseEventKind::ScrollUp,
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::NONE,
+        };
+
+        app.navigation.screen = Screen::Sessions;
+        assert!(update(&mut app, AppEvent::Mouse(scroll_up())).is_empty());
+        assert_eq!(app.render.chat_scroll_offset(), 4);
+
+        app.navigation.screen = Screen::Chat;
+        app.navigation.popup = Popup::Help;
+        assert!(update(&mut app, AppEvent::Mouse(scroll_up())).is_empty());
+        assert_eq!(app.render.chat_scroll_offset(), 4);
+
+        app.navigation.popup = Popup::None;
+        app.navigation.screen = Screen::Delegate;
+        assert!(update(&mut app, AppEvent::Mouse(scroll_up())).is_empty());
+        assert_eq!(app.render.chat_scroll_offset(), 7);
     }
 
     #[test]
@@ -957,7 +1008,7 @@ mod tests {
         app.chat.streaming_thinking_message_id = Some("assistant-1".into());
         app.chat.streaming_content = "answer".into();
         app.chat.streaming_content_message_id = Some("assistant-1".into());
-        app.chat.scroll_offset = 8;
+        app.render.set_chat_scroll_offset(8);
         seed_content_cache(&mut app);
         seed_thinking_cache(&mut app);
         seed_card_cache(&mut app, 7);
@@ -973,7 +1024,7 @@ mod tests {
             Some("elic-live")
         );
         assert!(app.chat.elicitation_ui.is_some());
-        assert_eq!(app.chat.scroll_offset, 0);
+        assert_eq!(app.render.chat_scroll_offset(), 0);
         assert!(app.chat.streaming_content.is_empty());
         assert!(app.chat.streaming_thinking.is_empty());
         assert!(!content_cache_populated(&app));
@@ -1005,9 +1056,11 @@ mod tests {
         seed_content_cache(&mut app);
         seed_thinking_cache(&mut app);
         seed_card_cache(&mut app, 2);
+        app.render.set_chat_scroll_offset(6);
         let log_count_before_duplicate = app.diagnostics.logs.len();
         let effects = apply_session_update(&mut app, supported_elicitation("elic-live"));
         assert!(effects.is_empty());
+        assert_eq!(app.render.chat_scroll_offset(), 6);
         assert_eq!(app.chat.messages.len(), 2);
         assert!(content_cache_populated(&app));
         assert!(thinking_cache_populated(&app));
@@ -1022,6 +1075,7 @@ mod tests {
         seed_content_cache(&mut app);
         seed_thinking_cache(&mut app);
         seed_card_cache(&mut app, 7);
+        app.render.set_chat_scroll_offset(7);
         let log_count_before_replay = app.diagnostics.logs.len();
 
         let effects = update(
@@ -1032,6 +1086,7 @@ mod tests {
             }),
         );
         assert!(effects.is_empty());
+        assert_eq!(app.render.chat_scroll_offset(), 0);
         assert!(app.chat.elicitation.is_none());
         assert!(app.chat.elicitation_ui.is_none());
         assert!(matches!(
@@ -1058,9 +1113,11 @@ mod tests {
             "question - answer in the panel above input"
         );
 
+        app.render.set_chat_scroll_offset(5);
         let log_count_before_unsupported = app.diagnostics.logs.len();
         let effects = apply_session_update(&mut app, unsupported_elicitation("elic-unsupported"));
         assert!(effects.is_empty());
+        assert_eq!(app.render.chat_scroll_offset(), 0);
         assert!(app.chat.elicitation.is_none());
         assert!(app.chat.elicitation_ui.is_none());
         assert!(matches!(
@@ -2494,6 +2551,7 @@ mod tests {
             .messages
             .push(ChatEntry::Error("stale chat".into()));
         app.chat.streaming_content = "stale stream".into();
+        app.render.test_seed_chat_viewport(8, 34);
         app.composer.input = "preserved draft".into();
         app.composer.input_cursor = 4;
         app.composer.file_index = vec![FileIndexEntryLite {
@@ -2540,6 +2598,8 @@ mod tests {
         assert_eq!(app.profiles.session_profile_id("session-1"), Some("code"));
         assert!(app.chat.messages.is_empty());
         assert!(app.chat.streaming_content.is_empty());
+        assert_eq!(app.render.chat_scroll_offset(), 0);
+        assert_eq!(app.render.test_chat_previous_total_height(), 0);
         assert_eq!(app.composer.input, "preserved draft");
         assert_eq!(app.composer.input_cursor, 4);
         assert!(app.composer.file_index.is_empty());
@@ -2598,6 +2658,7 @@ mod tests {
         app.chat
             .messages
             .push(ChatEntry::Error("stale chat".into()));
+        app.render.test_seed_chat_viewport(6, 28);
         app.composer.file_index = vec![FileIndexEntryLite {
             path: "src/lib.rs".into(),
             is_dir: false,
@@ -2622,6 +2683,8 @@ mod tests {
         assert_eq!(app.sessions.agent_id.as_deref(), Some("agent-local"));
         assert_eq!(app.sessions.mode_before_review, None);
         assert!(app.chat.messages.is_empty());
+        assert_eq!(app.render.chat_scroll_offset(), 0);
+        assert_eq!(app.render.test_chat_previous_total_height(), 0);
         assert!(app.composer.file_index.is_empty());
         assert_eq!(app.diagnostics.status, "ready");
         let diagnostic = app.diagnostics.logs.last().expect("load diagnostic");
@@ -2664,6 +2727,7 @@ mod tests {
             .pending_delegate_child_states
             .insert("keep-child".into(), DelegateChildState::OtherProgress);
         app.chat.activity = ActivityState::Thinking;
+        app.render.test_seed_chat_viewport(7, 39);
 
         let remote_effects = update(
             &mut app,
@@ -2686,6 +2750,8 @@ mod tests {
                 .contains_key("keep-child")
         );
         assert_eq!(app.navigation.screen, Screen::Delegate);
+        assert_eq!(app.render.chat_scroll_offset(), 0);
+        assert_eq!(app.render.test_chat_previous_total_height(), 0);
         assert!(app.profiles.session_profile_id("remote-child").is_none());
         assert_eq!(
             remote_effects,
@@ -3235,6 +3301,7 @@ mod tests {
         seed_content_cache(&mut app);
         seed_thinking_cache(&mut app);
         seed_card_cache(&mut app, 5);
+        app.render.set_chat_scroll_offset(6);
         app.diagnostics.status = "question pending".into();
         let log_count_before = app.diagnostics.logs.len();
 
@@ -3247,6 +3314,7 @@ mod tests {
         );
 
         assert!(effects.is_empty());
+        assert_eq!(app.render.chat_scroll_offset(), 6);
         assert!(app.chat.elicitation.is_none());
         assert!(app.chat.elicitation_ui.is_none());
         assert!(matches!(
@@ -3363,6 +3431,7 @@ mod tests {
         seed_content_cache(&mut app);
         seed_thinking_cache(&mut app);
         seed_card_cache(&mut app, 5);
+        app.render.set_chat_scroll_offset(7);
         app.diagnostics.status = "question pending".into();
         let log_count_before = app.diagnostics.logs.len();
 
@@ -3375,6 +3444,7 @@ mod tests {
         );
 
         assert!(effects.is_empty());
+        assert_eq!(app.render.chat_scroll_offset(), 7);
         assert_eq!(
             app.chat
                 .elicitation

--- a/src/application.rs
+++ b/src/application.rs
@@ -200,8 +200,8 @@ fn handle_runtime_event(app: &mut App, event: RuntimeEvent) -> Vec<Effect> {
             ClipboardTarget::MeshInvite => app.apply_mesh_clipboard_result(success),
         },
         RuntimeEvent::ExternalEditorFinished { outcome } => {
-            app.render.invalidate_card_cache();
-            app.render.invalidate_content_cache();
+            app.render
+                .apply_change(crate::render_state::RenderChange::ExternalEditorReturned);
             match outcome {
                 ExternalEditorOutcome::Completed(updated_input) => {
                     app.composer.replace_input_from_editor(updated_input);
@@ -1412,6 +1412,27 @@ mod tests {
             ChatEntry::Assistant { content, thinking: Some(thinking), message_id: Some(id) }
                 if content == "final" && thinking == "second plan" && id == "assistant-2"
         ));
+
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 13);
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::SessionUpdate {
+                session_id: "active".into(),
+                update: crate::acp_state::AcpSessionUpdate::AssistantMessage {
+                    content: "duplicate final".into(),
+                    thinking: Some("duplicate thinking".into()),
+                    message_id: Some("assistant-2".into()),
+                },
+                is_replay: false,
+            }),
+        );
+        assert!(effects.is_empty());
+        assert!(!content_cache_populated(&app));
+        assert!(!thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 13);
+        assert_eq!(app.chat.messages.len(), 2);
     }
 
     #[test]
@@ -1600,6 +1621,21 @@ mod tests {
         assert_eq!(diagnostics[0].message, "error: backend rejected prompt");
         assert_eq!(app.composer.input, "preserved input");
         assert_eq!(app.mesh.mesh_invite_name, "preserved invite");
+
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 11);
+        let effects = update(
+            &mut app,
+            AppEvent::Acp(AcpAppEvent::PromptFailed {
+                local_id: "missing".into(),
+                message: "backend rejected prompt".into(),
+            }),
+        );
+        assert!(effects.is_empty());
+        assert!(content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 0);
     }
 
     #[test]
@@ -3131,6 +3167,8 @@ mod tests {
         let mut app = App::new();
         app.composer.input = "draft".into();
         seed_card_cache(&mut app, 2);
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
 
         let effects = update(
             &mut app,
@@ -3142,6 +3180,8 @@ mod tests {
         assert_eq!(app.composer.input, "revised");
         assert_eq!(app.composer.input_cursor, "revised".len());
         assert_eq!(card_cache_count(&app), 0);
+        assert!(!content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
         assert_eq!(app.diagnostics.status, "loaded prompt from external editor");
         assert_eq!(effects, vec![Effect::Terminal(TerminalAction::Redraw)]);
     }
@@ -3150,6 +3190,9 @@ mod tests {
     fn editor_cancel_and_failure_preserve_input_and_request_redraw() {
         let mut app = App::new();
         app.composer.input = "draft".into();
+        seed_card_cache(&mut app, 2);
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
 
         let effects = update(
             &mut app,
@@ -3158,9 +3201,15 @@ mod tests {
             }),
         );
         assert_eq!(app.composer.input, "draft");
+        assert_eq!(card_cache_count(&app), 0);
+        assert!(!content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
         assert_eq!(app.diagnostics.status, "external editor cancelled");
         assert_eq!(effects, vec![Effect::Terminal(TerminalAction::Redraw)]);
 
+        seed_card_cache(&mut app, 2);
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
         let effects = update(
             &mut app,
             AppEvent::Runtime(RuntimeEvent::ExternalEditorFinished {
@@ -3168,6 +3217,9 @@ mod tests {
             }),
         );
         assert_eq!(app.composer.input, "draft");
+        assert_eq!(card_cache_count(&app), 0);
+        assert!(!content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
         assert_eq!(
             app.diagnostics.status,
             "external editor failed: editor exited"

--- a/src/application.rs
+++ b/src/application.rs
@@ -8,6 +8,7 @@ use crate::{
     command::Command,
     connection_state::ConnState,
     diagnostics::LogLevel,
+    domain::chat::ElicitationResponseOutcome,
     handlers,
     server_manager::ServerEvent,
 };
@@ -33,7 +34,7 @@ pub(crate) enum RuntimeEvent {
     },
     ElicitationResponseSent {
         elicitation_id: String,
-        outcome: String,
+        outcome: ElicitationResponseOutcome,
     },
     CommandFailed {
         command: Command,
@@ -61,7 +62,7 @@ pub(crate) enum Effect {
         elicitation_id: String,
         action: String,
         content: Option<serde_json::Value>,
-        outcome: String,
+        outcome: ElicitationResponseOutcome,
     },
     PersistConfig,
     CopyToClipboard {
@@ -263,7 +264,7 @@ mod tests {
                 DelegationUpdate, SessionOp,
             },
             auth::{OAuthFlow, OAuthFlowKind, OAuthResult, OAuthResultStatus},
-            chat::ChatEntry,
+            chat::{ChatEntry, ElicitationResponseOutcome},
             elicitation::ElicitationState,
             mesh::{MeshInviteCreatedInfo, MeshNodesInfo, RemoteNodeInfo},
             model::DelegateModelPreference,
@@ -1041,7 +1042,7 @@ mod tests {
                 ChatEntry::Elicitation { elicitation_id: unsupported, outcome: Some(outcome), .. },
             ] if replay == "elic-replay"
                 && unsupported == "elic-unsupported"
-                && outcome == "unsupported schema - cannot answer in TUI"
+                && outcome == &ElicitationResponseOutcome::UnsupportedSchema
         ));
         assert_eq!(app.render.card_cache.processed_messages, 7);
         assert_eq!(
@@ -3161,7 +3162,7 @@ mod tests {
             &mut app,
             AppEvent::Runtime(RuntimeEvent::ElicitationResponseSent {
                 elicitation_id: "elic-1".into(),
-                outcome: "accepted".into(),
+                outcome: ElicitationResponseOutcome::Text("accepted".into()),
             }),
         );
 
@@ -3171,7 +3172,8 @@ mod tests {
         assert!(matches!(
             app.chat.messages.as_slice(),
             [ChatEntry::Elicitation { elicitation_id, outcome: Some(outcome), .. }]
-                if elicitation_id == "elic-1" && outcome == "accepted"
+                if elicitation_id == "elic-1"
+                    && outcome == &ElicitationResponseOutcome::Text("accepted".into())
         ));
         assert!(app.render.streaming_cache.get(3).is_some());
         assert!(app.render.streaming_thinking_cache.get(4).is_some());
@@ -3245,7 +3247,7 @@ mod tests {
             &mut app,
             AppEvent::Runtime(RuntimeEvent::ElicitationResponseSent {
                 elicitation_id: "elic-old".into(),
-                outcome: "accepted".into(),
+                outcome: ElicitationResponseOutcome::Text("accepted".into()),
             }),
         );
 
@@ -3268,7 +3270,9 @@ mod tests {
             [
                 ChatEntry::Elicitation { elicitation_id: old_id, outcome: Some(outcome), .. },
                 ChatEntry::Elicitation { elicitation_id: new_id, outcome: None, .. },
-            ] if old_id == "elic-old" && outcome == "accepted" && new_id == "elic-new"
+            ] if old_id == "elic-old"
+                && outcome == &ElicitationResponseOutcome::Text("accepted".into())
+                && new_id == "elic-new"
         ));
     }
 
@@ -3286,7 +3290,7 @@ mod tests {
             &mut app,
             AppEvent::Runtime(RuntimeEvent::ElicitationResponseSent {
                 elicitation_id: "missing".into(),
-                outcome: "accepted".into(),
+                outcome: ElicitationResponseOutcome::Text("accepted".into()),
             }),
         );
 
@@ -3323,7 +3327,7 @@ mod tests {
             &mut app,
             AppEvent::Runtime(RuntimeEvent::ElicitationResponseSent {
                 elicitation_id: "elic-1".into(),
-                outcome: "accepted".into(),
+                outcome: ElicitationResponseOutcome::Text("accepted".into()),
             }),
         );
         assert!(first_effects.is_empty());
@@ -3334,14 +3338,15 @@ mod tests {
             &mut app,
             AppEvent::Runtime(RuntimeEvent::ElicitationResponseSent {
                 elicitation_id: "elic-1".into(),
-                outcome: "declined".into(),
+                outcome: ElicitationResponseOutcome::Declined,
             }),
         );
         assert!(duplicate_effects.is_empty());
         assert!(matches!(
             app.chat.messages.as_slice(),
             [ChatEntry::Elicitation { elicitation_id, outcome: Some(outcome), .. }]
-                if elicitation_id == "elic-1" && outcome == "declined"
+                if elicitation_id == "elic-1"
+                    && outcome == &ElicitationResponseOutcome::Declined
         ));
         assert_eq!(app.render.card_cache.processed_messages, 0);
         assert_eq!(app.diagnostics.status, "preserved status");

--- a/src/application.rs
+++ b/src/application.rs
@@ -277,6 +277,34 @@ mod tests {
         navigation_state::{Popup, Screen},
     };
 
+    fn seed_card_cache(app: &mut App, source_entry_count: usize) {
+        app.render.test_seed_card_cache(source_entry_count);
+    }
+
+    fn card_cache_count(app: &App) -> usize {
+        app.render.test_card_source_entry_count()
+    }
+
+    fn seed_content_cache(app: &mut App) {
+        app.render
+            .test_seed_streaming_cache(crate::render_state::StreamKind::Content);
+    }
+
+    fn seed_thinking_cache(app: &mut App) {
+        app.render
+            .test_seed_streaming_cache(crate::render_state::StreamKind::Thinking);
+    }
+
+    fn content_cache_populated(app: &App) -> bool {
+        app.render
+            .test_streaming_cache_populated(crate::render_state::StreamKind::Content)
+    }
+
+    fn thinking_cache_populated(app: &App) -> bool {
+        app.render
+            .test_streaming_cache_populated(crate::render_state::StreamKind::Thinking)
+    }
+
     fn add_elicitation(app: &mut App, elicitation_id: &str, active: bool) {
         app.chat.messages.push(ChatEntry::Elicitation {
             elicitation_id: elicitation_id.into(),
@@ -437,7 +465,7 @@ mod tests {
     fn delegation_lifecycle_acp_route_is_filtered_ranked_and_release_safe() {
         let mut app = App::new();
         app.sessions.session_id = Some("parent".into());
-        app.render.card_cache.processed_messages = 7;
+        seed_card_cache(&mut app, 7);
 
         let effects = update(
             &mut app,
@@ -448,7 +476,7 @@ mod tests {
             ))),
         );
         assert!(effects.is_empty());
-        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert_eq!(card_cache_count(&app), 0);
         assert_eq!(app.delegates.delegate_entries.len(), 1);
         assert_eq!(
             app.delegates.delegate_entries[0].status,
@@ -459,7 +487,7 @@ mod tests {
             "done"
         );
 
-        app.render.card_cache.processed_messages = 8;
+        seed_card_cache(&mut app, 8);
         let effects = update(
             &mut app,
             AppEvent::Acp(AcpAppEvent::DelegationUpdate(delegation_update(
@@ -469,13 +497,13 @@ mod tests {
             ))),
         );
         assert!(effects.is_empty());
-        assert_eq!(app.render.card_cache.processed_messages, 8);
+        assert_eq!(card_cache_count(&app), 8);
         assert_eq!(
             app.delegates.delegate_entries[0].status,
             DelegateStatus::Completed
         );
 
-        app.render.card_cache.processed_messages = 9;
+        seed_card_cache(&mut app, 9);
         let effects = update(
             &mut app,
             AppEvent::Acp(AcpAppEvent::DelegationUpdate(delegation_update(
@@ -485,7 +513,7 @@ mod tests {
             ))),
         );
         assert!(effects.is_empty());
-        assert_eq!(app.render.card_cache.processed_messages, 9);
+        assert_eq!(card_cache_count(&app), 9);
         assert_eq!(app.delegates.delegate_entries.len(), 1);
     }
 
@@ -497,9 +525,9 @@ mod tests {
         app.chat.streaming_content_message_id = Some("assistant-1".into());
         app.chat.streaming_thinking = "delegate plan".into();
         app.chat.streaming_thinking_message_id = Some("assistant-1".into());
-        app.render.streaming_cache.store(15, Vec::new());
-        app.render.streaming_thinking_cache.store(13, Vec::new());
-        app.render.card_cache.processed_messages = 7;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 7);
 
         let effects = update(
             &mut app,
@@ -527,9 +555,9 @@ mod tests {
         assert_eq!(app.chat.session_stats.total_tool_calls, 1);
         assert!(app.chat.streaming_content.is_empty());
         assert!(app.chat.streaming_thinking.is_empty());
-        assert!(app.render.streaming_cache.get(15).is_none());
-        assert!(app.render.streaming_thinking_cache.get(13).is_none());
-        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert!(!content_cache_populated(&app));
+        assert!(!thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 0);
         assert_eq!(app.diagnostics.status, "tool: delegate");
         let diagnostic = app.diagnostics.logs.last().expect("delegate tool status");
         assert_eq!(diagnostic.level, LogLevel::Debug);
@@ -593,9 +621,9 @@ mod tests {
         app.chat.activity = ActivityState::Thinking;
         app.chat.streaming_content = "preserved while suppressed".into();
         app.chat.streaming_content_message_id = Some("assistant-suppressed".into());
-        app.render.streaming_cache.store(26, Vec::new());
-        app.render.streaming_thinking_cache.store(9, Vec::new());
-        app.render.card_cache.processed_messages = 8;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 8);
         let status_before = app.diagnostics.status.clone();
         let log_count_before = app.diagnostics.logs.len();
 
@@ -615,9 +643,9 @@ mod tests {
         assert_eq!(app.chat.session_stats.total_tool_calls, 0);
         assert_eq!(app.diagnostics.status, status_before);
         assert_eq!(app.diagnostics.logs.len(), log_count_before);
-        assert!(app.render.streaming_cache.get(26).is_some());
-        assert!(app.render.streaming_thinking_cache.get(9).is_some());
-        assert_eq!(app.render.card_cache.processed_messages, 8);
+        assert!(content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 8);
 
         app.chat.suppress_turn_output = false;
         app.chat.streaming_thinking = "plan".into();
@@ -640,9 +668,9 @@ mod tests {
         assert_eq!(app.chat.session_stats.total_tool_calls, 1);
         assert!(app.chat.streaming_content.is_empty());
         assert!(app.chat.streaming_thinking.is_empty());
-        assert!(app.render.streaming_cache.get(26).is_none());
-        assert!(app.render.streaming_thinking_cache.get(9).is_none());
-        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert!(!content_cache_populated(&app));
+        assert!(!thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 0);
         assert_eq!(app.diagnostics.status, "tool: shell");
         let diagnostic = app.diagnostics.logs.last().expect("shell tool status");
         assert_eq!(diagnostic.level, LogLevel::Debug);
@@ -661,9 +689,9 @@ mod tests {
                 && command == "cargo check"
         ));
 
-        app.render.streaming_cache.store(15, Vec::new());
-        app.render.streaming_thinking_cache.store(16, Vec::new());
-        app.render.card_cache.processed_messages = 9;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 9);
         let effects = apply_session_update(
             &mut app,
             AcpSessionUpdate::ToolCallStart {
@@ -681,18 +709,18 @@ mod tests {
         );
         assert_eq!(app.chat.session_stats.total_tool_calls, 1);
         assert_eq!(app.chat.messages.len(), 2);
-        assert!(app.render.streaming_cache.get(15).is_some());
-        assert!(app.render.streaming_thinking_cache.get(16).is_some());
-        assert_eq!(app.render.card_cache.processed_messages, 9);
+        assert!(content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 9);
         assert_eq!(app.diagnostics.status, "tool: question");
         let diagnostic = app.diagnostics.logs.last().expect("question tool status");
         assert_eq!(diagnostic.level, LogLevel::Debug);
         assert_eq!(diagnostic.target, "tool");
         assert_eq!(diagnostic.message, "tool: question");
 
-        app.render.streaming_cache.store(17, Vec::new());
-        app.render.streaming_thinking_cache.store(18, Vec::new());
-        app.render.card_cache.processed_messages = 10;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 10);
         let effects = apply_session_update(
             &mut app,
             AcpSessionUpdate::ToolCallStart {
@@ -705,9 +733,9 @@ mod tests {
         assert_eq!(app.chat.session_stats.total_tool_calls, 1);
         assert_eq!(app.chat.messages.len(), 2);
         assert!(app.chat.streaming_thinking.is_empty());
-        assert!(app.render.streaming_cache.get(17).is_some());
-        assert!(app.render.streaming_thinking_cache.get(18).is_none());
-        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert!(content_cache_populated(&app));
+        assert!(!thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 0);
         assert!(matches!(
             &app.chat.messages[1],
             ChatEntry::ToolCall { detail: ToolDetail::Shell { command, .. }, .. }
@@ -719,9 +747,9 @@ mod tests {
     fn chat_tool_end_acp_route_is_idempotent_and_release_safe() {
         let mut app = App::new();
         app.sessions.session_id = Some("active".into());
-        app.render.streaming_cache.store(11, Vec::new());
-        app.render.streaming_thinking_cache.store(12, Vec::new());
-        app.render.card_cache.processed_messages = 7;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 7);
 
         let effects = apply_session_update(
             &mut app,
@@ -735,9 +763,9 @@ mod tests {
         assert!(effects.is_empty());
         assert!(app.sessions.session_activity.contains_key("active"));
         assert!(app.chat.messages.is_empty());
-        assert!(app.render.streaming_cache.get(11).is_some());
-        assert!(app.render.streaming_thinking_cache.get(12).is_some());
-        assert_eq!(app.render.card_cache.processed_messages, 7);
+        assert!(content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 7);
 
         let failed_end = AcpSessionUpdate::ToolCallEnd {
             tool_call_id: Some("tool-1".into()),
@@ -747,22 +775,22 @@ mod tests {
         };
         let effects = apply_session_update(&mut app, failed_end.clone());
         assert!(effects.is_empty());
-        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert_eq!(card_cache_count(&app), 0);
         assert!(matches!(
             app.chat.messages.as_slice(),
             [ChatEntry::ToolCall { tool_call_id: Some(id), name, is_error: true, detail: ToolDetail::Generic { input: None, result: Some(result) } }]
                 if id == "tool-1" && name == "shell (failed)" && result == "failed before start"
         ));
 
-        app.render.card_cache.processed_messages = 8;
+        seed_card_cache(&mut app, 8);
         let effects = apply_session_update(&mut app, failed_end);
         assert!(effects.is_empty());
         assert_eq!(app.chat.messages.len(), 1);
-        assert_eq!(app.render.card_cache.processed_messages, 8);
+        assert_eq!(card_cache_count(&app), 8);
 
-        app.render.streaming_cache.store(13, Vec::new());
-        app.render.streaming_thinking_cache.store(14, Vec::new());
-        app.render.card_cache.processed_messages = 9;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 9);
         let effects = apply_session_update(
             &mut app,
             AcpSessionUpdate::ToolCallStart {
@@ -774,9 +802,9 @@ mod tests {
         assert!(effects.is_empty());
         assert_eq!(app.chat.session_stats.total_tool_calls, 0);
         assert_eq!(app.chat.messages.len(), 1);
-        assert!(app.render.streaming_cache.get(13).is_some());
-        assert!(app.render.streaming_thinking_cache.get(14).is_none());
-        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert!(content_cache_populated(&app));
+        assert!(!thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 0);
         assert_eq!(app.diagnostics.status, "tool: shell");
         let diagnostic = app.diagnostics.logs.last().expect("late shell status");
         assert_eq!(diagnostic.level, LogLevel::Debug);
@@ -788,9 +816,9 @@ mod tests {
                 if id == "tool-1" && name == "shell" && command == "echo late"
         ));
 
-        app.render.streaming_cache.store(15, Vec::new());
-        app.render.streaming_thinking_cache.store(16, Vec::new());
-        app.render.card_cache.processed_messages = 10;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 10);
         let effects = apply_session_update(
             &mut app,
             AcpSessionUpdate::ToolCallEnd {
@@ -801,16 +829,16 @@ mod tests {
             },
         );
         assert!(effects.is_empty());
-        assert!(app.render.streaming_cache.get(15).is_some());
-        assert!(app.render.streaming_thinking_cache.get(16).is_some());
-        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert!(content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 0);
         assert!(matches!(
             app.chat.messages.as_slice(),
             [ChatEntry::ToolCall { is_error: true, detail: ToolDetail::Shell { output: Some(output), .. }, .. }]
                 if output.stdout == "line one\nline two" && output.stderr.is_empty()
         ));
 
-        app.render.card_cache.processed_messages = 11;
+        seed_card_cache(&mut app, 11);
         let effects = apply_session_update(
             &mut app,
             AcpSessionUpdate::ToolCallEnd {
@@ -822,7 +850,7 @@ mod tests {
         );
         assert!(effects.is_empty());
         assert_eq!(app.chat.messages.len(), 1);
-        assert_eq!(app.render.card_cache.processed_messages, 11);
+        assert_eq!(card_cache_count(&app), 11);
     }
 
     #[test]
@@ -833,7 +861,7 @@ mod tests {
         app.chat.streaming_content = "active stream".into();
         app.chat.activity = ActivityState::Streaming;
         app.chat.apply_usage(900, 9_000, Some(9.0));
-        app.render.card_cache.processed_messages = 6;
+        seed_card_cache(&mut app, 6);
 
         let effects = update(
             &mut app,
@@ -848,7 +876,7 @@ mod tests {
         );
         assert!(effects.is_empty());
         assert!(app.sessions.session_activity.contains_key("child-1"));
-        assert_eq!(app.render.card_cache.processed_messages, 6);
+        assert_eq!(card_cache_count(&app), 6);
         assert!(matches!(
             app.chat.messages.as_slice(),
             [ChatEntry::Error(message)] if message == "preserved"
@@ -889,7 +917,7 @@ mod tests {
         assert_eq!(app.chat.context_limit, 9_000);
         assert_eq!(app.chat.cumulative_cost, Some(9.0));
         assert_eq!(app.diagnostics.logs.len(), log_count_before_usage);
-        assert_eq!(app.render.card_cache.processed_messages, 6);
+        assert_eq!(card_cache_count(&app), 6);
 
         let effects = update(
             &mut app,
@@ -912,7 +940,7 @@ mod tests {
                 .pending_delegate_child_states
                 .contains_key("child-1")
         );
-        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert_eq!(card_cache_count(&app), 0);
         assert!(matches!(
             app.chat.messages.as_slice(),
             [ChatEntry::Error(message)] if message == "preserved"
@@ -930,9 +958,9 @@ mod tests {
         app.chat.streaming_content = "answer".into();
         app.chat.streaming_content_message_id = Some("assistant-1".into());
         app.chat.scroll_offset = 8;
-        app.render.streaming_cache.store(6, Vec::new());
-        app.render.streaming_thinking_cache.store(4, Vec::new());
-        app.render.card_cache.processed_messages = 7;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 7);
         let log_count_before = app.diagnostics.logs.len();
 
         let effects = apply_session_update(&mut app, supported_elicitation("elic-live"));
@@ -948,9 +976,9 @@ mod tests {
         assert_eq!(app.chat.scroll_offset, 0);
         assert!(app.chat.streaming_content.is_empty());
         assert!(app.chat.streaming_thinking.is_empty());
-        assert!(app.render.streaming_cache.get(6).is_none());
-        assert!(app.render.streaming_thinking_cache.get(4).is_none());
-        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert!(!content_cache_populated(&app));
+        assert!(!thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 0);
         assert!(matches!(
             app.chat.messages.as_slice(),
             [
@@ -974,16 +1002,16 @@ mod tests {
             "question - answer in the panel above input"
         );
 
-        app.render.streaming_cache.store(9, Vec::new());
-        app.render.streaming_thinking_cache.store(10, Vec::new());
-        app.render.card_cache.processed_messages = 2;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 2);
         let log_count_before_duplicate = app.diagnostics.logs.len();
         let effects = apply_session_update(&mut app, supported_elicitation("elic-live"));
         assert!(effects.is_empty());
         assert_eq!(app.chat.messages.len(), 2);
-        assert!(app.render.streaming_cache.get(9).is_some());
-        assert!(app.render.streaming_thinking_cache.get(10).is_some());
-        assert_eq!(app.render.card_cache.processed_messages, 2);
+        assert!(content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 2);
         assert_eq!(app.diagnostics.logs.len(), log_count_before_duplicate);
     }
 
@@ -991,9 +1019,9 @@ mod tests {
     fn chat_elicitation_replay_and_unsupported_routes_preserve_exact_behavior() {
         let mut app = App::new();
         app.sessions.session_id = Some("active".into());
-        app.render.streaming_cache.store(5, Vec::new());
-        app.render.streaming_thinking_cache.store(6, Vec::new());
-        app.render.card_cache.processed_messages = 7;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 7);
         let log_count_before_replay = app.diagnostics.logs.len();
 
         let effects = update(
@@ -1011,9 +1039,9 @@ mod tests {
             [ChatEntry::Elicitation { elicitation_id, outcome: None, .. }]
                 if elicitation_id == "elic-replay"
         ));
-        assert!(app.render.streaming_cache.get(5).is_some());
-        assert!(app.render.streaming_thinking_cache.get(6).is_some());
-        assert_eq!(app.render.card_cache.processed_messages, 7);
+        assert!(content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 7);
         assert_eq!(
             app.diagnostics.status,
             "question - answer in the panel above input"
@@ -1044,7 +1072,7 @@ mod tests {
                 && unsupported == "elic-unsupported"
                 && outcome == &ElicitationResponseOutcome::UnsupportedSchema
         ));
-        assert_eq!(app.render.card_cache.processed_messages, 7);
+        assert_eq!(card_cache_count(&app), 7);
         assert_eq!(
             app.diagnostics.status,
             "question skipped - unsupported schema"
@@ -1068,7 +1096,7 @@ mod tests {
         app.sessions.session_id = Some("parent".into());
         add_elicitation(&mut app, "active-elicitation", true);
         app.chat.streaming_content = "active stream".into();
-        app.render.card_cache.processed_messages = 6;
+        seed_card_cache(&mut app, 6);
         app.diagnostics.status = "preserved status".into();
         let log_count_before = app.diagnostics.logs.len();
 
@@ -1091,7 +1119,7 @@ mod tests {
         assert!(app.chat.elicitation_ui.is_some());
         assert_eq!(app.chat.streaming_content, "active stream");
         assert_eq!(app.chat.messages.len(), 1);
-        assert_eq!(app.render.card_cache.processed_messages, 6);
+        assert_eq!(card_cache_count(&app), 6);
         assert_eq!(app.diagnostics.status, "preserved status");
         assert_eq!(app.diagnostics.logs.len(), log_count_before);
         assert!(matches!(
@@ -1109,9 +1137,9 @@ mod tests {
         app.sessions.session_id = Some("active".into());
         app.chat.apply_usage(128, 4_096, Some(1.5));
         app.chat.add_active_llm_duration(Duration::from_secs(2));
-        app.render.streaming_cache.store(5, Vec::new());
-        app.render.streaming_thinking_cache.store(6, Vec::new());
-        app.render.card_cache.processed_messages = 7;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 7);
         app.diagnostics.status = "preserved status".into();
         app.push_log(LogLevel::Debug, "test", "before usage");
         let log_count_before = app.diagnostics.logs.len();
@@ -1178,18 +1206,18 @@ mod tests {
         assert_eq!(diagnostics[2].level, LogLevel::Info);
         assert_eq!(diagnostics[2].target, "usage");
         assert_eq!(diagnostics[2].message, "usage: active time 3s");
-        assert!(app.render.streaming_cache.get(5).is_some());
-        assert!(app.render.streaming_thinking_cache.get(6).is_some());
-        assert_eq!(app.render.card_cache.processed_messages, 7);
+        assert!(content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 7);
     }
 
     #[test]
     fn chat_usage_timing_replay_preserves_summary_and_diagnostic_order() {
         let mut app = App::new();
         app.sessions.session_id = Some("active".into());
-        app.render.streaming_cache.store(8, Vec::new());
-        app.render.streaming_thinking_cache.store(9, Vec::new());
-        app.render.card_cache.processed_messages = 10;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 10);
         let log_count_before = app.diagnostics.logs.len();
 
         let effects = update(
@@ -1227,9 +1255,9 @@ mod tests {
             diagnostics[2].message,
             "usage: context 30/120 tokens (25%), cost $0.5000"
         );
-        assert!(app.render.streaming_cache.get(8).is_some());
-        assert!(app.render.streaming_thinking_cache.get(9).is_some());
-        assert_eq!(app.render.card_cache.processed_messages, 10);
+        assert!(content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 10);
     }
 
     #[test]
@@ -1238,9 +1266,9 @@ mod tests {
         app.sessions.session_id = Some("active".into());
         app.chat.streaming_content = "discarded".into();
         app.chat.streaming_thinking = "discarded thinking".into();
-        app.render.streaming_cache.store(9, Vec::new());
-        app.render.streaming_thinking_cache.store(8, Vec::new());
-        app.render.card_cache.processed_messages = 7;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 7);
 
         let effects = update(
             &mut app,
@@ -1256,9 +1284,9 @@ mod tests {
         assert!(app.chat.streaming_content.is_empty());
         assert!(app.chat.streaming_thinking.is_empty());
         assert!(app.chat.session_stats.open_llm_request_instant.is_some());
-        assert!(app.render.streaming_cache.get(9).is_none());
-        assert!(app.render.streaming_thinking_cache.get(8).is_none());
-        assert_eq!(app.render.card_cache.processed_messages, 7);
+        assert!(!content_cache_populated(&app));
+        assert!(!thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 7);
         assert_eq!(app.diagnostics.status, "thinking...");
         let diagnostic = app.diagnostics.logs.last().expect("turn diagnostic");
         assert_eq!(diagnostic.level, LogLevel::Debug);
@@ -1266,7 +1294,7 @@ mod tests {
         assert_eq!(diagnostic.message, "thinking...");
 
         let local_id = app.chat.push_pending_prompt("  repeat\n".into());
-        app.render.card_cache.processed_messages = 8;
+        seed_card_cache(&mut app, 8);
         let effects = update(
             &mut app,
             AppEvent::Acp(AcpAppEvent::SessionUpdate {
@@ -1279,7 +1307,7 @@ mod tests {
             }),
         );
         assert!(effects.is_empty());
-        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert_eq!(card_cache_count(&app), 0);
         assert!(matches!(
             app.chat.messages.as_slice(),
             [ChatEntry::User { text, message_id: Some(id) }]
@@ -1288,7 +1316,7 @@ mod tests {
         assert_eq!(app.chat.undoable_turns[0].message_id, "server-user");
 
         app.sessions.session_activity.remove("active");
-        app.render.card_cache.processed_messages = 9;
+        seed_card_cache(&mut app, 9);
         let effects = update(
             &mut app,
             AppEvent::Acp(AcpAppEvent::SessionUpdate {
@@ -1301,7 +1329,7 @@ mod tests {
             }),
         );
         assert!(effects.is_empty());
-        assert_eq!(app.render.card_cache.processed_messages, 9);
+        assert_eq!(card_cache_count(&app), 9);
         assert_eq!(app.chat.messages.len(), 1);
     }
 
@@ -1310,9 +1338,9 @@ mod tests {
         let mut app = App::new();
         app.sessions.session_id = Some("active".into());
         app.chat.activity = ActivityState::Thinking;
-        app.render.streaming_cache.store(5, Vec::new());
-        app.render.streaming_thinking_cache.store(6, Vec::new());
-        app.render.card_cache.processed_messages = 7;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 7);
 
         for update_value in [
             crate::acp_state::AcpSessionUpdate::AssistantThinkingDelta {
@@ -1334,9 +1362,9 @@ mod tests {
             );
             assert!(effects.is_empty());
         }
-        assert!(app.render.streaming_cache.get(5).is_some());
-        assert!(app.render.streaming_thinking_cache.get(6).is_some());
-        assert_eq!(app.render.card_cache.processed_messages, 7);
+        assert!(content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 7);
 
         let effects = update(
             &mut app,
@@ -1350,9 +1378,9 @@ mod tests {
             }),
         );
         assert!(effects.is_empty());
-        assert!(app.render.streaming_cache.get(5).is_none());
-        assert!(app.render.streaming_thinking_cache.get(6).is_none());
-        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert!(!content_cache_populated(&app));
+        assert!(!thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 0);
         assert!(matches!(
             app.chat.messages.as_slice(),
             [ChatEntry::Assistant { content, thinking: Some(thinking), message_id: Some(id) }]
@@ -1360,9 +1388,9 @@ mod tests {
         ));
         assert_eq!(app.chat.streaming_thinking, "second plan");
 
-        app.render.streaming_cache.store(10, Vec::new());
-        app.render.streaming_thinking_cache.store(11, Vec::new());
-        app.render.card_cache.processed_messages = 12;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 12);
         let effects = update(
             &mut app,
             AppEvent::Acp(AcpAppEvent::SessionUpdate {
@@ -1376,9 +1404,9 @@ mod tests {
             }),
         );
         assert!(effects.is_empty());
-        assert!(app.render.streaming_cache.get(10).is_none());
-        assert!(app.render.streaming_thinking_cache.get(11).is_none());
-        assert_eq!(app.render.card_cache.processed_messages, 12);
+        assert!(!content_cache_populated(&app));
+        assert!(!thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 12);
         assert!(matches!(
             &app.chat.messages[1],
             ChatEntry::Assistant { content, thinking: Some(thinking), message_id: Some(id) }
@@ -1400,8 +1428,8 @@ mod tests {
         );
         app.chat.streaming_content = "discarded".into();
         app.chat.streaming_thinking = "discarded thinking".into();
-        app.render.streaming_cache.store(9, Vec::new());
-        app.render.streaming_thinking_cache.store(8, Vec::new());
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
         let effects = update(
             &mut app,
             AppEvent::Acp(AcpAppEvent::SessionUpdate {
@@ -1416,8 +1444,8 @@ mod tests {
         assert!(app.chat.streaming_content.is_empty());
         assert!(app.chat.streaming_thinking.is_empty());
         assert!(app.chat.messages.is_empty());
-        assert!(app.render.streaming_cache.get(9).is_none());
-        assert!(app.render.streaming_thinking_cache.get(8).is_none());
+        assert!(!content_cache_populated(&app));
+        assert!(!thinking_cache_populated(&app));
         assert_eq!(app.diagnostics.status, "cancelled");
         let diagnostic = app.diagnostics.logs.last().expect("cancel diagnostic");
         assert_eq!(diagnostic.level, LogLevel::Warn);
@@ -1465,9 +1493,9 @@ mod tests {
         app.chat.messages.push(ChatEntry::Error("preserved".into()));
         app.chat.session_stats.open_llm_request_instant =
             Some(Instant::now() - Duration::from_secs(2));
-        app.render.streaming_cache.store(5, Vec::new());
-        app.render.streaming_thinking_cache.store(6, Vec::new());
-        app.render.card_cache.processed_messages = 7;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 7);
         app.composer.input = "preserved input".into();
         app.mesh.mesh_invite_name = "preserved invite".into();
         let log_count_before = app.diagnostics.logs.len();
@@ -1493,9 +1521,9 @@ mod tests {
             [ChatEntry::Error(preserved), ChatEntry::Error(inserted)]
                 if preserved == "preserved" && inserted == "connection lost"
         ));
-        assert!(app.render.streaming_cache.get(5).is_some());
-        assert!(app.render.streaming_thinking_cache.get(6).is_some());
-        assert_eq!(app.render.card_cache.processed_messages, 7);
+        assert!(content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 7);
         assert_eq!(app.diagnostics.status, "error: connection lost");
         let diagnostics = &app.diagnostics.logs[log_count_before..];
         assert_eq!(diagnostics.len(), 1);
@@ -1513,7 +1541,7 @@ mod tests {
         );
         assert!(effects.is_empty());
         assert_eq!(app.chat.messages.len(), 2);
-        assert_eq!(app.render.card_cache.processed_messages, 7);
+        assert_eq!(card_cache_count(&app), 7);
         assert_eq!(app.diagnostics.logs.len(), log_count_before + 1);
     }
 
@@ -1526,9 +1554,9 @@ mod tests {
         app.chat.recent_prompt_text = Some("preserved prompt".into());
         app.chat.session_stats.open_llm_request_instant =
             Some(Instant::now() - Duration::from_secs(2));
-        app.render.streaming_cache.store(8, Vec::new());
-        app.render.streaming_thinking_cache.store(9, Vec::new());
-        app.render.card_cache.processed_messages = 10;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 10);
         app.composer.input = "preserved input".into();
         app.mesh.mesh_invite_name = "preserved invite".into();
         let log_count_before = app.diagnostics.logs.len();
@@ -1561,9 +1589,9 @@ mod tests {
         assert!(app.chat.messages.iter().all(|entry| {
             !matches!(entry, ChatEntry::User { message_id: Some(id), .. } if id == &failed_id)
         }));
-        assert!(app.render.streaming_cache.get(8).is_some());
-        assert!(app.render.streaming_thinking_cache.get(9).is_some());
-        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert!(content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 0);
         assert_eq!(app.diagnostics.status, "error: backend rejected prompt");
         let diagnostics = &app.diagnostics.logs[log_count_before..];
         assert_eq!(diagnostics.len(), 1);
@@ -1584,9 +1612,9 @@ mod tests {
         app.chat.streaming_thinking_message_id = Some("thinking-id".into());
         app.chat.recent_prompt_text = Some("prompt".into());
         app.chat.pending_fork_message_id = Some("fork-target".into());
-        app.render.streaming_cache.store(7, Vec::new());
-        app.render.streaming_thinking_cache.store(8, Vec::new());
-        app.render.card_cache.processed_messages = 9;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 9);
         let log_count = app.diagnostics.logs.len();
         let status = app.diagnostics.status.clone();
 
@@ -1621,9 +1649,9 @@ mod tests {
                 .and_then(|state| state.frontier_message_id.as_deref()),
             Some("one")
         );
-        assert!(app.render.streaming_cache.get(7).is_some());
-        assert!(app.render.streaming_thinking_cache.get(8).is_some());
-        assert_eq!(app.render.card_cache.processed_messages, 9);
+        assert!(content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 9);
         assert_eq!(app.diagnostics.logs.len(), log_count);
         assert_eq!(app.diagnostics.status, status);
     }
@@ -1661,9 +1689,9 @@ mod tests {
         app.chat.streaming_thinking = "keep thinking".into();
         app.chat.streaming_thinking_message_id = Some("thinking-id".into());
         app.chat.recent_prompt_text = Some("discard prompt".into());
-        app.render.streaming_cache.store(15, Vec::new());
-        app.render.streaming_thinking_cache.store(13, Vec::new());
-        app.render.card_cache.processed_messages = 7;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 7);
         let log_count = app.diagnostics.logs.len();
 
         let effects = update(
@@ -1691,9 +1719,9 @@ mod tests {
         assert_eq!(state.frontier_message_id.as_deref(), Some("two"));
         assert!(state.stack[0].reverted_files.is_empty());
         assert_eq!(state.stack[1].reverted_files, ["src/main.rs"]);
-        assert!(app.render.streaming_cache.get(15).is_none());
-        assert!(app.render.streaming_thinking_cache.get(13).is_some());
-        assert_eq!(app.render.card_cache.processed_messages, 7);
+        assert!(!content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 7);
         assert_eq!(app.diagnostics.status, "undone - reloading session");
         let diagnostics = &app.diagnostics.logs[log_count..];
         assert_eq!(diagnostics.len(), 1);
@@ -1720,9 +1748,9 @@ mod tests {
         app.chat.streaming_thinking = "preserve thinking".into();
         app.chat.streaming_thinking_message_id = Some("preserve-thinking-id".into());
         app.chat.recent_prompt_text = Some("preserve prompt".into());
-        app.render.streaming_cache.store(16, Vec::new());
-        app.render.streaming_thinking_cache.store(17, Vec::new());
-        app.render.card_cache.processed_messages = 8;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 8);
         let log_count = app.diagnostics.logs.len();
         let effects = update(
             &mut app,
@@ -1758,9 +1786,9 @@ mod tests {
                 .and_then(|state| state.frontier_message_id.as_deref()),
             Some("one")
         );
-        assert!(app.render.streaming_cache.get(16).is_some());
-        assert!(app.render.streaming_thinking_cache.get(17).is_some());
-        assert_eq!(app.render.card_cache.processed_messages, 8);
+        assert!(content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 8);
         assert_eq!(app.diagnostics.status, "undo failed");
         let diagnostics = &app.diagnostics.logs[log_count..];
         assert_eq!(diagnostics.len(), 1);
@@ -1790,9 +1818,9 @@ mod tests {
         app.chat.streaming_thinking = "keep thinking".into();
         app.chat.streaming_thinking_message_id = Some("thinking-id".into());
         app.chat.recent_prompt_text = Some("keep prompt".into());
-        app.render.streaming_cache.store(12, Vec::new());
-        app.render.streaming_thinking_cache.store(13, Vec::new());
-        app.render.card_cache.processed_messages = 14;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 14);
         let log_count = app.diagnostics.logs.len();
 
         let effects = update(
@@ -1817,9 +1845,9 @@ mod tests {
             Some("thinking-id")
         );
         assert_eq!(app.chat.recent_prompt_text.as_deref(), Some("keep prompt"));
-        assert!(app.render.streaming_cache.get(12).is_some());
-        assert!(app.render.streaming_thinking_cache.get(13).is_some());
-        assert_eq!(app.render.card_cache.processed_messages, 14);
+        assert!(content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 14);
         assert_eq!(app.diagnostics.status, "redone - reloading session");
         let diagnostics = &app.diagnostics.logs[log_count..];
         assert_eq!(diagnostics.len(), 1);
@@ -1960,8 +1988,8 @@ mod tests {
         app.chat.streaming_thinking = "keep thinking".into();
         app.chat.streaming_thinking_message_id = Some("thinking-id".into());
         app.chat.recent_prompt_text = Some("discard prompt".into());
-        app.render.streaming_cache.store(7, Vec::new());
-        app.render.streaming_thinking_cache.store(8, Vec::new());
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
         let log_count = app.diagnostics.logs.len();
 
         let effects = update(
@@ -1981,8 +2009,8 @@ mod tests {
         assert!(app.chat.streaming_content_message_id.is_none());
         assert_eq!(app.chat.streaming_thinking, "keep thinking");
         assert!(app.chat.recent_prompt_text.is_none());
-        assert!(app.render.streaming_cache.get(7).is_none());
-        assert!(app.render.streaming_thinking_cache.get(8).is_some());
+        assert!(!content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
         assert_eq!(app.diagnostics.status, "undone - reloading session");
         assert_eq!(app.diagnostics.logs.len(), log_count + 1);
 
@@ -2436,9 +2464,9 @@ mod tests {
             path: "src/main.rs".into(),
             is_dir: false,
         }];
-        app.render.streaming_cache.store(7, Vec::new());
-        app.render.streaming_thinking_cache.store(8, Vec::new());
-        app.render.card_cache.processed_messages = 2;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 2);
         app.sessions.mode_before_review = Some("plan".into());
         app.models.agents_profile_id = Some("code".into());
         app.models.agents = vec![agent("primary"), agent("coder")];
@@ -2479,9 +2507,9 @@ mod tests {
         assert_eq!(app.composer.input, "preserved draft");
         assert_eq!(app.composer.input_cursor, 4);
         assert!(app.composer.file_index.is_empty());
-        assert!(app.render.streaming_cache.get(7).is_none());
-        assert!(app.render.streaming_thinking_cache.get(8).is_none());
-        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert!(!content_cache_populated(&app));
+        assert!(!thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 0);
         assert_eq!(app.diagnostics.status, "session created");
         let diagnostic = app.diagnostics.logs.last().expect("creation diagnostic");
         assert_eq!(diagnostic.level, LogLevel::Info);
@@ -3102,7 +3130,7 @@ mod tests {
     fn editor_results_apply_state_then_request_redraw() {
         let mut app = App::new();
         app.composer.input = "draft".into();
-        app.render.card_cache.processed_messages = 2;
+        seed_card_cache(&mut app, 2);
 
         let effects = update(
             &mut app,
@@ -3113,7 +3141,7 @@ mod tests {
 
         assert_eq!(app.composer.input, "revised");
         assert_eq!(app.composer.input_cursor, "revised".len());
-        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert_eq!(card_cache_count(&app), 0);
         assert_eq!(app.diagnostics.status, "loaded prompt from external editor");
         assert_eq!(effects, vec![Effect::Terminal(TerminalAction::Redraw)]);
     }
@@ -3152,9 +3180,9 @@ mod tests {
         let mut app = App::new();
         add_elicitation(&mut app, "elic-1", true);
         app.connection.conn = ConnState::Connected;
-        app.render.streaming_cache.store(3, Vec::new());
-        app.render.streaming_thinking_cache.store(4, Vec::new());
-        app.render.card_cache.processed_messages = 5;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 5);
         app.diagnostics.status = "question pending".into();
         let log_count_before = app.diagnostics.logs.len();
 
@@ -3175,9 +3203,9 @@ mod tests {
                 if elicitation_id == "elic-1"
                     && outcome == &ElicitationResponseOutcome::Text("accepted".into())
         ));
-        assert!(app.render.streaming_cache.get(3).is_some());
-        assert!(app.render.streaming_thinking_cache.get(4).is_some());
-        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert!(content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 0);
         assert_eq!(app.diagnostics.status, "ready");
         let diagnostics = &app.diagnostics.logs[log_count_before..];
         assert_eq!(diagnostics.len(), 1);
@@ -3190,9 +3218,9 @@ mod tests {
     fn elicitation_command_failure_leaves_active_card_pending() {
         let mut app = App::new();
         add_elicitation(&mut app, "elic-1", true);
-        app.render.streaming_cache.store(3, Vec::new());
-        app.render.streaming_thinking_cache.store(4, Vec::new());
-        app.render.card_cache.processed_messages = 5;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 5);
         let log_count_before = app.diagnostics.logs.len();
 
         let effects = update(
@@ -3221,9 +3249,9 @@ mod tests {
             [ChatEntry::Elicitation { elicitation_id, outcome: None, .. }]
                 if elicitation_id == "elic-1"
         ));
-        assert!(app.render.streaming_cache.get(3).is_some());
-        assert!(app.render.streaming_thinking_cache.get(4).is_some());
-        assert_eq!(app.render.card_cache.processed_messages, 5);
+        assert!(content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 5);
         assert_eq!(app.diagnostics.status, "channel closed");
         let diagnostics = &app.diagnostics.logs[log_count_before..];
         assert_eq!(diagnostics.len(), 1);
@@ -3237,9 +3265,9 @@ mod tests {
         let mut app = App::new();
         add_elicitation(&mut app, "elic-old", false);
         add_elicitation(&mut app, "elic-new", true);
-        app.render.streaming_cache.store(3, Vec::new());
-        app.render.streaming_thinking_cache.store(4, Vec::new());
-        app.render.card_cache.processed_messages = 2;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 2);
         app.diagnostics.status = "newer question pending".into();
         let log_count_before = app.diagnostics.logs.len();
 
@@ -3260,9 +3288,9 @@ mod tests {
             Some("elic-new")
         );
         assert!(app.chat.elicitation_ui.is_some());
-        assert!(app.render.streaming_cache.get(3).is_some());
-        assert!(app.render.streaming_thinking_cache.get(4).is_some());
-        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert!(content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 0);
         assert_eq!(app.diagnostics.status, "newer question pending");
         assert_eq!(app.diagnostics.logs.len(), log_count_before);
         assert!(matches!(
@@ -3280,9 +3308,9 @@ mod tests {
     fn unknown_elicitation_ack_is_a_complete_noop() {
         let mut app = App::new();
         add_elicitation(&mut app, "elic-active", true);
-        app.render.streaming_cache.store(3, Vec::new());
-        app.render.streaming_thinking_cache.store(4, Vec::new());
-        app.render.card_cache.processed_messages = 5;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 5);
         app.diagnostics.status = "question pending".into();
         let log_count_before = app.diagnostics.logs.len();
 
@@ -3308,9 +3336,9 @@ mod tests {
             [ChatEntry::Elicitation { elicitation_id, outcome: None, .. }]
                 if elicitation_id == "elic-active"
         ));
-        assert!(app.render.streaming_cache.get(3).is_some());
-        assert!(app.render.streaming_thinking_cache.get(4).is_some());
-        assert_eq!(app.render.card_cache.processed_messages, 5);
+        assert!(content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 5);
         assert_eq!(app.diagnostics.status, "question pending");
         assert_eq!(app.diagnostics.logs.len(), log_count_before);
     }
@@ -3319,7 +3347,7 @@ mod tests {
     fn duplicate_elicitation_ack_rewrites_and_invalidates_again_without_status_refresh() {
         let mut app = App::new();
         add_elicitation(&mut app, "elic-1", false);
-        app.render.card_cache.processed_messages = 5;
+        seed_card_cache(&mut app, 5);
         app.diagnostics.status = "preserved status".into();
         let log_count_before = app.diagnostics.logs.len();
 
@@ -3331,8 +3359,8 @@ mod tests {
             }),
         );
         assert!(first_effects.is_empty());
-        assert_eq!(app.render.card_cache.processed_messages, 0);
-        app.render.card_cache.processed_messages = 6;
+        assert_eq!(card_cache_count(&app), 0);
+        seed_card_cache(&mut app, 6);
 
         let duplicate_effects = update(
             &mut app,
@@ -3348,7 +3376,7 @@ mod tests {
                 if elicitation_id == "elic-1"
                     && outcome == &ElicitationResponseOutcome::Declined
         ));
-        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert_eq!(card_cache_count(&app), 0);
         assert_eq!(app.diagnostics.status, "preserved status");
         assert_eq!(app.diagnostics.logs.len(), log_count_before);
     }
@@ -3361,9 +3389,9 @@ mod tests {
         app.chat.recent_prompt_text = Some("preserved prompt".into());
         app.chat.session_stats.open_llm_request_instant = Some(Instant::now());
         let open_timing = app.chat.session_stats.open_llm_request_instant;
-        app.render.streaming_cache.store(3, Vec::new());
-        app.render.streaming_thinking_cache.store(4, Vec::new());
-        app.render.card_cache.processed_messages = 2;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 2);
         let log_count_before = app.diagnostics.logs.len();
 
         let effects = update(
@@ -3396,9 +3424,9 @@ mod tests {
         );
         assert_eq!(app.chat.session_stats.open_llm_request_instant, open_timing);
         assert_eq!(app.chat.session_stats.active_llm_duration, Duration::ZERO);
-        assert!(app.render.streaming_cache.get(3).is_some());
-        assert!(app.render.streaming_thinking_cache.get(4).is_some());
-        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert!(content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 0);
         assert_eq!(app.diagnostics.status, "channel closed");
         let diagnostics = &app.diagnostics.logs[log_count_before..];
         assert_eq!(diagnostics.len(), 1);
@@ -3414,9 +3442,9 @@ mod tests {
         app.chat.recent_prompt_text = Some("preserved prompt".into());
         app.chat.session_stats.open_llm_request_instant = Some(Instant::now());
         let open_timing = app.chat.session_stats.open_llm_request_instant;
-        app.render.streaming_cache.store(5, Vec::new());
-        app.render.streaming_thinking_cache.store(6, Vec::new());
-        app.render.card_cache.processed_messages = 7;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 7);
         let log_count_before = app.diagnostics.logs.len();
 
         let effects = update(
@@ -3442,9 +3470,9 @@ mod tests {
         );
         assert_eq!(app.chat.session_stats.open_llm_request_instant, open_timing);
         assert_eq!(app.chat.session_stats.active_llm_duration, Duration::ZERO);
-        assert!(app.render.streaming_cache.get(5).is_some());
-        assert!(app.render.streaming_thinking_cache.get(6).is_some());
-        assert_eq!(app.render.card_cache.processed_messages, 7);
+        assert!(content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 7);
         assert_eq!(app.diagnostics.status, "unknown prompt failed");
         let diagnostics = &app.diagnostics.logs[log_count_before..];
         assert_eq!(diagnostics.len(), 1);
@@ -3460,9 +3488,9 @@ mod tests {
         app.chat.recent_prompt_text = Some("preserved prompt".into());
         app.chat.session_stats.open_llm_request_instant = Some(Instant::now());
         let open_timing = app.chat.session_stats.open_llm_request_instant;
-        app.render.streaming_cache.store(8, Vec::new());
-        app.render.streaming_thinking_cache.store(9, Vec::new());
-        app.render.card_cache.processed_messages = 10;
+        seed_content_cache(&mut app);
+        seed_thinking_cache(&mut app);
+        seed_card_cache(&mut app, 10);
         let log_count_before = app.diagnostics.logs.len();
 
         let effects = update(
@@ -3485,9 +3513,9 @@ mod tests {
         );
         assert_eq!(app.chat.session_stats.open_llm_request_instant, open_timing);
         assert_eq!(app.chat.session_stats.active_llm_duration, Duration::ZERO);
-        assert!(app.render.streaming_cache.get(8).is_some());
-        assert!(app.render.streaming_thinking_cache.get(9).is_some());
-        assert_eq!(app.render.card_cache.processed_messages, 10);
+        assert!(content_cache_populated(&app));
+        assert!(thinking_cache_populated(&app));
+        assert_eq!(card_cache_count(&app), 10);
         assert_eq!(app.diagnostics.status, "cancel channel closed");
         let diagnostics = &app.diagnostics.logs[log_count_before..];
         assert_eq!(diagnostics.len(), 1);

--- a/src/application.rs
+++ b/src/application.rs
@@ -261,8 +261,8 @@ mod tests {
         domain::tool::ToolDetail,
         domain::{
             activity::{
-                ActivityState, DelegateChildState, DelegateStatus, DelegationState,
-                DelegationUpdate, SessionOp,
+                ActivityState, DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus,
+                DelegationState, DelegationUpdate, SessionOp,
             },
             auth::{OAuthFlow, OAuthFlowKind, OAuthResult, OAuthResultStatus},
             chat::{ChatEntry, ElicitationResponseOutcome},
@@ -277,6 +277,12 @@ mod tests {
         },
         navigation_state::{Popup, Screen},
     };
+
+    fn draw_app(app: &mut App, width: u16, height: u16) {
+        let backend = ratatui::backend::TestBackend::new(width, height);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal.draw(|frame| crate::ui::draw(frame, app)).unwrap();
+    }
 
     fn seed_card_cache(app: &mut App, source_entry_count: usize) {
         app.render.test_seed_card_cache(source_entry_count);
@@ -463,6 +469,201 @@ mod tests {
             }),
         );
         assert!(effects.is_empty());
+    }
+
+    #[test]
+    fn render_metric_key_routes_preserve_start_and_popup_filter_contracts() {
+        let mut app = App::new();
+        app.sessions.session_groups = vec![SessionGroup {
+            cwd: Some("/repo".into()),
+            sessions: (0..6)
+                .map(|index| SessionSummary {
+                    session_id: format!("session-{index}"),
+                    title: Some(format!("Session {index}")),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        }];
+        app.sessions.session_cursor = 4;
+        app.render.test_seed_start_page_scroll(4);
+
+        assert!(
+            update(
+                &mut app,
+                AppEvent::Key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE)),
+            )
+            .is_empty()
+        );
+        assert_eq!(app.sessions.session_cursor, 3);
+        assert_eq!(app.render.start_page_scroll(), 3);
+
+        app.render.test_seed_start_page_scroll(8);
+        assert!(
+            update(
+                &mut app,
+                AppEvent::Key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE)),
+            )
+            .is_empty()
+        );
+        assert_eq!(app.sessions.session_filter, "x");
+        assert_eq!(app.sessions.session_cursor, 0);
+        assert_eq!(app.render.start_page_scroll(), 0);
+
+        app.render.test_seed_start_page_scroll(8);
+        assert!(
+            update(
+                &mut app,
+                AppEvent::Key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)),
+            )
+            .is_empty()
+        );
+        assert!(app.sessions.session_filter.is_empty());
+        assert_eq!(app.render.start_page_scroll(), 0);
+
+        app.navigation.popup = Popup::SessionSelect;
+        app.sessions.session_cursor = 4;
+        app.render.test_seed_start_page_scroll(8);
+        app.render.publish_session_popup_visible_rows(5);
+        app.render.publish_delegate_popup_visible_rows(7);
+        assert!(
+            update(
+                &mut app,
+                AppEvent::Key(KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE)),
+            )
+            .is_empty()
+        );
+        assert_eq!(app.sessions.session_filter, "p");
+        assert_eq!(app.sessions.session_cursor, 0);
+        assert_eq!(app.render.start_page_scroll(), 8);
+        assert_eq!(app.render.test_session_popup_visible_rows(), 5);
+        assert_eq!(app.render.test_delegate_popup_visible_rows(), 7);
+    }
+
+    #[test]
+    fn popup_draw_page_tab_close_and_reopen_retain_independent_metrics() {
+        let mut app = App::new();
+        app.connection.conn = crate::connection_state::ConnState::Connected;
+        app.navigation.popup = Popup::SessionSelect;
+        app.sessions.session_groups = vec![SessionGroup {
+            cwd: Some("/repo".into()),
+            sessions: (0..8)
+                .map(|index| SessionSummary {
+                    session_id: format!("session-{index}"),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        }];
+        app.delegates.delegate_entries = (0..8)
+            .map(|index| DelegateEntry {
+                delegation_id: format!("delegate-{index}"),
+                child_session_id: Some(format!("child-{index}")),
+                delegate_tool_call_id: None,
+                target_agent_id: Some("coder".into()),
+                objective: format!("Task {index}"),
+                status: DelegateStatus::InProgress,
+                stats: DelegateStats::default(),
+                started_at: None,
+                ended_at: None,
+                child_state: DelegateChildState::None,
+            })
+            .collect();
+
+        assert!(
+            update(
+                &mut app,
+                AppEvent::Key(KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE)),
+            )
+            .is_empty()
+        );
+        assert_eq!(app.sessions.session_cursor, 1);
+
+        app.sessions.session_cursor = 0;
+        app.render.publish_delegate_popup_visible_rows(9);
+        draw_app(&mut app, 90, 20);
+        assert_eq!(app.render.test_session_popup_visible_rows(), 6);
+        assert_eq!(app.render.test_delegate_popup_visible_rows(), 9);
+        assert!(
+            update(
+                &mut app,
+                AppEvent::Key(KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE)),
+            )
+            .is_empty()
+        );
+        assert_eq!(app.sessions.session_cursor, 5);
+        assert!(
+            update(
+                &mut app,
+                AppEvent::Key(KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE)),
+            )
+            .is_empty()
+        );
+        assert_eq!(app.sessions.session_cursor, 0);
+
+        assert!(
+            update(
+                &mut app,
+                AppEvent::Key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)),
+            )
+            .is_empty()
+        );
+        draw_app(&mut app, 90, 20);
+        assert_eq!(app.render.test_session_popup_visible_rows(), 6);
+        assert_eq!(app.render.test_delegate_popup_visible_rows(), 6);
+        assert!(
+            update(
+                &mut app,
+                AppEvent::Key(KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE)),
+            )
+            .is_empty()
+        );
+        assert_eq!(app.delegates.delegate_cursor, 5);
+        assert_eq!(app.sessions.session_cursor, 0);
+        assert!(
+            update(
+                &mut app,
+                AppEvent::Key(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE)),
+            )
+            .is_empty()
+        );
+        assert_eq!(app.delegates.delegate_filter, "z");
+        assert_eq!(app.delegates.delegate_cursor, 0);
+        assert_eq!(app.render.test_delegate_popup_visible_rows(), 6);
+
+        assert!(
+            update(
+                &mut app,
+                AppEvent::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+            )
+            .is_empty()
+        );
+        assert_eq!(app.navigation.popup, Popup::None);
+        assert_eq!(app.render.test_session_popup_visible_rows(), 6);
+        assert_eq!(app.render.test_delegate_popup_visible_rows(), 6);
+
+        assert!(
+            update(
+                &mut app,
+                AppEvent::Key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL)),
+            )
+            .is_empty()
+        );
+        update(
+            &mut app,
+            AppEvent::Key(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE)),
+        );
+        assert_eq!(app.navigation.popup, Popup::SessionSelect);
+        assert_eq!(app.sessions.session_popup_tab, 0);
+        assert_eq!(app.render.test_session_popup_visible_rows(), 6);
+        assert_eq!(app.render.test_delegate_popup_visible_rows(), 6);
+
+        app.open_delegate_popup();
+        assert_eq!(app.sessions.session_popup_tab, 1);
+        assert!(app.delegates.delegate_filter.is_empty());
+        assert_eq!(app.delegates.delegate_cursor, 0);
+        assert_eq!(app.render.test_session_popup_visible_rows(), 6);
+        assert_eq!(app.render.test_delegate_popup_visible_rows(), 6);
     }
 
     #[test]
@@ -2562,6 +2763,9 @@ mod tests {
             .push(ChatEntry::Error("stale chat".into()));
         app.chat.streaming_content = "stale stream".into();
         app.render.test_seed_chat_viewport(8, 34);
+        app.render.test_seed_start_page_scroll(6);
+        app.render.publish_session_popup_visible_rows(5);
+        app.render.publish_delegate_popup_visible_rows(7);
         app.composer.input = "preserved draft".into();
         app.composer.input_cursor = 4;
         app.composer.file_index = vec![FileIndexEntryLite {
@@ -2610,6 +2814,9 @@ mod tests {
         assert!(app.chat.streaming_content.is_empty());
         assert_eq!(app.render.chat_scroll_offset(), 0);
         assert_eq!(app.render.test_chat_previous_total_height(), 0);
+        assert_eq!(app.render.start_page_scroll(), 6);
+        assert_eq!(app.render.test_session_popup_visible_rows(), 5);
+        assert_eq!(app.render.test_delegate_popup_visible_rows(), 7);
         assert_eq!(app.composer.input, "preserved draft");
         assert_eq!(app.composer.input_cursor, 4);
         assert!(app.composer.file_index.is_empty());
@@ -2669,6 +2876,9 @@ mod tests {
             .messages
             .push(ChatEntry::Error("stale chat".into()));
         app.render.test_seed_chat_viewport(6, 28);
+        app.render.test_seed_start_page_scroll(4);
+        app.render.publish_session_popup_visible_rows(5);
+        app.render.publish_delegate_popup_visible_rows(7);
         app.composer.file_index = vec![FileIndexEntryLite {
             path: "src/lib.rs".into(),
             is_dir: false,
@@ -2695,6 +2905,9 @@ mod tests {
         assert!(app.chat.messages.is_empty());
         assert_eq!(app.render.chat_scroll_offset(), 0);
         assert_eq!(app.render.test_chat_previous_total_height(), 0);
+        assert_eq!(app.render.start_page_scroll(), 4);
+        assert_eq!(app.render.test_session_popup_visible_rows(), 5);
+        assert_eq!(app.render.test_delegate_popup_visible_rows(), 7);
         assert!(app.composer.file_index.is_empty());
         assert_eq!(app.diagnostics.status, "ready");
         let diagnostic = app.diagnostics.logs.last().expect("load diagnostic");

--- a/src/chat_state.rs
+++ b/src/chat_state.rs
@@ -1,7 +1,6 @@
 use std::time::{Duration, Instant};
 
 use crate::application::Effect;
-use crate::composer_state::build_input_visual_layout;
 use crate::diagnostics::LogLevel;
 use crate::domain::activity::{ActivityState, SessionOp, SessionStatsLite};
 use crate::domain::chat::{ChatEntry, ElicitationResponseOutcome};
@@ -11,6 +10,7 @@ use crate::domain::session::{
     UndoStackSnapshot, UndoState, UndoableTurn,
 };
 use crate::domain::tool::ToolDetail;
+use crate::input_layout::build_input_visual_layout;
 use crate::tool_detail;
 
 const CANCEL_CONFIRM_TIMEOUT: Duration = Duration::from_millis(1000);
@@ -22,8 +22,6 @@ pub(crate) struct ElicitationUiState {
     pub(crate) text_cursor: usize,
     pub(crate) custom_active: bool,
     pub(crate) custom_cursor: usize,
-    pub(crate) custom_line_width: usize,
-    pub(crate) custom_scroll: u16,
 }
 
 impl ElicitationUiState {
@@ -95,9 +93,8 @@ impl ElicitationUiState {
             .unwrap_or(input.len());
     }
 
-    pub(crate) fn custom_move_visual(&mut self, input: &str, delta: i32) {
-        let layout =
-            build_input_visual_layout(input, self.custom_cursor, self.custom_line_width.max(1), 2);
+    pub(crate) fn custom_move_visual(&mut self, input: &str, line_width: usize, delta: i32) {
+        let layout = build_input_visual_layout(input, self.custom_cursor, line_width, 2);
         let row = (layout.cursor_row as i32 + delta)
             .clamp(0, layout.total_rows().saturating_sub(1) as i32) as usize;
         self.custom_cursor = layout.cursor_offset_for_row_col(row, layout.cursor_text_col);
@@ -3789,15 +3786,40 @@ mod tests {
     }
 
     #[test]
+    fn elicitation_custom_editor_preserves_utf8_editing_and_hard_line_navigation() {
+        let mut ui = ElicitationUiState::default();
+        let mut input = String::new();
+
+        ui.custom_insert(&mut input, '界');
+        ui.custom_insert(&mut input, 'é');
+        assert_eq!(ui.custom_cursor, input.len());
+        ui.custom_left(&input);
+        assert_eq!(ui.custom_cursor, "界".len());
+        ui.custom_delete(&mut input);
+        assert_eq!(input, "界");
+        ui.custom_backspace(&mut input);
+        assert!(input.is_empty());
+        assert_eq!(ui.custom_cursor, 0);
+
+        input = "ab\n界d".into();
+        ui.custom_cursor = input.len();
+        ui.custom_home(&input);
+        assert_eq!(ui.custom_cursor, "ab\n".len());
+        ui.custom_end(&input);
+        assert_eq!(ui.custom_cursor, input.len());
+        ui.custom_move_visual(&input, 20, -1);
+        assert_eq!(ui.custom_cursor, 2);
+    }
+
+    #[test]
     fn elicitation_editor_reuses_composer_visual_layout() {
         let mut ui = ElicitationUiState {
             custom_cursor: 4,
-            custom_line_width: 4,
             ..Default::default()
         };
-        ui.custom_move_visual("abcdef", -1);
+        ui.custom_move_visual("abcdef", 4, -1);
         assert_eq!(ui.custom_cursor, 2);
-        ui.custom_move_visual("abcdef", 1);
+        ui.custom_move_visual("abcdef", 4, 1);
         assert_eq!(ui.custom_cursor, 4);
     }
 }

--- a/src/chat_state.rs
+++ b/src/chat_state.rs
@@ -205,7 +205,7 @@ pub(crate) enum ToolStartPreparationTransition {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ToolStartInsertionTransition {
     Reconciled,
-    Inserted,
+    Inserted { moved_thinking: bool },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -320,7 +320,6 @@ pub(crate) enum HistoryTransition {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum HistoryCoordination {
-    InvalidateContentCache,
     Status {
         level: LogLevel,
         target: &'static str,
@@ -335,9 +334,6 @@ pub(crate) enum HistoryCoordination {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ChatCoordination {
-    InvalidateContentCache,
-    InvalidateThinkingCache,
-    InvalidateCardCache,
     Log {
         level: LogLevel,
         target: &'static str,
@@ -419,15 +415,11 @@ impl ChatState {
                 self.begin_turn(is_replay);
                 (
                     ChatTransition::TurnStarted,
-                    vec![
-                        ChatCoordination::InvalidateContentCache,
-                        ChatCoordination::InvalidateThinkingCache,
-                        ChatCoordination::Status {
-                            level: LogLevel::Debug,
-                            target: "activity",
-                            message: "thinking...".into(),
-                        },
-                    ],
+                    vec![ChatCoordination::Status {
+                        level: LogLevel::Debug,
+                        target: "activity",
+                        message: "thinking...".into(),
+                    }],
                 )
             }
             ChatAction::UserMessage {
@@ -436,21 +428,16 @@ impl ChatState {
                 is_replay,
             } => {
                 let transition = self.push_user_message(text, message_id, is_replay);
-                let coordination = matches!(transition, UserMessageTransition::Reconciled)
-                    .then_some(ChatCoordination::InvalidateCardCache)
-                    .into_iter()
-                    .collect();
-                (ChatTransition::UserMessage(transition), coordination)
+                (ChatTransition::UserMessage(transition), Vec::new())
             }
             ChatAction::AssistantContentDelta {
                 content,
                 message_id,
             } => {
                 let transition = self.append_streaming_content(&content, message_id);
-                let coordination = Self::stream_boundary_coordination(transition);
                 (
                     ChatTransition::AssistantContentDelta(transition),
-                    coordination,
+                    Vec::new(),
                 )
             }
             ChatAction::AssistantThinkingDelta {
@@ -459,10 +446,9 @@ impl ChatState {
                 is_replay,
             } => {
                 let transition = self.append_streaming_thinking(&content, message_id, is_replay);
-                let coordination = Self::stream_boundary_coordination(transition);
                 (
                     ChatTransition::AssistantThinkingDelta(transition),
-                    coordination,
+                    Vec::new(),
                 )
             }
             ChatAction::AssistantMessage {
@@ -471,14 +457,7 @@ impl ChatState {
                 message_id,
             } => {
                 let transition = self.push_assistant_message(content, thinking, message_id);
-                let mut coordination = vec![
-                    ChatCoordination::InvalidateContentCache,
-                    ChatCoordination::InvalidateThinkingCache,
-                ];
-                if transition == AssistantMessageTransition::ReplacedThinking {
-                    coordination.push(ChatCoordination::InvalidateCardCache);
-                }
-                (ChatTransition::AssistantMessage(transition), coordination)
+                (ChatTransition::AssistantMessage(transition), Vec::new())
             }
             ChatAction::AcpError { message } => {
                 self.end_llm_request_span(None);
@@ -501,39 +480,29 @@ impl ChatState {
                         prompt_rolled_back,
                         error_inserted,
                     },
-                    vec![
-                        ChatCoordination::InvalidateCardCache,
-                        ChatCoordination::Status {
-                            level: LogLevel::Error,
-                            target: "acp",
-                            message: format!("error: {message}"),
-                        },
-                    ],
+                    vec![ChatCoordination::Status {
+                        level: LogLevel::Error,
+                        target: "acp",
+                        message: format!("error: {message}"),
+                    }],
                 )
             }
             ChatAction::RuntimePromptDispatchFailed { local_id } => {
                 let prompt_rolled_back = self.rollback_pending_prompt(&local_id);
                 (
                     ChatTransition::RuntimePromptDispatchFailed { prompt_rolled_back },
-                    prompt_rolled_back
-                        .then_some(ChatCoordination::InvalidateCardCache)
-                        .into_iter()
-                        .collect(),
+                    Vec::new(),
                 )
             }
             ChatAction::Cancelled { is_replay } => {
                 self.cancel_turn(is_replay);
                 (
                     ChatTransition::Cancelled,
-                    vec![
-                        ChatCoordination::InvalidateContentCache,
-                        ChatCoordination::InvalidateThinkingCache,
-                        ChatCoordination::Status {
-                            level: LogLevel::Warn,
-                            target: "activity",
-                            message: "cancelled".into(),
-                        },
-                    ],
+                    vec![ChatCoordination::Status {
+                        level: LogLevel::Warn,
+                        target: "activity",
+                        message: "cancelled".into(),
+                    }],
                 )
             }
             ChatAction::Finished {
@@ -543,15 +512,11 @@ impl ChatState {
                 self.finish_turn(is_replay);
                 (
                     ChatTransition::Finished,
-                    vec![
-                        ChatCoordination::InvalidateContentCache,
-                        ChatCoordination::InvalidateThinkingCache,
-                        ChatCoordination::Status {
-                            level: LogLevel::Debug,
-                            target: "activity",
-                            message: format!("finished: {finish_reason}"),
-                        },
-                    ],
+                    vec![ChatCoordination::Status {
+                        level: LogLevel::Debug,
+                        target: "activity",
+                        message: format!("finished: {finish_reason}"),
+                    }],
                 )
             }
         };
@@ -590,7 +555,6 @@ impl ChatState {
                         (
                             HistoryTransition::UndoApplied,
                             vec![
-                                HistoryCoordination::InvalidateContentCache,
                                 HistoryCoordination::Status {
                                     level: LogLevel::Info,
                                     target: "session",
@@ -723,18 +687,11 @@ impl ChatState {
 
                 self.activity = ActivityState::RunningTool { name: name.clone() };
                 let finalized_streaming = self.finalize_streaming_segment();
-                let mut coordination = vec![ChatCoordination::Status {
+                let coordination = vec![ChatCoordination::Status {
                     level: LogLevel::Debug,
                     target: "tool",
                     message: format!("tool: {name}"),
                 }];
-                if finalized_streaming {
-                    coordination.extend([
-                        ChatCoordination::InvalidateContentCache,
-                        ChatCoordination::InvalidateThinkingCache,
-                        ChatCoordination::InvalidateCardCache,
-                    ]);
-                }
                 let preparation = if name == "question" {
                     ToolStartPreparationTransition::QuestionOnly {
                         finalized_streaming,
@@ -755,21 +712,17 @@ impl ChatState {
                     self.clear_streaming_thinking();
                     (
                         ChatToolTransition::StartInserted(ToolStartInsertionTransition::Reconciled),
-                        vec![
-                            ChatCoordination::InvalidateThinkingCache,
-                            ChatCoordination::InvalidateCardCache,
-                        ],
+                        Vec::new(),
                     )
                 } else {
                     self.record_tool_call();
                     let moved_thinking = self.push_streaming_thinking_entry();
                     self.push_tool_call(tool_call_id, name, false, detail);
                     (
-                        ChatToolTransition::StartInserted(ToolStartInsertionTransition::Inserted),
-                        moved_thinking
-                            .then_some(ChatCoordination::InvalidateThinkingCache)
-                            .into_iter()
-                            .collect(),
+                        ChatToolTransition::StartInserted(ToolStartInsertionTransition::Inserted {
+                            moved_thinking,
+                        }),
+                        Vec::new(),
                     )
                 }
             }
@@ -803,7 +756,7 @@ impl ChatState {
                 } else {
                     false
                 };
-                if is_error && failure_before.is_none() {
+                let transition = if is_error && failure_before.is_none() {
                     self.push_tool_call(
                         tool_call_id,
                         format!("{name} (failed)"),
@@ -815,24 +768,16 @@ impl ChatState {
                             })
                             .unwrap_or(ToolDetail::None),
                     );
-                    (
-                        ChatToolTransition::Ended(ToolEndTransition::FallbackInserted),
-                        vec![ChatCoordination::InvalidateCardCache],
-                    )
+                    ToolEndTransition::FallbackInserted
                 } else if detail_updated || marked_failed {
-                    (
-                        ChatToolTransition::Ended(ToolEndTransition::Updated {
-                            detail_updated,
-                            marked_failed,
-                        }),
-                        vec![ChatCoordination::InvalidateCardCache],
-                    )
+                    ToolEndTransition::Updated {
+                        detail_updated,
+                        marked_failed,
+                    }
                 } else {
-                    (
-                        ChatToolTransition::Ended(ToolEndTransition::NoOp),
-                        Vec::new(),
-                    )
-                }
+                    ToolEndTransition::NoOp
+                };
+                (ChatToolTransition::Ended(transition), Vec::new())
             }
         };
         ChatToolOutcome {
@@ -937,15 +882,6 @@ impl ChatState {
                 });
                 self.scroll_offset = 0;
 
-                let mut coordination = if finalized_streaming {
-                    vec![
-                        ChatCoordination::InvalidateContentCache,
-                        ChatCoordination::InvalidateThinkingCache,
-                        ChatCoordination::InvalidateCardCache,
-                    ]
-                } else {
-                    Vec::new()
-                };
                 let (transition, status) = if supported {
                     (
                         ElicitationTransition::InsertedSupported {
@@ -971,8 +907,7 @@ impl ChatState {
                         },
                     )
                 };
-                coordination.push(status);
-                (transition, coordination)
+                (transition, vec![status])
             }
             ElicitationAction::ResponseAcknowledged {
                 elicitation_id,
@@ -1003,16 +938,10 @@ impl ChatState {
                     self.elicitation_ui = None;
                     (
                         ElicitationTransition::ResolvedActive,
-                        vec![
-                            ChatCoordination::InvalidateCardCache,
-                            ChatCoordination::RefreshTransientStatus,
-                        ],
+                        vec![ChatCoordination::RefreshTransientStatus],
                     )
                 } else {
-                    (
-                        ElicitationTransition::ResolvedStale,
-                        vec![ChatCoordination::InvalidateCardCache],
-                    )
+                    (ElicitationTransition::ResolvedStale, Vec::new())
                 }
             }
         };
@@ -1020,18 +949,6 @@ impl ChatState {
             transition,
             coordination,
             effects: Vec::new(),
-        }
-    }
-
-    fn stream_boundary_coordination(transition: StreamingDeltaTransition) -> Vec<ChatCoordination> {
-        if transition.finalized_previous {
-            vec![
-                ChatCoordination::InvalidateContentCache,
-                ChatCoordination::InvalidateThinkingCache,
-                ChatCoordination::InvalidateCardCache,
-            ]
-        } else {
-            Vec::new()
         }
     }
 
@@ -2365,7 +2282,6 @@ mod tests {
             HistoryOutcome {
                 transition: HistoryTransition::UndoApplied,
                 coordination: vec![
-                    HistoryCoordination::InvalidateContentCache,
                     HistoryCoordination::Status {
                         level: LogLevel::Info,
                         target: "session",
@@ -2909,16 +2825,11 @@ mod tests {
         );
         assert_eq!(
             first.coordination,
-            vec![
-                ChatCoordination::InvalidateContentCache,
-                ChatCoordination::InvalidateThinkingCache,
-                ChatCoordination::InvalidateCardCache,
-                ChatCoordination::Status {
-                    level: LogLevel::Info,
-                    target: "elicitation",
-                    message: "question - answer in the panel above input".into(),
-                },
-            ]
+            vec![ChatCoordination::Status {
+                level: LogLevel::Info,
+                target: "elicitation",
+                message: "question - answer in the panel above input".into(),
+            },]
         );
         assert!(first.effects.is_empty());
         assert!(matches!(
@@ -3012,10 +2923,7 @@ mod tests {
             outcome: ElicitationResponseOutcome::Declined,
         });
         assert_eq!(stale.transition, ElicitationTransition::ResolvedStale);
-        assert_eq!(
-            stale.coordination,
-            vec![ChatCoordination::InvalidateCardCache]
-        );
+        assert_eq!(stale.coordination, Vec::new());
         assert!(stale.effects.is_empty());
         assert_eq!(
             chat.elicitation
@@ -3032,10 +2940,7 @@ mod tests {
         assert_eq!(active.transition, ElicitationTransition::ResolvedActive);
         assert_eq!(
             active.coordination,
-            vec![
-                ChatCoordination::InvalidateCardCache,
-                ChatCoordination::RefreshTransientStatus,
-            ]
+            vec![ChatCoordination::RefreshTransientStatus,]
         );
         assert!(active.effects.is_empty());
         assert!(chat.elicitation.is_none());
@@ -3046,10 +2951,7 @@ mod tests {
             outcome: ElicitationResponseOutcome::Text("accepted".into()),
         });
         assert_eq!(duplicate.transition, ElicitationTransition::ResolvedStale);
-        assert_eq!(
-            duplicate.coordination,
-            vec![ChatCoordination::InvalidateCardCache]
-        );
+        assert_eq!(duplicate.coordination, Vec::new());
         assert!(duplicate.effects.is_empty());
         assert!(matches!(
             chat.messages.as_slice(),
@@ -3170,16 +3072,11 @@ mod tests {
                         finalized_streaming: true,
                     },
                 ),
-                coordination: vec![
-                    ChatCoordination::Status {
-                        level: LogLevel::Debug,
-                        target: "tool",
-                        message: "tool: shell".into(),
-                    },
-                    ChatCoordination::InvalidateContentCache,
-                    ChatCoordination::InvalidateThinkingCache,
-                    ChatCoordination::InvalidateCardCache,
-                ],
+                coordination: vec![ChatCoordination::Status {
+                    level: LogLevel::Debug,
+                    target: "tool",
+                    message: "tool: shell".into(),
+                },],
                 effects: Vec::new(),
             }
         );
@@ -3250,12 +3147,11 @@ mod tests {
 
         assert_eq!(
             outcome.transition,
-            ChatToolTransition::StartInserted(ToolStartInsertionTransition::Inserted)
+            ChatToolTransition::StartInserted(ToolStartInsertionTransition::Inserted {
+                moved_thinking: true,
+            })
         );
-        assert_eq!(
-            outcome.coordination,
-            vec![ChatCoordination::InvalidateThinkingCache]
-        );
+        assert!(outcome.coordination.is_empty());
         assert!(outcome.effects.is_empty());
         assert_eq!(chat.session_stats.total_tool_calls, 8);
         assert!(matches!(
@@ -3277,7 +3173,9 @@ mod tests {
         });
         assert_eq!(
             saturated.transition,
-            ChatToolTransition::StartInserted(ToolStartInsertionTransition::Inserted)
+            ChatToolTransition::StartInserted(ToolStartInsertionTransition::Inserted {
+                moved_thinking: false,
+            })
         );
         assert_eq!(chat.session_stats.total_tool_calls, u32::MAX);
     }
@@ -3312,13 +3210,7 @@ mod tests {
             outcome.transition,
             ChatToolTransition::StartInserted(ToolStartInsertionTransition::Reconciled)
         );
-        assert_eq!(
-            outcome.coordination,
-            vec![
-                ChatCoordination::InvalidateThinkingCache,
-                ChatCoordination::InvalidateCardCache,
-            ]
-        );
+        assert_eq!(outcome.coordination, vec![]);
         assert!(outcome.effects.is_empty());
         assert_eq!(chat.messages.len(), 1);
         assert_eq!(chat.session_stats.total_tool_calls, 7);
@@ -3345,10 +3237,7 @@ mod tests {
             inserted.transition,
             ChatToolTransition::Ended(ToolEndTransition::FallbackInserted)
         );
-        assert_eq!(
-            inserted.coordination,
-            vec![ChatCoordination::InvalidateCardCache]
-        );
+        assert_eq!(inserted.coordination, Vec::new());
         assert!(inserted.effects.is_empty());
 
         let repeated = chat.reduce_tool(failed);
@@ -3434,10 +3323,7 @@ mod tests {
                 marked_failed: true,
             })
         );
-        assert_eq!(
-            updated.coordination,
-            vec![ChatCoordination::InvalidateCardCache]
-        );
+        assert_eq!(updated.coordination, Vec::new());
         assert!(updated.effects.is_empty());
         assert!(matches!(
             chat.messages.as_slice(),
@@ -3541,14 +3427,11 @@ mod tests {
                     prompt_rolled_back: true,
                     error_inserted: true,
                 },
-                coordination: vec![
-                    ChatCoordination::InvalidateCardCache,
-                    ChatCoordination::Status {
-                        level: LogLevel::Error,
-                        target: "acp",
-                        message: "error: backend rejected prompt".into(),
-                    },
-                ],
+                coordination: vec![ChatCoordination::Status {
+                    level: LogLevel::Error,
+                    target: "acp",
+                    message: "error: backend rejected prompt".into(),
+                },],
                 effects: Vec::new(),
             }
         );
@@ -3603,7 +3486,7 @@ mod tests {
                 transition: ChatTransition::RuntimePromptDispatchFailed {
                     prompt_rolled_back: true,
                 },
-                coordination: vec![ChatCoordination::InvalidateCardCache],
+                coordination: Vec::new(),
                 effects: Vec::new(),
             }
         );
@@ -3649,15 +3532,11 @@ mod tests {
         assert_eq!(outcome.transition, ChatTransition::TurnStarted);
         assert_eq!(
             outcome.coordination,
-            vec![
-                ChatCoordination::InvalidateContentCache,
-                ChatCoordination::InvalidateThinkingCache,
-                ChatCoordination::Status {
-                    level: LogLevel::Debug,
-                    target: "activity",
-                    message: "thinking...".into(),
-                },
-            ]
+            vec![ChatCoordination::Status {
+                level: LogLevel::Debug,
+                target: "activity",
+                message: "thinking...".into(),
+            },]
         );
         assert!(outcome.effects.is_empty());
         assert_eq!(live.activity, ActivityState::Thinking);
@@ -3703,10 +3582,7 @@ mod tests {
             reconciled.transition,
             ChatTransition::UserMessage(UserMessageTransition::Reconciled)
         );
-        assert_eq!(
-            reconciled.coordination,
-            vec![ChatCoordination::InvalidateCardCache]
-        );
+        assert_eq!(reconciled.coordination, Vec::new());
         assert!(matches!(
             &chat.messages[0],
             ChatEntry::User { message_id: Some(id), .. } if id == "server-1"
@@ -3797,14 +3673,7 @@ mod tests {
                 ignored_duplicate: false,
             })
         );
-        assert_eq!(
-            boundary.coordination,
-            vec![
-                ChatCoordination::InvalidateContentCache,
-                ChatCoordination::InvalidateThinkingCache,
-                ChatCoordination::InvalidateCardCache,
-            ]
-        );
+        assert_eq!(boundary.coordination, vec![]);
         assert!(matches!(
             chat.messages.as_slice(),
             [ChatEntry::Assistant { content, thinking: Some(thinking), message_id: Some(id) }]
@@ -3816,10 +3685,7 @@ mod tests {
 
     #[test]
     fn reducer_final_assistant_merges_replaces_and_deduplicates_exactly() {
-        let expected_base_coordination = vec![
-            ChatCoordination::InvalidateContentCache,
-            ChatCoordination::InvalidateThinkingCache,
-        ];
+        let expected_base_coordination = vec![];
         let mut chat = ChatState::new();
         chat.streaming_content = "partial".into();
         chat.streaming_content_message_id = Some("assistant-1".into());
@@ -3868,14 +3734,7 @@ mod tests {
             replaced.transition,
             ChatTransition::AssistantMessage(AssistantMessageTransition::ReplacedThinking)
         );
-        assert_eq!(
-            replaced.coordination,
-            vec![
-                ChatCoordination::InvalidateContentCache,
-                ChatCoordination::InvalidateThinkingCache,
-                ChatCoordination::InvalidateCardCache,
-            ]
-        );
+        assert_eq!(replaced.coordination, vec![]);
         assert!(matches!(
             &chat.messages[1],
             ChatEntry::Assistant { content, thinking: Some(thinking), message_id: Some(id) }
@@ -3894,15 +3753,11 @@ mod tests {
         assert_eq!(outcome.transition, ChatTransition::Cancelled);
         assert_eq!(
             outcome.coordination,
-            vec![
-                ChatCoordination::InvalidateContentCache,
-                ChatCoordination::InvalidateThinkingCache,
-                ChatCoordination::Status {
-                    level: LogLevel::Warn,
-                    target: "activity",
-                    message: "cancelled".into(),
-                },
-            ]
+            vec![ChatCoordination::Status {
+                level: LogLevel::Warn,
+                target: "activity",
+                message: "cancelled".into(),
+            },]
         );
         assert_eq!(cancelled.activity, ActivityState::Idle);
         assert!(cancelled.session_stats.open_llm_request_instant.is_none());
@@ -3921,15 +3776,11 @@ mod tests {
         assert_eq!(outcome.transition, ChatTransition::Finished);
         assert_eq!(
             outcome.coordination,
-            vec![
-                ChatCoordination::InvalidateContentCache,
-                ChatCoordination::InvalidateThinkingCache,
-                ChatCoordination::Status {
-                    level: LogLevel::Debug,
-                    target: "activity",
-                    message: "finished: EndTurn".into(),
-                },
-            ]
+            vec![ChatCoordination::Status {
+                level: LogLevel::Debug,
+                target: "activity",
+                message: "finished: EndTurn".into(),
+            },]
         );
         assert_eq!(finished.activity, ActivityState::Idle);
         assert!(finished.session_stats.open_llm_request_instant.is_none());

--- a/src/chat_state.rs
+++ b/src/chat_state.rs
@@ -220,7 +220,7 @@ pub(crate) enum ToolEndTransition {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ToolResultDetailState {
-    Shell(Option<(Vec<String>, usize)>),
+    Shell(Option<crate::domain::tool::ShellOutput>),
     ReadTool(Option<u64>, Option<u64>),
     Edit(Option<usize>),
     MultiEdit(Vec<Option<usize>>),
@@ -808,7 +808,12 @@ impl ChatState {
                         tool_call_id,
                         format!("{name} (failed)"),
                         true,
-                        result.map(ToolDetail::Summary).unwrap_or(ToolDetail::None),
+                        result
+                            .map(|result| ToolDetail::Generic {
+                                input: None,
+                                result: Some(result),
+                            })
+                            .unwrap_or(ToolDetail::None),
                     );
                     (
                         ChatToolTransition::Ended(ToolEndTransition::FallbackInserted),
@@ -1931,11 +1936,7 @@ impl ChatState {
 
 fn tool_result_detail_state(detail: &ToolDetail) -> ToolResultDetailState {
     match detail {
-        ToolDetail::Shell { output_tail, .. } => ToolResultDetailState::Shell(
-            output_tail
-                .as_ref()
-                .map(|tail| (tail.lines.clone(), tail.hidden_line_count)),
-        ),
+        ToolDetail::Shell { output, .. } => ToolResultDetailState::Shell(output.clone()),
         ToolDetail::ReadTool {
             start_line,
             end_line,
@@ -3255,7 +3256,10 @@ mod tests {
             Some("tool-1".into()),
             "shell (failed)".into(),
             true,
-            ToolDetail::Summary("failed".into()),
+            ToolDetail::Generic {
+                input: None,
+                result: Some("failed".into()),
+            },
         );
 
         let outcome = chat.reduce_tool(ChatToolAction::InsertOrReconcileToolStart {
@@ -3263,8 +3267,9 @@ mod tests {
             name: "shell".into(),
             detail: ToolDetail::Shell {
                 command: "echo late".into(),
+                arguments: Vec::new(),
                 workdir: None,
-                output_tail: None,
+                output: None,
             },
         });
 
@@ -3325,8 +3330,9 @@ mod tests {
             name: "shell".into(),
             detail: ToolDetail::Shell {
                 command: "echo late".into(),
+                arguments: Vec::new(),
                 workdir: None,
-                output_tail: None,
+                output: None,
             },
         });
         assert_eq!(
@@ -3373,8 +3379,9 @@ mod tests {
             false,
             ToolDetail::Shell {
                 command: "cargo check".into(),
+                arguments: Vec::new(),
                 workdir: Some("/repo".into()),
-                output_tail: None,
+                output: None,
             },
         );
         let end = ChatToolAction::ToolCallEnd {
@@ -3399,8 +3406,8 @@ mod tests {
         assert!(updated.effects.is_empty());
         assert!(matches!(
             chat.messages.as_slice(),
-            [ChatEntry::ToolCall { is_error: true, detail: ToolDetail::Shell { output_tail: Some(tail), .. }, .. }]
-                if tail.lines == ["line one", "line two"]
+            [ChatEntry::ToolCall { is_error: true, detail: ToolDetail::Shell { output: Some(output), .. }, .. }]
+                if output.stdout == "line one\nline two" && output.stderr.is_empty()
         ));
 
         let repeated = chat.reduce_tool(end);

--- a/src/chat_state.rs
+++ b/src/chat_state.rs
@@ -388,7 +388,6 @@ pub(crate) struct ChatState {
     pub(crate) fork_filter: String,
     pub(crate) fork_cursor: usize,
     pub(crate) pending_fork_message_id: Option<String>,
-    pub(crate) scroll_offset: u16,
     pub(crate) activity: ActivityState,
     pub(crate) streaming_content: String,
     pub(crate) streaming_content_message_id: Option<String>,
@@ -880,7 +879,6 @@ impl ChatState {
                     source,
                     outcome: (!supported).then_some(ElicitationResponseOutcome::UnsupportedSchema),
                 });
-                self.scroll_offset = 0;
 
                 let (transition, status) = if supported {
                     (
@@ -959,7 +957,6 @@ impl ChatState {
             fork_filter: String::new(),
             fork_cursor: 0,
             pending_fork_message_id: None,
-            scroll_offset: 0,
             activity: ActivityState::Idle,
             streaming_content: String::new(),
             streaming_content_message_id: None,
@@ -987,7 +984,6 @@ impl ChatState {
         self.streaming_content_message_id = None;
         self.streaming_thinking.clear();
         self.streaming_thinking_message_id = None;
-        self.scroll_offset = 0;
         self.undo_state = None;
         self.undoable_turns.clear();
         self.recent_prompt_text = None;
@@ -1205,7 +1201,6 @@ impl ChatState {
             text,
             message_id: Some(local_id.clone()),
         });
-        self.scroll_offset = 0;
         local_id
     }
 
@@ -1914,7 +1909,6 @@ mod tests {
         assert!(chat.fork_filter.is_empty());
         assert_eq!(chat.fork_cursor, 0);
         assert!(chat.pending_fork_message_id.is_none());
-        assert_eq!(chat.scroll_offset, 0);
         assert_eq!(chat.activity, ActivityState::Idle);
         assert!(chat.streaming_content.is_empty());
         assert!(chat.streaming_content_message_id.is_none());
@@ -1942,7 +1936,6 @@ mod tests {
         chat.fork_filter = "keep".into();
         chat.fork_cursor = 3;
         chat.pending_fork_message_id = Some("keep-fork".into());
-        chat.scroll_offset = 7;
         chat.activity = ActivityState::Streaming;
         chat.streaming_content = "content".into();
         chat.streaming_content_message_id = Some("content-id".into());
@@ -1971,7 +1964,6 @@ mod tests {
         assert_eq!(chat.fork_filter, "keep");
         assert_eq!(chat.fork_cursor, 3);
         assert_eq!(chat.pending_fork_message_id.as_deref(), Some("keep-fork"));
-        assert_eq!(chat.scroll_offset, 0);
         assert_eq!(chat.activity, ActivityState::Streaming);
         assert!(chat.streaming_content.is_empty());
         assert!(chat.streaming_content_message_id.is_none());
@@ -2697,7 +2689,6 @@ mod tests {
         };
 
         let mut live = ChatState::new();
-        live.scroll_offset = 9;
         let live_outcome = live.reduce_elicitation(request(false));
         assert_eq!(
             live_outcome,
@@ -2721,7 +2712,6 @@ mod tests {
         assert_eq!(active.fields.len(), 1);
         assert!(active.allow_custom);
         assert!(live.elicitation_ui.is_some());
-        assert_eq!(live.scroll_offset, 0);
         assert!(matches!(
             live.messages.as_slice(),
             [ChatEntry::Elicitation { elicitation_id, message, source, outcome: None }]

--- a/src/chat_state.rs
+++ b/src/chat_state.rs
@@ -4,7 +4,7 @@ use crate::application::Effect;
 use crate::composer_state::build_input_visual_layout;
 use crate::diagnostics::LogLevel;
 use crate::domain::activity::{ActivityState, SessionOp, SessionStatsLite};
-use crate::domain::chat::{ChatEntry, format_outcome_labels};
+use crate::domain::chat::{ChatEntry, ElicitationResponseOutcome};
 use crate::domain::elicitation::ElicitationState;
 use crate::domain::session::{
     ForkBoundaryKind, ForkResult, ForkTurnItem, RedoResult, UndoFrame, UndoFrameStatus, UndoResult,
@@ -130,7 +130,7 @@ pub(crate) enum ElicitationAction {
     },
     ResponseAcknowledged {
         elicitation_id: String,
-        outcome: String,
+        outcome: ElicitationResponseOutcome,
     },
 }
 
@@ -933,8 +933,7 @@ impl ChatState {
                     elicitation_id,
                     message,
                     source,
-                    outcome: (!supported)
-                        .then(|| "unsupported schema - cannot answer in TUI".into()),
+                    outcome: (!supported).then_some(ElicitationResponseOutcome::UnsupportedSchema),
                 });
                 self.scroll_offset = 0;
 
@@ -1917,7 +1916,7 @@ impl ChatState {
             let ChatEntry::Elicitation { outcome, .. } = entry else {
                 continue;
             };
-            if outcome.as_deref() != Some("responded") {
+            if outcome.as_ref() != Some(&ElicitationResponseOutcome::Responded) {
                 continue;
             }
             let Some(answer_entry) = answer_iter.next() else {
@@ -1926,10 +1925,14 @@ impl ChatState {
             let labels = answer_entry
                 .get("answers")
                 .and_then(|answers| answers.as_array())
-                .map(|answers| answers.iter().filter_map(|answer| answer.as_str()))
-                .into_iter()
-                .flatten();
-            *outcome = Some(format_outcome_labels(labels));
+                .map(|answers| {
+                    answers
+                        .iter()
+                        .filter_map(|answer| answer.as_str().map(str::to_string))
+                        .collect()
+                })
+                .unwrap_or_default();
+            *outcome = Some(ElicitationResponseOutcome::Selected(labels));
         }
     }
 }
@@ -1961,7 +1964,6 @@ fn move_wrapping_cursor(cursor: usize, len: usize, delta: isize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::chat::OUTCOME_BULLET;
     use crate::domain::tool::ToolDetail;
 
     fn user(text: &str, message_id: Option<&str>) -> ChatEntry {
@@ -2688,7 +2690,7 @@ mod tests {
 
         let outcome = chat.reduce_elicitation(ElicitationAction::ResponseAcknowledged {
             elicitation_id: "elic-1".into(),
-            outcome: "responded".into(),
+            outcome: ElicitationResponseOutcome::Responded,
         });
         assert_eq!(outcome.transition, ElicitationTransition::ResolvedActive);
         assert!(chat.elicitation.is_none());
@@ -2698,7 +2700,38 @@ mod tests {
         assert!(matches!(
             &chat.messages[0],
             ChatEntry::Elicitation { outcome: Some(outcome), .. }
-                if outcome == &format!("{OUTCOME_BULLET}Alpha\n{OUTCOME_BULLET}Beta")
+                if outcome == &ElicitationResponseOutcome::Selected(vec!["Alpha".into(), "Beta".into()])
+        ));
+    }
+
+    #[test]
+    fn elicitation_backfill_ignores_malformed_results_and_preserves_missing_answers_behavior() {
+        let mut chat = ChatState::new();
+        chat.messages.push(ChatEntry::Elicitation {
+            elicitation_id: "elic-1".into(),
+            message: "Pick".into(),
+            source: "question".into(),
+            outcome: Some(ElicitationResponseOutcome::Responded),
+        });
+
+        for result in ["not json", r#"{"answers":"invalid"}"#] {
+            chat.backfill_elicitation_outcomes(result);
+            assert!(matches!(
+                chat.messages.as_slice(),
+                [ChatEntry::Elicitation {
+                    outcome: Some(ElicitationResponseOutcome::Responded),
+                    ..
+                }]
+            ));
+        }
+
+        chat.backfill_elicitation_outcomes(r#"{"answers":[{"question":"Pick"}]}"#);
+        assert!(matches!(
+            chat.messages.as_slice(),
+            [ChatEntry::Elicitation {
+                outcome: Some(ElicitationResponseOutcome::Selected(labels)),
+                ..
+            }] if labels.is_empty()
         ));
     }
 
@@ -2839,8 +2872,10 @@ mod tests {
             assert!(chat.elicitation_ui.is_none());
             assert!(matches!(
                 chat.messages.as_slice(),
-                [ChatEntry::Elicitation { outcome: Some(outcome), .. }]
-                    if outcome == "unsupported schema - cannot answer in TUI"
+                [ChatEntry::Elicitation {
+                    outcome: Some(ElicitationResponseOutcome::UnsupportedSchema),
+                    ..
+                }]
             ));
         }
     }
@@ -2955,7 +2990,7 @@ mod tests {
 
         let unknown = chat.reduce_elicitation(ElicitationAction::ResponseAcknowledged {
             elicitation_id: "missing".into(),
-            outcome: "accepted".into(),
+            outcome: ElicitationResponseOutcome::Text("accepted".into()),
         });
         assert_eq!(
             unknown,
@@ -2974,7 +3009,7 @@ mod tests {
 
         let stale = chat.reduce_elicitation(ElicitationAction::ResponseAcknowledged {
             elicitation_id: "elic-old".into(),
-            outcome: "declined".into(),
+            outcome: ElicitationResponseOutcome::Declined,
         });
         assert_eq!(stale.transition, ElicitationTransition::ResolvedStale);
         assert_eq!(
@@ -2992,7 +3027,7 @@ mod tests {
 
         let active = chat.reduce_elicitation(ElicitationAction::ResponseAcknowledged {
             elicitation_id: "elic-new".into(),
-            outcome: "accepted".into(),
+            outcome: ElicitationResponseOutcome::Text("accepted".into()),
         });
         assert_eq!(active.transition, ElicitationTransition::ResolvedActive);
         assert_eq!(
@@ -3008,7 +3043,7 @@ mod tests {
 
         let duplicate = chat.reduce_elicitation(ElicitationAction::ResponseAcknowledged {
             elicitation_id: "elic-new".into(),
-            outcome: "accepted".into(),
+            outcome: ElicitationResponseOutcome::Text("accepted".into()),
         });
         assert_eq!(duplicate.transition, ElicitationTransition::ResolvedStale);
         assert_eq!(
@@ -3022,9 +3057,9 @@ mod tests {
                 ChatEntry::Elicitation { elicitation_id: old, outcome: Some(old_outcome), .. },
                 ChatEntry::Elicitation { elicitation_id: new, outcome: Some(new_outcome), .. },
             ] if old == "elic-old"
-                && old_outcome == "declined"
+                && old_outcome == &ElicitationResponseOutcome::Declined
                 && new == "elic-new"
-                && new_outcome == "accepted"
+                && new_outcome == &ElicitationResponseOutcome::Text("accepted".into())
         ));
     }
 

--- a/src/composer_state.rs
+++ b/src/composer_state.rs
@@ -2,7 +2,8 @@ use std::collections::HashSet;
 
 use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
-use unicode_width::UnicodeWidthChar;
+
+use crate::input_layout::build_input_visual_layout;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct FileIndexEntryLite {
@@ -29,8 +30,6 @@ pub(crate) struct SlashCompletionState {
 pub(crate) struct ComposerState {
     pub(crate) input: String,
     pub(crate) input_cursor: usize,
-    pub(crate) input_scroll: u16,
-    pub(crate) input_line_width: usize,
     pub(crate) input_preferred_col: Option<usize>,
     pub(crate) file_index: Vec<FileIndexEntryLite>,
     pub(crate) file_index_generated_at: Option<u64>,
@@ -40,163 +39,11 @@ pub(crate) struct ComposerState {
     pub(crate) slash_state: Option<SlashCompletionState>,
 }
 
-pub(crate) struct InputVisualRow {
-    pub(crate) text: String,
-    pub(crate) start: usize,
-    pub(crate) end: usize,
-    pub(crate) columns: Vec<(usize, usize)>,
-}
-
-pub(crate) struct InputVisualLayout {
-    pub(crate) rows: Vec<InputVisualRow>,
-    pub(crate) cursor_row: usize,
-    pub(crate) cursor_col: usize,
-    pub(crate) cursor_text_col: usize,
-}
-
-impl InputVisualLayout {
-    pub(crate) fn total_rows(&self) -> usize {
-        self.rows.len()
-    }
-
-    pub(crate) fn cursor_offset_for_row_col(&self, row: usize, preferred_col: usize) -> usize {
-        let Some(row) = self.rows.get(row) else {
-            return 0;
-        };
-        let mut best = row.end;
-        for (col, offset) in &row.columns {
-            if *col <= preferred_col {
-                best = *offset;
-            } else {
-                break;
-            }
-        }
-        best
-    }
-}
-
-pub(crate) fn build_input_visual_layout(
-    input: &str,
-    input_cursor: usize,
-    line_width: usize,
-    prefix_width: usize,
-) -> InputVisualLayout {
-    let line_width = line_width.max(1);
-    let mut rows: Vec<InputVisualRow> = Vec::new();
-    let mut row_text = String::new();
-    let mut row_columns = vec![(0usize, 0usize)];
-    let mut row_start = 0usize;
-    let mut row_end = 0usize;
-    let mut col = prefix_width;
-    let mut text_col = 0usize;
-    let mut cursor_row = 0usize;
-    let mut cursor_col = prefix_width;
-    let mut cursor_text_col = 0usize;
-    let mut cursor_found = input_cursor == 0;
-
-    let row_prefix_width = |rows_len: usize| if rows_len == 0 { prefix_width } else { 0 };
-
-    if cursor_found {
-        cursor_row = 0;
-        cursor_col = prefix_width;
-        cursor_text_col = 0;
-    }
-
-    let finish_row = |rows: &mut Vec<InputVisualRow>,
-                      row_text: &mut String,
-                      row_columns: &mut Vec<(usize, usize)>,
-                      row_start: &mut usize,
-                      row_end: &mut usize,
-                      next_start: usize| {
-        rows.push(InputVisualRow {
-            text: std::mem::take(row_text),
-            start: *row_start,
-            end: *row_end,
-            columns: std::mem::take(row_columns),
-        });
-        *row_columns = vec![(0, next_start)];
-        *row_start = next_start;
-        *row_end = next_start;
-    };
-
-    for (byte_idx, ch) in input.char_indices() {
-        if !cursor_found && byte_idx == input_cursor {
-            cursor_row = rows.len();
-            cursor_col = col;
-            cursor_text_col = text_col;
-            cursor_found = true;
-        }
-
-        if ch == '\n' {
-            row_end = byte_idx;
-            finish_row(
-                &mut rows,
-                &mut row_text,
-                &mut row_columns,
-                &mut row_start,
-                &mut row_end,
-                byte_idx + ch.len_utf8(),
-            );
-            col = row_prefix_width(rows.len());
-            text_col = 0;
-            continue;
-        }
-
-        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
-        if ch_width > 0 && col + ch_width > line_width {
-            finish_row(
-                &mut rows,
-                &mut row_text,
-                &mut row_columns,
-                &mut row_start,
-                &mut row_end,
-                byte_idx,
-            );
-            col = row_prefix_width(rows.len());
-            text_col = 0;
-            if !cursor_found && byte_idx == input_cursor {
-                cursor_row = rows.len();
-                cursor_col = col;
-                cursor_text_col = 0;
-                cursor_found = true;
-            }
-        }
-
-        row_text.push(ch);
-        col += ch_width;
-        text_col += ch_width;
-        row_end = byte_idx + ch.len_utf8();
-        row_columns.push((text_col, row_end));
-    }
-
-    if !cursor_found && input_cursor == input.len() {
-        cursor_row = rows.len();
-        cursor_col = col;
-        cursor_text_col = text_col;
-    }
-
-    rows.push(InputVisualRow {
-        text: row_text,
-        start: row_start,
-        end: row_end,
-        columns: row_columns,
-    });
-
-    InputVisualLayout {
-        rows,
-        cursor_row,
-        cursor_col,
-        cursor_text_col,
-    }
-}
-
 impl ComposerState {
     pub(crate) fn new() -> Self {
         Self {
             input: String::new(),
             input_cursor: 0,
-            input_scroll: 0,
-            input_line_width: 1,
             input_preferred_col: None,
             file_index: Vec::new(),
             file_index_generated_at: None,
@@ -214,13 +61,11 @@ impl ComposerState {
     pub(crate) fn clear_input(&mut self) {
         self.input.clear();
         self.input_cursor = 0;
-        self.input_scroll = 0;
     }
 
     pub(crate) fn replace_input(&mut self, input: String) {
         self.input = input;
         self.input_cursor = self.input.len();
-        self.input_scroll = 0;
     }
 
     pub(crate) fn input_insert(&mut self, character: char) {
@@ -300,13 +145,9 @@ impl ComposerState {
         self.refresh_slash_state();
     }
 
-    pub(crate) fn input_up_visual(&mut self, prefix_width: usize) {
-        let layout = build_input_visual_layout(
-            &self.input,
-            self.input_cursor,
-            self.input_line_width,
-            prefix_width,
-        );
+    pub(crate) fn input_up_visual(&mut self, line_width: usize, prefix_width: usize) {
+        let layout =
+            build_input_visual_layout(&self.input, self.input_cursor, line_width, prefix_width);
         if layout.cursor_row == 0 {
             self.input_preferred_col = Some(layout.cursor_text_col);
             return;
@@ -318,13 +159,9 @@ impl ComposerState {
         self.refresh_slash_state();
     }
 
-    pub(crate) fn input_down_visual(&mut self, prefix_width: usize) {
-        let layout = build_input_visual_layout(
-            &self.input,
-            self.input_cursor,
-            self.input_line_width,
-            prefix_width,
-        );
+    pub(crate) fn input_down_visual(&mut self, line_width: usize, prefix_width: usize) {
+        let layout =
+            build_input_visual_layout(&self.input, self.input_cursor, line_width, prefix_width);
         if layout.cursor_row + 1 >= layout.total_rows() {
             self.input_preferred_col = Some(layout.cursor_text_col);
             return;
@@ -598,8 +435,6 @@ mod tests {
 
         assert!(state.input.is_empty());
         assert_eq!(state.input_cursor, 0);
-        assert_eq!(state.input_scroll, 0);
-        assert_eq!(state.input_line_width, 1);
         assert_eq!(state.input_preferred_col, None);
         assert!(state.file_index.is_empty());
         assert_eq!(state.file_index_generated_at, None);
@@ -614,17 +449,14 @@ mod tests {
         let mut state = ComposerState::new();
         state.input = "old".into();
         state.input_cursor = 2;
-        state.input_scroll = 3;
 
         state.clear_input();
         assert!(state.input.is_empty());
         assert_eq!(state.input_cursor, 0);
-        assert_eq!(state.input_scroll, 0);
 
         state.replace_input("new".into());
         assert_eq!(state.input, "new");
         assert_eq!(state.input_cursor, 3);
-        assert_eq!(state.input_scroll, 0);
     }
 
     #[test]
@@ -674,24 +506,45 @@ mod tests {
         let mut state = ComposerState::new();
         state.input = "abcdef".into();
         state.input_cursor = 4;
-        state.input_line_width = 4;
 
-        state.input_up_visual(2);
+        state.input_up_visual(4, 2);
         assert_eq!(state.input_cursor, 2);
         assert_eq!(state.input_preferred_col, Some(2));
-        state.input_down_visual(2);
+        state.input_down_visual(4, 2);
         assert_eq!(state.input_cursor, 4);
 
         state.input = "ab\ncd".into();
         state.input_cursor = 1;
-        state.input_line_width = 6;
         state.input_preferred_col = None;
-        state.input_down_visual(2);
+        state.input_down_visual(6, 2);
         assert_eq!(state.input_cursor, 4);
 
         state.input_left();
         assert_eq!(state.input_cursor, 3);
         assert_eq!(state.input_preferred_col, None);
+    }
+
+    #[test]
+    fn visual_movement_retains_preferred_column_across_unequal_rows_and_boundaries() {
+        let mut state = ComposerState::new();
+        state.input = "abcd\nx\nwxyz".into();
+        state.input_cursor = state.input.len();
+
+        state.input_up_visual(20, 2);
+        assert_eq!(state.input_cursor, "abcd\nx".len());
+        assert_eq!(state.input_preferred_col, Some(4));
+        state.input_up_visual(20, 2);
+        assert_eq!(state.input_cursor, 4);
+        state.input_up_visual(20, 2);
+        assert_eq!(state.input_cursor, 4);
+        assert_eq!(state.input_preferred_col, Some(4));
+        state.input_down_visual(20, 2);
+        assert_eq!(state.input_cursor, "abcd\nx".len());
+        state.input_down_visual(20, 2);
+        assert_eq!(state.input_cursor, state.input.len());
+        state.input_down_visual(20, 2);
+        assert_eq!(state.input_cursor, state.input.len());
+        assert_eq!(state.input_preferred_col, Some(4));
     }
 
     #[test]
@@ -919,7 +772,6 @@ mod tests {
         state.replace_input_from_editor("/mo".into());
 
         assert_eq!(state.input_cursor, 3);
-        assert_eq!(state.input_scroll, 0);
         assert!(state.mention_state.is_none());
         assert!(state.slash_state.is_some());
 
@@ -933,13 +785,12 @@ mod tests {
         let mut state = ComposerState::new();
         state.input = "abc".into();
         state.input_cursor = 2;
-        state.input_line_width = 10;
 
-        state.input_up_visual(2);
+        state.input_up_visual(10, 2);
         assert_eq!(state.input_cursor, 2);
         assert_eq!(state.input_preferred_col, Some(2));
         state.input_preferred_col = None;
-        state.input_down_visual(2);
+        state.input_down_visual(10, 2);
         assert_eq!(state.input_cursor, 2);
         assert_eq!(state.input_preferred_col, Some(2));
     }
@@ -949,8 +800,6 @@ mod tests {
         let mut state = ComposerState::new();
         state.input = "draft".into();
         state.input_cursor = 3;
-        state.input_scroll = 2;
-        state.input_line_width = 40;
         state.input_preferred_col = Some(4);
         state.file_index = vec![entry("src/main.rs", false)];
         state.file_index_generated_at = Some(7);
@@ -970,8 +819,6 @@ mod tests {
 
         assert_eq!(state.input, "/mo");
         assert_eq!(state.input_cursor, 3);
-        assert_eq!(state.input_scroll, 2);
-        assert_eq!(state.input_line_width, 40);
         assert_eq!(state.input_preferred_col, Some(4));
         assert!(state.file_index.is_empty());
         assert_eq!(state.file_index_generated_at, None);

--- a/src/delegates_state.rs
+++ b/src/delegates_state.rs
@@ -82,7 +82,6 @@ struct DelegateLifecycleUpdate {
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct DelegatesState {
-    pub(crate) delegate_popup_visible_rows: usize,
     pub(crate) delegate_entries: Vec<DelegateEntry>,
     pub(crate) delegate_cursor: usize,
     pub(crate) delegate_filter: String,
@@ -266,7 +265,6 @@ impl DelegatesState {
 
     pub(crate) fn new() -> Self {
         Self {
-            delegate_popup_visible_rows: 0,
             delegate_entries: Vec::new(),
             delegate_cursor: 0,
             delegate_filter: String::new(),
@@ -326,8 +324,7 @@ impl DelegatesState {
         self.delegate_cursor = self.delegate_cursor.saturating_add(1).min(max);
     }
 
-    pub(crate) fn move_cursor_page(&mut self, down: bool) {
-        let step = self.delegate_popup_visible_rows.saturating_sub(1).max(1);
+    pub(crate) fn move_cursor_page(&mut self, step: usize, down: bool) {
         if down {
             let max = self.visible_entries().len().saturating_sub(1);
             self.delegate_cursor = self.delegate_cursor.saturating_add(step).min(max);
@@ -659,10 +656,9 @@ mod tests {
     }
 
     #[test]
-    fn constructor_uses_all_fourteen_exact_defaults() {
+    fn constructor_uses_exact_defaults() {
         let state = DelegatesState::new();
 
-        assert_eq!(state.delegate_popup_visible_rows, 0);
         assert!(state.delegate_entries.is_empty());
         assert_eq!(state.delegate_cursor, 0);
         assert!(state.delegate_filter.is_empty());
@@ -716,12 +712,11 @@ mod tests {
                 )
             })
             .collect();
-        state.delegate_popup_visible_rows = 4;
 
         state.move_cursor_down();
-        state.move_cursor_page(true);
+        state.move_cursor_page(3, true);
         assert_eq!(state.delegate_cursor, 4);
-        state.move_cursor_page(false);
+        state.move_cursor_page(3, false);
         assert_eq!(state.delegate_cursor, 1);
         state.filter_insert('d');
         state.filter_insert('o');
@@ -732,20 +727,6 @@ mod tests {
         assert_eq!(state.delegate_cursor, 0);
         state.reset_popup();
         assert!(state.delegate_filter.is_empty());
-        assert_eq!(state.delegate_cursor, 0);
-    }
-
-    #[test]
-    fn page_movement_falls_back_to_one_when_visible_rows_are_unknown() {
-        let mut state = DelegatesState::new();
-        state.delegate_entries = vec![
-            entry("d1", "one", None, DelegateStatus::InProgress),
-            entry("d2", "two", None, DelegateStatus::InProgress),
-        ];
-
-        state.move_cursor_page(true);
-        assert_eq!(state.delegate_cursor, 1);
-        state.move_cursor_page(false);
         assert_eq!(state.delegate_cursor, 0);
     }
 
@@ -931,7 +912,6 @@ mod tests {
             .insert("d1".to_string(), "boom".to_string());
         state.delegate_filter = "stale".to_string();
         state.delegate_cursor = 3;
-        state.delegate_popup_visible_rows = 5;
         state.parent_session_id = Some("parent".to_string());
 
         let entries_before = state.delegate_entries.clone();
@@ -950,7 +930,6 @@ mod tests {
         assert!(state.delegation_errors.is_empty());
         assert_eq!(state.delegate_filter, "stale");
         assert_eq!(state.delegate_cursor, 3);
-        assert_eq!(state.delegate_popup_visible_rows, 5);
     }
 
     #[test]

--- a/src/delegates_state.rs
+++ b/src/delegates_state.rs
@@ -58,15 +58,10 @@ pub(crate) struct DelegateContext {
     pub(crate) inactive_activity_session_id: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum DelegateCoordination {
-    InvalidateCardCache,
-}
-
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct DelegateOutcome {
     pub(crate) changed: bool,
-    pub(crate) coordination: Vec<DelegateCoordination>,
+    pub(crate) presentation_changed: bool,
     pub(crate) effects: Vec<Effect>,
 }
 
@@ -138,7 +133,7 @@ impl DelegatesState {
                     result_summary: update.result_summary,
                     error: update.error,
                 });
-                Self::outcome_with_card_invalidation(accepted && *self != before)
+                Self::presentation_outcome(accepted && *self != before)
             }
             DelegateAction::ProvisionalToolDelegate {
                 tool_call_id,
@@ -160,7 +155,7 @@ impl DelegatesState {
                     .to_string();
                 let changed =
                     self.upsert_provisional_delegate(&tool_call_id, target_agent_id, objective);
-                Self::outcome_with_card_invalidation(changed)
+                Self::presentation_outcome(changed)
             }
             DelegateAction::InactiveChildActivity {
                 session_id,
@@ -170,14 +165,7 @@ impl DelegatesState {
                     return DelegateOutcome::default();
                 }
                 let changed = self.apply_child_activity(&session_id, activity);
-                DelegateOutcome {
-                    changed,
-                    coordination: changed
-                        .then_some(DelegateCoordination::InvalidateCardCache)
-                        .into_iter()
-                        .collect(),
-                    effects: Vec::new(),
-                }
+                Self::presentation_outcome(changed)
             }
             DelegateAction::ResolveLoadedSessionParent(discovered_parent) => {
                 let parent_before = self.parent_session_id.clone();
@@ -211,13 +199,10 @@ impl DelegatesState {
         }
     }
 
-    fn outcome_with_card_invalidation(changed: bool) -> DelegateOutcome {
+    fn presentation_outcome(changed: bool) -> DelegateOutcome {
         DelegateOutcome {
             changed,
-            coordination: changed
-                .then_some(DelegateCoordination::InvalidateCardCache)
-                .into_iter()
-                .collect(),
+            presentation_changed: changed,
             effects: Vec::new(),
         }
     }
@@ -1007,10 +992,7 @@ mod tests {
             context.clone(),
         );
         assert!(accepted.changed);
-        assert_eq!(
-            accepted.coordination,
-            vec![DelegateCoordination::InvalidateCardCache]
-        );
+        assert!(accepted.presentation_changed);
         assert!(accepted.effects.is_empty());
 
         let stale = state.reduce(
@@ -1029,6 +1011,7 @@ mod tests {
             context.clone(),
         );
         assert!(equal_rank_tie.changed);
+        assert!(equal_rank_tie.presentation_changed);
         assert_eq!(state.delegate_entries[0].status, DelegateStatus::Failed);
         assert_eq!(state.delegation_errors["d1"], "boom");
         assert!(!state.delegation_result_summaries.contains_key("d1"));
@@ -1053,10 +1036,7 @@ mod tests {
 
         let inserted = state.reduce(action.clone(), DelegateContext::default());
         assert!(inserted.changed);
-        assert_eq!(
-            inserted.coordination,
-            vec![DelegateCoordination::InvalidateCardCache]
-        );
+        assert!(inserted.presentation_changed);
         assert!(inserted.effects.is_empty());
         assert_eq!(
             state.reduce(action, DelegateContext::default()),
@@ -1095,6 +1075,7 @@ mod tests {
             },
         );
         assert!(authoritative.changed);
+        assert!(authoritative.presentation_changed);
         assert_eq!(state.delegate_entries.len(), 1);
         let entry = &state.delegate_entries[0];
         assert_eq!(entry.delegation_id, "d1");
@@ -1106,7 +1087,7 @@ mod tests {
     }
 
     #[test]
-    fn reducer_inactive_activity_stages_then_attaches_and_orders_coordination() {
+    fn reducer_inactive_activity_stages_then_attaches_and_reports_presentation_changes() {
         let mut state = DelegatesState::new();
         let context = DelegateContext {
             active_session_id: Some("parent".into()),
@@ -1125,7 +1106,7 @@ mod tests {
             },
         );
         assert!(!rejected.changed);
-        assert!(rejected.coordination.is_empty());
+        assert!(!rejected.presentation_changed);
         assert!(state.pending_delegate_child_states.is_empty());
         assert!(state.pending_delegate_child_stats.is_empty());
 
@@ -1139,7 +1120,7 @@ mod tests {
             context.clone(),
         );
         assert!(!staged.changed);
-        assert!(staged.coordination.is_empty());
+        assert!(!staged.presentation_changed);
         assert!(staged.effects.is_empty());
         assert_eq!(
             state.pending_delegate_child_states["child"],
@@ -1166,6 +1147,7 @@ mod tests {
             context.clone(),
         );
         assert!(linked.changed);
+        assert!(linked.presentation_changed);
         assert_eq!(state.delegate_entries[0].stats.messages, 1);
         assert_eq!(
             state.delegate_entries[0].child_state,
@@ -1182,10 +1164,7 @@ mod tests {
             context.clone(),
         );
         assert!(changed.changed);
-        assert_eq!(
-            changed.coordination,
-            vec![DelegateCoordination::InvalidateCardCache]
-        );
+        assert!(changed.presentation_changed);
         assert_eq!(state.delegate_entries[0].stats.tool_calls, 1);
 
         let unchanged = state.reduce(
@@ -1196,7 +1175,7 @@ mod tests {
             context,
         );
         assert!(!unchanged.changed);
-        assert!(unchanged.coordination.is_empty());
+        assert!(!unchanged.presentation_changed);
     }
 
     #[test]
@@ -1212,7 +1191,7 @@ mod tests {
             DelegateContext::default(),
         );
         assert!(resolved.changed);
-        assert!(resolved.coordination.is_empty());
+        assert!(!resolved.presentation_changed);
         assert!(resolved.effects.is_empty());
         assert_eq!(state.parent_session_id.as_deref(), Some("staged-parent"));
         assert_eq!(state.pending_parent_session_id, None);
@@ -1236,6 +1215,7 @@ mod tests {
             DelegateContext::default(),
         );
         assert!(cleared_parent.changed);
+        assert!(!cleared_parent.presentation_changed);
         assert_eq!(
             state.reduce(
                 DelegateAction::ClearNewRootParent,
@@ -1248,6 +1228,7 @@ mod tests {
             DelegateContext::default(),
         );
         assert!(cleared_root.changed);
+        assert!(!cleared_root.presentation_changed);
         assert!(state.delegate_entries.is_empty());
         assert_eq!(
             state.reduce(

--- a/src/domain/auth.rs
+++ b/src/domain/auth.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -11,22 +9,20 @@ pub enum AuthMethod {
     EnvVar,
 }
 
-impl fmt::Display for AuthMethod {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::OAuth => write!(f, "OAuth"),
-            Self::ApiKey => write!(f, "API Key"),
-            Self::EnvVar => write!(f, "Env"),
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum OAuthStatus {
     Connected,
     Expired,
     NotAuthenticated,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthStatus {
+    Unconfigurable,
+    Expired,
+    Active(AuthMethod),
+    NotConfigured,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -100,19 +96,16 @@ impl AuthProviderEntry {
         None
     }
 
-    /// Badge label for current auth state.
-    pub fn auth_badge_label(&self) -> &'static str {
+    /// Classify the provider's current authentication state.
+    pub fn auth_status(&self) -> AuthStatus {
         if self.is_unconfigurable() {
-            return "OAuth required";
-        }
-        if self.oauth_status == Some(OAuthStatus::Expired) {
-            return "Expired";
-        }
-        match self.effective_auth() {
-            Some(AuthMethod::OAuth) => "OAuth",
-            Some(AuthMethod::ApiKey) => "API Key",
-            Some(AuthMethod::EnvVar) => "Env",
-            None => "Not configured",
+            AuthStatus::Unconfigurable
+        } else if self.oauth_status == Some(OAuthStatus::Expired) {
+            AuthStatus::Expired
+        } else if let Some(method) = self.effective_auth() {
+            AuthStatus::Active(method)
+        } else {
+            AuthStatus::NotConfigured
         }
     }
 
@@ -205,7 +198,7 @@ mod tests {
         let mut p = make_provider("OpenAI");
         p.oauth_status = Some(OAuthStatus::Connected);
         assert_eq!(p.effective_auth(), Some(AuthMethod::OAuth));
-        assert_eq!(p.auth_badge_label(), "OAuth");
+        assert_eq!(p.auth_status(), AuthStatus::Active(AuthMethod::OAuth));
         assert!(p.is_auth_active());
     }
 
@@ -214,7 +207,7 @@ mod tests {
         let mut p = make_api_key_only("Groq");
         p.has_stored_api_key = true;
         assert_eq!(p.effective_auth(), Some(AuthMethod::ApiKey));
-        assert_eq!(p.auth_badge_label(), "API Key");
+        assert_eq!(p.auth_status(), AuthStatus::Active(AuthMethod::ApiKey));
         assert!(p.is_auth_active());
     }
 
@@ -223,22 +216,22 @@ mod tests {
         let mut p = make_api_key_only("DeepSeek");
         p.has_env_api_key = true;
         assert_eq!(p.effective_auth(), Some(AuthMethod::EnvVar));
-        assert_eq!(p.auth_badge_label(), "Env");
+        assert_eq!(p.auth_status(), AuthStatus::Active(AuthMethod::EnvVar));
     }
 
     #[test]
     fn auth_provider_entry_not_configured() {
         let p = make_provider("OpenAI");
         assert_eq!(p.effective_auth(), None);
-        assert_eq!(p.auth_badge_label(), "Not configured");
+        assert_eq!(p.auth_status(), AuthStatus::NotConfigured);
         assert!(!p.is_auth_active());
     }
 
     #[test]
-    fn auth_provider_entry_expired_badge() {
+    fn auth_provider_entry_expired_status() {
         let mut p = make_oauth_only("Codex");
         p.oauth_status = Some(OAuthStatus::Expired);
-        assert_eq!(p.auth_badge_label(), "Expired");
+        assert_eq!(p.auth_status(), AuthStatus::Expired);
     }
 
     #[test]
@@ -254,17 +247,21 @@ mod tests {
             preferred_method: None,
         };
         assert!(p.is_unconfigurable());
-        assert_eq!(p.auth_badge_label(), "OAuth required");
+        assert_eq!(p.auth_status(), AuthStatus::Unconfigurable);
     }
 
     #[test]
-    fn auth_provider_entry_preferred_method_overrides_default_order() {
-        let mut p = make_provider("OpenAI");
-        p.oauth_status = Some(OAuthStatus::Connected);
-        p.has_stored_api_key = true;
-        p.preferred_method = Some(AuthMethod::ApiKey);
-        // With preference ApiKey, should pick that over OAuth even though both are available
-        assert_eq!(p.effective_auth(), Some(AuthMethod::ApiKey));
+    fn auth_provider_entry_preferred_method_controls_effective_auth_order() {
+        for preferred in [AuthMethod::OAuth, AuthMethod::ApiKey, AuthMethod::EnvVar] {
+            let mut provider = make_provider("OpenAI");
+            provider.oauth_status = Some(OAuthStatus::Connected);
+            provider.has_stored_api_key = true;
+            provider.has_env_api_key = true;
+            provider.preferred_method = Some(preferred);
+
+            assert_eq!(provider.effective_auth(), Some(preferred));
+            assert_eq!(provider.auth_status(), AuthStatus::Active(preferred));
+        }
     }
 
     #[test]
@@ -338,13 +335,6 @@ mod tests {
 
         result.status = OAuthResultStatus::Failure;
         assert!(!result.is_success());
-    }
-
-    #[test]
-    fn auth_method_display_labels_match_ui_contract() {
-        assert_eq!(AuthMethod::OAuth.to_string(), "OAuth");
-        assert_eq!(AuthMethod::ApiKey.to_string(), "API Key");
-        assert_eq!(AuthMethod::EnvVar.to_string(), "Env");
     }
 
     #[test]

--- a/src/domain/chat.rs
+++ b/src/domain/chat.rs
@@ -1,6 +1,15 @@
 use crate::domain::tool::ToolDetail;
 
-pub const OUTCOME_BULLET: &str = "\u{25B8} ";
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ElicitationResponseOutcome {
+    Selected(Vec<String>),
+    Text(String),
+    Boolean(bool),
+    Declined,
+    Cancelled,
+    UnsupportedSchema,
+    Responded,
+}
 
 #[derive(Debug, Clone)]
 pub enum ChatEntry {
@@ -37,55 +46,40 @@ pub enum ChatEntry {
         elicitation_id: String,
         message: String,
         source: String,
-        /// None = pending; Some = responded with this outcome label.
-        outcome: Option<String>,
+        /// None is pending; Some records the semantic response state.
+        outcome: Option<ElicitationResponseOutcome>,
     },
-}
-
-pub fn format_outcome_label(label: &str) -> String {
-    let mut formatted = String::with_capacity(OUTCOME_BULLET.len() + label.len());
-    formatted.push_str(OUTCOME_BULLET);
-    formatted.push_str(label);
-    formatted
-}
-
-pub fn format_outcome_labels<'a>(labels: impl IntoIterator<Item = &'a str>) -> String {
-    let mut labels = labels.into_iter();
-    let Some(first) = labels.next() else {
-        return String::new();
-    };
-
-    let mut formatted = format_outcome_label(first);
-    for label in labels {
-        formatted.push('\n');
-        formatted.push_str(OUTCOME_BULLET);
-        formatted.push_str(label);
-    }
-    formatted
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{OUTCOME_BULLET, format_outcome_label, format_outcome_labels};
+    use super::ElicitationResponseOutcome;
 
     #[test]
-    fn format_outcome_label_prefixes_single_label() {
-        assert_eq!(
-            format_outcome_label("Beta"),
-            format!("{OUTCOME_BULLET}Beta")
+    fn elicitation_response_outcomes_preserve_semantic_payloads_and_states() {
+        let selected = ElicitationResponseOutcome::Selected(vec!["Alpha".into(), "Beta".into()]);
+        assert!(matches!(
+            selected,
+            ElicitationResponseOutcome::Selected(labels)
+                if labels == ["Alpha".to_string(), "Beta".to_string()]
+        ));
+
+        let text = ElicitationResponseOutcome::Text("line one\nline two".into());
+        assert!(matches!(
+            text,
+            ElicitationResponseOutcome::Text(value) if value == "line one\nline two"
+        ));
+        assert_ne!(
+            ElicitationResponseOutcome::Boolean(true),
+            ElicitationResponseOutcome::Boolean(false),
         );
-    }
-
-    #[test]
-    fn format_outcome_labels_joins_multiple_labels_with_newlines() {
-        assert_eq!(
-            format_outcome_labels(["Alpha", "Beta", "Gamma"]),
-            format!("{OUTCOME_BULLET}Alpha\n{OUTCOME_BULLET}Beta\n{OUTCOME_BULLET}Gamma"),
+        assert_ne!(
+            ElicitationResponseOutcome::Declined,
+            ElicitationResponseOutcome::Cancelled,
         );
-    }
-
-    #[test]
-    fn format_outcome_labels_returns_empty_for_no_labels() {
-        assert!(format_outcome_labels(std::iter::empty()).is_empty());
+        assert_ne!(
+            ElicitationResponseOutcome::UnsupportedSchema,
+            ElicitationResponseOutcome::Responded,
+        );
     }
 }

--- a/src/domain/tool.rs
+++ b/src/domain/tool.rs
@@ -1,46 +1,67 @@
-#[derive(Debug, Clone)]
-pub struct DiffPreviewSection {
-    pub header: String,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShellOutput {
+    pub stdout: String,
+    pub stderr: String,
+    /// Number of nonblank output lines omitted before this captured output.
+    pub preceding_line_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MultiEditSection {
+    pub edit_index: usize,
+    pub replace_all: bool,
     pub old: String,
     pub new: String,
     pub start_line: Option<usize>,
 }
 
-#[derive(Debug, Clone)]
-pub struct ShellOutputTail {
-    pub lines: Vec<String>,
-    pub hidden_line_count: usize,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SymbolReplacement {
+    pub path: String,
+    pub symbol: String,
+    pub new_text: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SymbolDiffSection {
+    pub path: String,
+    pub symbol: String,
+    pub old: String,
+    pub new: String,
+    pub start_line: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TodoItem {
+    pub content: String,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SearchResultCounts {
+    pub files: usize,
+    pub matches: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexMetadata {
+    pub language: String,
+    pub imports: usize,
+    pub functions: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ToolDetail {
     None,
-    /// Compact one-liner info for display after the tool name.
-    Summary(String),
-    /// One-liner header with output displayed below it.
-    SummaryWithOutput {
-        header: String,
-        output: String,
-    },
-    Edit {
-        file: String,
-        old: String,
-        new: String,
-        start_line: Option<usize>,
-    },
-    MultiEdit {
-        file: String,
-        edit_count: usize,
-        sections: Vec<DiffPreviewSection>,
-    },
-    ReplaceSymbol {
-        title: String,
-        sections: Vec<DiffPreviewSection>,
+    Generic {
+        input: Option<String>,
+        result: Option<String>,
     },
     Shell {
         command: String,
+        arguments: Vec<String>,
         workdir: Option<String>,
-        output_tail: Option<ShellOutputTail>,
+        output: Option<ShellOutput>,
     },
     ReadTool {
         path: String,
@@ -50,5 +71,64 @@ pub enum ToolDetail {
     WriteFile {
         path: String,
         content: String,
+    },
+    Edit {
+        file: String,
+        old: String,
+        new: String,
+        replace_all: bool,
+        start_line: Option<usize>,
+    },
+    MultiEdit {
+        file: String,
+        edit_count: usize,
+        sections: Vec<MultiEditSection>,
+    },
+    ReplaceSymbolInput {
+        replacements: Vec<SymbolReplacement>,
+    },
+    ReplaceSymbolDiff {
+        replacements: Vec<SymbolReplacement>,
+        sections: Vec<SymbolDiffSection>,
+    },
+    SearchText {
+        pattern: String,
+        path: String,
+        include: String,
+        counts: Option<SearchResultCounts>,
+    },
+    Glob {
+        pattern: String,
+        path: String,
+    },
+    List {
+        path: String,
+    },
+    Index {
+        path: String,
+        metadata: Option<IndexMetadata>,
+    },
+    DeleteFile {
+        path: String,
+    },
+    Browse {
+        url: String,
+    },
+    Todo {
+        items: Vec<TodoItem>,
+    },
+    Delegate {
+        target_agent_id: String,
+        objective: String,
+    },
+    LanguageQuery {
+        action: String,
+        uri: String,
+    },
+    Question {
+        prompt: String,
+    },
+    ApplyPatch {
+        patch: String,
     },
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -10,9 +10,6 @@ use crate::navigation_state::{CommandPaletteAction, Popup, Screen};
 use crate::render_state::RenderChange;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 
-fn popup_page_step(visible_rows: usize) -> usize {
-    visible_rows.saturating_sub(1).max(1)
-}
 use crate::command::{Command, PromptBlock};
 use crate::connection_state::ConnState;
 use crate::theme;
@@ -868,11 +865,11 @@ pub(crate) fn apply_popup_session_key(
         KeyCode::Up => app.sessions.move_popup_cursor_up(),
         KeyCode::Down => app.sessions.move_popup_cursor_down(),
         KeyCode::PageUp => {
-            let step = popup_page_step(app.sessions.session_popup_visible_rows);
+            let step = app.render.session_popup_page_step();
             app.sessions.move_popup_cursor_page(step, false);
         }
         KeyCode::PageDown => {
-            let step = popup_page_step(app.sessions.session_popup_visible_rows);
+            let step = app.render.session_popup_page_step();
             app.sessions.move_popup_cursor_page(step, true);
         }
         KeyCode::Enter => {
@@ -1053,8 +1050,14 @@ pub(crate) fn apply_delegate_popup_key(
         }
         KeyCode::Up => app.delegates.move_cursor_up(),
         KeyCode::Down => app.delegates.move_cursor_down(),
-        KeyCode::PageUp => app.delegates.move_cursor_page(false),
-        KeyCode::PageDown => app.delegates.move_cursor_page(true),
+        KeyCode::PageUp => {
+            let step = app.render.delegate_popup_page_step();
+            app.delegates.move_cursor_page(step, false);
+        }
+        KeyCode::PageDown => {
+            let step = app.render.delegate_popup_page_step();
+            app.delegates.move_cursor_page(step, true);
+        }
         KeyCode::Enter => {
             let selected = app.delegates.selected_entry().map(|entry| {
                 (
@@ -2149,7 +2152,11 @@ pub(crate) fn apply_sessions_key(
     use crate::session_state::StartPageItem;
 
     match key {
-        KeyCode::Up => app.sessions.move_start_cursor_up(),
+        KeyCode::Up => {
+            app.sessions.move_start_cursor_up();
+            app.render
+                .keep_start_page_cursor_visible_from_above(app.sessions.session_cursor);
+        }
         KeyCode::Down => app.sessions.move_start_cursor_down(),
         KeyCode::Enter => {
             let items = app.sessions.visible_start_items();
@@ -2226,8 +2233,14 @@ pub(crate) fn apply_sessions_key(
             }
             // Delete on a GroupHeader: no-op
         }
-        KeyCode::Backspace => app.sessions.start_filter_backspace(),
-        KeyCode::Char(c) => app.sessions.start_filter_insert(c),
+        KeyCode::Backspace => {
+            app.sessions.start_filter_backspace();
+            app.render.reset_start_page_scroll();
+        }
+        KeyCode::Char(c) => {
+            app.sessions.start_filter_insert(c);
+            app.render.reset_start_page_scroll();
+        }
         _ => {}
     }
     SessionKeyAction::None

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -63,6 +63,7 @@ pub(crate) fn handle_elicitation_key(app: &mut App, key: KeyEvent) -> Vec<Effect
     use crate::domain::elicitation::ElicitationFieldKind;
 
     let mut effects = Vec::new();
+    let custom_line_width = app.render.elicitation_custom_line_width();
     let (Some(state), Some(ui)) = (
         app.chat.elicitation.as_mut(),
         app.chat.elicitation_ui.as_mut(),
@@ -120,7 +121,7 @@ pub(crate) fn handle_elicitation_key(app: &mut App, key: KeyEvent) -> Vec<Effect
         match key.code {
             KeyCode::Esc => {
                 ui.custom_active = false;
-                ui.custom_scroll = 0;
+                app.render.reset_elicitation_custom_scroll();
             }
             KeyCode::Enter if key.modifiers.contains(KeyModifiers::SHIFT) => {
                 ui.custom_insert(&mut state.custom_input, '\n');
@@ -145,8 +146,8 @@ pub(crate) fn handle_elicitation_key(app: &mut App, key: KeyEvent) -> Vec<Effect
             KeyCode::Right => ui.custom_right(&state.custom_input),
             KeyCode::Home => ui.custom_home(&state.custom_input),
             KeyCode::End => ui.custom_end(&state.custom_input),
-            KeyCode::Up => ui.custom_move_visual(&state.custom_input, -1),
-            KeyCode::Down => ui.custom_move_visual(&state.custom_input, 1),
+            KeyCode::Up => ui.custom_move_visual(&state.custom_input, custom_line_width, -1),
+            KeyCode::Down => ui.custom_move_visual(&state.custom_input, custom_line_width, 1),
             _ => {}
         }
         return effects;
@@ -482,6 +483,7 @@ pub(crate) fn handle_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
     if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
         if !app.composer.input.is_empty() {
             app.composer.clear_input();
+            app.render.reset_composer_input_geometry();
             return Vec::new();
         }
         return vec![Effect::Quit];
@@ -695,6 +697,7 @@ pub(crate) fn handle_chord(app: &mut App, key: KeyEvent) -> Vec<Effect> {
             } else if let Some(turn) = app.chat.current_undo_target().cloned() {
                 if app.composer.input.trim().is_empty() && !turn.text.is_empty() {
                     app.composer.replace_input(turn.text.clone());
+                    app.render.reset_composer_input_geometry();
                 }
                 app.chat.push_pending_undo(&turn);
                 app.chat.activity = ActivityState::SessionOp(SessionOp::Undo);
@@ -1300,9 +1303,6 @@ pub(crate) fn handle_theme_popup_key(app: &mut App, key: KeyEvent) -> Vec<Effect
 }
 
 pub(crate) fn handle_chat_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
-    if app.composer.input_line_width == 0 {
-        app.composer.input_line_width = 1;
-    }
     let input_blocked = app.chat.input_blocked_by_activity();
     let mut effects = Vec::new();
     match key.code {
@@ -1395,7 +1395,8 @@ pub(crate) fn handle_chat_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
             } else if app.composer.mention_state.is_some() {
                 app.composer.move_mention_selection(-1);
             } else {
-                app.composer.input_up_visual(2);
+                let line_width = app.render.composer_input_line_width();
+                app.composer.input_up_visual(line_width, 2);
             }
         }
         KeyCode::Down => {
@@ -1407,7 +1408,8 @@ pub(crate) fn handle_chat_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
             } else if app.composer.mention_state.is_some() {
                 app.composer.move_mention_selection(1);
             } else {
-                app.composer.input_down_visual(2);
+                let line_width = app.render.composer_input_line_width();
+                app.composer.input_down_visual(line_width, 2);
             }
         }
         KeyCode::PageUp => app.render.scroll_chat_up(10),
@@ -1694,6 +1696,7 @@ fn try_execute_slash_command(app: &mut App) -> (SlashResult, Vec<Effect>) {
             } else if let Some(turn) = app.chat.current_undo_target().cloned() {
                 if app.composer.input.trim().is_empty() && !turn.text.is_empty() {
                     app.composer.replace_input(turn.text.clone());
+                    app.render.reset_composer_input_geometry();
                 }
                 app.chat.push_pending_undo(&turn);
                 app.chat.activity = ActivityState::SessionOp(SessionOp::Undo);
@@ -2241,7 +2244,7 @@ mod model_popup_tests {
     use crate::domain::chat::ChatEntry;
     use crate::domain::model::ModelEntry;
     use crate::domain::profile::{AgentInfo, ProfileInfo};
-    use crate::domain::session::{SessionGroup, SessionSummary};
+    use crate::domain::session::{SessionGroup, SessionSummary, UndoableTurn};
     use crate::runtime::TestEffects;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
@@ -2272,11 +2275,13 @@ mod model_popup_tests {
         let mut app = App::new();
         app.connection.conn = ConnState::Connected;
         app.composer.replace_input(" hello ".into());
+        app.render.test_seed_composer_input_geometry(24, 2);
         app.render.set_chat_scroll_offset(9);
 
         effects.extend(handle_chat_key(&mut app, key(KeyCode::Enter)));
 
         assert!(app.composer.input.is_empty());
+        assert_eq!(app.render.test_composer_input_geometry(), (1, 0, false));
         assert_eq!(app.render.chat_scroll_offset(), 0);
         let local_id = match app.chat.messages.as_slice() {
             [
@@ -2300,6 +2305,7 @@ mod model_popup_tests {
         let mut app = App::new();
         app.connection.conn = ConnState::Connected;
         app.composer.replace_input("   ".into());
+        app.render.test_seed_composer_input_geometry(18, 1);
         app.render.set_chat_scroll_offset(9);
 
         let effects = handle_chat_key(&mut app, key(KeyCode::Enter));
@@ -2307,6 +2313,7 @@ mod model_popup_tests {
         assert!(effects.is_empty());
         assert!(app.composer.input.is_empty());
         assert!(app.chat.messages.is_empty());
+        assert_eq!(app.render.test_composer_input_geometry(), (1, 0, false));
         assert_eq!(app.render.chat_scroll_offset(), 0);
     }
 
@@ -2362,7 +2369,7 @@ mod model_popup_tests {
         let mut app = App::new();
         app.composer.input = "draft".into();
         app.composer.input_cursor = 3;
-        app.composer.input_scroll = 2;
+        app.render.test_seed_composer_input_geometry(20, 2);
         app.composer.input_preferred_col = Some(4);
         app.composer.refresh_mention_state();
         app.composer.input = "/mo".into();
@@ -2372,11 +2379,51 @@ mod model_popup_tests {
 
         assert_eq!(app.take_input(), "/mo");
         assert_eq!(app.composer.input_cursor, 0);
-        assert_eq!(app.composer.input_scroll, 0);
+        assert_eq!(app.render.test_composer_input_geometry(), (1, 0, false));
         assert_eq!(app.composer.input_preferred_col, None);
         assert!(app.composer.mention_state.is_none());
         assert!(app.composer.slash_state.is_none());
         assert_eq!(app.render.chat_scroll_offset(), 0);
+    }
+
+    #[test]
+    fn chord_and_slash_undo_replacements_reset_render_geometry() {
+        let turn = UndoableTurn {
+            turn_id: "turn-1".into(),
+            message_id: "message-1".into(),
+            text: "restored prompt".into(),
+        };
+
+        let mut chord_app = App::new();
+        chord_app.connection.conn = ConnState::Connected;
+        chord_app.chat.undoable_turns.push(turn.clone());
+        chord_app.render.test_seed_composer_input_geometry(25, 2);
+        let effects = handle_chord(&mut chord_app, key(KeyCode::Char('u')));
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::Command(Command::Undo { message_id })] if message_id == "message-1"
+        ));
+        assert_eq!(chord_app.composer.input, "restored prompt");
+        assert_eq!(
+            chord_app.render.test_composer_input_geometry(),
+            (1, 0, false)
+        );
+
+        let mut slash_app = App::new();
+        slash_app.connection.conn = ConnState::Connected;
+        slash_app.chat.undoable_turns.push(turn);
+        slash_app.composer.replace_input("/undo".into());
+        slash_app.render.test_seed_composer_input_geometry(31, 3);
+        let effects = handle_chat_key(&mut slash_app, key(KeyCode::Enter));
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::Command(Command::Undo { message_id })] if message_id == "message-1"
+        ));
+        assert_eq!(slash_app.composer.input, "restored prompt");
+        assert_eq!(
+            slash_app.render.test_composer_input_geometry(),
+            (1, 0, false)
+        );
     }
 
     #[test]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -603,10 +603,10 @@ pub(crate) fn handle_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
 pub(crate) fn handle_mouse(app: &mut App, mouse: MouseEvent) -> Vec<Effect> {
     match (mouse.kind, &app.navigation.screen, &app.navigation.popup) {
         (MouseEventKind::ScrollUp, Screen::Chat | Screen::Delegate, Popup::None) => {
-            app.chat.scroll_offset = app.chat.scroll_offset.saturating_add(3);
+            app.render.scroll_chat_up(3);
         }
         (MouseEventKind::ScrollDown, Screen::Chat | Screen::Delegate, Popup::None) => {
-            app.chat.scroll_offset = app.chat.scroll_offset.saturating_sub(3);
+            app.render.scroll_chat_down(3);
         }
         _ => {}
     }
@@ -1001,12 +1001,12 @@ pub(crate) fn apply_session_fork_toggle_key(app: &mut App, popup_items: bool) ->
 
 fn handle_delegate_view_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
     match key.code {
-        KeyCode::Up => app.chat.scroll_offset = app.chat.scroll_offset.saturating_add(1),
-        KeyCode::Down => app.chat.scroll_offset = app.chat.scroll_offset.saturating_sub(1),
-        KeyCode::PageUp => app.chat.scroll_offset = app.chat.scroll_offset.saturating_add(10),
-        KeyCode::PageDown => app.chat.scroll_offset = app.chat.scroll_offset.saturating_sub(10),
-        KeyCode::Home => app.chat.scroll_offset = u16::MAX,
-        KeyCode::End => app.chat.scroll_offset = 0,
+        KeyCode::Up => app.render.scroll_chat_up(1),
+        KeyCode::Down => app.render.scroll_chat_down(1),
+        KeyCode::PageUp => app.render.scroll_chat_up(10),
+        KeyCode::PageDown => app.render.scroll_chat_down(10),
+        KeyCode::Home => app.render.scroll_chat_to_top(),
+        KeyCode::End => app.render.scroll_chat_to_bottom(),
         KeyCode::Esc => {
             if let Some(parent_sid) = app.delegates.parent_session_id.clone() {
                 return send_load_session_commands(
@@ -1410,8 +1410,8 @@ pub(crate) fn handle_chat_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
                 app.composer.input_down_visual(2);
             }
         }
-        KeyCode::PageUp => app.chat.scroll_offset = app.chat.scroll_offset.saturating_add(10),
-        KeyCode::PageDown => app.chat.scroll_offset = app.chat.scroll_offset.saturating_sub(10),
+        KeyCode::PageUp => app.render.scroll_chat_up(10),
+        KeyCode::PageDown => app.render.scroll_chat_down(10),
         KeyCode::Backspace if !input_blocked => app.composer.input_backspace(),
         KeyCode::Delete if !input_blocked => app.composer.input_delete(),
         KeyCode::Left if !input_blocked => app.composer.input_left(),
@@ -1419,7 +1419,7 @@ pub(crate) fn handle_chat_key(app: &mut App, key: KeyEvent) -> Vec<Effect> {
         KeyCode::Home if !input_blocked => app.composer.input_home(),
         KeyCode::End => {
             if input_blocked || app.composer.input.is_empty() {
-                app.chat.scroll_offset = 0;
+                app.render.scroll_chat_to_bottom();
             } else {
                 app.composer.input_end();
             }
@@ -2272,10 +2272,12 @@ mod model_popup_tests {
         let mut app = App::new();
         app.connection.conn = ConnState::Connected;
         app.composer.replace_input(" hello ".into());
+        app.render.set_chat_scroll_offset(9);
 
         effects.extend(handle_chat_key(&mut app, key(KeyCode::Enter)));
 
         assert!(app.composer.input.is_empty());
+        assert_eq!(app.render.chat_scroll_offset(), 0);
         let local_id = match app.chat.messages.as_slice() {
             [
                 ChatEntry::User {
@@ -2290,6 +2292,36 @@ mod model_popup_tests {
             Some(Command::Prompt { prompt, local_id: sent_id })
                 if sent_id == local_id
                     && matches!(prompt.as_slice(), [PromptBlock::Text { text }] if text == "hello")
+        ));
+    }
+
+    #[test]
+    fn whitespace_prompt_early_return_still_snaps_chat_to_bottom() {
+        let mut app = App::new();
+        app.connection.conn = ConnState::Connected;
+        app.composer.replace_input("   ".into());
+        app.render.set_chat_scroll_offset(9);
+
+        let effects = handle_chat_key(&mut app, key(KeyCode::Enter));
+
+        assert!(effects.is_empty());
+        assert!(app.composer.input.is_empty());
+        assert!(app.chat.messages.is_empty());
+        assert_eq!(app.render.chat_scroll_offset(), 0);
+    }
+
+    #[test]
+    fn optimistic_prompt_insertion_snaps_chat_to_bottom() {
+        let mut app = App::new();
+        app.render.set_chat_scroll_offset(9);
+
+        let local_id = app.push_pending_prompt("hello".into());
+
+        assert_eq!(app.render.chat_scroll_offset(), 0);
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::User { text, message_id: Some(message_id) }]
+                if text == "hello" && message_id == &local_id
         ));
     }
 
@@ -2336,7 +2368,7 @@ mod model_popup_tests {
         app.composer.input = "/mo".into();
         app.composer.input_cursor = 3;
         app.composer.refresh_slash_state();
-        app.chat.scroll_offset = 7;
+        app.render.set_chat_scroll_offset(7);
 
         assert_eq!(app.take_input(), "/mo");
         assert_eq!(app.composer.input_cursor, 0);
@@ -2344,7 +2376,7 @@ mod model_popup_tests {
         assert_eq!(app.composer.input_preferred_col, None);
         assert!(app.composer.mention_state.is_none());
         assert!(app.composer.slash_state.is_none());
-        assert_eq!(app.chat.scroll_offset, 0);
+        assert_eq!(app.render.chat_scroll_offset(), 0);
     }
 
     #[test]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -4,7 +4,7 @@ use crate::auth_state::AuthPanel;
 use crate::diagnostics::LogLevel;
 use crate::domain::activity::{ActivityState, SessionOp};
 use crate::domain::auth::{OAuthFlowKind, OAuthStatus};
-use crate::domain::chat::format_outcome_labels;
+use crate::domain::chat::ElicitationResponseOutcome;
 use crate::domain::model::ModelEntry;
 use crate::navigation_state::{CommandPaletteAction, Popup, Screen};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
@@ -44,7 +44,7 @@ fn elicitation_response_effect(
     elicitation_id: String,
     action: &str,
     content: Option<serde_json::Value>,
-    outcome: String,
+    outcome: ElicitationResponseOutcome,
 ) -> Effect {
     Effect::ElicitationResponse {
         elicitation_id,
@@ -72,43 +72,46 @@ pub(crate) fn handle_elicitation_key(app: &mut App, key: KeyEvent) -> Vec<Effect
         return effects;
     };
 
-    let selected_display = |state: &crate::domain::elicitation::ElicitationState,
+    let selected_outcome = |state: &crate::domain::elicitation::ElicitationState,
                             custom_active: bool| {
         let field = &state.fields[field_index];
         if custom_active {
-            return format_outcome_labels([state.custom_input.trim()]);
+            return ElicitationResponseOutcome::Selected(vec![
+                state.custom_input.trim().to_string(),
+            ]);
         }
         match &field.kind {
-            ElicitationFieldKind::SingleSelect { options } => options
-                .iter()
-                .find(|option| state.selected.get(&field.name) == Some(&option.value))
-                .map(|option| format_outcome_labels([option.label.as_str()]))
-                .unwrap_or_default(),
-            ElicitationFieldKind::MultiSelect { options } => state
-                .selected
-                .get(&field.name)
-                .and_then(serde_json::Value::as_array)
-                .map(|values| {
-                    format_outcome_labels(
+            ElicitationFieldKind::SingleSelect { options } => ElicitationResponseOutcome::Selected(
+                options
+                    .iter()
+                    .find(|option| state.selected.get(&field.name) == Some(&option.value))
+                    .map(|option| vec![option.label.clone()])
+                    .unwrap_or_default(),
+            ),
+            ElicitationFieldKind::MultiSelect { options } => {
+                let labels = state
+                    .selected
+                    .get(&field.name)
+                    .and_then(serde_json::Value::as_array)
+                    .map(|values| {
                         options
                             .iter()
                             .filter(|option| values.contains(&option.value))
-                            .map(|option| option.label.as_str()),
-                    )
-                })
-                .unwrap_or_default(),
-            ElicitationFieldKind::TextInput | ElicitationFieldKind::NumberInput { .. } => {
-                state.text_input.clone()
+                            .map(|option| option.label.clone())
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                ElicitationResponseOutcome::Selected(labels)
             }
-            ElicitationFieldKind::BooleanToggle => match state
+            ElicitationFieldKind::TextInput | ElicitationFieldKind::NumberInput { .. } => {
+                ElicitationResponseOutcome::Text(state.text_input.clone())
+            }
+            ElicitationFieldKind::BooleanToggle => state
                 .selected
                 .get(&field.name)
                 .and_then(serde_json::Value::as_bool)
-            {
-                Some(true) => "Yes".into(),
-                Some(false) => "No".into(),
-                None => String::new(),
-            },
+                .map(ElicitationResponseOutcome::Boolean)
+                .unwrap_or_else(|| ElicitationResponseOutcome::Text(String::new())),
         }
     };
 
@@ -124,12 +127,12 @@ pub(crate) fn handle_elicitation_key(app: &mut App, key: KeyEvent) -> Vec<Effect
             KeyCode::Enter if state.is_valid(Some(&state.custom_input)) => {
                 let elicitation_id = state.elicitation_id.clone();
                 let content = state.build_accept_content(Some(&state.custom_input));
-                let display = selected_display(state, true);
+                let outcome = selected_outcome(state, true);
                 effects.push(elicitation_response_effect(
                     elicitation_id,
                     "accept",
                     Some(content),
-                    display,
+                    outcome,
                 ));
             }
             KeyCode::Char(character) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -164,7 +167,7 @@ pub(crate) fn handle_elicitation_key(app: &mut App, key: KeyEvent) -> Vec<Effect
                 elicitation_id,
                 "decline",
                 None,
-                "declined".into(),
+                ElicitationResponseOutcome::Declined,
             ));
         }
         KeyCode::Down => {
@@ -206,12 +209,12 @@ pub(crate) fn handle_elicitation_key(app: &mut App, key: KeyEvent) -> Vec<Effect
             if state.is_valid(None) {
                 let elicitation_id = state.elicitation_id.clone();
                 let content = state.build_accept_content(None);
-                let display = selected_display(state, false);
+                let outcome = selected_outcome(state, false);
                 effects.push(elicitation_response_effect(
                     elicitation_id,
                     "accept",
                     Some(content),
-                    display,
+                    outcome,
                 ));
             }
         }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -7,6 +7,7 @@ use crate::domain::auth::{OAuthFlowKind, OAuthStatus};
 use crate::domain::chat::ElicitationResponseOutcome;
 use crate::domain::model::ModelEntry;
 use crate::navigation_state::{CommandPaletteAction, Popup, Screen};
+use crate::render_state::RenderChange;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 
 fn popup_page_step(visible_rows: usize) -> usize {
@@ -1284,7 +1285,7 @@ pub(crate) fn handle_theme_popup_key(app: &mut App, key: KeyEvent) -> Vec<Effect
             {
                 theme::Theme::set_by_index(idx);
                 theme::Theme::begin_frame();
-                app.render.invalidate_theme_caches();
+                app.render.apply_change(RenderChange::ThemeChanged);
                 app.navigation.popup = Popup::None;
                 return vec![Effect::PersistConfig];
             }

--- a/src/input_layout.rs
+++ b/src/input_layout.rs
@@ -1,0 +1,250 @@
+use unicode_width::UnicodeWidthChar;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InputVisualRow {
+    pub(crate) text: String,
+    pub(crate) start: usize,
+    pub(crate) end: usize,
+    pub(crate) columns: Vec<(usize, usize)>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InputVisualLayout {
+    pub(crate) rows: Vec<InputVisualRow>,
+    pub(crate) cursor_row: usize,
+    pub(crate) cursor_col: usize,
+    pub(crate) cursor_text_col: usize,
+}
+
+impl InputVisualLayout {
+    pub(crate) fn total_rows(&self) -> usize {
+        self.rows.len()
+    }
+
+    pub(crate) fn cursor_offset_for_row_col(&self, row: usize, preferred_col: usize) -> usize {
+        let Some(row) = self.rows.get(row) else {
+            return 0;
+        };
+        let mut best = row.end;
+        for (col, offset) in &row.columns {
+            if *col <= preferred_col {
+                best = *offset;
+            } else {
+                break;
+            }
+        }
+        best
+    }
+}
+
+pub(crate) fn build_input_visual_layout(
+    input: &str,
+    input_cursor: usize,
+    line_width: usize,
+    prefix_width: usize,
+) -> InputVisualLayout {
+    let line_width = line_width.max(1);
+    let mut rows: Vec<InputVisualRow> = Vec::new();
+    let mut row_text = String::new();
+    let mut row_columns = vec![(0usize, 0usize)];
+    let mut row_start = 0usize;
+    let mut row_end = 0usize;
+    let mut col = prefix_width;
+    let mut text_col = 0usize;
+    let mut cursor_row = 0usize;
+    let mut cursor_col = prefix_width;
+    let mut cursor_text_col = 0usize;
+    let mut cursor_found = input_cursor == 0;
+
+    let row_prefix_width = |rows_len: usize| if rows_len == 0 { prefix_width } else { 0 };
+
+    if cursor_found {
+        cursor_row = 0;
+        cursor_col = prefix_width;
+        cursor_text_col = 0;
+    }
+
+    let finish_row = |rows: &mut Vec<InputVisualRow>,
+                      row_text: &mut String,
+                      row_columns: &mut Vec<(usize, usize)>,
+                      row_start: &mut usize,
+                      row_end: &mut usize,
+                      next_start: usize| {
+        rows.push(InputVisualRow {
+            text: std::mem::take(row_text),
+            start: *row_start,
+            end: *row_end,
+            columns: std::mem::take(row_columns),
+        });
+        *row_columns = vec![(0, next_start)];
+        *row_start = next_start;
+        *row_end = next_start;
+    };
+
+    for (byte_idx, ch) in input.char_indices() {
+        if !cursor_found && byte_idx == input_cursor {
+            cursor_row = rows.len();
+            cursor_col = col;
+            cursor_text_col = text_col;
+            cursor_found = true;
+        }
+
+        if ch == '\n' {
+            row_end = byte_idx;
+            finish_row(
+                &mut rows,
+                &mut row_text,
+                &mut row_columns,
+                &mut row_start,
+                &mut row_end,
+                byte_idx + ch.len_utf8(),
+            );
+            col = row_prefix_width(rows.len());
+            text_col = 0;
+            continue;
+        }
+
+        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if ch_width > 0 && col + ch_width > line_width {
+            finish_row(
+                &mut rows,
+                &mut row_text,
+                &mut row_columns,
+                &mut row_start,
+                &mut row_end,
+                byte_idx,
+            );
+            col = row_prefix_width(rows.len());
+            text_col = 0;
+            if !cursor_found && byte_idx == input_cursor {
+                cursor_row = rows.len();
+                cursor_col = col;
+                cursor_text_col = 0;
+                cursor_found = true;
+            }
+        }
+
+        row_text.push(ch);
+        col += ch_width;
+        text_col += ch_width;
+        row_end = byte_idx + ch.len_utf8();
+        row_columns.push((text_col, row_end));
+    }
+
+    if !cursor_found && input_cursor == input.len() {
+        cursor_row = rows.len();
+        cursor_col = col;
+        cursor_text_col = text_col;
+    }
+
+    rows.push(InputVisualRow {
+        text: row_text,
+        start: row_start,
+        end: row_end,
+        columns: row_columns,
+    });
+
+    InputVisualLayout {
+        rows,
+        cursor_row,
+        cursor_col,
+        cursor_text_col,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row_texts(layout: &InputVisualLayout) -> Vec<&str> {
+        layout.rows.iter().map(|row| row.text.as_str()).collect()
+    }
+
+    #[test]
+    fn unicode_widths_combining_scalars_and_utf8_cursor_offsets_are_preserved() {
+        let input = "a界e\u{301}b";
+        let cursor = "a界e\u{301}".len();
+        let layout = build_input_visual_layout(input, cursor, 4, 1);
+
+        assert_eq!(row_texts(&layout), vec!["a界", "e\u{301}b"]);
+        assert_eq!((layout.cursor_row, layout.cursor_col), (1, 1));
+        assert_eq!(layout.cursor_text_col, 1);
+        assert_eq!(
+            layout.rows[1].columns,
+            vec![(0, "a界".len()), (1, 5), (1, cursor), (2, input.len())]
+        );
+    }
+
+    #[test]
+    fn hard_consecutive_and_trailing_newlines_keep_empty_rows_and_byte_boundaries() {
+        let input = "a\n\n";
+        let on_first_newline = build_input_visual_layout(input, 1, 8, 2);
+        let after_first_newline = build_input_visual_layout(input, 2, 8, 2);
+        let at_end = build_input_visual_layout(input, input.len(), 8, 2);
+
+        assert_eq!(row_texts(&at_end), vec!["a", "", ""]);
+        assert_eq!(
+            (on_first_newline.cursor_row, on_first_newline.cursor_col),
+            (0, 3)
+        );
+        assert_eq!(
+            (
+                after_first_newline.cursor_row,
+                after_first_newline.cursor_col
+            ),
+            (1, 0)
+        );
+        assert_eq!((at_end.cursor_row, at_end.cursor_col), (2, 0));
+        assert_eq!((at_end.rows[2].start, at_end.rows[2].end), (3, 3));
+    }
+
+    #[test]
+    fn cursor_at_wrap_trigger_stays_on_previous_row_end() {
+        let layout = build_input_visual_layout("abcd", 2, 4, 2);
+
+        assert_eq!(row_texts(&layout), vec!["ab", "cd"]);
+        assert_eq!((layout.cursor_row, layout.cursor_col), (0, 4));
+        assert_eq!(layout.cursor_text_col, 2);
+    }
+
+    #[test]
+    fn zero_and_one_width_preserve_prefix_only_first_row() {
+        for width in [0, 1] {
+            let layout = build_input_visual_layout("a", 1, width, 2);
+            assert_eq!(row_texts(&layout), vec!["", "a"]);
+            assert_eq!((layout.cursor_row, layout.cursor_col), (1, 1));
+            assert_eq!((layout.rows[0].start, layout.rows[0].end), (0, 0));
+        }
+    }
+
+    #[test]
+    fn character_wider_than_line_wraps_once_then_is_inserted() {
+        let layout = build_input_visual_layout("界", "界".len(), 1, 0);
+
+        assert_eq!(row_texts(&layout), vec!["", "界"]);
+        assert_eq!((layout.cursor_row, layout.cursor_col), (1, 2));
+    }
+
+    #[test]
+    fn empty_input_always_returns_one_prefixed_row() {
+        let layout = build_input_visual_layout("", 0, 0, 2);
+
+        assert_eq!(layout.total_rows(), 1);
+        assert_eq!(row_texts(&layout), vec![""]);
+        assert_eq!((layout.cursor_row, layout.cursor_col), (0, 2));
+    }
+
+    #[test]
+    fn target_column_uses_last_display_column_not_exceeding_preference() {
+        let layout = build_input_visual_layout("a界b", 0, 20, 2);
+
+        assert_eq!(layout.cursor_offset_for_row_col(0, 0), 0);
+        assert_eq!(layout.cursor_offset_for_row_col(0, 2), 1);
+        assert_eq!(layout.cursor_offset_for_row_col(0, 3), "a界".len());
+        assert_eq!(
+            layout.cursor_offset_for_row_col(0, usize::MAX),
+            "a界b".len()
+        );
+        assert_eq!(layout.cursor_offset_for_row_col(1, 0), 0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ mod diagnostics;
 mod domain;
 mod handlers;
 mod highlight;
+mod input_layout;
 mod markdown;
 mod mesh;
 mod mesh_state;

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -6,7 +6,9 @@ use ratatui::{
 
 use crate::highlight::Highlighter;
 use crate::theme::Theme;
-use crate::ui::{MD_BULLET, MD_HRULE_CHAR};
+
+pub(crate) const MD_HRULE_CHAR: &str = "\u{2500}";
+pub(crate) const MD_BULLET: &str = "\u{2022} ";
 
 /// A block inside a card — either plain text or a deferred table.
 #[derive(Clone)]

--- a/src/render_state.rs
+++ b/src/render_state.rs
@@ -858,6 +858,12 @@ impl StreamingCache {
     }
 }
 
+#[derive(Default)]
+struct ChatViewportState {
+    scroll_offset: u16,
+    previous_total_height: u16,
+}
+
 /// Owner for render-local cards, caches, identity, and viewport accounting.
 pub(crate) struct RenderState {
     highlighter: Highlighter,
@@ -866,7 +872,7 @@ pub(crate) struct RenderState {
     streaming_thinking_cache: StreamingCache,
     session_identity: Option<SessionIdentity>,
     session_epoch: u64,
-    pub(crate) prev_total_height: u16,
+    chat_viewport: ChatViewportState,
     pub(crate) tick: u64,
     #[cfg(test)]
     invalidation_order: Vec<CacheInvalidation>,
@@ -889,7 +895,7 @@ impl RenderState {
             streaming_thinking_cache: StreamingCache::new(),
             session_identity: None,
             session_epoch: 0,
-            prev_total_height: 0,
+            chat_viewport: ChatViewportState::default(),
             tick: 0,
             #[cfg(test)]
             invalidation_order: Vec::new(),
@@ -915,6 +921,7 @@ impl RenderState {
         match change {
             RenderChange::SessionChanged(identity) => {
                 self.advance_session_epoch(identity);
+                self.reset_chat_viewport();
                 self.invalidate_content_cache();
                 self.invalidate_thinking_cache();
                 self.invalidate_card_cache();
@@ -1016,16 +1023,61 @@ impl RenderState {
         self.tick = tick;
     }
 
-    pub(crate) fn compensate_scroll_for_growth(
-        &mut self,
-        total_height: u16,
-        scroll_offset: &mut u16,
-    ) {
-        let growth = total_height.saturating_sub(self.prev_total_height);
-        if *scroll_offset > 0 && growth > 0 {
-            *scroll_offset = (*scroll_offset).saturating_add(growth);
+    pub(crate) fn chat_scroll_offset(&self) -> u16 {
+        self.chat_viewport.scroll_offset
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_chat_scroll_offset(&mut self, offset: u16) {
+        self.chat_viewport.scroll_offset = offset;
+    }
+
+    pub(crate) fn scroll_chat_up(&mut self, rows: u16) {
+        self.chat_viewport.scroll_offset = self.chat_viewport.scroll_offset.saturating_add(rows);
+    }
+
+    pub(crate) fn scroll_chat_down(&mut self, rows: u16) {
+        self.chat_viewport.scroll_offset = self.chat_viewport.scroll_offset.saturating_sub(rows);
+    }
+
+    pub(crate) fn scroll_chat_to_top(&mut self) {
+        self.chat_viewport.scroll_offset = u16::MAX;
+    }
+
+    pub(crate) fn scroll_chat_to_bottom(&mut self) {
+        self.chat_viewport.scroll_offset = 0;
+    }
+
+    pub(crate) fn compensate_chat_growth(&mut self, total_height: u16) {
+        let growth = total_height.saturating_sub(self.chat_viewport.previous_total_height);
+        if self.chat_viewport.scroll_offset > 0 && growth > 0 {
+            self.chat_viewport.scroll_offset =
+                self.chat_viewport.scroll_offset.saturating_add(growth);
         }
-        self.prev_total_height = total_height;
+        self.chat_viewport.previous_total_height = total_height;
+    }
+
+    pub(crate) fn clamp_chat_scroll(&mut self, total_height: u16, viewport_height: u16) -> u16 {
+        let max_scroll = total_height.saturating_sub(viewport_height);
+        self.chat_viewport.scroll_offset = self.chat_viewport.scroll_offset.min(max_scroll);
+        max_scroll.saturating_sub(self.chat_viewport.scroll_offset)
+    }
+
+    pub(crate) fn reset_chat_viewport(&mut self) {
+        self.chat_viewport = ChatViewportState::default();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_chat_previous_total_height(&self) -> u16 {
+        self.chat_viewport.previous_total_height
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_seed_chat_viewport(&mut self, offset: u16, previous_total_height: u16) {
+        self.chat_viewport = ChatViewportState {
+            scroll_offset: offset,
+            previous_total_height,
+        };
     }
 
     #[cfg(test)]
@@ -1128,7 +1180,8 @@ mod tests {
         assert!(!state.test_streaming_cache_populated(StreamKind::Content));
         assert!(!state.test_streaming_cache_populated(StreamKind::Thinking));
         assert_eq!(state.test_session_epoch(), 0);
-        assert_eq!(state.prev_total_height, 0);
+        assert_eq!(state.chat_scroll_offset(), 0);
+        assert_eq!(state.test_chat_previous_total_height(), 0);
         assert_eq!(state.tick, 0);
     }
 
@@ -1278,17 +1331,23 @@ mod tests {
             CacheInvalidation::Thinking,
             CacheInvalidation::Finalized,
         ];
+        state.test_seed_chat_viewport(9, 27);
 
         state.apply_change(RenderChange::SessionChanged(session.clone()));
         assert_eq!(state.test_session_epoch(), 1);
+        assert_eq!(state.chat_scroll_offset(), 0);
+        assert_eq!(state.test_chat_previous_total_height(), 0);
         assert_cache_scope(&state, false, false, false, &expected_order);
 
         state.test_seed_card_cache(2);
         state.test_seed_streaming_cache(StreamKind::Content);
         state.test_seed_streaming_cache(StreamKind::Thinking);
+        state.test_seed_chat_viewport(u16::MAX, 12);
         state.invalidation_order.clear();
         state.apply_change(RenderChange::SessionChanged(session));
         assert_eq!(state.test_session_epoch(), 2);
+        assert_eq!(state.chat_scroll_offset(), 0);
+        assert_eq!(state.test_chat_previous_total_height(), 0);
         assert_cache_scope(&state, false, false, false, &expected_order);
     }
 
@@ -1359,21 +1418,120 @@ mod tests {
     }
 
     #[test]
-    fn height_growth_compensates_only_when_scrolled_up() {
+    fn chat_viewport_movement_saturates_without_touching_render_policy() {
+        let mut state = seeded_caches();
+        state.compensate_chat_growth(12);
+        let card_identity = state.test_card_identity(0);
+        let content_identity = state.test_streaming_cache_identity(StreamKind::Content);
+        let thinking_identity = state.test_streaming_cache_identity(StreamKind::Thinking);
+
+        state.set_chat_scroll_offset(u16::MAX - 1);
+        state.scroll_chat_up(3);
+        assert_eq!(state.chat_scroll_offset(), u16::MAX);
+        state.scroll_chat_down(u16::MAX);
+        assert_eq!(state.chat_scroll_offset(), 0);
+        state.scroll_chat_down(1);
+        assert_eq!(state.chat_scroll_offset(), 0);
+        state.scroll_chat_to_top();
+        assert_eq!(state.chat_scroll_offset(), u16::MAX);
+        state.scroll_chat_to_bottom();
+        assert_eq!(state.chat_scroll_offset(), 0);
+        assert_eq!(state.test_chat_previous_total_height(), 12);
+
+        assert_eq!(state.test_card_identity(0), card_identity);
+        assert_eq!(
+            state.test_streaming_cache_identity(StreamKind::Content),
+            content_identity
+        );
+        assert_eq!(
+            state.test_streaming_cache_identity(StreamKind::Thinking),
+            thinking_identity
+        );
+        assert_eq!(state.test_session_epoch(), 0);
+        assert!(state.invalidation_order.is_empty());
+    }
+
+    #[test]
+    fn bottom_pinned_chat_viewport_stays_pinned_during_growth() {
         let mut state = RenderState::new();
-        let mut scroll_offset = 4;
 
-        state.compensate_scroll_for_growth(10, &mut scroll_offset);
-        assert_eq!(scroll_offset, 14);
-        assert_eq!(state.prev_total_height, 10);
+        state.compensate_chat_growth(10);
+        state.compensate_chat_growth(17);
 
-        state.compensate_scroll_for_growth(7, &mut scroll_offset);
-        assert_eq!(scroll_offset, 14);
-        assert_eq!(state.prev_total_height, 7);
+        assert_eq!(state.chat_scroll_offset(), 0);
+        assert_eq!(state.test_chat_previous_total_height(), 17);
+        assert_eq!(state.clamp_chat_scroll(17, 5), 12);
+        assert_eq!(state.chat_scroll_offset(), 0);
+    }
 
-        scroll_offset = 0;
-        state.compensate_scroll_for_growth(12, &mut scroll_offset);
-        assert_eq!(scroll_offset, 0);
-        assert_eq!(state.prev_total_height, 12);
+    #[test]
+    fn scrolled_chat_growth_preserves_top_origin_slice() {
+        let mut state = RenderState::new();
+        state.compensate_chat_growth(10);
+        state.set_chat_scroll_offset(3);
+        assert_eq!(state.clamp_chat_scroll(10, 4), 3);
+
+        state.compensate_chat_growth(15);
+
+        assert_eq!(state.chat_scroll_offset(), 8);
+        assert_eq!(state.test_chat_previous_total_height(), 15);
+        assert_eq!(state.clamp_chat_scroll(15, 4), 3);
+    }
+
+    #[test]
+    fn shrink_updates_baseline_then_clamps_chat_scroll() {
+        let mut state = RenderState::new();
+        state.test_seed_chat_viewport(12, 20);
+
+        state.compensate_chat_growth(8);
+
+        assert_eq!(state.test_chat_previous_total_height(), 8);
+        assert_eq!(state.clamp_chat_scroll(8, 5), 0);
+        assert_eq!(state.chat_scroll_offset(), 3);
+    }
+
+    #[test]
+    fn chat_scroll_clamp_handles_empty_short_zero_and_tiny_viewports() {
+        let mut state = RenderState::new();
+        state.scroll_chat_to_top();
+        assert_eq!(state.clamp_chat_scroll(0, 0), 0);
+        assert_eq!(state.chat_scroll_offset(), 0);
+
+        state.scroll_chat_to_top();
+        assert_eq!(state.clamp_chat_scroll(3, 5), 0);
+        assert_eq!(state.chat_scroll_offset(), 0);
+
+        state.set_chat_scroll_offset(2);
+        assert_eq!(state.clamp_chat_scroll(5, 0), 3);
+        assert_eq!(state.chat_scroll_offset(), 2);
+
+        state.scroll_chat_to_top();
+        assert_eq!(state.clamp_chat_scroll(5, 1), 0);
+        assert_eq!(state.chat_scroll_offset(), 4);
+    }
+
+    #[test]
+    fn reset_chat_viewport_clears_offset_and_baseline_only() {
+        let mut state = seeded_caches();
+        state.test_seed_chat_viewport(7, 19);
+        let card_identity = state.test_card_identity(0);
+        let content_identity = state.test_streaming_cache_identity(StreamKind::Content);
+        let thinking_identity = state.test_streaming_cache_identity(StreamKind::Thinking);
+
+        state.reset_chat_viewport();
+
+        assert_eq!(state.chat_scroll_offset(), 0);
+        assert_eq!(state.test_chat_previous_total_height(), 0);
+        assert_eq!(state.test_card_identity(0), card_identity);
+        assert_eq!(
+            state.test_streaming_cache_identity(StreamKind::Content),
+            content_identity
+        );
+        assert_eq!(
+            state.test_streaming_cache_identity(StreamKind::Thinking),
+            thinking_identity
+        );
+        assert_eq!(state.test_session_epoch(), 0);
+        assert!(state.invalidation_order.is_empty());
     }
 }

--- a/src/render_state.rs
+++ b/src/render_state.rs
@@ -865,6 +865,21 @@ struct ChatViewportState {
     previous_total_height: u16,
 }
 
+#[derive(Default)]
+struct StartPageMetrics {
+    scroll: usize,
+}
+
+#[derive(Default)]
+struct SessionPopupMetrics {
+    visible_rows: usize,
+}
+
+#[derive(Default)]
+struct DelegatePopupMetrics {
+    visible_rows: usize,
+}
+
 struct ComposerInputGeometry {
     line_width: usize,
     scroll: u16,
@@ -906,6 +921,9 @@ pub(crate) struct RenderState {
     session_identity: Option<SessionIdentity>,
     session_epoch: u64,
     chat_viewport: ChatViewportState,
+    start_page: StartPageMetrics,
+    session_popup: SessionPopupMetrics,
+    delegate_popup: DelegatePopupMetrics,
     composer_input: ComposerInputGeometry,
     elicitation_custom_editor: ElicitationCustomEditorGeometry,
     pub(crate) tick: u64,
@@ -931,6 +949,9 @@ impl RenderState {
             session_identity: None,
             session_epoch: 0,
             chat_viewport: ChatViewportState::default(),
+            start_page: StartPageMetrics::default(),
+            session_popup: SessionPopupMetrics::default(),
+            delegate_popup: DelegatePopupMetrics::default(),
             composer_input: ComposerInputGeometry::default(),
             elicitation_custom_editor: ElicitationCustomEditorGeometry::default(),
             tick: 0,
@@ -1058,6 +1079,55 @@ impl RenderState {
 
     pub(crate) fn replace_tick(&mut self, tick: u64) {
         self.tick = tick;
+    }
+
+    pub(crate) fn start_page_scroll(&self) -> usize {
+        self.start_page.scroll
+    }
+
+    pub(crate) fn reset_start_page_scroll(&mut self) {
+        self.start_page.scroll = 0;
+    }
+
+    pub(crate) fn keep_start_page_cursor_visible_from_above(&mut self, cursor: usize) {
+        if cursor < self.start_page.scroll {
+            self.start_page.scroll = cursor;
+        }
+    }
+
+    pub(crate) fn clamp_start_page_scroll(
+        &mut self,
+        cursor: usize,
+        total_rows: usize,
+        visible_rows: usize,
+    ) -> usize {
+        if cursor >= self.start_page.scroll.saturating_add(visible_rows) {
+            self.start_page.scroll = cursor.saturating_add(1).saturating_sub(visible_rows);
+        }
+        if cursor < self.start_page.scroll {
+            self.start_page.scroll = cursor;
+        }
+        self.start_page.scroll = self
+            .start_page
+            .scroll
+            .min(total_rows.saturating_sub(visible_rows));
+        self.start_page.scroll
+    }
+
+    pub(crate) fn publish_session_popup_visible_rows(&mut self, rows: usize) {
+        self.session_popup.visible_rows = rows;
+    }
+
+    pub(crate) fn session_popup_page_step(&self) -> usize {
+        self.session_popup.visible_rows.saturating_sub(1).max(1)
+    }
+
+    pub(crate) fn publish_delegate_popup_visible_rows(&mut self, rows: usize) {
+        self.delegate_popup.visible_rows = rows;
+    }
+
+    pub(crate) fn delegate_popup_page_step(&self) -> usize {
+        self.delegate_popup.visible_rows.saturating_sub(1).max(1)
     }
 
     pub(crate) fn prepare_composer_input_layout(
@@ -1196,6 +1266,21 @@ impl RenderState {
 
     pub(crate) fn reset_chat_viewport(&mut self) {
         self.chat_viewport = ChatViewportState::default();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_session_popup_visible_rows(&self) -> usize {
+        self.session_popup.visible_rows
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_delegate_popup_visible_rows(&self) -> usize {
+        self.delegate_popup.visible_rows
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_seed_start_page_scroll(&mut self, scroll: usize) {
+        self.start_page.scroll = scroll;
     }
 
     #[cfg(test)]
@@ -1345,7 +1430,99 @@ mod tests {
         assert_eq!(state.test_chat_previous_total_height(), 0);
         assert_eq!(state.test_composer_input_geometry(), (1, 0, false));
         assert_eq!(state.test_elicitation_custom_geometry(), (1, 0, false));
+        assert_eq!(state.start_page_scroll(), 0);
+        assert_eq!(state.test_session_popup_visible_rows(), 0);
+        assert_eq!(state.test_delegate_popup_visible_rows(), 0);
+        assert_eq!(state.session_popup_page_step(), 1);
+        assert_eq!(state.delegate_popup_page_step(), 1);
         assert_eq!(state.tick, 0);
+    }
+
+    #[test]
+    fn start_page_scroll_visibility_clamping_and_reset_preserve_exact_boundaries() {
+        let mut state = RenderState::new();
+
+        state.test_seed_start_page_scroll(6);
+        state.keep_start_page_cursor_visible_from_above(4);
+        assert_eq!(state.start_page_scroll(), 4);
+        state.keep_start_page_cursor_visible_from_above(7);
+        assert_eq!(state.start_page_scroll(), 4);
+
+        assert_eq!(state.clamp_start_page_scroll(9, 20, 4), 6);
+        assert_eq!(state.clamp_start_page_scroll(6, 20, 4), 6);
+        assert_eq!(state.clamp_start_page_scroll(2, 20, 4), 2);
+        assert_eq!(state.clamp_start_page_scroll(2, 3, 5), 0);
+
+        state.test_seed_start_page_scroll(usize::MAX);
+        assert_eq!(
+            state.clamp_start_page_scroll(usize::MAX, usize::MAX, 0),
+            usize::MAX
+        );
+        assert_eq!(
+            state.clamp_start_page_scroll(usize::MAX, usize::MAX, 1),
+            usize::MAX - 1
+        );
+        assert_eq!(state.clamp_start_page_scroll(10, 10, 3), 7);
+
+        state.publish_session_popup_visible_rows(5);
+        state.publish_delegate_popup_visible_rows(7);
+        state.reset_start_page_scroll();
+        assert_eq!(state.start_page_scroll(), 0);
+        assert_eq!(state.test_session_popup_visible_rows(), 5);
+        assert_eq!(state.test_delegate_popup_visible_rows(), 7);
+    }
+
+    #[test]
+    fn popup_page_steps_use_one_row_overlap_and_saturating_fallback() {
+        let mut state = RenderState::new();
+
+        for (rows, expected) in [(0, 1), (1, 1), (2, 1), (5, 4), (usize::MAX, usize::MAX - 1)] {
+            state.publish_session_popup_visible_rows(rows);
+            assert_eq!(state.test_session_popup_visible_rows(), rows);
+            assert_eq!(state.session_popup_page_step(), expected);
+
+            state.publish_delegate_popup_visible_rows(rows);
+            assert_eq!(state.test_delegate_popup_visible_rows(), rows);
+            assert_eq!(state.delegate_popup_page_step(), expected);
+        }
+    }
+
+    #[test]
+    fn render_metric_changes_do_not_touch_other_render_owned_state() {
+        let mut state = seeded_caches();
+        state.advance_session_epoch(identity("session", None, false));
+        state.test_seed_chat_viewport(4, 18);
+        state.test_seed_composer_input_geometry(9, 3);
+        state.test_seed_elicitation_custom_geometry(7, 2);
+        state.replace_tick(11);
+        let card_identity = state.test_card_identity(0);
+        let content_identity = state.test_streaming_cache_identity(StreamKind::Content);
+        let thinking_identity = state.test_streaming_cache_identity(StreamKind::Thinking);
+        state.invalidation_order.clear();
+
+        state.test_seed_start_page_scroll(8);
+        state.keep_start_page_cursor_visible_from_above(3);
+        state.clamp_start_page_scroll(6, 12, 4);
+        state.reset_start_page_scroll();
+        state.publish_session_popup_visible_rows(5);
+        state.publish_delegate_popup_visible_rows(7);
+
+        assert_eq!(state.test_card_identity(0), card_identity);
+        assert_eq!(
+            state.test_streaming_cache_identity(StreamKind::Content),
+            content_identity
+        );
+        assert_eq!(
+            state.test_streaming_cache_identity(StreamKind::Thinking),
+            thinking_identity
+        );
+        assert_eq!(state.test_session_epoch(), 1);
+        assert_eq!(state.chat_scroll_offset(), 4);
+        assert_eq!(state.test_chat_previous_total_height(), 18);
+        assert_eq!(state.test_composer_input_geometry(), (9, 3, true));
+        assert_eq!(state.test_elicitation_custom_geometry(), (7, 2, true));
+        assert_eq!(state.tick, 11);
+        assert!(state.invalidation_order.is_empty());
     }
 
     #[test]
@@ -1495,11 +1672,17 @@ mod tests {
             CacheInvalidation::Finalized,
         ];
         state.test_seed_chat_viewport(9, 27);
+        state.test_seed_start_page_scroll(6);
+        state.publish_session_popup_visible_rows(5);
+        state.publish_delegate_popup_visible_rows(7);
 
         state.apply_change(RenderChange::SessionChanged(session.clone()));
         assert_eq!(state.test_session_epoch(), 1);
         assert_eq!(state.chat_scroll_offset(), 0);
         assert_eq!(state.test_chat_previous_total_height(), 0);
+        assert_eq!(state.start_page_scroll(), 6);
+        assert_eq!(state.test_session_popup_visible_rows(), 5);
+        assert_eq!(state.test_delegate_popup_visible_rows(), 7);
         assert_cache_scope(&state, false, false, false, &expected_order);
 
         state.test_seed_card_cache(2);
@@ -1511,6 +1694,9 @@ mod tests {
         assert_eq!(state.test_session_epoch(), 2);
         assert_eq!(state.chat_scroll_offset(), 0);
         assert_eq!(state.test_chat_previous_total_height(), 0);
+        assert_eq!(state.start_page_scroll(), 6);
+        assert_eq!(state.test_session_popup_visible_rows(), 5);
+        assert_eq!(state.test_delegate_popup_visible_rows(), 7);
         assert_cache_scope(&state, false, false, false, &expected_order);
     }
 

--- a/src/render_state.rs
+++ b/src/render_state.rs
@@ -1,13 +1,860 @@
+use std::cell::{Cell, Ref, RefCell};
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    text::{Line, Span},
+    widgets::{Block, Paragraph, Wrap},
+};
+
+use crate::domain::activity::{DelegateEntry, DelegateStatus};
+use crate::domain::chat::{ChatEntry, ElicitationResponseOutcome};
+use crate::domain::tool::ToolDetail;
 use crate::highlight::Highlighter;
 use crate::markdown::CardBlock;
-use crate::ui::CardCache;
+use crate::theme::Theme;
 
-/// Temporary phase 4 owner for render-local state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionKind {
+    Local,
+    Remote,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionIdentity {
+    session_id: Option<String>,
+    remote_node_id: Option<String>,
+    kind: SessionKind,
+}
+
+impl SessionIdentity {
+    pub(crate) fn new(
+        session_id: Option<String>,
+        remote_node_id: Option<String>,
+        is_remote: bool,
+    ) -> Self {
+        Self {
+            session_id,
+            remote_node_id,
+            kind: if is_remote {
+                SessionKind::Remote
+            } else {
+                SessionKind::Local
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionCacheKey {
+    epoch: u64,
+    identity: SessionIdentity,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ThemeCacheKey {
+    index: usize,
+    revision: u64,
+}
+
+impl ThemeCacheKey {
+    pub(crate) fn new(index: usize, revision: u64) -> Self {
+        Self { index, revision }
+    }
+
+    pub(crate) fn current_frame() -> Self {
+        Self::new(Theme::frame_index(), Theme::render_revision())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FinalizedRenderContextKey {
+    session: SessionCacheKey,
+    full_width: u16,
+    theme: ThemeCacheKey,
+    show_thinking: bool,
+    effective_cwd: Option<String>,
+}
+
+impl FinalizedRenderContextKey {
+    pub(crate) fn new(
+        session: SessionCacheKey,
+        full_width: u16,
+        theme: ThemeCacheKey,
+        show_thinking: bool,
+        effective_cwd: Option<String>,
+    ) -> Self {
+        Self {
+            session,
+            full_width,
+            theme,
+            show_thinking,
+            effective_cwd,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DelegatePresentationKey {
+    Queued,
+    Matched {
+        delegation_id: String,
+        matched_tool_id: Option<String>,
+        status: DelegateStatus,
+        awaiting_input: bool,
+        started_at: Option<i64>,
+        ended_at: Option<i64>,
+        duration_secs: Option<u64>,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum DelegatePresentationKeyRef<'a> {
+    Queued,
+    Matched {
+        delegation_id: &'a str,
+        matched_tool_id: Option<&'a str>,
+        status: DelegateStatus,
+        awaiting_input: bool,
+        started_at: Option<i64>,
+        ended_at: Option<i64>,
+        duration_secs: Option<u64>,
+    },
+}
+
+impl<'a> DelegatePresentationKeyRef<'a> {
+    pub(crate) fn from_entry(entry: Option<&'a DelegateEntry>, now_unix_secs: i64) -> Self {
+        let Some(entry) = entry else {
+            return Self::Queued;
+        };
+        let duration_secs = entry.started_at.map(|start| {
+            let end = entry.ended_at.unwrap_or(now_unix_secs);
+            (end - start).max(0) as u64
+        });
+        Self::Matched {
+            delegation_id: &entry.delegation_id,
+            matched_tool_id: entry.delegate_tool_call_id.as_deref(),
+            status: entry.status,
+            awaiting_input: entry.awaiting_input(),
+            started_at: entry.started_at,
+            ended_at: entry.ended_at,
+            duration_secs,
+        }
+    }
+
+    fn to_owned(self) -> DelegatePresentationKey {
+        match self {
+            Self::Queued => DelegatePresentationKey::Queued,
+            Self::Matched {
+                delegation_id,
+                matched_tool_id,
+                status,
+                awaiting_input,
+                started_at,
+                ended_at,
+                duration_secs,
+            } => DelegatePresentationKey::Matched {
+                delegation_id: delegation_id.to_string(),
+                matched_tool_id: matched_tool_id.map(str::to_string),
+                status,
+                awaiting_input,
+                started_at,
+                ended_at,
+                duration_secs,
+            },
+        }
+    }
+}
+
+impl DelegatePresentationKey {
+    fn matches_ref(&self, other: DelegatePresentationKeyRef<'_>) -> bool {
+        match (self, other) {
+            (Self::Queued, DelegatePresentationKeyRef::Queued) => true,
+            (
+                Self::Matched {
+                    delegation_id,
+                    matched_tool_id,
+                    status,
+                    awaiting_input,
+                    started_at,
+                    ended_at,
+                    duration_secs,
+                },
+                DelegatePresentationKeyRef::Matched {
+                    delegation_id: other_delegation_id,
+                    matched_tool_id: other_tool_id,
+                    status: other_status,
+                    awaiting_input: other_awaiting_input,
+                    started_at: other_started_at,
+                    ended_at: other_ended_at,
+                    duration_secs: other_duration_secs,
+                },
+            ) => {
+                delegation_id == other_delegation_id
+                    && matched_tool_id.as_deref() == other_tool_id
+                    && *status == other_status
+                    && *awaiting_input == other_awaiting_input
+                    && *started_at == other_started_at
+                    && *ended_at == other_ended_at
+                    && *duration_secs == other_duration_secs
+            }
+            _ => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum FinalizedMessageKey {
+    User {
+        ordinal: usize,
+        message_id: Option<String>,
+        text: String,
+    },
+    Assistant {
+        ordinal: usize,
+        message_id: Option<String>,
+        content: String,
+        thinking: Option<String>,
+    },
+    Thinking {
+        ordinal: usize,
+        message_id: Option<String>,
+        content: String,
+    },
+    ToolCall {
+        ordinal: usize,
+        tool_call_id: Option<String>,
+        name: String,
+        is_error: bool,
+        detail: Box<ToolDetail>,
+        delegate: Option<DelegatePresentationKey>,
+    },
+    CompactionStart {
+        ordinal: usize,
+        token_estimate: u32,
+    },
+    CompactionEnd {
+        ordinal: usize,
+        token_estimate: Option<u32>,
+        summary: String,
+        summary_len: u32,
+    },
+    Info {
+        ordinal: usize,
+        text: String,
+    },
+    Error {
+        ordinal: usize,
+        text: String,
+    },
+    Elicitation {
+        ordinal: usize,
+        elicitation_id: String,
+        message: String,
+        outcome: Option<ElicitationResponseOutcome>,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct FinalizedMessageKeyRef<'a> {
+    ordinal: usize,
+    entry: &'a ChatEntry,
+    delegate: Option<DelegatePresentationKeyRef<'a>>,
+}
+
+impl<'a> FinalizedMessageKeyRef<'a> {
+    pub(crate) fn new(
+        ordinal: usize,
+        entry: &'a ChatEntry,
+        delegate: Option<DelegatePresentationKeyRef<'a>>,
+    ) -> Self {
+        Self {
+            ordinal,
+            entry,
+            delegate,
+        }
+    }
+
+    fn to_owned(self) -> FinalizedMessageKey {
+        match self.entry {
+            ChatEntry::User { text, message_id } => FinalizedMessageKey::User {
+                ordinal: self.ordinal,
+                message_id: message_id.clone(),
+                text: text.clone(),
+            },
+            ChatEntry::Assistant {
+                content,
+                thinking,
+                message_id,
+            } => FinalizedMessageKey::Assistant {
+                ordinal: self.ordinal,
+                message_id: message_id.clone(),
+                content: content.clone(),
+                thinking: thinking.clone(),
+            },
+            ChatEntry::Thinking {
+                content,
+                message_id,
+            } => FinalizedMessageKey::Thinking {
+                ordinal: self.ordinal,
+                message_id: message_id.clone(),
+                content: content.clone(),
+            },
+            ChatEntry::ToolCall {
+                tool_call_id,
+                name,
+                is_error,
+                detail,
+            } => FinalizedMessageKey::ToolCall {
+                ordinal: self.ordinal,
+                tool_call_id: tool_call_id.clone(),
+                name: name.clone(),
+                is_error: *is_error,
+                detail: Box::new(detail.clone()),
+                delegate: self.delegate.map(DelegatePresentationKeyRef::to_owned),
+            },
+            ChatEntry::CompactionStart { token_estimate } => FinalizedMessageKey::CompactionStart {
+                ordinal: self.ordinal,
+                token_estimate: *token_estimate,
+            },
+            ChatEntry::CompactionEnd {
+                token_estimate,
+                summary,
+                summary_len,
+            } => FinalizedMessageKey::CompactionEnd {
+                ordinal: self.ordinal,
+                token_estimate: *token_estimate,
+                summary: summary.clone(),
+                summary_len: *summary_len,
+            },
+            ChatEntry::Info(text) => FinalizedMessageKey::Info {
+                ordinal: self.ordinal,
+                text: text.clone(),
+            },
+            ChatEntry::Error(text) => FinalizedMessageKey::Error {
+                ordinal: self.ordinal,
+                text: text.clone(),
+            },
+            ChatEntry::Elicitation {
+                elicitation_id,
+                message,
+                outcome,
+                ..
+            } => FinalizedMessageKey::Elicitation {
+                ordinal: self.ordinal,
+                elicitation_id: elicitation_id.clone(),
+                message: message.clone(),
+                outcome: outcome.clone(),
+            },
+        }
+    }
+}
+
+impl FinalizedMessageKey {
+    fn matches_ref(&self, other: FinalizedMessageKeyRef<'_>) -> bool {
+        match (self, other.entry) {
+            (
+                Self::User {
+                    ordinal,
+                    message_id,
+                    text,
+                },
+                ChatEntry::User {
+                    text: other_text,
+                    message_id: other_id,
+                },
+            ) => *ordinal == other.ordinal && message_id == other_id && text == other_text,
+            (
+                Self::Assistant {
+                    ordinal,
+                    message_id,
+                    content,
+                    thinking,
+                },
+                ChatEntry::Assistant {
+                    content: other_content,
+                    thinking: other_thinking,
+                    message_id: other_id,
+                },
+            ) => {
+                *ordinal == other.ordinal
+                    && message_id == other_id
+                    && content == other_content
+                    && thinking == other_thinking
+            }
+            (
+                Self::Thinking {
+                    ordinal,
+                    message_id,
+                    content,
+                },
+                ChatEntry::Thinking {
+                    content: other_content,
+                    message_id: other_id,
+                },
+            ) => *ordinal == other.ordinal && message_id == other_id && content == other_content,
+            (
+                Self::ToolCall {
+                    ordinal,
+                    tool_call_id,
+                    name,
+                    is_error,
+                    detail,
+                    delegate,
+                },
+                ChatEntry::ToolCall {
+                    tool_call_id: other_id,
+                    name: other_name,
+                    is_error: other_is_error,
+                    detail: other_detail,
+                },
+            ) => {
+                *ordinal == other.ordinal
+                    && tool_call_id == other_id
+                    && name == other_name
+                    && *is_error == *other_is_error
+                    && detail.as_ref() == other_detail
+                    && match (delegate, other.delegate) {
+                        (Some(stored), Some(lookup)) => stored.matches_ref(lookup),
+                        (None, None) => true,
+                        _ => false,
+                    }
+            }
+            (
+                Self::CompactionStart {
+                    ordinal,
+                    token_estimate,
+                },
+                ChatEntry::CompactionStart {
+                    token_estimate: other_estimate,
+                },
+            ) => *ordinal == other.ordinal && token_estimate == other_estimate,
+            (
+                Self::CompactionEnd {
+                    ordinal,
+                    token_estimate,
+                    summary,
+                    summary_len,
+                },
+                ChatEntry::CompactionEnd {
+                    token_estimate: other_estimate,
+                    summary: other_summary,
+                    summary_len: other_len,
+                },
+            ) => {
+                *ordinal == other.ordinal
+                    && token_estimate == other_estimate
+                    && summary == other_summary
+                    && summary_len == other_len
+            }
+            (Self::Info { ordinal, text }, ChatEntry::Info(other_text)) => {
+                *ordinal == other.ordinal && text == other_text
+            }
+            (Self::Error { ordinal, text }, ChatEntry::Error(other_text)) => {
+                *ordinal == other.ordinal && text == other_text
+            }
+            (
+                Self::Elicitation {
+                    ordinal,
+                    elicitation_id,
+                    message,
+                    outcome,
+                },
+                ChatEntry::Elicitation {
+                    elicitation_id: other_id,
+                    message: other_message,
+                    outcome: other_outcome,
+                    ..
+                },
+            ) => {
+                *ordinal == other.ordinal
+                    && elicitation_id == other_id
+                    && message == other_message
+                    && outcome == other_outcome
+            }
+            _ => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FinalizedCardKey {
+    kind: CardKind,
+    source_keys: Vec<FinalizedMessageKey>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FinalizedCardKeyRef<'a> {
+    kind: CardKind,
+    source_keys: Vec<FinalizedMessageKeyRef<'a>>,
+}
+
+impl<'a> FinalizedCardKeyRef<'a> {
+    pub(crate) fn new(kind: CardKind, source_keys: Vec<FinalizedMessageKeyRef<'a>>) -> Self {
+        Self { kind, source_keys }
+    }
+
+    pub(crate) fn kind(&self) -> &CardKind {
+        &self.kind
+    }
+
+    fn to_owned(&self) -> FinalizedCardKey {
+        FinalizedCardKey {
+            kind: self.kind.clone(),
+            source_keys: self
+                .source_keys
+                .iter()
+                .copied()
+                .map(FinalizedMessageKeyRef::to_owned)
+                .collect(),
+        }
+    }
+}
+
+impl FinalizedCardKey {
+    fn matches_ref(&self, other: &FinalizedCardKeyRef<'_>) -> bool {
+        self.kind == other.kind
+            && self.source_keys.len() == other.source_keys.len()
+            && self
+                .source_keys
+                .iter()
+                .zip(&other.source_keys)
+                .all(|(stored, lookup)| stored.matches_ref(*lookup))
+    }
+}
+
+// Message cards use background color only, without borders.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CardKind {
+    User,
+    Assistant,
+    Tool { compact: bool },
+    Streaming,
+    Thinking,
+    Compaction,
+    Error,
+    Info,
+    Elicitation,
+}
+
+pub(crate) struct Card {
+    #[cfg(test)]
+    identity: u64,
+    pub(crate) kind: CardKind,
+    blocks: Vec<CardBlock>,
+    top_pad: u16,
+    bottom_pad: u16,
+    cached_width: Cell<Option<u16>>,
+    cached_lines: RefCell<Vec<Line<'static>>>,
+}
+
+impl Card {
+    pub(crate) fn new(kind: CardKind, blocks: Vec<CardBlock>) -> Self {
+        let (top_pad, bottom_pad): (u16, u16) = match kind {
+            CardKind::Tool { compact: true } => (0, 0),
+            CardKind::Tool { compact: false } => (1, 0),
+            _ => (1, 1),
+        };
+        Self {
+            #[cfg(test)]
+            identity: NEXT_CARD_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+            kind,
+            blocks,
+            top_pad,
+            bottom_pad,
+            cached_width: Cell::new(None),
+            cached_lines: RefCell::new(Vec::new()),
+        }
+    }
+
+    /// Rebuild cached lines if the width has changed, then return a borrow.
+    pub(crate) fn lines_for(&self, inner_w: u16) -> Ref<'_, Vec<Line<'static>>> {
+        if self.cached_width.get() != Some(inner_w) {
+            let mut lines = Vec::new();
+            for block in &self.blocks {
+                match block {
+                    CardBlock::Text(line) => lines.push(line.clone()),
+                    CardBlock::Table(table) => lines.extend(table.layout(inner_w as usize)),
+                }
+            }
+            *self.cached_lines.borrow_mut() = lines;
+            self.cached_width.set(Some(inner_w));
+        }
+        self.cached_lines.borrow()
+    }
+
+    /// Compute visual height using the full card render width.
+    pub(crate) fn height(&self, width: u16) -> u16 {
+        let inner_w = width.saturating_sub(4);
+        let lines = self.lines_for(inner_w);
+        let line_rows: u16 = lines
+            .iter()
+            .map(|line| {
+                let width = line.width();
+                let inner_width = inner_w as usize;
+                if inner_width == 0 || width == 0 {
+                    1
+                } else {
+                    width.div_ceil(inner_width) as u16
+                }
+            })
+            .sum::<u16>()
+            .max(1);
+        self.top_pad + line_rows + self.bottom_pad
+    }
+
+    pub(crate) fn render(&self, frame: &mut Frame, area: Rect, clip_top: u16) {
+        if area.height == 0 || area.width == 0 {
+            return;
+        }
+
+        let (background_style, text_style) = match self.kind {
+            CardKind::User => (Theme::user_card(), Theme::user_text()),
+            CardKind::Assistant | CardKind::Streaming => {
+                (Theme::assistant_card(), Theme::assistant_text())
+            }
+            CardKind::Tool { .. } => (Theme::assistant_card(), Theme::tool_text()),
+            CardKind::Thinking => (Theme::assistant_card(), Theme::thinking()),
+            CardKind::Compaction => (Theme::assistant_card(), Theme::status_accent()),
+            CardKind::Error => (Theme::assistant_card(), Theme::error_text()),
+            CardKind::Info => (Theme::assistant_card(), Theme::info_text()),
+            CardKind::Elicitation => (Theme::assistant_card(), Theme::status_accent()),
+        };
+
+        frame.render_widget(Block::default().style(background_style), area);
+
+        let has_top_pad = !matches!(self.kind, CardKind::Tool { compact: true });
+        let visible_top_pad = u16::from(clip_top == 0 && has_top_pad);
+        let content_skip = clip_top.saturating_sub(1);
+        let content_height = area.height.saturating_sub(visible_top_pad);
+        if content_height == 0 {
+            return;
+        }
+
+        let content_area = Rect {
+            x: area.x + 2,
+            y: area.y + visible_top_pad,
+            width: area.width.saturating_sub(4),
+            height: content_height,
+        };
+        let lines = self.lines_for(area.width.saturating_sub(4));
+        let styled_lines: Vec<Line<'static>> = lines
+            .iter()
+            .map(|line| {
+                Line::from(
+                    line.spans
+                        .iter()
+                        .map(|span| {
+                            let style = if span.style.fg.is_some() {
+                                span.style.bg(background_style.bg.unwrap_or(Theme::bg()))
+                            } else {
+                                text_style
+                            };
+                            Span::styled(span.content.clone(), style)
+                        })
+                        .collect::<Vec<_>>(),
+                )
+            })
+            .collect();
+        frame.render_widget(
+            Paragraph::new(styled_lines)
+                .wrap(Wrap { trim: false })
+                .scroll((content_skip, 0)),
+            content_area,
+        );
+    }
+}
+
+#[cfg(test)]
+static NEXT_CARD_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+struct CardCache {
+    context: Option<FinalizedRenderContextKey>,
+    keys: Vec<FinalizedCardKey>,
+    cards: Vec<Card>,
+    #[cfg(test)]
+    source_entry_count: usize,
+}
+
+impl CardCache {
+    fn new() -> Self {
+        Self {
+            context: None,
+            keys: Vec::new(),
+            cards: Vec::new(),
+            #[cfg(test)]
+            source_entry_count: 0,
+        }
+    }
+
+    fn invalidate(&mut self) {
+        self.context = None;
+        self.keys.clear();
+        self.cards.clear();
+        #[cfg(test)]
+        {
+            self.source_entry_count = 0;
+        }
+    }
+
+    fn first_mismatch(
+        &self,
+        context: &FinalizedRenderContextKey,
+        desired: &[FinalizedCardKeyRef<'_>],
+    ) -> usize {
+        if self.context.as_ref() != Some(context) {
+            return 0;
+        }
+        let shared_len = self.keys.len().min(desired.len());
+        self.keys
+            .iter()
+            .zip(desired)
+            .position(|(stored, lookup)| !stored.matches_ref(lookup))
+            .unwrap_or(shared_len)
+    }
+
+    fn truncate(&mut self, index: usize) {
+        self.keys.truncate(index);
+        self.cards.truncate(index);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StreamKind {
+    Content,
+    Thinking,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StreamingCacheKey {
+    session: SessionCacheKey,
+    kind: StreamKind,
+    message_id: Option<String>,
+    paired_message_id: Option<String>,
+    fallback_ordinal: usize,
+    content: String,
+    full_width: u16,
+    theme: ThemeCacheKey,
+    show_thinking: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct StreamingCacheKeyRef<'a> {
+    session: &'a SessionCacheKey,
+    kind: StreamKind,
+    message_id: Option<&'a str>,
+    paired_message_id: Option<&'a str>,
+    fallback_ordinal: usize,
+    content: &'a str,
+    full_width: u16,
+    theme: ThemeCacheKey,
+    show_thinking: bool,
+}
+
+impl<'a> StreamingCacheKeyRef<'a> {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        session: &'a SessionCacheKey,
+        kind: StreamKind,
+        message_id: Option<&'a str>,
+        paired_message_id: Option<&'a str>,
+        fallback_ordinal: usize,
+        content: &'a str,
+        full_width: u16,
+        theme: ThemeCacheKey,
+        show_thinking: bool,
+    ) -> Self {
+        Self {
+            session,
+            kind,
+            message_id,
+            paired_message_id,
+            fallback_ordinal,
+            content,
+            full_width,
+            theme,
+            show_thinking,
+        }
+    }
+
+    fn to_owned(self) -> StreamingCacheKey {
+        StreamingCacheKey {
+            session: self.session.clone(),
+            kind: self.kind,
+            message_id: self.message_id.map(str::to_string),
+            paired_message_id: self.paired_message_id.map(str::to_string),
+            fallback_ordinal: self.fallback_ordinal,
+            content: self.content.to_string(),
+            full_width: self.full_width,
+            theme: self.theme,
+            show_thinking: self.show_thinking,
+        }
+    }
+}
+
+impl StreamingCacheKey {
+    fn matches_ref(&self, other: StreamingCacheKeyRef<'_>) -> bool {
+        self.session == *other.session
+            && self.kind == other.kind
+            && self.message_id.as_deref() == other.message_id
+            && self.paired_message_id.as_deref() == other.paired_message_id
+            && self.fallback_ordinal == other.fallback_ordinal
+            && self.content == other.content
+            && self.full_width == other.full_width
+            && self.theme == other.theme
+            && self.show_thinking == other.show_thinking
+    }
+}
+
+struct StreamingCacheEntry {
+    #[cfg(test)]
+    identity: u64,
+    key: StreamingCacheKey,
+    blocks: Vec<CardBlock>,
+}
+
+#[cfg(test)]
+static NEXT_STREAMING_CACHE_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+struct StreamingCache {
+    entry: Option<StreamingCacheEntry>,
+}
+
+impl StreamingCache {
+    fn new() -> Self {
+        Self { entry: None }
+    }
+
+    fn get(&self, key: StreamingCacheKeyRef<'_>) -> Option<&[CardBlock]> {
+        (!key.content.is_empty())
+            .then_some(())
+            .and(self.entry.as_ref())
+            .filter(|entry| entry.key.matches_ref(key))
+            .map(|entry| entry.blocks.as_slice())
+    }
+
+    fn store(&mut self, key: StreamingCacheKeyRef<'_>, blocks: Vec<CardBlock>) {
+        self.entry = (!key.content.is_empty()).then(|| StreamingCacheEntry {
+            #[cfg(test)]
+            identity: NEXT_STREAMING_CACHE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+            key: key.to_owned(),
+            blocks,
+        });
+    }
+
+    fn invalidate(&mut self) {
+        self.entry = None;
+    }
+}
+
+/// Owner for render-local cards, caches, identity, and viewport accounting.
 pub(crate) struct RenderState {
-    pub(crate) highlighter: Highlighter,
-    pub(crate) card_cache: CardCache,
-    pub(crate) streaming_cache: StreamingCache,
-    pub(crate) streaming_thinking_cache: StreamingCache,
+    highlighter: Highlighter,
+    card_cache: CardCache,
+    streaming_cache: StreamingCache,
+    streaming_thinking_cache: StreamingCache,
+    session_identity: Option<SessionIdentity>,
+    session_epoch: u64,
     pub(crate) prev_total_height: u16,
     pub(crate) tick: u64,
 }
@@ -19,8 +866,81 @@ impl RenderState {
             card_cache: CardCache::new(),
             streaming_cache: StreamingCache::new(),
             streaming_thinking_cache: StreamingCache::new(),
+            session_identity: None,
+            session_epoch: 0,
             prev_total_height: 0,
             tick: 0,
+        }
+    }
+
+    pub(crate) fn highlighter(&self) -> &Highlighter {
+        &self.highlighter
+    }
+
+    pub(crate) fn cards(&self) -> &[Card] {
+        &self.card_cache.cards
+    }
+
+    pub(crate) fn observe_session(&mut self, identity: &SessionIdentity) -> SessionCacheKey {
+        if self.session_identity.as_ref() != Some(identity) {
+            self.advance_session_epoch(identity.clone());
+        }
+        self.session_cache_key(identity)
+    }
+
+    pub(crate) fn advance_session_epoch(&mut self, identity: SessionIdentity) {
+        self.session_identity = Some(identity);
+        self.session_epoch = self.session_epoch.saturating_add(1);
+    }
+
+    fn session_cache_key(&self, identity: &SessionIdentity) -> SessionCacheKey {
+        SessionCacheKey {
+            epoch: self.session_epoch,
+            identity: identity.clone(),
+        }
+    }
+
+    pub(crate) fn prepare_finalized_cards(
+        &mut self,
+        context: FinalizedRenderContextKey,
+        desired: &[FinalizedCardKeyRef<'_>],
+    ) -> usize {
+        let mismatch = self.card_cache.first_mismatch(&context, desired);
+        self.card_cache.truncate(mismatch);
+        self.card_cache.context = Some(context);
+        mismatch
+    }
+
+    pub(crate) fn push_finalized_card(&mut self, key: &FinalizedCardKeyRef<'_>, card: Card) {
+        self.card_cache.keys.push(key.to_owned());
+        self.card_cache.cards.push(card);
+    }
+
+    pub(crate) fn finish_finalized_cards(&mut self, source_entry_count: usize) {
+        debug_assert_eq!(self.card_cache.keys.len(), self.card_cache.cards.len());
+        #[cfg(test)]
+        {
+            self.card_cache.source_entry_count = source_entry_count;
+        }
+        #[cfg(not(test))]
+        let _ = source_entry_count;
+    }
+
+    pub(crate) fn streaming_blocks(&self, key: StreamingCacheKeyRef<'_>) -> Option<&[CardBlock]> {
+        match key.kind {
+            StreamKind::Content => self.streaming_cache.get(key),
+            StreamKind::Thinking => self.streaming_thinking_cache.get(key),
+        }
+    }
+
+    pub(crate) fn store_streaming_blocks(
+        &mut self,
+        key: StreamingCacheKeyRef<'_>,
+        blocks: Vec<CardBlock>,
+    ) {
+        match key.kind {
+            StreamKind::Content => self.streaming_cache.store(key, blocks),
+            StreamKind::Thinking => self.streaming_thinking_cache.store(key, blocks),
         }
     }
 
@@ -57,39 +977,65 @@ impl RenderState {
         }
         self.prev_total_height = total_height;
     }
-}
 
-/// Cache for rendered streaming markdown to avoid re-parsing every frame.
-/// Invalidated when the corresponding streaming buffer grows or is cleared.
-pub(crate) struct StreamingCache {
-    rendered_len: usize,
-    blocks: Vec<CardBlock>,
-}
+    #[cfg(test)]
+    pub(crate) fn test_seed_card_cache(&mut self, source_entry_count: usize) {
+        self.card_cache.invalidate();
+        self.card_cache.source_entry_count = source_entry_count;
+        self.card_cache.cards.push(Card::new(
+            CardKind::Info,
+            vec![CardBlock::Text(Line::from("card sentinel"))],
+        ));
+    }
 
-impl StreamingCache {
-    pub(crate) fn new() -> Self {
-        Self {
-            rendered_len: 0,
-            blocks: Vec::new(),
+    #[cfg(test)]
+    pub(crate) fn test_card_source_entry_count(&self) -> usize {
+        self.card_cache.source_entry_count
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_card_identity(&self, index: usize) -> Option<u64> {
+        self.card_cache.cards.get(index).map(|card| card.identity)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_seed_streaming_cache(&mut self, kind: StreamKind) {
+        let identity = SessionIdentity::new(Some("sentinel".into()), None, false);
+        let session = SessionCacheKey { epoch: 1, identity };
+        let key = StreamingCacheKeyRef::new(
+            &session,
+            kind,
+            Some("message"),
+            None,
+            1,
+            "sentinel",
+            80,
+            ThemeCacheKey::new(0, 0),
+            true,
+        );
+        self.store_streaming_blocks(key, vec![CardBlock::Text(Line::from("stream sentinel"))]);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_streaming_cache_populated(&self, kind: StreamKind) -> bool {
+        match kind {
+            StreamKind::Content => self.streaming_cache.entry.is_some(),
+            StreamKind::Thinking => self.streaming_thinking_cache.entry.is_some(),
         }
     }
 
-    pub(crate) fn get(&self, content_len: usize) -> Option<&[CardBlock]> {
-        if content_len > 0 && content_len == self.rendered_len {
-            Some(&self.blocks)
-        } else {
-            None
+    #[cfg(test)]
+    pub(crate) fn test_streaming_cache_identity(&self, kind: StreamKind) -> Option<u64> {
+        match kind {
+            StreamKind::Content => self.streaming_cache.entry.as_ref(),
+            StreamKind::Thinking => self.streaming_thinking_cache.entry.as_ref(),
         }
+        .map(|entry| entry.identity)
     }
 
-    pub(crate) fn store(&mut self, content_len: usize, blocks: Vec<CardBlock>) {
-        self.rendered_len = content_len;
-        self.blocks = blocks;
-    }
-
-    pub(crate) fn invalidate(&mut self) {
-        self.rendered_len = 0;
-        self.blocks.clear();
+    #[cfg(test)]
+    pub(crate) fn test_session_epoch(&self) -> u64 {
+        self.session_epoch
     }
 }
 
@@ -99,126 +1045,238 @@ mod tests {
 
     use super::*;
 
-    fn block(text: &'static str) -> CardBlock {
-        CardBlock::Text(Line::from(text))
+    fn identity(id: &str, node: Option<&str>, remote: bool) -> SessionIdentity {
+        SessionIdentity::new(Some(id.to_string()), node.map(str::to_string), remote)
     }
 
-    fn seed_all_caches(state: &mut RenderState) {
-        state.card_cache.processed_messages = 2;
-        state.streaming_cache.store(7, vec![block("content")]);
-        state
-            .streaming_thinking_cache
-            .store(8, vec![block("thinking")]);
-    }
-
-    #[test]
-    fn constructor_uses_exact_six_field_defaults() {
-        let RenderState {
-            highlighter: _,
-            card_cache,
-            streaming_cache,
-            streaming_thinking_cache,
-            prev_total_height,
-            tick,
-        } = RenderState::new();
-
-        assert!(card_cache.cards.is_empty());
-        assert_eq!(card_cache.processed_messages, 0);
-        assert!(streaming_cache.get(1).is_none());
-        assert!(streaming_thinking_cache.get(1).is_none());
-        assert_eq!(prev_total_height, 0);
-        assert_eq!(tick, 0);
+    fn stream_key<'a>(
+        session: &'a SessionCacheKey,
+        kind: StreamKind,
+        message_id: Option<&'a str>,
+        paired_message_id: Option<&'a str>,
+        content: &'a str,
+    ) -> StreamingCacheKeyRef<'a> {
+        StreamingCacheKeyRef::new(
+            session,
+            kind,
+            message_id,
+            paired_message_id,
+            4,
+            content,
+            80,
+            ThemeCacheKey::new(2, 7),
+            true,
+        )
     }
 
     #[test]
-    fn streaming_cache_hits_only_the_stored_nonzero_length() {
-        let mut cache = StreamingCache::new();
-        cache.store(7, vec![block("content")]);
+    fn constructor_starts_with_empty_private_caches_and_zero_layout_state() {
+        let state = RenderState::new();
 
-        assert!(cache.get(0).is_none());
-        assert!(cache.get(6).is_none());
-        assert_eq!(cache.get(7).map(<[_]>::len), Some(1));
-        assert!(cache.get(8).is_none());
+        assert!(state.cards().is_empty());
+        assert_eq!(state.test_card_source_entry_count(), 0);
+        assert!(!state.test_streaming_cache_populated(StreamKind::Content));
+        assert!(!state.test_streaming_cache_populated(StreamKind::Thinking));
+        assert_eq!(state.test_session_epoch(), 0);
+        assert_eq!(state.prev_total_height, 0);
+        assert_eq!(state.tick, 0);
     }
 
     #[test]
-    fn individual_invalidations_clear_only_the_selected_cache() {
+    fn session_observation_and_explicit_reload_use_monotonic_epochs() {
         let mut state = RenderState::new();
-        seed_all_caches(&mut state);
+        let local = identity("same", None, false);
+        let remote = identity("same", Some("node-1"), true);
+
+        assert_eq!(state.observe_session(&local).epoch, 1);
+        assert_eq!(state.observe_session(&local).epoch, 1);
+        state.advance_session_epoch(local.clone());
+        assert_eq!(state.observe_session(&local).epoch, 2);
+        assert_eq!(state.observe_session(&remote).epoch, 3);
+    }
+
+    #[test]
+    fn streaming_key_compares_exact_content_ids_kind_and_session() {
+        let mut state = RenderState::new();
+        let local = identity("session", None, false);
+        let session = state.observe_session(&local);
+        let content = stream_key(
+            &session,
+            StreamKind::Content,
+            Some("a1"),
+            Some("t1"),
+            "same",
+        );
+        state.store_streaming_blocks(content, vec![CardBlock::Text(Line::from("cached"))]);
+
+        assert!(state.streaming_blocks(content).is_some());
+        assert!(
+            state
+                .streaming_blocks(stream_key(
+                    &session,
+                    StreamKind::Content,
+                    Some("a1"),
+                    Some("t1"),
+                    "size",
+                ))
+                .is_none(),
+            "same-length replacement must miss"
+        );
+        assert!(
+            state
+                .streaming_blocks(stream_key(
+                    &session,
+                    StreamKind::Content,
+                    Some("a2"),
+                    Some("t1"),
+                    "same",
+                ))
+                .is_none()
+        );
+        assert!(
+            state
+                .streaming_blocks(stream_key(
+                    &session,
+                    StreamKind::Thinking,
+                    Some("a1"),
+                    Some("t1"),
+                    "same",
+                ))
+                .is_none()
+        );
+        for changed in [
+            StreamingCacheKeyRef {
+                full_width: 79,
+                ..content
+            },
+            StreamingCacheKeyRef {
+                fallback_ordinal: 5,
+                ..content
+            },
+            StreamingCacheKeyRef {
+                theme: ThemeCacheKey::new(2, 8),
+                ..content
+            },
+            StreamingCacheKeyRef {
+                show_thinking: false,
+                ..content
+            },
+        ] {
+            assert!(state.streaming_blocks(changed).is_none());
+        }
+
+        state.advance_session_epoch(local.clone());
+        let reloaded = state.observe_session(&local);
+        assert!(
+            state
+                .streaming_blocks(stream_key(
+                    &reloaded,
+                    StreamKind::Content,
+                    Some("a1"),
+                    Some("t1"),
+                    "same",
+                ))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn empty_stream_content_never_hits_or_stores() {
+        let mut state = RenderState::new();
+        let local = identity("session", None, false);
+        let session = state.observe_session(&local);
+        let empty = stream_key(&session, StreamKind::Content, None, None, "");
+
+        state.store_streaming_blocks(empty, vec![CardBlock::Text(Line::from("unexpected"))]);
+        assert!(state.streaming_blocks(empty).is_none());
+        assert!(!state.test_streaming_cache_populated(StreamKind::Content));
+    }
+
+    #[test]
+    fn individual_invalidations_clear_only_selected_storage() {
+        let mut state = RenderState::new();
+        state.test_seed_card_cache(2);
+        state.test_seed_streaming_cache(StreamKind::Content);
+        state.test_seed_streaming_cache(StreamKind::Thinking);
 
         state.invalidate_content_cache();
-        assert_eq!(state.card_cache.processed_messages, 2);
-        assert!(state.streaming_cache.get(7).is_none());
-        assert!(state.streaming_thinking_cache.get(8).is_some());
+        assert_eq!(state.test_card_source_entry_count(), 2);
+        assert!(!state.test_streaming_cache_populated(StreamKind::Content));
+        assert!(state.test_streaming_cache_populated(StreamKind::Thinking));
 
         state.invalidate_thinking_cache();
-        assert_eq!(state.card_cache.processed_messages, 2);
-        assert!(state.streaming_thinking_cache.get(8).is_none());
+        assert_eq!(state.test_card_source_entry_count(), 2);
+        assert!(!state.test_streaming_cache_populated(StreamKind::Thinking));
 
         state.invalidate_card_cache();
-        assert_eq!(state.card_cache.processed_messages, 0);
+        assert_eq!(state.test_card_source_entry_count(), 0);
     }
 
     #[test]
-    fn theme_invalidation_clears_all_three_caches() {
+    fn session_switch_invalidation_keeps_new_stream_storage_isolated() {
         let mut state = RenderState::new();
-        seed_all_caches(&mut state);
-
-        state.invalidate_theme_caches();
-
-        assert_eq!(state.card_cache.processed_messages, 0);
-        assert!(state.streaming_cache.get(7).is_none());
-        assert!(state.streaming_thinking_cache.get(8).is_none());
-    }
-
-    #[test]
-    fn session_switch_invalidation_keeps_streaming_sessions_isolated() {
-        let mut state = RenderState::new();
-        seed_all_caches(&mut state);
+        state.test_seed_card_cache(2);
+        state.test_seed_streaming_cache(StreamKind::Content);
+        state.test_seed_streaming_cache(StreamKind::Thinking);
 
         state.invalidate_content_cache();
         state.invalidate_thinking_cache();
         state.invalidate_card_cache();
-        state.streaming_cache.store(4, vec![block("next")]);
+        state.test_seed_streaming_cache(StreamKind::Content);
 
-        assert_eq!(state.card_cache.processed_messages, 0);
-        assert!(state.streaming_cache.get(7).is_none());
-        assert!(state.streaming_cache.get(4).is_some());
-        assert!(state.streaming_thinking_cache.get(8).is_none());
+        assert_eq!(state.test_card_source_entry_count(), 0);
+        assert!(state.test_streaming_cache_populated(StreamKind::Content));
+        assert!(!state.test_streaming_cache_populated(StreamKind::Thinking));
     }
 
     #[test]
     fn external_editor_invalidation_retains_thinking_cache() {
         let mut state = RenderState::new();
-        seed_all_caches(&mut state);
+        state.test_seed_card_cache(2);
+        state.test_seed_streaming_cache(StreamKind::Content);
+        state.test_seed_streaming_cache(StreamKind::Thinking);
 
         state.invalidate_card_cache();
         state.invalidate_content_cache();
 
-        assert_eq!(state.card_cache.processed_messages, 0);
-        assert!(state.streaming_cache.get(7).is_none());
-        assert!(state.streaming_thinking_cache.get(8).is_some());
+        assert_eq!(state.test_card_source_entry_count(), 0);
+        assert!(!state.test_streaming_cache_populated(StreamKind::Content));
+        assert!(state.test_streaming_cache_populated(StreamKind::Thinking));
     }
 
     #[test]
-    fn delegate_invalidation_clears_only_card_cache() {
+    fn delegate_invalidation_clears_only_finalized_cards() {
         let mut state = RenderState::new();
-        seed_all_caches(&mut state);
+        state.test_seed_card_cache(2);
+        state.test_seed_streaming_cache(StreamKind::Content);
+        state.test_seed_streaming_cache(StreamKind::Thinking);
 
         state.invalidate_card_cache();
 
-        assert_eq!(state.card_cache.processed_messages, 0);
-        assert!(state.streaming_cache.get(7).is_some());
-        assert!(state.streaming_thinking_cache.get(8).is_some());
+        assert_eq!(state.test_card_source_entry_count(), 0);
+        assert!(state.test_streaming_cache_populated(StreamKind::Content));
+        assert!(state.test_streaming_cache_populated(StreamKind::Thinking));
+    }
+
+    #[test]
+    fn theme_invalidation_clears_all_three_caches() {
+        let mut state = RenderState::new();
+        state.test_seed_card_cache(2);
+        state.test_seed_streaming_cache(StreamKind::Content);
+        state.test_seed_streaming_cache(StreamKind::Thinking);
+
+        state.invalidate_theme_caches();
+
+        assert_eq!(state.test_card_source_entry_count(), 0);
+        assert!(!state.test_streaming_cache_populated(StreamKind::Content));
+        assert!(!state.test_streaming_cache_populated(StreamKind::Thinking));
     }
 
     #[test]
     fn tick_replacement_preserves_wall_clock_derived_value() {
         let mut state = RenderState::new();
-
         state.replace_tick(17);
         state.replace_tick(3);
-
         assert_eq!(state.tick, 3);
     }
 

--- a/src/render_state.rs
+++ b/src/render_state.rs
@@ -11,6 +11,7 @@ use crate::domain::activity::{DelegateEntry, DelegateStatus};
 use crate::domain::chat::{ChatEntry, ElicitationResponseOutcome};
 use crate::domain::tool::ToolDetail;
 use crate::highlight::Highlighter;
+use crate::input_layout::{InputVisualLayout, build_input_visual_layout};
 use crate::markdown::CardBlock;
 use crate::theme::Theme;
 
@@ -864,6 +865,38 @@ struct ChatViewportState {
     previous_total_height: u16,
 }
 
+struct ComposerInputGeometry {
+    line_width: usize,
+    scroll: u16,
+    layout: Option<InputVisualLayout>,
+}
+
+impl Default for ComposerInputGeometry {
+    fn default() -> Self {
+        Self {
+            line_width: 1,
+            scroll: 0,
+            layout: None,
+        }
+    }
+}
+
+struct ElicitationCustomEditorGeometry {
+    line_width: usize,
+    scroll: u16,
+    layout: Option<InputVisualLayout>,
+}
+
+impl Default for ElicitationCustomEditorGeometry {
+    fn default() -> Self {
+        Self {
+            line_width: 1,
+            scroll: 0,
+            layout: None,
+        }
+    }
+}
+
 /// Owner for render-local cards, caches, identity, and viewport accounting.
 pub(crate) struct RenderState {
     highlighter: Highlighter,
@@ -873,6 +906,8 @@ pub(crate) struct RenderState {
     session_identity: Option<SessionIdentity>,
     session_epoch: u64,
     chat_viewport: ChatViewportState,
+    composer_input: ComposerInputGeometry,
+    elicitation_custom_editor: ElicitationCustomEditorGeometry,
     pub(crate) tick: u64,
     #[cfg(test)]
     invalidation_order: Vec<CacheInvalidation>,
@@ -896,6 +931,8 @@ impl RenderState {
             session_identity: None,
             session_epoch: 0,
             chat_viewport: ChatViewportState::default(),
+            composer_input: ComposerInputGeometry::default(),
+            elicitation_custom_editor: ElicitationCustomEditorGeometry::default(),
             tick: 0,
             #[cfg(test)]
             invalidation_order: Vec::new(),
@@ -1023,6 +1060,100 @@ impl RenderState {
         self.tick = tick;
     }
 
+    pub(crate) fn prepare_composer_input_layout(
+        &mut self,
+        input: &str,
+        cursor: usize,
+        line_width: usize,
+        prefix_width: usize,
+    ) -> InputVisualLayout {
+        let line_width = line_width.max(1);
+        let layout = build_input_visual_layout(input, cursor, line_width, prefix_width);
+        self.composer_input.line_width = line_width;
+        self.composer_input.layout = Some(layout.clone());
+        layout
+    }
+
+    pub(crate) fn composer_input_line_width(&self) -> usize {
+        self.composer_input.line_width
+    }
+
+    pub(crate) fn ensure_composer_input_cursor_visible(
+        &mut self,
+        visible_rows: u16,
+        hidden: bool,
+    ) -> u16 {
+        if hidden {
+            self.composer_input.scroll = 0;
+            return 0;
+        }
+        let Some(layout) = self.composer_input.layout.as_ref() else {
+            return self.composer_input.scroll;
+        };
+        let cursor_row = layout.cursor_row as u16;
+        if cursor_row >= self.composer_input.scroll + visible_rows {
+            self.composer_input.scroll = cursor_row - visible_rows + 1;
+        }
+        if cursor_row < self.composer_input.scroll {
+            self.composer_input.scroll = cursor_row;
+        }
+        let total_rows = layout.total_rows() as u16;
+        self.composer_input.scroll = self
+            .composer_input
+            .scroll
+            .min(total_rows.saturating_sub(visible_rows));
+        self.composer_input.scroll
+    }
+
+    pub(crate) fn reset_composer_input_geometry(&mut self) {
+        self.composer_input = ComposerInputGeometry::default();
+    }
+
+    pub(crate) fn prepare_elicitation_custom_layout(
+        &mut self,
+        input: &str,
+        cursor: usize,
+        line_width: usize,
+        prefix_width: usize,
+    ) -> InputVisualLayout {
+        let line_width = line_width.max(1);
+        let layout = build_input_visual_layout(input, cursor, line_width, prefix_width);
+        self.elicitation_custom_editor.line_width = line_width;
+        self.elicitation_custom_editor.layout = Some(layout.clone());
+        layout
+    }
+
+    pub(crate) fn elicitation_custom_line_width(&self) -> usize {
+        self.elicitation_custom_editor.line_width
+    }
+
+    pub(crate) fn ensure_elicitation_custom_cursor_visible(&mut self, visible_rows: u16) -> u16 {
+        let Some(layout) = self.elicitation_custom_editor.layout.as_ref() else {
+            return self.elicitation_custom_editor.scroll;
+        };
+        let cursor_row = layout.cursor_row as u16;
+        if cursor_row >= self.elicitation_custom_editor.scroll + visible_rows {
+            self.elicitation_custom_editor.scroll = cursor_row - visible_rows + 1;
+        }
+        if cursor_row < self.elicitation_custom_editor.scroll {
+            self.elicitation_custom_editor.scroll = cursor_row;
+        }
+        let total_rows = layout.total_rows() as u16;
+        self.elicitation_custom_editor.scroll = self
+            .elicitation_custom_editor
+            .scroll
+            .min(total_rows.saturating_sub(visible_rows));
+        self.elicitation_custom_editor.scroll
+    }
+
+    pub(crate) fn reset_elicitation_custom_scroll(&mut self) {
+        self.elicitation_custom_editor.scroll = 0;
+    }
+
+    pub(crate) fn reset_elicitation_custom_geometry(&mut self) {
+        self.elicitation_custom_editor = ElicitationCustomEditorGeometry::default();
+    }
+
     pub(crate) fn chat_scroll_offset(&self) -> u16 {
         self.chat_viewport.scroll_offset
     }
@@ -1065,6 +1196,36 @@ impl RenderState {
 
     pub(crate) fn reset_chat_viewport(&mut self) {
         self.chat_viewport = ChatViewportState::default();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_composer_input_geometry(&self) -> (usize, u16, bool) {
+        (
+            self.composer_input.line_width,
+            self.composer_input.scroll,
+            self.composer_input.layout.is_some(),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_elicitation_custom_geometry(&self) -> (usize, u16, bool) {
+        (
+            self.elicitation_custom_editor.line_width,
+            self.elicitation_custom_editor.scroll,
+            self.elicitation_custom_editor.layout.is_some(),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_seed_composer_input_geometry(&mut self, width: usize, scroll: u16) {
+        self.prepare_composer_input_layout("a\nb\nc\nd\ne\nf", 11, width, 2);
+        self.composer_input.scroll = scroll;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_seed_elicitation_custom_geometry(&mut self, width: usize, scroll: u16) {
+        self.prepare_elicitation_custom_layout("a\nb\nc\nd\ne\nf", 11, width, 2);
+        self.elicitation_custom_editor.scroll = scroll;
     }
 
     #[cfg(test)]
@@ -1182,6 +1343,8 @@ mod tests {
         assert_eq!(state.test_session_epoch(), 0);
         assert_eq!(state.chat_scroll_offset(), 0);
         assert_eq!(state.test_chat_previous_total_height(), 0);
+        assert_eq!(state.test_composer_input_geometry(), (1, 0, false));
+        assert_eq!(state.test_elicitation_custom_geometry(), (1, 0, false));
         assert_eq!(state.tick, 0);
     }
 
@@ -1415,6 +1578,66 @@ mod tests {
         state.replace_tick(17);
         state.replace_tick(3);
         assert_eq!(state.tick, 3);
+    }
+
+    #[test]
+    fn editor_geometry_preparation_scroll_and_resets_preserve_exact_boundaries() {
+        let mut state = RenderState::new();
+
+        let composer = state.prepare_composer_input_layout("a\nb\nc\nd\ne\nf", 11, 8, 2);
+        assert_eq!(composer.total_rows(), 6);
+        assert_eq!(state.test_composer_input_geometry(), (8, 0, true));
+        assert_eq!(state.ensure_composer_input_cursor_visible(5, false), 1);
+        state.prepare_composer_input_layout("a\nb\nc\nd\ne\nf", 0, 4, 2);
+        assert_eq!(state.ensure_composer_input_cursor_visible(5, false), 0);
+        state.test_seed_composer_input_geometry(9, 3);
+        assert_eq!(state.ensure_composer_input_cursor_visible(5, true), 0);
+        assert_eq!(state.test_composer_input_geometry(), (9, 0, true));
+        state.reset_composer_input_geometry();
+        assert_eq!(state.test_composer_input_geometry(), (1, 0, false));
+
+        let custom = state.prepare_elicitation_custom_layout("a\nb\nc\nd\ne\nf", 11, 7, 2);
+        assert_eq!(custom.total_rows(), 6);
+        assert_eq!(state.ensure_elicitation_custom_cursor_visible(5), 1);
+        assert_eq!(state.test_elicitation_custom_geometry(), (7, 1, true));
+        assert_eq!(state.ensure_elicitation_custom_cursor_visible(0), 5);
+        state.reset_elicitation_custom_scroll();
+        assert_eq!(state.test_elicitation_custom_geometry(), (7, 0, true));
+        state.reset_elicitation_custom_geometry();
+        assert_eq!(state.test_elicitation_custom_geometry(), (1, 0, false));
+    }
+
+    #[test]
+    fn editor_geometry_changes_do_not_touch_caches_epoch_viewport_or_invalidation() {
+        let mut state = seeded_caches();
+        state.advance_session_epoch(identity("session", None, false));
+        state.test_seed_chat_viewport(4, 18);
+        let card_identity = state.test_card_identity(0);
+        let content_identity = state.test_streaming_cache_identity(StreamKind::Content);
+        let thinking_identity = state.test_streaming_cache_identity(StreamKind::Thinking);
+        state.invalidation_order.clear();
+
+        state.prepare_composer_input_layout("composer", 8, 12, 2);
+        state.ensure_composer_input_cursor_visible(2, false);
+        state.reset_composer_input_geometry();
+        state.prepare_elicitation_custom_layout("custom", 6, 10, 2);
+        state.ensure_elicitation_custom_cursor_visible(0);
+        state.reset_elicitation_custom_scroll();
+        state.reset_elicitation_custom_geometry();
+
+        assert_eq!(state.test_card_identity(0), card_identity);
+        assert_eq!(
+            state.test_streaming_cache_identity(StreamKind::Content),
+            content_identity
+        );
+        assert_eq!(
+            state.test_streaming_cache_identity(StreamKind::Thinking),
+            thinking_identity
+        );
+        assert_eq!(state.test_session_epoch(), 1);
+        assert_eq!(state.chat_scroll_offset(), 4);
+        assert_eq!(state.test_chat_previous_total_height(), 18);
+        assert!(state.invalidation_order.is_empty());
     }
 
     #[test]

--- a/src/render_state.rs
+++ b/src/render_state.rs
@@ -46,6 +46,17 @@ impl SessionIdentity {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RenderChange {
+    SessionChanged(SessionIdentity),
+    FinalizedMessagesChanged,
+    StreamingContentChanged,
+    StreamingThinkingChanged,
+    DelegatePresentationChanged,
+    ThemeChanged,
+    ExternalEditorReturned,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SessionCacheKey {
     epoch: u64,
     identity: SessionIdentity,
@@ -857,6 +868,16 @@ pub(crate) struct RenderState {
     session_epoch: u64,
     pub(crate) prev_total_height: u16,
     pub(crate) tick: u64,
+    #[cfg(test)]
+    invalidation_order: Vec<CacheInvalidation>,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CacheInvalidation {
+    Finalized,
+    Content,
+    Thinking,
 }
 
 impl RenderState {
@@ -870,6 +891,8 @@ impl RenderState {
             session_epoch: 0,
             prev_total_height: 0,
             tick: 0,
+            #[cfg(test)]
+            invalidation_order: Vec::new(),
         }
     }
 
@@ -888,7 +911,28 @@ impl RenderState {
         self.session_cache_key(identity)
     }
 
-    pub(crate) fn advance_session_epoch(&mut self, identity: SessionIdentity) {
+    pub(crate) fn apply_change(&mut self, change: RenderChange) {
+        match change {
+            RenderChange::SessionChanged(identity) => {
+                self.advance_session_epoch(identity);
+                self.invalidate_content_cache();
+                self.invalidate_thinking_cache();
+                self.invalidate_card_cache();
+            }
+            RenderChange::FinalizedMessagesChanged | RenderChange::DelegatePresentationChanged => {
+                self.invalidate_card_cache()
+            }
+            RenderChange::StreamingContentChanged => self.invalidate_content_cache(),
+            RenderChange::StreamingThinkingChanged => self.invalidate_thinking_cache(),
+            RenderChange::ThemeChanged => self.invalidate_theme_caches(),
+            RenderChange::ExternalEditorReturned => {
+                self.invalidate_card_cache();
+                self.invalidate_content_cache();
+            }
+        }
+    }
+
+    fn advance_session_epoch(&mut self, identity: SessionIdentity) {
         self.session_identity = Some(identity);
         self.session_epoch = self.session_epoch.saturating_add(1);
     }
@@ -944,19 +988,25 @@ impl RenderState {
         }
     }
 
-    pub(crate) fn invalidate_card_cache(&mut self) {
+    fn invalidate_card_cache(&mut self) {
         self.card_cache.invalidate();
+        #[cfg(test)]
+        self.invalidation_order.push(CacheInvalidation::Finalized);
     }
 
-    pub(crate) fn invalidate_content_cache(&mut self) {
+    fn invalidate_content_cache(&mut self) {
         self.streaming_cache.invalidate();
+        #[cfg(test)]
+        self.invalidation_order.push(CacheInvalidation::Content);
     }
 
-    pub(crate) fn invalidate_thinking_cache(&mut self) {
+    fn invalidate_thinking_cache(&mut self) {
         self.streaming_thinking_cache.invalidate();
+        #[cfg(test)]
+        self.invalidation_order.push(CacheInvalidation::Thinking);
     }
 
-    pub(crate) fn invalidate_theme_caches(&mut self) {
+    fn invalidate_theme_caches(&mut self) {
         self.invalidate_card_cache();
         self.invalidate_content_cache();
         self.invalidate_thinking_cache();
@@ -1192,84 +1242,112 @@ mod tests {
         assert!(!state.test_streaming_cache_populated(StreamKind::Content));
     }
 
-    #[test]
-    fn individual_invalidations_clear_only_selected_storage() {
+    fn seeded_caches() -> RenderState {
         let mut state = RenderState::new();
         state.test_seed_card_cache(2);
         state.test_seed_streaming_cache(StreamKind::Content);
         state.test_seed_streaming_cache(StreamKind::Thinking);
+        state
+    }
 
-        state.invalidate_content_cache();
-        assert_eq!(state.test_card_source_entry_count(), 2);
-        assert!(!state.test_streaming_cache_populated(StreamKind::Content));
-        assert!(state.test_streaming_cache_populated(StreamKind::Thinking));
-
-        state.invalidate_thinking_cache();
-        assert_eq!(state.test_card_source_entry_count(), 2);
-        assert!(!state.test_streaming_cache_populated(StreamKind::Thinking));
-
-        state.invalidate_card_cache();
-        assert_eq!(state.test_card_source_entry_count(), 0);
+    fn assert_cache_scope(
+        state: &RenderState,
+        cards: bool,
+        content: bool,
+        thinking: bool,
+        order: &[CacheInvalidation],
+    ) {
+        assert_eq!(state.test_card_source_entry_count() > 0, cards);
+        assert_eq!(
+            state.test_streaming_cache_populated(StreamKind::Content),
+            content
+        );
+        assert_eq!(
+            state.test_streaming_cache_populated(StreamKind::Thinking),
+            thinking
+        );
+        assert_eq!(state.invalidation_order, order);
     }
 
     #[test]
-    fn session_switch_invalidation_keeps_new_stream_storage_isolated() {
-        let mut state = RenderState::new();
+    fn session_change_advances_epoch_and_clears_content_thinking_then_cards() {
+        let mut state = seeded_caches();
+        let session = identity("same", None, false);
+        let expected_order = [
+            CacheInvalidation::Content,
+            CacheInvalidation::Thinking,
+            CacheInvalidation::Finalized,
+        ];
+
+        state.apply_change(RenderChange::SessionChanged(session.clone()));
+        assert_eq!(state.test_session_epoch(), 1);
+        assert_cache_scope(&state, false, false, false, &expected_order);
+
         state.test_seed_card_cache(2);
         state.test_seed_streaming_cache(StreamKind::Content);
         state.test_seed_streaming_cache(StreamKind::Thinking);
-
-        state.invalidate_content_cache();
-        state.invalidate_thinking_cache();
-        state.invalidate_card_cache();
-        state.test_seed_streaming_cache(StreamKind::Content);
-
-        assert_eq!(state.test_card_source_entry_count(), 0);
-        assert!(state.test_streaming_cache_populated(StreamKind::Content));
-        assert!(!state.test_streaming_cache_populated(StreamKind::Thinking));
+        state.invalidation_order.clear();
+        state.apply_change(RenderChange::SessionChanged(session));
+        assert_eq!(state.test_session_epoch(), 2);
+        assert_cache_scope(&state, false, false, false, &expected_order);
     }
 
     #[test]
-    fn external_editor_invalidation_retains_thinking_cache() {
-        let mut state = RenderState::new();
-        state.test_seed_card_cache(2);
-        state.test_seed_streaming_cache(StreamKind::Content);
-        state.test_seed_streaming_cache(StreamKind::Thinking);
-
-        state.invalidate_card_cache();
-        state.invalidate_content_cache();
-
-        assert_eq!(state.test_card_source_entry_count(), 0);
-        assert!(!state.test_streaming_cache_populated(StreamKind::Content));
-        assert!(state.test_streaming_cache_populated(StreamKind::Thinking));
+    fn finalized_message_change_clears_only_cards() {
+        let mut state = seeded_caches();
+        state.apply_change(RenderChange::FinalizedMessagesChanged);
+        assert_cache_scope(&state, false, true, true, &[CacheInvalidation::Finalized]);
     }
 
     #[test]
-    fn delegate_invalidation_clears_only_finalized_cards() {
-        let mut state = RenderState::new();
-        state.test_seed_card_cache(2);
-        state.test_seed_streaming_cache(StreamKind::Content);
-        state.test_seed_streaming_cache(StreamKind::Thinking);
-
-        state.invalidate_card_cache();
-
-        assert_eq!(state.test_card_source_entry_count(), 0);
-        assert!(state.test_streaming_cache_populated(StreamKind::Content));
-        assert!(state.test_streaming_cache_populated(StreamKind::Thinking));
+    fn streaming_content_change_clears_only_content() {
+        let mut state = seeded_caches();
+        state.apply_change(RenderChange::StreamingContentChanged);
+        assert_cache_scope(&state, true, false, true, &[CacheInvalidation::Content]);
     }
 
     #[test]
-    fn theme_invalidation_clears_all_three_caches() {
-        let mut state = RenderState::new();
-        state.test_seed_card_cache(2);
-        state.test_seed_streaming_cache(StreamKind::Content);
-        state.test_seed_streaming_cache(StreamKind::Thinking);
+    fn streaming_thinking_change_clears_only_thinking() {
+        let mut state = seeded_caches();
+        state.apply_change(RenderChange::StreamingThinkingChanged);
+        assert_cache_scope(&state, true, true, false, &[CacheInvalidation::Thinking]);
+    }
 
-        state.invalidate_theme_caches();
+    #[test]
+    fn delegate_presentation_change_clears_only_cards() {
+        let mut state = seeded_caches();
+        state.apply_change(RenderChange::DelegatePresentationChanged);
+        assert_cache_scope(&state, false, true, true, &[CacheInvalidation::Finalized]);
+    }
 
-        assert_eq!(state.test_card_source_entry_count(), 0);
-        assert!(!state.test_streaming_cache_populated(StreamKind::Content));
-        assert!(!state.test_streaming_cache_populated(StreamKind::Thinking));
+    #[test]
+    fn theme_change_clears_cards_content_then_thinking() {
+        let mut state = seeded_caches();
+        state.apply_change(RenderChange::ThemeChanged);
+        assert_cache_scope(
+            &state,
+            false,
+            false,
+            false,
+            &[
+                CacheInvalidation::Finalized,
+                CacheInvalidation::Content,
+                CacheInvalidation::Thinking,
+            ],
+        );
+    }
+
+    #[test]
+    fn external_editor_return_clears_cards_and_content_but_retains_thinking() {
+        let mut state = seeded_caches();
+        state.apply_change(RenderChange::ExternalEditorReturned);
+        assert_cache_scope(
+            &state,
+            false,
+            false,
+            true,
+            &[CacheInvalidation::Finalized, CacheInvalidation::Content],
+        );
     }
 
     #[test]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -596,6 +596,7 @@ mod tests {
             effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Down)));
         }
         effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Enter)));
+        app.render.test_seed_elicitation_custom_geometry(19, 3);
         effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Esc)));
 
         assert!(
@@ -604,6 +605,7 @@ mod tests {
                 .as_ref()
                 .is_some_and(|ui| !ui.custom_active)
         );
+        assert_eq!(app.render.test_elicitation_custom_geometry(), (19, 0, true));
         assert!(effects.next_command().is_none());
 
         effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Esc)));
@@ -966,13 +968,40 @@ mod external_editor_tests {
     }
 
     #[test]
+    fn composer_visual_movement_uses_default_published_and_resized_render_widths() {
+        let mut app = App::new();
+        app.navigation.screen = Screen::Chat;
+        app.composer.input = "abc".into();
+        app.composer.input_cursor = app.composer.input.len();
+
+        handle_chat_key(&mut app, KeyEvent::new(KeyCode::Up, KeyModifiers::empty()));
+        assert_eq!(app.render.composer_input_line_width(), 1);
+        assert_eq!(app.composer.input_cursor, 2);
+
+        app.composer.input_cursor = app.composer.input.len();
+        app.composer.input_preferred_col = None;
+        app.render.prepare_composer_input_layout("abc", 3, 4, 2);
+        handle_chat_key(&mut app, KeyEvent::new(KeyCode::Up, KeyModifiers::empty()));
+        assert_eq!(app.composer.input_cursor, 1);
+
+        app.composer.input_preferred_col = None;
+        app.render.prepare_composer_input_layout("abc", 1, 20, 2);
+        handle_chat_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Down, KeyModifiers::empty()),
+        );
+        assert_eq!(app.composer.input_cursor, 1);
+        assert_eq!(app.composer.input_preferred_col, Some(1));
+    }
+
+    #[test]
     fn chat_up_down_navigate_wrapped_input_without_scrolling_history() {
         let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
         app.composer.input = "abcdef".into();
         app.composer.input_cursor = 4;
-        app.composer.input_line_width = 4;
+        app.render.prepare_composer_input_layout("abcdef", 4, 4, 2);
         app.render.set_chat_scroll_offset(7);
 
         effects.extend(handle_chat_key(

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2626,7 +2626,7 @@ mod session_popup_key_tests {
             Some("/a"),
             &["s1", "s2", "s3", "s4", "s5", "s6", "s7"],
         )];
-        app.sessions.session_popup_visible_rows = 4;
+        app.render.publish_session_popup_visible_rows(4);
 
         apply_popup_session_key(&mut app, KeyCode::PageDown);
         assert_eq!(app.sessions.session_cursor, 3);
@@ -2643,7 +2643,7 @@ mod session_popup_key_tests {
             Some("/a"),
             &["s1", "s2", "s3", "s4", "s5", "s6", "s7"],
         )];
-        app.sessions.session_popup_visible_rows = 4;
+        app.render.publish_session_popup_visible_rows(4);
         app.sessions.session_cursor = 6;
 
         apply_popup_session_key(&mut app, KeyCode::PageUp);
@@ -3300,7 +3300,7 @@ mod delegate_popup_key_tests {
             make_entry("d6", "Polish UI", Some("child-6")),
             make_entry("d7", "Ship release", Some("child-7")),
         ]);
-        app.delegates.delegate_popup_visible_rows = 4;
+        app.render.publish_delegate_popup_visible_rows(4);
 
         apply_delegate_popup_key(&mut app, KeyCode::PageDown);
         assert_eq!(app.delegates.delegate_cursor, 3);
@@ -3318,7 +3318,7 @@ mod delegate_popup_key_tests {
             make_entry("d6", "Polish UI", Some("child-6")),
             make_entry("d7", "Ship release", Some("child-7")),
         ]);
-        app.delegates.delegate_popup_visible_rows = 4;
+        app.render.publish_delegate_popup_visible_rows(4);
         app.delegates.delegate_cursor = 6;
 
         apply_delegate_popup_key(&mut app, KeyCode::PageUp);

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -202,6 +202,8 @@ impl TestEffects {
 
 #[cfg(test)]
 mod tests {
+    use serial_test::serial;
+
     use super::*;
     use crate::command::PromptBlock;
     use crate::domain::chat::{ChatEntry, ElicitationResponseOutcome};
@@ -837,6 +839,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn invalidate_theme_caches_clears_all_render_caches() {
         use crate::theme::Theme;
 
@@ -873,23 +876,21 @@ mod tests {
             })
             .expect("edit preview should contain a styled file span");
 
-        app.render.streaming_cache.store(
-            5,
-            vec![crate::markdown::CardBlock::Text(ratatui::text::Line::from(
-                "stream",
-            ))],
-        );
-        app.render.streaming_thinking_cache.store(
-            3,
-            vec![crate::markdown::CardBlock::Text(ratatui::text::Line::from(
-                "think",
-            ))],
-        );
+        app.render
+            .test_seed_streaming_cache(crate::render_state::StreamKind::Content);
+        app.render
+            .test_seed_streaming_cache(crate::render_state::StreamKind::Thinking);
 
-        assert!(app.render.streaming_cache.get(5).is_some());
-        assert!(app.render.streaming_thinking_cache.get(3).is_some());
+        assert!(
+            app.render
+                .test_streaming_cache_populated(crate::render_state::StreamKind::Content)
+        );
+        assert!(
+            app.render
+                .test_streaming_cache_populated(crate::render_state::StreamKind::Thinking)
+        );
         assert_eq!(
-            app.render.card_cache.processed_messages,
+            app.render.test_card_source_entry_count(),
             app.chat.messages.len(),
             "card_cache should be populated"
         );
@@ -902,15 +903,18 @@ mod tests {
         app.render.invalidate_theme_caches();
 
         assert_eq!(
-            app.render.card_cache.processed_messages, 0,
+            app.render.test_card_source_entry_count(),
+            0,
             "card_cache should be invalidated"
         );
         assert!(
-            app.render.streaming_cache.get(5).is_none(),
+            !app.render
+                .test_streaming_cache_populated(crate::render_state::StreamKind::Content),
             "streaming_cache should be invalidated"
         );
         assert!(
-            app.render.streaming_thinking_cache.get(3).is_none(),
+            !app.render
+                .test_streaming_cache_populated(crate::render_state::StreamKind::Thinking),
             "streaming_thinking_cache should be invalidated"
         );
         assert!(matches!(

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -840,7 +840,7 @@ mod tests {
 
     #[test]
     #[serial]
-    fn invalidate_theme_caches_clears_all_render_caches() {
+    fn theme_selection_clears_all_render_caches() {
         use crate::theme::Theme;
 
         Theme::set_by_index(0);
@@ -895,12 +895,13 @@ mod tests {
             "card_cache should be populated"
         );
 
-        // Match the production order: snapshot the selected theme, then clear styled caches.
-        Theme::set_by_index(2);
-        Theme::begin_frame();
+        app.navigation.popup = crate::navigation_state::Popup::ThemeSelect;
+        app.navigation.theme_cursor = 2;
+        let effects = handle_theme_popup_key(&mut app, key(KeyCode::Enter));
+        assert_eq!(effects, vec![Effect::PersistConfig]);
+        assert_eq!(app.navigation.popup, crate::navigation_state::Popup::None);
         let current_preview_fg = Theme::diff_file().fg.expect("diff_file should define fg");
         assert_ne!(old_preview_fg, current_preview_fg);
-        app.render.invalidate_theme_caches();
 
         assert_eq!(
             app.render.test_card_source_entry_count(),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -204,7 +204,7 @@ impl TestEffects {
 mod tests {
     use super::*;
     use crate::command::PromptBlock;
-    use crate::domain::chat::{ChatEntry, OUTCOME_BULLET};
+    use crate::domain::chat::{ChatEntry, ElicitationResponseOutcome};
     use crate::domain::elicitation::{
         ElicitationField, ElicitationFieldKind, ElicitationOption, ElicitationState,
     };
@@ -295,7 +295,7 @@ mod tests {
                         elicitation_id: "test-id".into(),
                         action: "accept".into(),
                         content: Some(serde_json::json!({ "choice": "a" })),
-                        outcome: format!("{OUTCOME_BULLET}Alpha"),
+                        outcome: ElicitationResponseOutcome::Selected(vec!["Alpha".into()]),
                     },
                     Effect::Command(Command::Init),
                 ],
@@ -309,7 +309,7 @@ mod tests {
         assert!(app.chat.messages.iter().any(|entry| matches!(
             entry,
             ChatEntry::Elicitation { outcome: Some(outcome), .. }
-                if outcome == &format!("{OUTCOME_BULLET}Alpha")
+                if outcome == &ElicitationResponseOutcome::Selected(vec!["Alpha".into()])
         )));
     }
 
@@ -328,7 +328,7 @@ mod tests {
                     elicitation_id: "test-id".into(),
                     action: "decline".into(),
                     content: None,
-                    outcome: "declined".into(),
+                    outcome: ElicitationResponseOutcome::Declined,
                 }],
             )
             .unwrap();
@@ -461,6 +461,29 @@ mod tests {
         }])
     }
 
+    fn make_multi_select_elicitation() -> ElicitationState {
+        ElicitationState::new_for_test(vec![ElicitationField {
+            name: "choices".into(),
+            title: "Pick several".into(),
+            description: None,
+            required: true,
+            kind: ElicitationFieldKind::MultiSelect {
+                options: vec![
+                    ElicitationOption {
+                        value: serde_json::json!("a"),
+                        label: "Alpha".into(),
+                        description: None,
+                    },
+                    ElicitationOption {
+                        value: serde_json::json!("b"),
+                        label: "Beta".into(),
+                        description: None,
+                    },
+                ],
+            },
+        }])
+    }
+
     // ── Elicitation key handling ──────────────────────────────────────────────
 
     #[test]
@@ -492,7 +515,7 @@ mod tests {
                 elicitation_id: "test-id".into(),
                 action: "accept".into(),
                 content: Some(serde_json::json!({ "choice": "b" })),
-                outcome: format!("{OUTCOME_BULLET}Beta"),
+                outcome: ElicitationResponseOutcome::Selected(vec!["Beta".into()]),
             }]
         );
         assert!(app.chat.elicitation.is_some());
@@ -500,6 +523,28 @@ mod tests {
             app.chat.messages.as_slice(),
             [ChatEntry::Elicitation { outcome: None, .. }]
         ));
+    }
+
+    #[test]
+    fn elicitation_multi_select_preserves_wire_and_label_order() {
+        let mut app = make_app_with_elicitation(make_multi_select_elicitation());
+        let mut effects = TestEffects::default();
+
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Down)));
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Char(' '))));
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Up)));
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Char(' '))));
+        effects.extend(handle_elicitation_key(&mut app, key(KeyCode::Enter)));
+
+        assert_eq!(
+            effects.as_slice(),
+            &[Effect::ElicitationResponse {
+                elicitation_id: "test-id".into(),
+                action: "accept".into(),
+                content: Some(serde_json::json!({ "choices": ["b", "a"] })),
+                outcome: ElicitationResponseOutcome::Selected(vec!["Alpha".into(), "Beta".into(),]),
+            }]
+        );
     }
 
     #[test]
@@ -536,7 +581,7 @@ mod tests {
                 elicitation_id: "test-id".into(),
                 action: "accept".into(),
                 content: Some(serde_json::json!({ "choice": "custom\nanswer" })),
-                outcome: format!("{OUTCOME_BULLET}custom\nanswer"),
+                outcome: ElicitationResponseOutcome::Selected(vec!["custom\nanswer".into()]),
             }]
         );
     }
@@ -567,7 +612,7 @@ mod tests {
                 elicitation_id: "test-id".into(),
                 action: "decline".into(),
                 content: None,
-                outcome: "declined".into(),
+                outcome: ElicitationResponseOutcome::Declined,
             }]
         );
     }
@@ -599,7 +644,7 @@ mod tests {
                 elicitation_id: "test-id".into(),
                 action: "decline".into(),
                 content: None,
-                outcome: "declined".into(),
+                outcome: ElicitationResponseOutcome::Declined,
             }]
         );
         assert!(app.chat.elicitation.is_some());
@@ -628,7 +673,7 @@ mod tests {
                 elicitation_id: "test-id".into(),
                 action: "accept".into(),
                 content: Some(serde_json::json!({ "name": "Alice" })),
-                outcome: "Alice".into(),
+                outcome: ElicitationResponseOutcome::Text("Alice".into()),
             }]
         );
         assert!(app.chat.elicitation.is_some());
@@ -636,6 +681,31 @@ mod tests {
             app.chat.messages.as_slice(),
             [ChatEntry::Elicitation { outcome: None, .. }]
         ));
+    }
+
+    #[test]
+    fn elicitation_enter_on_number_field_preserves_text_outcome_and_numeric_wire_value() {
+        let mut app =
+            make_app_with_elicitation(ElicitationState::new_for_test(vec![ElicitationField {
+                name: "count".into(),
+                title: "Count".into(),
+                description: None,
+                required: true,
+                kind: ElicitationFieldKind::NumberInput { integer: true },
+            }]));
+        app.chat.elicitation.as_mut().unwrap().text_input = "42".into();
+
+        let effects = handle_elicitation_key(&mut app, key(KeyCode::Enter));
+
+        assert_eq!(
+            effects,
+            vec![Effect::ElicitationResponse {
+                elicitation_id: "test-id".into(),
+                action: "accept".into(),
+                content: Some(serde_json::json!({ "count": 42 })),
+                outcome: ElicitationResponseOutcome::Text("42".into()),
+            }]
+        );
     }
 
     #[test]
@@ -714,7 +784,7 @@ mod tests {
                 elicitation_id: "test-id".into(),
                 action: "accept".into(),
                 content: Some(serde_json::json!({ "confirm": true })),
-                outcome: "Yes".into(),
+                outcome: ElicitationResponseOutcome::Boolean(true),
             }]
         );
     }
@@ -743,7 +813,7 @@ mod tests {
                 elicitation_id: "test-id".into(),
                 action: "accept".into(),
                 content: Some(serde_json::json!({ "confirm": false })),
-                outcome: "No".into(),
+                outcome: ElicitationResponseOutcome::Boolean(false),
             }]
         );
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -973,21 +973,21 @@ mod external_editor_tests {
         app.composer.input = "abcdef".into();
         app.composer.input_cursor = 4;
         app.composer.input_line_width = 4;
-        app.chat.scroll_offset = 7;
+        app.render.set_chat_scroll_offset(7);
 
         effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Up, KeyModifiers::empty()),
         ));
         assert_eq!(app.composer.input_cursor, 2);
-        assert_eq!(app.chat.scroll_offset, 7);
+        assert_eq!(app.render.chat_scroll_offset(), 7);
 
         effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::Down, KeyModifiers::empty()),
         ));
         assert_eq!(app.composer.input_cursor, 4);
-        assert_eq!(app.chat.scroll_offset, 7);
+        assert_eq!(app.render.chat_scroll_offset(), 7);
     }
 
     #[test]
@@ -995,19 +995,77 @@ mod external_editor_tests {
         let mut effects = TestEffects::default();
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
-        app.chat.scroll_offset = 3;
+        app.render.set_chat_scroll_offset(3);
 
         effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::PageUp, KeyModifiers::empty()),
         ));
-        assert_eq!(app.chat.scroll_offset, 13);
+        assert_eq!(app.render.chat_scroll_offset(), 13);
 
         effects.extend(handle_chat_key(
             &mut app,
             KeyEvent::new(KeyCode::PageDown, KeyModifiers::empty()),
         ));
-        assert_eq!(app.chat.scroll_offset, 3);
+        assert_eq!(app.render.chat_scroll_offset(), 3);
+    }
+
+    #[test]
+    fn delegate_keys_preserve_exact_shared_viewport_steps() {
+        let mut effects = TestEffects::default();
+        let mut app = App::new();
+        app.navigation.screen = Screen::Delegate;
+        app.render.set_chat_scroll_offset(10);
+
+        for (key, expected) in [
+            (KeyCode::Up, 11),
+            (KeyCode::Down, 10),
+            (KeyCode::PageUp, 20),
+            (KeyCode::PageDown, 10),
+            (KeyCode::Home, u16::MAX),
+            (KeyCode::End, 0),
+        ] {
+            effects.extend(handle_key(
+                &mut app,
+                KeyEvent::new(key, KeyModifiers::empty()),
+            ));
+            assert_eq!(app.render.chat_scroll_offset(), expected);
+        }
+    }
+
+    #[test]
+    fn chat_end_routes_between_composer_and_viewport_contextually() {
+        let mut effects = TestEffects::default();
+        let mut app = App::new();
+        app.navigation.screen = Screen::Chat;
+        app.composer.input = "draft".into();
+        app.composer.input_cursor = 1;
+        app.render.set_chat_scroll_offset(7);
+
+        effects.extend(handle_chat_key(
+            &mut app,
+            KeyEvent::new(KeyCode::End, KeyModifiers::empty()),
+        ));
+        assert_eq!(app.composer.input_cursor, app.composer.input.len());
+        assert_eq!(app.render.chat_scroll_offset(), 7);
+
+        app.composer.input.clear();
+        effects.extend(handle_chat_key(
+            &mut app,
+            KeyEvent::new(KeyCode::End, KeyModifiers::empty()),
+        ));
+        assert_eq!(app.render.chat_scroll_offset(), 0);
+
+        app.composer.input = "blocked".into();
+        app.composer.input_cursor = 1;
+        app.chat.activity = ActivityState::SessionOp(SessionOp::Undo);
+        app.render.set_chat_scroll_offset(5);
+        effects.extend(handle_chat_key(
+            &mut app,
+            KeyEvent::new(KeyCode::End, KeyModifiers::empty()),
+        ));
+        assert_eq!(app.composer.input_cursor, 1);
+        assert_eq!(app.render.chat_scroll_offset(), 0);
     }
 
     #[test]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -786,6 +786,7 @@ mod tests {
                 file: "f.rs".into(),
                 old: "aaa".into(),
                 new: "bbb".into(),
+                replace_all: false,
                 start_line: None,
             },
         });

--- a/src/session_state.rs
+++ b/src/session_state.rs
@@ -142,8 +142,6 @@ pub(crate) struct SessionsState {
     pub(crate) hydrated_session_groups: HashSet<String>,
     pub(crate) expanded_session_children: HashSet<String>,
     pub(crate) pending_session_child_loads: HashSet<String>,
-    pub(crate) start_page_scroll: usize,
-    pub(crate) session_popup_visible_rows: usize,
     pub(crate) session_id: Option<String>,
     pub(crate) agent_id: Option<String>,
     pub(crate) agent_mode: String,
@@ -307,8 +305,6 @@ impl SessionsState {
             hydrated_session_groups: HashSet::new(),
             expanded_session_children: HashSet::new(),
             pending_session_child_loads: HashSet::new(),
-            start_page_scroll: 0,
-            session_popup_visible_rows: 0,
             session_id: None,
             agent_id: None,
             agent_mode: "build".into(),
@@ -548,9 +544,6 @@ impl SessionsState {
 
     pub(crate) fn move_start_cursor_up(&mut self) {
         self.session_cursor = self.session_cursor.saturating_sub(1);
-        if self.session_cursor < self.start_page_scroll {
-            self.start_page_scroll = self.session_cursor;
-        }
     }
 
     pub(crate) fn move_start_cursor_down(&mut self) {
@@ -581,13 +574,11 @@ impl SessionsState {
     pub(crate) fn start_filter_insert(&mut self, character: char) {
         self.session_filter.push(character);
         self.session_cursor = 0;
-        self.start_page_scroll = 0;
     }
 
     pub(crate) fn start_filter_backspace(&mut self) {
         self.session_filter.pop();
         self.session_cursor = 0;
-        self.start_page_scroll = 0;
     }
 
     pub(crate) fn popup_filter_insert(&mut self, character: char) {
@@ -1507,8 +1498,6 @@ mod tests {
         assert!(state.hydrated_session_groups.is_empty());
         assert!(state.expanded_session_children.is_empty());
         assert!(state.pending_session_child_loads.is_empty());
-        assert_eq!(state.start_page_scroll, 0);
-        assert_eq!(state.session_popup_visible_rows, 0);
         assert_eq!(state.session_id, None);
         assert_eq!(state.agent_id, None);
         assert_eq!(state.agent_mode, "build");
@@ -1608,20 +1597,16 @@ mod tests {
     }
 
     #[test]
-    fn cursor_filter_and_scroll_transitions_keep_view_contracts_distinct() {
+    fn start_and_popup_filter_transitions_reset_semantic_cursor() {
         let mut state = SessionsState::new();
         state.session_cursor = 4;
-        state.start_page_scroll = 3;
         state.start_filter_insert('x');
         assert_eq!(state.session_filter, "x");
         assert_eq!(state.session_cursor, 0);
-        assert_eq!(state.start_page_scroll, 0);
 
         state.session_cursor = 4;
-        state.start_page_scroll = 3;
         state.popup_filter_backspace();
         assert_eq!(state.session_cursor, 0);
-        assert_eq!(state.start_page_scroll, 3);
     }
 
     #[test]

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -18,28 +18,44 @@ pub(crate) fn u32_to_color(c: u32) -> Color {
 
 /// Global theme instance — uses atomic index into DARK_THEMES.
 static THEME_IDX: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+static THEME_REVISION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
-// Per-frame snapshot of the theme index. Avoids repeated atomic loads
-// during a single render pass. Updated by `Theme::begin_frame()`.
+// Per-frame snapshots keep cache keys and styles on the same theme version.
 thread_local! {
     static FRAME_THEME_IDX: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static FRAME_THEME_REVISION: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
 }
 
 impl Theme {
     pub fn init(id: &str) {
         let idx = DARK_THEMES.iter().position(|t| t.id == id).unwrap_or(0);
-        THEME_IDX.store(idx, std::sync::atomic::Ordering::Relaxed);
-        FRAME_THEME_IDX.set(idx);
+        Self::set_index_if_changed(idx);
+        Self::begin_frame();
     }
 
     pub fn set_by_index(idx: usize) {
         if idx < DARK_THEMES.len() {
-            THEME_IDX.store(idx, std::sync::atomic::Ordering::Relaxed);
+            Self::set_index_if_changed(idx);
+        }
+    }
+
+    fn set_index_if_changed(idx: usize) {
+        let previous = THEME_IDX.swap(idx, std::sync::atomic::Ordering::Relaxed);
+        if previous != idx {
+            THEME_REVISION.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
     }
 
     pub fn current_index() -> usize {
         THEME_IDX.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub(crate) fn frame_index() -> usize {
+        FRAME_THEME_IDX.get()
+    }
+
+    pub(crate) fn render_revision() -> u64 {
+        FRAME_THEME_REVISION.get()
     }
 
     pub fn current_id() -> &'static str {
@@ -440,14 +456,18 @@ impl Theme {
     /// Call once at frame start to avoid repeated atomic loads.
     pub fn begin_frame() {
         FRAME_THEME_IDX.set(THEME_IDX.load(std::sync::atomic::Ordering::Relaxed));
+        FRAME_THEME_REVISION.set(THEME_REVISION.load(std::sync::atomic::Ordering::Relaxed));
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use serial_test::serial;
+
     use super::*;
 
     #[test]
+    #[serial]
     fn begin_frame_snapshots_theme_index() {
         // Set theme to index 2
         Theme::set_by_index(2);
@@ -476,6 +496,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn styles_use_frame_snapshot() {
         Theme::set_by_index(3);
         Theme::begin_frame();
@@ -497,6 +518,34 @@ mod tests {
     }
 
     #[test]
+    #[serial]
+    fn theme_revision_is_monotonic_only_for_valid_index_changes() {
+        Theme::set_by_index(0);
+        Theme::begin_frame();
+        let start = Theme::render_revision();
+
+        Theme::set_by_index(2);
+        Theme::begin_frame();
+        let switched = Theme::render_revision();
+        assert!(switched > start);
+
+        Theme::set_by_index(2);
+        Theme::begin_frame();
+        assert_eq!(Theme::render_revision(), switched);
+
+        Theme::set_by_index(0);
+        Theme::begin_frame();
+        assert!(Theme::render_revision() > switched);
+
+        let returned = Theme::render_revision();
+        Theme::set_by_index(DARK_THEMES.len());
+        Theme::begin_frame();
+        assert_eq!(Theme::frame_index(), 0);
+        assert_eq!(Theme::render_revision(), returned);
+    }
+
+    #[test]
+    #[serial]
     fn profile_kind_uses_popup_background_and_kind_colors() {
         Theme::begin_frame();
 

--- a/src/tool_detail.rs
+++ b/src/tool_detail.rs
@@ -504,47 +504,44 @@ mod tests {
 
     #[test]
     fn delegate_tool_shows_agent_and_objective() {
-        let args = serde_json::json!({
+        let semantic_inputs = serde_json::json!({
             "target_agent_id": "coder",
             "objective": "List the contents of /tmp"
         });
-        let detail = parse_tool_detail("delegate", Some(&args), None);
-        match detail {
-            ToolDetail::Summary(s) => {
-                assert!(s.contains("coder"), "must contain agent name, got: {s}");
-                assert!(
-                    s.contains("List the contents"),
-                    "must contain objective, got: {s}"
-                );
-            }
-            other => panic!("expected Summary, got: {other:?}"),
-        }
+
+        let visible_detail = parse_tool_detail("delegate", Some(&semantic_inputs), None);
+
+        assert!(matches!(
+            visible_detail,
+            ToolDetail::Summary(summary) if summary == "(coder) List the contents of /tmp"
+        ));
     }
 
     #[test]
     fn delegate_tool_without_agent_shows_objective_only() {
-        let args = serde_json::json!({
+        let semantic_inputs = serde_json::json!({
             "objective": "Do something"
         });
-        let detail = parse_tool_detail("delegate", Some(&args), None);
-        match detail {
-            ToolDetail::Summary(s) => {
-                assert!(
-                    s.contains("Do something"),
-                    "must contain objective, got: {s}"
-                );
-            }
-            other => panic!("expected Summary, got: {other:?}"),
-        }
+
+        let visible_detail = parse_tool_detail("delegate", Some(&semantic_inputs), None);
+
+        assert!(matches!(
+            visible_detail,
+            ToolDetail::Summary(summary) if summary == "Do something"
+        ));
     }
 
-    fn assert_summary_truncates_with_ellipsis(tool_name: &str, args: serde_json::Value) {
+    fn assert_summary_truncates_with_ellipsis(
+        tool_name: &str,
+        args: serde_json::Value,
+        expected: &str,
+    ) {
         let detail = parse_tool_detail(tool_name, Some(&args), None);
 
         match detail {
-            ToolDetail::Summary(s) => {
-                assert!(s.ends_with(crate::ui::ELLIPSIS), "got: {s}");
-                assert!(s.is_char_boundary(s.len()), "got: {s}");
+            ToolDetail::Summary(summary) => {
+                assert_eq!(summary, expected);
+                assert!(summary.is_char_boundary(summary.len()));
             }
             other => panic!("expected Summary, got: {other:?}"),
         }
@@ -633,42 +630,40 @@ mod tests {
 
     #[test]
     fn read_tool_defaults_missing_offset_and_limit_for_display_range() {
-        let detail = parse_tool_detail(
-            "read_tool",
-            Some(&serde_json::json!({
-                "path": "apps/portal/priv/static/assets/css/app.css",
-                "limit": 300,
-            })),
-            None,
-        );
+        let cases = [
+            (
+                serde_json::json!({
+                    "path": "apps/portal/priv/static/assets/css/app.css",
+                    "limit": 300,
+                }),
+                "apps/portal/priv/static/assets/css/app.css",
+                300,
+            ),
+            (
+                serde_json::json!({ "path": "README.md" }),
+                "README.md",
+                DEFAULT_READ_TOOL_LIMIT,
+            ),
+            (
+                serde_json::json!({ "path": "README.md", "limit": 0 }),
+                "README.md",
+                DEFAULT_READ_TOOL_LIMIT,
+            ),
+        ];
 
-        match detail {
-            ToolDetail::ReadTool {
-                start_line,
-                end_line,
-                ..
-            } => {
-                assert_eq!(start_line, Some(1));
-                assert_eq!(end_line, Some(300));
+        for (semantic_inputs, expected_path, expected_end_line) in cases {
+            match parse_tool_detail("read_tool", Some(&semantic_inputs), None) {
+                ToolDetail::ReadTool {
+                    path,
+                    start_line,
+                    end_line,
+                } => {
+                    assert_eq!(path, expected_path);
+                    assert_eq!(start_line, Some(1));
+                    assert_eq!(end_line, Some(expected_end_line));
+                }
+                other => panic!("expected ReadTool, got: {other:?}"),
             }
-            other => panic!("expected ReadTool, got: {other:?}"),
-        }
-
-        let default_limit = parse_tool_detail(
-            "read_tool",
-            Some(&serde_json::json!({ "path": "README.md" })),
-            None,
-        );
-        match default_limit {
-            ToolDetail::ReadTool {
-                start_line,
-                end_line,
-                ..
-            } => {
-                assert_eq!(start_line, Some(1));
-                assert_eq!(end_line, Some(DEFAULT_READ_TOOL_LIMIT));
-            }
-            other => panic!("expected ReadTool, got: {other:?}"),
         }
     }
 
@@ -712,8 +707,8 @@ mod tests {
         }];
         let result = serde_json::json!({
             "exit_code": 0,
-            "stdout": "out1\nout2\nout3\nout4\nout5\nout6\n",
-            "stderr": "err1\nerr2\n",
+            "stdout": "out1  \n\n out2\nout3\nout4\nout5\nout6\n",
+            "stderr": "\nerr1  \n错误\n",
         })
         .to_string();
 
@@ -726,13 +721,16 @@ mod tests {
             ChatEntry::ToolCall {
                 detail:
                     ToolDetail::Shell {
+                        command,
+                        workdir,
                         output_tail: Some(tail),
-                        ..
                     },
                 ..
             } => {
+                assert_eq!(command, "cargo test");
+                assert_eq!(workdir, &None);
                 assert_eq!(tail.hidden_line_count, 3);
-                assert_eq!(tail.lines, ["out4", "out5", "out6", "err1", "err2"]);
+                assert_eq!(tail.lines, ["out4", "out5", "out6", "err1", "错误"]);
             }
             other => panic!("expected shell tail, got: {other:?}"),
         }
@@ -848,9 +846,20 @@ mod tests {
         ));
         match &messages[0] {
             ChatEntry::ToolCall {
-                detail: ToolDetail::Edit { start_line, .. },
+                detail:
+                    ToolDetail::Edit {
+                        file,
+                        old,
+                        new,
+                        start_line,
+                    },
                 ..
-            } => assert_eq!(*start_line, Some(42)),
+            } => {
+                assert_eq!(file, "src/lib.rs");
+                assert_eq!(old, "before\n");
+                assert_eq!(new, "after\n");
+                assert_eq!(*start_line, Some(42));
+            }
             other => panic!("expected Edit detail, got: {other:?}"),
         }
     }
@@ -883,10 +892,23 @@ mod tests {
         ));
         match &messages[0] {
             ChatEntry::ToolCall {
-                detail: ToolDetail::MultiEdit { sections, .. },
+                detail:
+                    ToolDetail::MultiEdit {
+                        file,
+                        edit_count,
+                        sections,
+                    },
                 ..
             } => {
+                assert_eq!(file, "src/lib.rs");
+                assert_eq!(*edit_count, 2);
+                assert_eq!(sections[0].header, "edit 1");
+                assert_eq!(sections[0].old, "aaa\n");
+                assert_eq!(sections[0].new, "bbb\n");
                 assert_eq!(sections[0].start_line, Some(10));
+                assert_eq!(sections[1].header, "edit 2");
+                assert_eq!(sections[1].old, "ccc\n");
+                assert_eq!(sections[1].new, "ddd\n");
                 assert_eq!(sections[1].start_line, Some(20));
             }
             other => panic!("expected multiedit detail, got: {other:?}"),
@@ -948,30 +970,43 @@ mod tests {
             Some(&serde_json::json!({"todos": [
                 {"content": "done", "status": "completed"},
                 {"content": "next", "status": "pending"},
+                {"content": "working", "status": "in_progress"},
             ]})),
             None,
         );
         assert!(matches!(
             detail,
-            ToolDetail::Summary(summary) if summary == "[x] done\n[ ] next"
+            ToolDetail::Summary(summary) if summary == "[x] done\n[ ] next\n[ ] working"
         ));
+
+        let missing = parse_tool_detail("todowrite", Some(&serde_json::json!({})), None);
+        let empty = parse_tool_detail("todowrite", Some(&serde_json::json!({ "todos": [] })), None);
+        assert!(matches!(missing, ToolDetail::None));
+        assert!(matches!(empty, ToolDetail::None));
     }
 
     #[test]
     fn browse_tool_truncates_utf8_url_on_char_boundary() {
-        let url = "https://example.com/docs/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa🔴/page";
+        let url = format!("https://example.test/{}tail", "界".repeat(50));
+        let expected = format!("{}…", url.chars().take(59).collect::<String>());
         let args = serde_json::json!({ "url": url });
 
-        assert_summary_truncates_with_ellipsis("browse", args);
+        assert_eq!(expected.chars().count(), 60);
+        assert_summary_truncates_with_ellipsis("browse", args, &expected);
     }
 
     #[test]
     fn delegate_tool_truncates_utf8_objective_on_char_boundary() {
-        let objective = "Review this objective with multibyte marker aaaaa🔴 done";
-        assert!(!objective.is_char_boundary(50));
-        let args = serde_json::json!({ "objective": objective });
+        let objective = format!("{}tail", "界".repeat(50));
+        let expected_objective = format!("{}…", objective.chars().take(49).collect::<String>());
+        let expected = format!("(coder) {expected_objective}");
+        let args = serde_json::json!({
+            "target_agent_id": "coder",
+            "objective": objective,
+        });
 
-        assert_summary_truncates_with_ellipsis("delegate", args);
+        assert_eq!(expected_objective.chars().count(), 50);
+        assert_summary_truncates_with_ellipsis("delegate", args, &expected);
     }
 
     #[test]
@@ -984,6 +1019,214 @@ mod tests {
             }
             other => panic!("expected Summary, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn structured_tool_inputs_preserve_raw_values_and_visible_diff_headers() {
+        let shell_inputs = serde_json::json!({
+            "command": "printf",
+            "args": ["hello world", "it's", "界", "", 7],
+            "workdir": "/tmp/工作",
+        });
+        match parse_tool_detail("shell", Some(&shell_inputs), Some("/ignored/session")) {
+            ToolDetail::Shell {
+                command,
+                workdir,
+                output_tail,
+            } => {
+                assert_eq!(command, "printf 'hello world' 'it'\\''s' '界' ''");
+                assert_eq!(workdir.as_deref(), Some("/tmp/工作"));
+                assert!(output_tail.is_none());
+            }
+            other => panic!("expected Shell, got: {other:?}"),
+        }
+
+        let write_inputs = serde_json::json!({
+            "path": "/workspace/src/界.rs",
+            "content": "fn 界() {\n    println!(\"ok\");\n}\n",
+        });
+        match parse_tool_detail("write_file", Some(&write_inputs), None) {
+            ToolDetail::WriteFile { path, content } => {
+                assert_eq!(path, "/workspace/src/界.rs");
+                assert_eq!(content, "fn 界() {\n    println!(\"ok\");\n}\n");
+            }
+            other => panic!("expected WriteFile, got: {other:?}"),
+        }
+
+        let edit_inputs = serde_json::json!({
+            "file_path": "/workspace/src/lib.rs",
+            "old_string": "before\n",
+            "new_string": "after\n",
+        });
+        match parse_tool_detail("edit", Some(&edit_inputs), None) {
+            ToolDetail::Edit {
+                file,
+                old,
+                new,
+                start_line,
+            } => {
+                assert_eq!(file, "/workspace/src/lib.rs");
+                assert_eq!(old, "before\n");
+                assert_eq!(new, "after\n");
+                assert_eq!(start_line, None);
+            }
+            other => panic!("expected Edit, got: {other:?}"),
+        }
+
+        let multiedit_inputs = serde_json::json!({
+            "filePath": "/workspace/src/lib.rs",
+            "edits": [
+                { "oldString": "one\n", "newString": "ONE\n", "replaceAll": true },
+                { "old_string": "two\n", "new_string": "TWO\n", "replace_all": false },
+                { "oldString": "missing new value" },
+            ],
+        });
+        match parse_tool_detail("multiedit", Some(&multiedit_inputs), None) {
+            ToolDetail::MultiEdit {
+                file,
+                edit_count,
+                sections,
+            } => {
+                assert_eq!(file, "/workspace/src/lib.rs");
+                assert_eq!(edit_count, 2);
+                assert_eq!(sections.len(), 2);
+                assert_eq!(sections[0].header, "edit 1 (all)");
+                assert_eq!(sections[0].old, "one\n");
+                assert_eq!(sections[0].new, "ONE\n");
+                assert_eq!(sections[0].start_line, None);
+                assert_eq!(sections[1].header, "edit 2");
+                assert_eq!(sections[1].old, "two\n");
+                assert_eq!(sections[1].new, "TWO\n");
+                assert_eq!(sections[1].start_line, None);
+            }
+            other => panic!("expected MultiEdit, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn summary_tool_matrix_pins_current_visible_formatting() {
+        let cases = [
+            (
+                "search_text",
+                serde_json::json!({
+                    "pattern": "needle",
+                    "path": "/workspace/project/src",
+                    "include": "*.rs",
+                }),
+                "\"needle\" *.rs",
+            ),
+            (
+                "search_text",
+                serde_json::json!({
+                    "pattern": "needle",
+                    "path": "/workspace/project/src/lib.rs",
+                }),
+                "\"needle\" src/lib.rs",
+            ),
+            (
+                "search_text",
+                serde_json::json!({ "pattern": "needle" }),
+                "\"needle\" .",
+            ),
+            (
+                "glob",
+                serde_json::json!({
+                    "pattern": "*.rs",
+                    "path": "/workspace/project/src",
+                }),
+                "*.rs in project/src",
+            ),
+            ("glob", serde_json::json!({ "pattern": "*.md" }), "*.md"),
+            ("ls", serde_json::json!({}), "."),
+            (
+                "index",
+                serde_json::json!({ "path": "/workspace/project/src/main.rs" }),
+                "src/main.rs",
+            ),
+            (
+                "delete_file",
+                serde_json::json!({ "path": "/workspace/project/tmp/out.txt" }),
+                "tmp/out.txt",
+            ),
+            (
+                "browse",
+                serde_json::json!({ "url": "https://example.test/docs" }),
+                "https://example.test/docs",
+            ),
+            (
+                "web_fetch",
+                serde_json::json!({ "url": "https://example.test/api" }),
+                "https://example.test/api",
+            ),
+            (
+                "language_query",
+                serde_json::json!({
+                    "action": "definition",
+                    "uri": "file:///workspace/project/src/lib.rs",
+                }),
+                "definition src/lib.rs",
+            ),
+            (
+                "question",
+                serde_json::json!({ "prompt": "Continue?" }),
+                "asking...",
+            ),
+            (
+                "apply_patch",
+                serde_json::json!({ "patch": "raw patch" }),
+                "patch",
+            ),
+        ];
+
+        for (tool_name, semantic_inputs, expected_visible_summary) in cases {
+            let detail = parse_tool_detail(tool_name, Some(&semantic_inputs), None);
+            assert!(
+                matches!(detail, ToolDetail::Summary(ref summary) if summary == expected_visible_summary),
+                "unexpected summary for {tool_name}: {detail:?}"
+            );
+        }
+
+        assert!(matches!(
+            parse_tool_detail(
+                "unknown_tool",
+                Some(&serde_json::json!({ "raw": true })),
+                None
+            ),
+            ToolDetail::None
+        ));
+        assert!(matches!(
+            parse_tool_detail("shell", None, None),
+            ToolDetail::None
+        ));
+    }
+
+    #[test]
+    fn replace_symbol_single_path_strips_cwd_and_shortens_visible_title() {
+        let semantic_inputs = serde_json::json!({
+            "replacements": [
+                {
+                    "path": "/workspace/project/src/nested/lib.rs",
+                    "symbol": "run",
+                    "newText": "fn run() {}",
+                },
+                {
+                    "path": "/workspace/project/src/nested/lib.rs",
+                    "symbol": "stop",
+                    "newText": "fn stop() {}",
+                },
+            ],
+        });
+
+        let visible_detail = parse_tool_detail(
+            "replace_symbol",
+            Some(&semantic_inputs),
+            Some("/workspace/project"),
+        );
+
+        assert!(matches!(
+            visible_detail,
+            ToolDetail::Summary(summary) if summary == "nested/lib.rs"
+        ));
     }
 
     #[test]

--- a/src/tool_detail.rs
+++ b/src/tool_detail.rs
@@ -1,17 +1,11 @@
-use std::path::Path;
-
 use serde_json::Value;
 
 use crate::domain::chat::ChatEntry;
-use crate::domain::tool::{DiffPreviewSection, ShellOutputTail, ToolDetail};
+use crate::domain::tool::{MultiEditSection, ShellOutput, SymbolReplacement, TodoItem, ToolDetail};
 
 const DEFAULT_READ_TOOL_LIMIT: u64 = 2000;
 
-pub(crate) fn parse_tool_detail(
-    tool_name: &str,
-    arguments: Option<&Value>,
-    cwd: Option<&str>,
-) -> ToolDetail {
+pub(crate) fn parse_tool_detail(tool_name: &str, arguments: Option<&Value>) -> ToolDetail {
     let Some(args) = arguments else {
         return ToolDetail::None;
     };
@@ -19,9 +13,19 @@ pub(crate) fn parse_tool_detail(
 
     match tool_name {
         "shell" => ToolDetail::Shell {
-            command: shell_command_display(&obj),
+            command: string_field(&obj, "command").unwrap_or_default(),
+            arguments: obj
+                .get("args")
+                .and_then(Value::as_array)
+                .map(|args| {
+                    args.iter()
+                        .filter_map(Value::as_str)
+                        .map(str::to_string)
+                        .collect()
+                })
+                .unwrap_or_default(),
             workdir: string_field(&obj, "workdir"),
-            output_tail: None,
+            output: None,
         },
         "read_tool" => {
             let path = string_field(&obj, "path").unwrap_or_default();
@@ -37,32 +41,28 @@ pub(crate) fn parse_tool_detail(
                 end_line: Some(offset.saturating_add(limit)),
             }
         }
-        "write_file" => {
-            let path = string_field(&obj, "path").unwrap_or_default();
-            let content = string_field(&obj, "content").unwrap_or_default();
-            ToolDetail::WriteFile { path, content }
-        }
-        "edit" => {
-            let file = string_field(&obj, "filePath")
+        "write_file" => ToolDetail::WriteFile {
+            path: string_field(&obj, "path").unwrap_or_default(),
+            content: string_field(&obj, "content").unwrap_or_default(),
+        },
+        "edit" => ToolDetail::Edit {
+            file: string_field(&obj, "filePath")
                 .or_else(|| string_field(&obj, "file_path"))
-                .unwrap_or_default();
-            let old = string_field(&obj, "oldString")
+                .unwrap_or_default(),
+            old: string_field(&obj, "oldString")
                 .or_else(|| string_field(&obj, "old_string"))
-                .unwrap_or_default();
-            let new = string_field(&obj, "newString")
+                .unwrap_or_default(),
+            new: string_field(&obj, "newString")
                 .or_else(|| string_field(&obj, "new_string"))
-                .unwrap_or_default();
-            ToolDetail::Edit {
-                file,
-                old,
-                new,
-                start_line: None,
-            }
-        }
+                .unwrap_or_default(),
+            replace_all: obj
+                .get("replaceAll")
+                .or_else(|| obj.get("replace_all"))
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            start_line: None,
+        },
         "multiedit" => {
-            let file = string_field(&obj, "filePath")
-                .or_else(|| string_field(&obj, "file_path"))
-                .unwrap_or_default();
             let sections = obj
                 .get("edits")
                 .and_then(Value::as_array)
@@ -70,25 +70,18 @@ pub(crate) fn parse_tool_detail(
                     edits
                         .iter()
                         .enumerate()
-                        .filter_map(|(idx, edit)| {
-                            let old = string_field(edit, "oldString")
-                                .or_else(|| string_field(edit, "old_string"))?;
-                            let new = string_field(edit, "newString")
-                                .or_else(|| string_field(edit, "new_string"))?;
-                            let suffix = if edit
-                                .get("replaceAll")
-                                .or_else(|| edit.get("replace_all"))
-                                .and_then(Value::as_bool)
-                                .unwrap_or(false)
-                            {
-                                " (all)"
-                            } else {
-                                ""
-                            };
-                            Some(DiffPreviewSection {
-                                header: format!("edit {}{}", idx + 1, suffix),
-                                old,
-                                new,
+                        .filter_map(|(index, edit)| {
+                            Some(MultiEditSection {
+                                edit_index: index + 1,
+                                replace_all: edit
+                                    .get("replaceAll")
+                                    .or_else(|| edit.get("replace_all"))
+                                    .and_then(Value::as_bool)
+                                    .unwrap_or(false),
+                                old: string_field(edit, "oldString")
+                                    .or_else(|| string_field(edit, "old_string"))?,
+                                new: string_field(edit, "newString")
+                                    .or_else(|| string_field(edit, "new_string"))?,
                                 start_line: None,
                             })
                         })
@@ -96,50 +89,54 @@ pub(crate) fn parse_tool_detail(
                 })
                 .unwrap_or_default();
             ToolDetail::MultiEdit {
-                file,
+                file: string_field(&obj, "filePath")
+                    .or_else(|| string_field(&obj, "file_path"))
+                    .unwrap_or_default(),
                 edit_count: sections.len(),
                 sections,
             }
         }
-        "search_text" => {
-            let pattern = string_field(&obj, "pattern").unwrap_or_default();
-            let path = string_field(&obj, "path").unwrap_or_default();
-            let include = string_field(&obj, "include").unwrap_or_default();
-            let location = if !include.is_empty() {
-                include
-            } else if !path.is_empty() {
-                short_path(&path).to_string()
-            } else {
-                ".".into()
-            };
-            ToolDetail::Summary(format!("\"{}\" {}", pattern, location))
-        }
-        "glob" => summary_path_arg(&obj, "pattern", "path"),
-        "ls" | "index" => ToolDetail::Summary(
-            string_field(&obj, "path")
-                .map(|path| short_path(&path).to_string())
-                .unwrap_or_else(|| ".".into()),
-        ),
-        "delete_file" => ToolDetail::Summary(
-            string_field(&obj, "path")
-                .map(|path| short_path(&path).to_string())
-                .unwrap_or_default(),
-        ),
-        "browse" | "web_fetch" => ToolDetail::Summary(
-            string_field(&obj, "url")
-                .map(|url| truncate_summary(&url, 60))
-                .unwrap_or_default(),
-        ),
-        "todowrite" => todo_summary(&obj),
-        "delegate" => delegate_summary(&obj),
-        "language_query" => {
-            let action = string_field(&obj, "action").unwrap_or_default();
-            let uri = string_field(&obj, "uri").unwrap_or_default();
-            ToolDetail::Summary(format!("{} {}", action, short_path(&uri)))
-        }
-        "question" => ToolDetail::Summary("asking...".into()),
-        "apply_patch" => ToolDetail::Summary("patch".into()),
-        "replace_symbol" => ToolDetail::Summary(replace_symbol_title(&obj, cwd)),
+        "search_text" => ToolDetail::SearchText {
+            pattern: string_field(&obj, "pattern").unwrap_or_default(),
+            path: string_field(&obj, "path").unwrap_or_default(),
+            include: string_field(&obj, "include").unwrap_or_default(),
+            counts: None,
+        },
+        "glob" => ToolDetail::Glob {
+            pattern: string_field(&obj, "pattern").unwrap_or_default(),
+            path: string_field(&obj, "path").unwrap_or_default(),
+        },
+        "ls" => ToolDetail::List {
+            path: string_field(&obj, "path").unwrap_or_default(),
+        },
+        "index" => ToolDetail::Index {
+            path: string_field(&obj, "path").unwrap_or_default(),
+            metadata: None,
+        },
+        "delete_file" => ToolDetail::DeleteFile {
+            path: string_field(&obj, "path").unwrap_or_default(),
+        },
+        "browse" | "web_fetch" => ToolDetail::Browse {
+            url: string_field(&obj, "url").unwrap_or_default(),
+        },
+        "todowrite" => todo_detail(&obj),
+        "delegate" => ToolDetail::Delegate {
+            target_agent_id: string_field(&obj, "target_agent_id").unwrap_or_default(),
+            objective: string_field(&obj, "objective").unwrap_or_default(),
+        },
+        "language_query" => ToolDetail::LanguageQuery {
+            action: string_field(&obj, "action").unwrap_or_default(),
+            uri: string_field(&obj, "uri").unwrap_or_default(),
+        },
+        "question" => ToolDetail::Question {
+            prompt: string_field(&obj, "prompt").unwrap_or_default(),
+        },
+        "apply_patch" => ToolDetail::ApplyPatch {
+            patch: string_field(&obj, "patch").unwrap_or_default(),
+        },
+        "replace_symbol" => ToolDetail::ReplaceSymbolInput {
+            replacements: symbol_replacements(&obj),
+        },
         _ => ToolDetail::None,
     }
 }
@@ -202,9 +199,9 @@ pub(crate) fn update_tool_detail(
         }
 
         match detail {
-            ToolDetail::Shell { output_tail, .. } if name.starts_with("shell") => {
-                if let Some(tail) = shell_output_tail_from_result(parsed.as_ref(), result) {
-                    *output_tail = Some(tail);
+            ToolDetail::Shell { output, .. } if name.starts_with("shell") => {
+                if let Some(result_output) = shell_output_from_result(parsed.as_ref(), result) {
+                    *output = Some(result_output);
                 }
             }
             ToolDetail::ReadTool {
@@ -282,35 +279,7 @@ fn string_field(obj: &Value, key: &str) -> Option<String> {
     })
 }
 
-fn shell_command_display(obj: &Value) -> String {
-    let command = string_field(obj, "command").unwrap_or_default();
-    let Some(args) = obj.get("args").and_then(Value::as_array) else {
-        return command;
-    };
-    let mut parts = Vec::with_capacity(args.len() + 1);
-    parts.push(shell_quote_arg(&command));
-    parts.extend(args.iter().filter_map(Value::as_str).map(shell_quote_arg));
-    if parts.len() == 1 {
-        command
-    } else {
-        parts.join(" ")
-    }
-}
-
-fn shell_quote_arg(arg: &str) -> String {
-    if arg.is_empty() {
-        return "''".to_string();
-    }
-    if arg
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '/' | ':' | '='))
-    {
-        return arg.to_string();
-    }
-    format!("'{}'", arg.replace('\'', "'\\''"))
-}
-
-fn shell_output_tail_from_result(parsed: Option<&Value>, raw: &str) -> Option<ShellOutputTail> {
+fn shell_output_from_result(parsed: Option<&Value>, raw: &str) -> Option<ShellOutput> {
     let (stdout, stderr) = parsed
         .and_then(|obj| {
             Some((
@@ -322,22 +291,57 @@ fn shell_output_tail_from_result(parsed: Option<&Value>, raw: &str) -> Option<Sh
             ))
         })
         .unwrap_or_else(|| (raw.to_string(), String::new()));
-    let lines = stdout
-        .lines()
-        .chain(stderr.lines())
-        .map(str::trim_end)
-        .filter(|line| !line.trim().is_empty())
-        .map(str::to_string)
-        .collect::<Vec<_>>();
-    if lines.is_empty() {
-        return None;
+    if stdout.is_empty() && stderr.is_empty() {
+        None
+    } else {
+        Some(ShellOutput {
+            stdout,
+            stderr,
+            preceding_line_count: 0,
+        })
     }
-    let keep = 5;
-    let hidden_line_count = lines.len().saturating_sub(keep);
-    Some(ShellOutputTail {
-        lines: lines.into_iter().skip(hidden_line_count).collect(),
-        hidden_line_count,
-    })
+}
+
+fn todo_detail(obj: &Value) -> ToolDetail {
+    let Some(todos) = obj.get("todos").and_then(Value::as_array) else {
+        return ToolDetail::None;
+    };
+    let items = todos
+        .iter()
+        .filter_map(|todo| {
+            Some(TodoItem {
+                content: todo.get("content")?.as_str()?.to_string(),
+                status: todo
+                    .get("status")
+                    .and_then(Value::as_str)
+                    .unwrap_or("pending")
+                    .to_string(),
+            })
+        })
+        .collect::<Vec<_>>();
+    if items.is_empty() {
+        ToolDetail::None
+    } else {
+        ToolDetail::Todo { items }
+    }
+}
+
+fn symbol_replacements(obj: &Value) -> Vec<SymbolReplacement> {
+    obj.get("replacements")
+        .and_then(Value::as_array)
+        .map(|replacements| {
+            replacements
+                .iter()
+                .map(|replacement| SymbolReplacement {
+                    path: string_field(replacement, "path").unwrap_or_default(),
+                    symbol: string_field(replacement, "symbol").unwrap_or_default(),
+                    new_text: string_field(replacement, "newText")
+                        .or_else(|| string_field(replacement, "new_text"))
+                        .unwrap_or_default(),
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn tool_result_text(parsed: Option<&Value>, raw: &str) -> String {
@@ -406,859 +410,691 @@ fn compact_receipt_old_starts(text: &str) -> Vec<usize> {
         .collect()
 }
 
-fn summary_path_arg(obj: &Value, main_key: &str, path_key: &str) -> ToolDetail {
-    let main = string_field(obj, main_key).unwrap_or_default();
-    let path = string_field(obj, path_key).unwrap_or_default();
-    if path.is_empty() {
-        ToolDetail::Summary(main)
-    } else {
-        ToolDetail::Summary(format!("{} in {}", main, short_path(&path)))
-    }
-}
-
-fn todo_summary(obj: &Value) -> ToolDetail {
-    let Some(todos) = obj.get("todos").and_then(Value::as_array) else {
-        return ToolDetail::None;
-    };
-    let lines = todos
-        .iter()
-        .filter_map(|todo| {
-            let content = todo.get("content").and_then(Value::as_str)?;
-            let status = todo
-                .get("status")
-                .and_then(Value::as_str)
-                .unwrap_or("pending");
-            let check = if status == "completed" { "x" } else { " " };
-            Some(format!("[{check}] {content}"))
-        })
-        .collect::<Vec<_>>();
-    if lines.is_empty() {
-        ToolDetail::None
-    } else {
-        ToolDetail::Summary(lines.join("\n"))
-    }
-}
-
-fn delegate_summary(obj: &Value) -> ToolDetail {
-    let agent = string_field(obj, "target_agent_id").unwrap_or_default();
-    let objective = string_field(obj, "objective").unwrap_or_default();
-    let objective = truncate_summary(&objective, 50);
-    if agent.is_empty() {
-        ToolDetail::Summary(objective)
-    } else {
-        ToolDetail::Summary(format!("({agent}) {objective}"))
-    }
-}
-
-fn replace_symbol_title(obj: &Value, cwd: Option<&str>) -> String {
-    let Some(replacements) = obj.get("replacements").and_then(Value::as_array) else {
-        return "symbols".into();
-    };
-    let mut files = replacements
-        .iter()
-        .filter_map(|replacement| string_field(replacement, "path"))
-        .map(|path| strip_cwd(&path, cwd))
-        .collect::<Vec<_>>();
-    files.sort();
-    files.dedup();
-    match files.as_slice() {
-        [] => "symbols".into(),
-        [one] => short_path(one).to_string(),
-        [first, ..] => format!("{} (+{})", short_path(first), files.len() - 1),
-    }
-}
-
-fn strip_cwd(path: &str, cwd: Option<&str>) -> String {
-    cwd.and_then(|cwd| Path::new(path).strip_prefix(cwd).ok())
-        .map(|path| path.to_string_lossy().into_owned())
-        .unwrap_or_else(|| path.to_string())
-}
-
-fn short_path(path: &str) -> &str {
-    let mut count = 0;
-    for (i, c) in path.char_indices().rev() {
-        if c == '/' {
-            count += 1;
-            if count == 2 {
-                return &path[i + 1..];
-            }
-        }
-    }
-    path
-}
-
-fn truncate_summary(value: &str, max_chars: usize) -> String {
-    if value.chars().count() <= max_chars {
-        return value.to_string();
-    }
-    let mut out = value
-        .chars()
-        .take(max_chars.saturating_sub(1))
-        .collect::<String>();
-    out.push('…');
-    out
-}
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn delegate_tool_shows_agent_and_objective() {
-        let semantic_inputs = serde_json::json!({
-            "target_agent_id": "coder",
-            "objective": "List the contents of /tmp"
-        });
-
-        let visible_detail = parse_tool_detail("delegate", Some(&semantic_inputs), None);
-
-        assert!(matches!(
-            visible_detail,
-            ToolDetail::Summary(summary) if summary == "(coder) List the contents of /tmp"
-        ));
+    fn parse(tool_name: &str, arguments: serde_json::Value) -> ToolDetail {
+        parse_tool_detail(tool_name, Some(&arguments))
     }
 
-    #[test]
-    fn delegate_tool_without_agent_shows_objective_only() {
-        let semantic_inputs = serde_json::json!({
-            "objective": "Do something"
-        });
-
-        let visible_detail = parse_tool_detail("delegate", Some(&semantic_inputs), None);
-
-        assert!(matches!(
-            visible_detail,
-            ToolDetail::Summary(summary) if summary == "Do something"
-        ));
-    }
-
-    fn assert_summary_truncates_with_ellipsis(
-        tool_name: &str,
-        args: serde_json::Value,
-        expected: &str,
-    ) {
-        let detail = parse_tool_detail(tool_name, Some(&args), None);
-
-        match detail {
-            ToolDetail::Summary(summary) => {
-                assert_eq!(summary, expected);
-                assert!(summary.is_char_boundary(summary.len()));
-            }
-            other => panic!("expected Summary, got: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn shell_tool_preserves_full_utf8_command() {
-        let command =
-            "cat > check/kimi.md << 'EOF'\n# Review: feat/profiles\n\n## 🔴 Critical / High";
-        let args = serde_json::json!({ "command": command });
-        let detail = parse_tool_detail("shell", Some(&args), None);
-
-        match detail {
-            ToolDetail::Shell { command: got, .. } => assert_eq!(got, command),
-            other => panic!("expected Shell, got: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn shell_tool_formats_arguments_like_the_production_card() {
-        let detail = parse_tool_detail(
-            "shell",
-            Some(&serde_json::json!({
-                "command": "echo",
-                "args": ["hello world", "", "safe"]
-            })),
-            None,
-        );
-
-        assert!(matches!(
-            detail,
-            ToolDetail::Shell { command, .. } if command == "echo 'hello world' '' safe"
-        ));
-    }
-
-    #[test]
-    fn shell_tool_uses_only_explicit_workdir() {
-        let explicit = parse_tool_detail(
-            "shell",
-            Some(&serde_json::json!({ "command": "pwd", "workdir": "/workspace/project" })),
-            Some("/session/cwd"),
-        );
-        match explicit {
-            ToolDetail::Shell { workdir, .. } => {
-                assert_eq!(workdir.as_deref(), Some("/workspace/project"))
-            }
-            other => panic!("expected Shell, got: {other:?}"),
-        }
-
-        let implicit = parse_tool_detail(
-            "shell",
-            Some(&serde_json::json!({ "command": "pwd" })),
-            Some("/session/cwd"),
-        );
-        match implicit {
-            ToolDetail::Shell { workdir, .. } => assert_eq!(workdir, None),
-            other => panic!("expected Shell, got: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn read_tool_uses_one_based_inclusive_display_range() {
-        let detail = parse_tool_detail(
-            "read_tool",
-            Some(&serde_json::json!({
-                "path": "src/acp_state.rs",
-                "offset": 2134,
-                "limit": 71,
-            })),
-            None,
-        );
-
-        match detail {
-            ToolDetail::ReadTool {
-                path,
-                start_line,
-                end_line,
-            } => {
-                assert_eq!(path, "src/acp_state.rs");
-                assert_eq!(start_line, Some(2135));
-                assert_eq!(end_line, Some(2205));
-            }
-            other => panic!("expected ReadTool, got: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn read_tool_defaults_missing_offset_and_limit_for_display_range() {
-        let cases = [
-            (
-                serde_json::json!({
-                    "path": "apps/portal/priv/static/assets/css/app.css",
-                    "limit": 300,
-                }),
-                "apps/portal/priv/static/assets/css/app.css",
-                300,
-            ),
-            (
-                serde_json::json!({ "path": "README.md" }),
-                "README.md",
-                DEFAULT_READ_TOOL_LIMIT,
-            ),
-            (
-                serde_json::json!({ "path": "README.md", "limit": 0 }),
-                "README.md",
-                DEFAULT_READ_TOOL_LIMIT,
-            ),
-        ];
-
-        for (semantic_inputs, expected_path, expected_end_line) in cases {
-            match parse_tool_detail("read_tool", Some(&semantic_inputs), None) {
-                ToolDetail::ReadTool {
-                    path,
-                    start_line,
-                    end_line,
-                } => {
-                    assert_eq!(path, expected_path);
-                    assert_eq!(start_line, Some(1));
-                    assert_eq!(end_line, Some(expected_end_line));
-                }
-                other => panic!("expected ReadTool, got: {other:?}"),
-            }
-        }
-    }
-
-    #[test]
-    fn read_tool_parses_json_string_arguments_for_display_range() {
-        let args = serde_json::Value::String(
-            r#"{"path":"apps/admin/lib/admin_web/components/layouts/root.html.heex","root":".","limit":220}"#
-                .into(),
-        );
-        let detail = parse_tool_detail("read_tool", Some(&args), None);
-
-        match detail {
-            ToolDetail::ReadTool {
-                path,
-                start_line,
-                end_line,
-            } => {
-                assert_eq!(
-                    path,
-                    "apps/admin/lib/admin_web/components/layouts/root.html.heex"
-                );
-                assert_eq!(start_line, Some(1));
-                assert_eq!(end_line, Some(220));
-            }
-            other => panic!("expected ReadTool, got: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn shell_tool_result_keeps_last_five_output_lines() {
-        let detail = parse_tool_detail(
-            "shell",
-            Some(&serde_json::json!({ "command": "cargo test" })),
-            None,
-        );
-        let mut messages = vec![ChatEntry::ToolCall {
-            tool_call_id: Some("shell-tail".into()),
-            name: "shell".into(),
+    fn tool_call(id: &str, name: &str, detail: ToolDetail) -> ChatEntry {
+        ChatEntry::ToolCall {
+            tool_call_id: Some(id.into()),
+            name: name.into(),
             is_error: false,
             detail,
-        }];
+        }
+    }
+
+    #[test]
+    fn delegate_and_browse_preserve_raw_untruncated_values() {
+        let objective = format!("{}tail", "界".repeat(50));
+        assert_eq!(
+            parse(
+                "delegate",
+                serde_json::json!({
+                    "target_agent_id": "coder",
+                    "objective": objective,
+                }),
+            ),
+            ToolDetail::Delegate {
+                target_agent_id: "coder".into(),
+                objective: objective.clone(),
+            }
+        );
+
+        let url = format!("https://example.test/{}tail", "界".repeat(50));
+        assert_eq!(
+            parse("browse", serde_json::json!({ "url": url })),
+            ToolDetail::Browse { url: url.clone() }
+        );
+        assert!(objective.chars().count() > 50);
+        assert!(url.chars().count() > 60);
+    }
+
+    #[test]
+    fn shell_preserves_command_arguments_workdir_and_full_raw_output() {
+        let detail = parse(
+            "shell",
+            serde_json::json!({
+                "command": "printf",
+                "args": ["hello world", "it's", "界", "", 7],
+                "workdir": "/tmp/工作",
+            }),
+        );
+        assert_eq!(
+            detail,
+            ToolDetail::Shell {
+                command: "printf".into(),
+                arguments: vec!["hello world".into(), "it's".into(), "界".into(), "".into()],
+                workdir: Some("/tmp/工作".into()),
+                output: None,
+            }
+        );
+
+        let mut messages = vec![tool_call("shell-1", "shell", detail)];
         let result = serde_json::json!({
-            "exit_code": 0,
             "stdout": "out1  \n\n out2\nout3\nout4\nout5\nout6\n",
             "stderr": "\nerr1  \n错误\n",
         })
         .to_string();
-
-        assert!(update_tool_detail(
-            &mut messages,
-            Some("shell-tail"),
-            &result
-        ));
-        match &messages[0] {
+        assert!(update_tool_detail(&mut messages, Some("shell-1"), &result));
+        assert!(matches!(
+            &messages[0],
             ChatEntry::ToolCall {
-                detail:
-                    ToolDetail::Shell {
-                        command,
-                        workdir,
-                        output_tail: Some(tail),
-                    },
+                detail: ToolDetail::Shell { output: Some(output), .. },
                 ..
-            } => {
-                assert_eq!(command, "cargo test");
-                assert_eq!(workdir, &None);
-                assert_eq!(tail.hidden_line_count, 3);
-                assert_eq!(tail.lines, ["out4", "out5", "out6", "err1", "错误"]);
-            }
-            other => panic!("expected shell tail, got: {other:?}"),
-        }
+            } if output.stdout == "out1  \n\n out2\nout3\nout4\nout5\nout6\n"
+                && output.stderr == "\nerr1  \n错误\n"
+        ));
     }
 
     #[test]
-    fn read_tool_result_refines_range_to_actual_line_numbers() {
-        let detail = parse_tool_detail(
+    fn read_tool_preserves_raw_path_and_semantic_one_based_range() {
+        let detail = parse(
             "read_tool",
-            Some(&serde_json::json!({
-                "path": "apps/portal/lib/portal_web/components/layouts/root.html.heex",
-                "limit": 260,
-            })),
-            None,
+            serde_json::json!({
+                "path": "/workspace/project/src/acp_state.rs",
+                "offset": 2134,
+                "limit": 71,
+            }),
         );
-        let mut messages = vec![ChatEntry::ToolCall {
-            tool_call_id: Some("read-lines".into()),
-            name: "read_tool".into(),
-            is_error: false,
-            detail,
-        }];
-        let result = "<path>/projects/querymt-org/service/apps/portal/lib/portal_web/components/layouts/root.html.heex</path>\n<type>file</type>\n<content>\n00001| <!DOCTYPE html>\n00002| <html lang=\"en\">\n00027| </html>\n\n(End of file - total 27 lines)\n</content>";
-
-        assert!(update_tool_detail(
-            &mut messages,
-            Some("read-lines"),
-            result
-        ));
-        match &messages[0] {
-            ChatEntry::ToolCall {
-                detail:
-                    ToolDetail::ReadTool {
-                        start_line,
-                        end_line,
-                        ..
-                    },
-                ..
-            } => {
-                assert_eq!(*start_line, Some(1));
-                assert_eq!(*end_line, Some(27));
-            }
-            other => panic!("expected read_tool detail, got: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn read_tool_result_refines_range_from_json_text_content() {
-        let detail = parse_tool_detail(
-            "read_tool",
-            Some(&serde_json::json!({
-                "path": "apps/portal/lib/portal_web/components/core_components.ex",
-                "offset": 40,
-                "limit": 390,
-            })),
-            None,
-        );
-        let mut messages = vec![ChatEntry::ToolCall {
-            tool_call_id: Some("read-json-lines".into()),
-            name: "read_tool".into(),
-            is_error: false,
-            detail,
-        }];
-        let result = serde_json::json!([{
-            "type": "text",
-            "text": "<path>/repo/core_components.ex</path>\n<type>file</type>\n<content>\n00041|   attr :id, :string\n00042|   slot :inner_block\n00430| end\n\n(File has more lines. Use 'offset' parameter to read beyond line 430)\n</content>"
-        }])
-        .to_string();
-
-        assert!(update_tool_detail(
-            &mut messages,
-            Some("read-json-lines"),
-            &result
-        ));
-        match &messages[0] {
-            ChatEntry::ToolCall {
-                detail:
-                    ToolDetail::ReadTool {
-                        start_line,
-                        end_line,
-                        ..
-                    },
-                ..
-            } => {
-                assert_eq!(*start_line, Some(41));
-                assert_eq!(*end_line, Some(430));
-            }
-            other => panic!("expected read_tool detail, got: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn edit_tool_result_uses_start_line_old() {
-        let detail = parse_tool_detail(
-            "edit",
-            Some(&serde_json::json!({
-                "filePath": "src/lib.rs",
-                "oldString": "before\n",
-                "newString": "after\n",
-            })),
-            None,
-        );
-        let mut messages = vec![ChatEntry::ToolCall {
-            tool_call_id: Some("edit-json-start".into()),
-            name: "edit".into(),
-            is_error: false,
-            detail,
-        }];
-
-        assert!(update_tool_detail(
-            &mut messages,
-            Some("edit-json-start"),
-            r#"{"startLineOld": 42}"#,
-        ));
-        match &messages[0] {
-            ChatEntry::ToolCall {
-                detail:
-                    ToolDetail::Edit {
-                        file,
-                        old,
-                        new,
-                        start_line,
-                    },
-                ..
-            } => {
-                assert_eq!(file, "src/lib.rs");
-                assert_eq!(old, "before\n");
-                assert_eq!(new, "after\n");
-                assert_eq!(*start_line, Some(42));
-            }
-            other => panic!("expected Edit detail, got: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn multiedit_tool_result_updates_preview_line_numbers() {
-        let detail = parse_tool_detail(
-            "multiedit",
-            Some(&serde_json::json!({
-                "filePath": "src/lib.rs",
-                "edits": [
-                    { "oldString": "aaa\n", "newString": "bbb\n" },
-                    { "oldString": "ccc\n", "newString": "ddd\n" }
-                ]
-            })),
-            None,
-        );
-        let mut messages = vec![ChatEntry::ToolCall {
-            tool_call_id: Some("multi-lines".into()),
-            name: "multiedit".into(),
-            is_error: false,
-            detail,
-        }];
-        let result = "OK paths=1 edits=2 added=2 deleted=2\nP src/lib.rs\nH replace old=10,1 new=10,1 +1 -1\nH replace old=20,1 new=20,1 +1 -1";
-
-        assert!(update_tool_detail(
-            &mut messages,
-            Some("multi-lines"),
-            result
-        ));
-        match &messages[0] {
-            ChatEntry::ToolCall {
-                detail:
-                    ToolDetail::MultiEdit {
-                        file,
-                        edit_count,
-                        sections,
-                    },
-                ..
-            } => {
-                assert_eq!(file, "src/lib.rs");
-                assert_eq!(*edit_count, 2);
-                assert_eq!(sections[0].header, "edit 1");
-                assert_eq!(sections[0].old, "aaa\n");
-                assert_eq!(sections[0].new, "bbb\n");
-                assert_eq!(sections[0].start_line, Some(10));
-                assert_eq!(sections[1].header, "edit 2");
-                assert_eq!(sections[1].old, "ccc\n");
-                assert_eq!(sections[1].new, "ddd\n");
-                assert_eq!(sections[1].start_line, Some(20));
-            }
-            other => panic!("expected multiedit detail, got: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn replace_symbol_uses_pure_summary_for_missing_and_empty_replacements() {
-        let missing = parse_tool_detail("replace_symbol", Some(&serde_json::json!({})), None);
-        assert!(matches!(missing, ToolDetail::Summary(summary) if summary == "symbols"));
-
-        let empty = parse_tool_detail(
-            "replace_symbol",
-            Some(&serde_json::json!({ "replacements": [] })),
-            None,
-        );
-        assert!(matches!(empty, ToolDetail::Summary(summary) if summary == "symbols"));
-    }
-
-    #[test]
-    fn strip_cwd_requires_a_path_component_boundary() {
         assert_eq!(
-            strip_cwd("/workspace-other/src/lib.rs", Some("/workspace")),
-            "/workspace-other/src/lib.rs"
-        );
-    }
-
-    #[test]
-    fn replace_symbol_uses_multi_path_summary() {
-        let detail = parse_tool_detail(
-            "replace_symbol",
-            Some(&serde_json::json!({
-                "replacements": [
-                    {
-                        "path": "/workspace/src/one.rs",
-                        "symbol": "one",
-                        "newText": "fn one() {}"
-                    },
-                    {
-                        "path": "/workspace/src/two.rs",
-                        "symbol": "two",
-                        "newText": "fn two() {}"
-                    }
-                ]
-            })),
-            Some("/workspace"),
-        );
-
-        assert!(matches!(
             detail,
-            ToolDetail::Summary(summary) if summary == "src/one.rs (+1)"
-        ));
-    }
-
-    #[test]
-    fn todowrite_shows_completed_and_pending_items() {
-        let detail = parse_tool_detail(
-            "todowrite",
-            Some(&serde_json::json!({"todos": [
-                {"content": "done", "status": "completed"},
-                {"content": "next", "status": "pending"},
-                {"content": "working", "status": "in_progress"},
-            ]})),
-            None,
+            ToolDetail::ReadTool {
+                path: "/workspace/project/src/acp_state.rs".into(),
+                start_line: Some(2135),
+                end_line: Some(2205),
+            }
         );
-        assert!(matches!(
-            detail,
-            ToolDetail::Summary(summary) if summary == "[x] done\n[ ] next\n[ ] working"
-        ));
 
-        let missing = parse_tool_detail("todowrite", Some(&serde_json::json!({})), None);
-        let empty = parse_tool_detail("todowrite", Some(&serde_json::json!({ "todos": [] })), None);
-        assert!(matches!(missing, ToolDetail::None));
-        assert!(matches!(empty, ToolDetail::None));
-    }
-
-    #[test]
-    fn browse_tool_truncates_utf8_url_on_char_boundary() {
-        let url = format!("https://example.test/{}tail", "界".repeat(50));
-        let expected = format!("{}…", url.chars().take(59).collect::<String>());
-        let args = serde_json::json!({ "url": url });
-
-        assert_eq!(expected.chars().count(), 60);
-        assert_summary_truncates_with_ellipsis("browse", args, &expected);
-    }
-
-    #[test]
-    fn delegate_tool_truncates_utf8_objective_on_char_boundary() {
-        let objective = format!("{}tail", "界".repeat(50));
-        let expected_objective = format!("{}…", objective.chars().take(49).collect::<String>());
-        let expected = format!("(coder) {expected_objective}");
-        let args = serde_json::json!({
-            "target_agent_id": "coder",
-            "objective": objective,
-        });
-
-        assert_eq!(expected_objective.chars().count(), 50);
-        assert_summary_truncates_with_ellipsis("delegate", args, &expected);
-    }
-
-    #[test]
-    fn index_tool_shows_short_path_from_arguments() {
-        let args = serde_json::json!({"path": "/home/user/project/src/main.rs"});
-        let detail = parse_tool_detail("index", Some(&args), None);
-        match detail {
-            ToolDetail::Summary(s) => {
-                assert_eq!(s, "src/main.rs");
-            }
-            other => panic!("expected Summary, got: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn structured_tool_inputs_preserve_raw_values_and_visible_diff_headers() {
-        let shell_inputs = serde_json::json!({
-            "command": "printf",
-            "args": ["hello world", "it's", "界", "", 7],
-            "workdir": "/tmp/工作",
-        });
-        match parse_tool_detail("shell", Some(&shell_inputs), Some("/ignored/session")) {
-            ToolDetail::Shell {
-                command,
-                workdir,
-                output_tail,
-            } => {
-                assert_eq!(command, "printf 'hello world' 'it'\\''s' '界' ''");
-                assert_eq!(workdir.as_deref(), Some("/tmp/工作"));
-                assert!(output_tail.is_none());
-            }
-            other => panic!("expected Shell, got: {other:?}"),
-        }
-
-        let write_inputs = serde_json::json!({
-            "path": "/workspace/src/界.rs",
-            "content": "fn 界() {\n    println!(\"ok\");\n}\n",
-        });
-        match parse_tool_detail("write_file", Some(&write_inputs), None) {
-            ToolDetail::WriteFile { path, content } => {
-                assert_eq!(path, "/workspace/src/界.rs");
-                assert_eq!(content, "fn 界() {\n    println!(\"ok\");\n}\n");
-            }
-            other => panic!("expected WriteFile, got: {other:?}"),
-        }
-
-        let edit_inputs = serde_json::json!({
-            "file_path": "/workspace/src/lib.rs",
-            "old_string": "before\n",
-            "new_string": "after\n",
-        });
-        match parse_tool_detail("edit", Some(&edit_inputs), None) {
-            ToolDetail::Edit {
-                file,
-                old,
-                new,
-                start_line,
-            } => {
-                assert_eq!(file, "/workspace/src/lib.rs");
-                assert_eq!(old, "before\n");
-                assert_eq!(new, "after\n");
-                assert_eq!(start_line, None);
-            }
-            other => panic!("expected Edit, got: {other:?}"),
-        }
-
-        let multiedit_inputs = serde_json::json!({
-            "filePath": "/workspace/src/lib.rs",
-            "edits": [
-                { "oldString": "one\n", "newString": "ONE\n", "replaceAll": true },
-                { "old_string": "two\n", "new_string": "TWO\n", "replace_all": false },
-                { "oldString": "missing new value" },
-            ],
-        });
-        match parse_tool_detail("multiedit", Some(&multiedit_inputs), None) {
-            ToolDetail::MultiEdit {
-                file,
-                edit_count,
-                sections,
-            } => {
-                assert_eq!(file, "/workspace/src/lib.rs");
-                assert_eq!(edit_count, 2);
-                assert_eq!(sections.len(), 2);
-                assert_eq!(sections[0].header, "edit 1 (all)");
-                assert_eq!(sections[0].old, "one\n");
-                assert_eq!(sections[0].new, "ONE\n");
-                assert_eq!(sections[0].start_line, None);
-                assert_eq!(sections[1].header, "edit 2");
-                assert_eq!(sections[1].old, "two\n");
-                assert_eq!(sections[1].new, "TWO\n");
-                assert_eq!(sections[1].start_line, None);
-            }
-            other => panic!("expected MultiEdit, got: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn summary_tool_matrix_pins_current_visible_formatting() {
-        let cases = [
+        for (arguments, expected_end) in [
             (
-                "search_text",
-                serde_json::json!({
-                    "pattern": "needle",
-                    "path": "/workspace/project/src",
-                    "include": "*.rs",
-                }),
-                "\"needle\" *.rs",
+                serde_json::json!({ "path": "README.md" }),
+                DEFAULT_READ_TOOL_LIMIT,
             ),
             (
+                serde_json::json!({ "path": "README.md", "limit": 0 }),
+                DEFAULT_READ_TOOL_LIMIT,
+            ),
+            (
+                serde_json::json!({ "path": "README.md", "limit": 300 }),
+                300,
+            ),
+        ] {
+            assert!(matches!(
+                parse("read_tool", arguments),
+                ToolDetail::ReadTool { start_line: Some(1), end_line: Some(end), .. }
+                    if end == expected_end
+            ));
+        }
+    }
+
+    #[test]
+    fn read_results_refine_semantic_line_ranges() {
+        let detail = parse(
+            "read_tool",
+            serde_json::json!({ "path": "src/lib.rs", "limit": 260 }),
+        );
+        let mut messages = vec![tool_call("read-1", "read_tool", detail)];
+        let result = "<content>\n00041| first\n00042| second\n00430| last\n</content>";
+        assert!(update_tool_detail(&mut messages, Some("read-1"), result));
+        assert!(matches!(
+            &messages[0],
+            ChatEntry::ToolCall {
+                detail: ToolDetail::ReadTool {
+                    start_line: Some(41),
+                    end_line: Some(430),
+                    ..
+                },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn edit_and_multiedit_preserve_raw_text_flags_indices_and_line_metadata() {
+        let edit = parse(
+            "edit",
+            serde_json::json!({
+                "file_path": "/workspace/src/lib.rs",
+                "old_string": "before\n",
+                "new_string": "after\n",
+                "replace_all": true,
+            }),
+        );
+        assert_eq!(
+            edit,
+            ToolDetail::Edit {
+                file: "/workspace/src/lib.rs".into(),
+                old: "before\n".into(),
+                new: "after\n".into(),
+                replace_all: true,
+                start_line: None,
+            }
+        );
+
+        let mut edit_messages = vec![tool_call("edit-1", "edit", edit)];
+        assert!(update_tool_detail(
+            &mut edit_messages,
+            Some("edit-1"),
+            r#"{"startLineOld":42}"#,
+        ));
+        assert!(matches!(
+            &edit_messages[0],
+            ChatEntry::ToolCall {
+                detail: ToolDetail::Edit {
+                    start_line: Some(42),
+                    ..
+                },
+                ..
+            }
+        ));
+
+        let multiedit = parse(
+            "multiedit",
+            serde_json::json!({
+                "filePath": "/workspace/src/lib.rs",
+                "edits": [
+                    { "oldString": "one\n", "newString": "ONE\n", "replaceAll": true },
+                    { "old_string": "two\n", "new_string": "TWO\n", "replace_all": false },
+                    { "oldString": "missing new value" },
+                ],
+            }),
+        );
+        let ToolDetail::MultiEdit {
+            file,
+            edit_count,
+            sections,
+        } = &multiedit
+        else {
+            panic!("expected MultiEdit, got {multiedit:?}");
+        };
+        assert_eq!(file, "/workspace/src/lib.rs");
+        assert_eq!(*edit_count, 2);
+        assert_eq!(
+            sections,
+            &[
+                MultiEditSection {
+                    edit_index: 1,
+                    replace_all: true,
+                    old: "one\n".into(),
+                    new: "ONE\n".into(),
+                    start_line: None,
+                },
+                MultiEditSection {
+                    edit_index: 2,
+                    replace_all: false,
+                    old: "two\n".into(),
+                    new: "TWO\n".into(),
+                    start_line: None,
+                },
+            ]
+        );
+
+        let mut multiedit_messages = vec![tool_call("multi-1", "multiedit", multiedit)];
+        let receipt = "old_start=10 old_lines=1\nold_start=20 old_lines=1";
+        assert!(update_tool_detail(
+            &mut multiedit_messages,
+            Some("multi-1"),
+            receipt,
+        ));
+        assert!(matches!(
+            &multiedit_messages[0],
+            ChatEntry::ToolCall {
+                detail: ToolDetail::MultiEdit { sections, .. },
+                ..
+            } if sections.iter().map(|section| section.start_line).collect::<Vec<_>>()
+                == [Some(10), Some(20)]
+        ));
+    }
+
+    #[test]
+    fn structured_tool_families_keep_raw_protocol_values() {
+        assert_eq!(
+            parse(
                 "search_text",
                 serde_json::json!({
                     "pattern": "needle",
                     "path": "/workspace/project/src/lib.rs",
+                    "include": "*.rs",
                 }),
-                "\"needle\" src/lib.rs",
             ),
-            (
-                "search_text",
-                serde_json::json!({ "pattern": "needle" }),
-                "\"needle\" .",
-            ),
-            (
+            ToolDetail::SearchText {
+                pattern: "needle".into(),
+                path: "/workspace/project/src/lib.rs".into(),
+                include: "*.rs".into(),
+                counts: None,
+            }
+        );
+        assert_eq!(
+            parse(
                 "glob",
-                serde_json::json!({
-                    "pattern": "*.rs",
-                    "path": "/workspace/project/src",
-                }),
-                "*.rs in project/src",
+                serde_json::json!({ "pattern": "*.rs", "path": "/workspace/project/src" }),
             ),
-            ("glob", serde_json::json!({ "pattern": "*.md" }), "*.md"),
-            ("ls", serde_json::json!({}), "."),
-            (
+            ToolDetail::Glob {
+                pattern: "*.rs".into(),
+                path: "/workspace/project/src".into(),
+            }
+        );
+        assert_eq!(
+            parse(
+                "ls",
+                serde_json::json!({ "path": "/workspace/project/src" })
+            ),
+            ToolDetail::List {
+                path: "/workspace/project/src".into(),
+            }
+        );
+        assert_eq!(
+            parse(
                 "index",
                 serde_json::json!({ "path": "/workspace/project/src/main.rs" }),
-                "src/main.rs",
             ),
-            (
+            ToolDetail::Index {
+                path: "/workspace/project/src/main.rs".into(),
+                metadata: None,
+            }
+        );
+        assert_eq!(
+            parse(
                 "delete_file",
                 serde_json::json!({ "path": "/workspace/project/tmp/out.txt" }),
-                "tmp/out.txt",
             ),
-            (
-                "browse",
-                serde_json::json!({ "url": "https://example.test/docs" }),
-                "https://example.test/docs",
-            ),
-            (
-                "web_fetch",
-                serde_json::json!({ "url": "https://example.test/api" }),
-                "https://example.test/api",
-            ),
-            (
+            ToolDetail::DeleteFile {
+                path: "/workspace/project/tmp/out.txt".into(),
+            }
+        );
+        assert_eq!(
+            parse(
                 "language_query",
                 serde_json::json!({
                     "action": "definition",
                     "uri": "file:///workspace/project/src/lib.rs",
                 }),
-                "definition src/lib.rs",
             ),
-            (
-                "question",
-                serde_json::json!({ "prompt": "Continue?" }),
-                "asking...",
-            ),
-            (
-                "apply_patch",
-                serde_json::json!({ "patch": "raw patch" }),
-                "patch",
-            ),
-        ];
+            ToolDetail::LanguageQuery {
+                action: "definition".into(),
+                uri: "file:///workspace/project/src/lib.rs".into(),
+            }
+        );
+        assert_eq!(
+            parse("question", serde_json::json!({ "prompt": "Continue?" })),
+            ToolDetail::Question {
+                prompt: "Continue?".into(),
+            }
+        );
+        assert_eq!(
+            parse("apply_patch", serde_json::json!({ "patch": "raw patch" })),
+            ToolDetail::ApplyPatch {
+                patch: "raw patch".into(),
+            }
+        );
+    }
 
-        for (tool_name, semantic_inputs, expected_visible_summary) in cases {
-            let detail = parse_tool_detail(tool_name, Some(&semantic_inputs), None);
-            assert!(
-                matches!(detail, ToolDetail::Summary(ref summary) if summary == expected_visible_summary),
-                "unexpected summary for {tool_name}: {detail:?}"
-            );
-        }
-
-        assert!(matches!(
-            parse_tool_detail(
-                "unknown_tool",
-                Some(&serde_json::json!({ "raw": true })),
-                None
+    #[test]
+    fn todo_and_replace_symbol_preserve_semantic_items_and_replacements() {
+        assert_eq!(
+            parse(
+                "todowrite",
+                serde_json::json!({ "todos": [
+                    { "content": "done", "status": "completed" },
+                    { "content": "next", "status": "pending" },
+                    { "content": "working", "status": "in_progress" },
+                ] }),
             ),
-            ToolDetail::None
-        ));
+            ToolDetail::Todo {
+                items: vec![
+                    TodoItem {
+                        content: "done".into(),
+                        status: "completed".into()
+                    },
+                    TodoItem {
+                        content: "next".into(),
+                        status: "pending".into()
+                    },
+                    TodoItem {
+                        content: "working".into(),
+                        status: "in_progress".into()
+                    },
+                ],
+            }
+        );
+        assert_eq!(
+            parse(
+                "replace_symbol",
+                serde_json::json!({ "replacements": [
+                    {
+                        "path": "/workspace/src/one.rs",
+                        "symbol": "one",
+                        "newText": "fn one() {}",
+                    },
+                    {
+                        "path": "/workspace/src/two.rs",
+                        "symbol": "two",
+                        "newText": "fn two() {}",
+                    },
+                ] }),
+            ),
+            ToolDetail::ReplaceSymbolInput {
+                replacements: vec![
+                    SymbolReplacement {
+                        path: "/workspace/src/one.rs".into(),
+                        symbol: "one".into(),
+                        new_text: "fn one() {}".into(),
+                    },
+                    SymbolReplacement {
+                        path: "/workspace/src/two.rs".into(),
+                        symbol: "two".into(),
+                        new_text: "fn two() {}".into(),
+                    },
+                ],
+            }
+        );
         assert!(matches!(
-            parse_tool_detail("shell", None, None),
+            parse("todowrite", serde_json::json!({ "todos": [] })),
             ToolDetail::None
         ));
     }
 
     #[test]
-    fn replace_symbol_single_path_strips_cwd_and_shortens_visible_title() {
-        let semantic_inputs = serde_json::json!({
-            "replacements": [
-                {
-                    "path": "/workspace/project/src/nested/lib.rs",
-                    "symbol": "run",
-                    "newText": "fn run() {}",
-                },
-                {
-                    "path": "/workspace/project/src/nested/lib.rs",
-                    "symbol": "stop",
-                    "newText": "fn stop() {}",
-                },
-            ],
-        });
-
-        let visible_detail = parse_tool_detail(
-            "replace_symbol",
-            Some(&semantic_inputs),
-            Some("/workspace/project"),
+    fn delegate_without_agent_preserves_objective_only() {
+        assert_eq!(
+            parse(
+                "delegate",
+                serde_json::json!({ "objective": "Do something" }),
+            ),
+            ToolDetail::Delegate {
+                target_agent_id: String::new(),
+                objective: "Do something".into(),
+            }
         );
+    }
 
+    #[test]
+    fn shell_preserves_full_utf8_multiline_command() {
+        let command =
+            "cat > check/kimi.md << 'EOF'\n# Review: feat/profiles\n\n## 🔴 Critical / High";
         assert!(matches!(
-            visible_detail,
-            ToolDetail::Summary(summary) if summary == "nested/lib.rs"
+            parse("shell", serde_json::json!({ "command": command })),
+            ToolDetail::Shell { command: parsed, arguments, .. }
+                if parsed == command && arguments.is_empty()
         ));
+    }
+
+    #[test]
+    fn shell_keeps_arguments_distinct_without_display_quoting() {
+        assert!(matches!(
+            parse(
+                "shell",
+                serde_json::json!({
+                    "command": "echo",
+                    "args": ["hello world", "", "safe"],
+                }),
+            ),
+            ToolDetail::Shell { command, arguments, .. }
+                if command == "echo" && arguments == ["hello world", "", "safe"]
+        ));
+    }
+
+    #[test]
+    fn shell_uses_only_explicit_workdir() {
+        assert!(matches!(
+            parse(
+                "shell",
+                serde_json::json!({ "command": "pwd", "workdir": "/workspace/project" }),
+            ),
+            ToolDetail::Shell { workdir: Some(workdir), .. }
+                if workdir == "/workspace/project"
+        ));
+        assert!(matches!(
+            parse("shell", serde_json::json!({ "command": "pwd" })),
+            ToolDetail::Shell { workdir: None, .. }
+        ));
+    }
+
+    #[test]
+    fn read_tool_parses_json_string_arguments() {
+        let arguments = Value::String(
+            r#"{"path":"apps/admin/lib/admin_web/components/layouts/root.html.heex","limit":220}"#
+                .into(),
+        );
+        assert_eq!(
+            parse_tool_detail("read_tool", Some(&arguments)),
+            ToolDetail::ReadTool {
+                path: "apps/admin/lib/admin_web/components/layouts/root.html.heex".into(),
+                start_line: Some(1),
+                end_line: Some(220),
+            }
+        );
+    }
+
+    #[test]
+    fn read_tool_result_refines_range_from_json_text_content() {
+        let detail = parse(
+            "read_tool",
+            serde_json::json!({ "path": "src/lib.rs", "offset": 40, "limit": 390 }),
+        );
+        let mut messages = vec![tool_call("read-json", "read_tool", detail)];
+        let result = serde_json::json!([{
+            "type": "text",
+            "text": "<content>\n00041| first\n00042| second\n00430| last\n</content>",
+        }])
+        .to_string();
+
+        assert!(update_tool_detail(
+            &mut messages,
+            Some("read-json"),
+            &result,
+        ));
+        assert!(matches!(
+            &messages[0],
+            ChatEntry::ToolCall {
+                detail: ToolDetail::ReadTool {
+                    start_line: Some(41),
+                    end_line: Some(430),
+                    ..
+                },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn edit_result_uses_compact_old_start_receipt() {
+        let detail = parse(
+            "edit",
+            serde_json::json!({
+                "filePath": "src/lib.rs",
+                "oldString": "before\n",
+                "newString": "after\n",
+            }),
+        );
+        let mut messages = vec![tool_call("edit-compact", "edit", detail)];
+
+        assert!(update_tool_detail(
+            &mut messages,
+            Some("edit-compact"),
+            "old_start=73 old_lines=1 new_start=73 new_lines=1",
+        ));
+        assert!(matches!(
+            &messages[0],
+            ChatEntry::ToolCall {
+                detail: ToolDetail::Edit {
+                    start_line: Some(73),
+                    ..
+                },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn multiedit_result_uses_hunk_old_start_metadata() {
+        let detail = parse(
+            "multiedit",
+            serde_json::json!({
+                "filePath": "src/lib.rs",
+                "edits": [
+                    { "oldString": "aaa\n", "newString": "bbb\n" },
+                    { "oldString": "ccc\n", "newString": "ddd\n" },
+                ],
+            }),
+        );
+        let mut messages = vec![tool_call("multi-hunks", "multiedit", detail)];
+        let result = "H replace old=10,1 new=10,1 +1 -1\nH replace old=20,1 new=20,1 +1 -1";
+
+        assert!(update_tool_detail(
+            &mut messages,
+            Some("multi-hunks"),
+            result,
+        ));
+        assert!(matches!(
+            &messages[0],
+            ChatEntry::ToolCall {
+                detail: ToolDetail::MultiEdit { sections, .. },
+                ..
+            } if sections.iter().map(|section| section.start_line).collect::<Vec<_>>()
+                == [Some(10), Some(20)]
+        ));
+    }
+
+    #[test]
+    fn replace_symbol_missing_and_empty_inputs_remain_semantic() {
+        for arguments in [
+            serde_json::json!({}),
+            serde_json::json!({ "replacements": [] }),
+        ] {
+            assert_eq!(
+                parse("replace_symbol", arguments),
+                ToolDetail::ReplaceSymbolInput {
+                    replacements: Vec::new(),
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn replace_symbol_duplicate_paths_are_not_display_deduplicated() {
+        let detail = parse(
+            "replace_symbol",
+            serde_json::json!({ "replacements": [
+                { "path": "/workspace/src/lib.rs", "symbol": "run", "newText": "run" },
+                { "path": "/workspace/src/lib.rs", "symbol": "stop", "newText": "stop" },
+            ] }),
+        );
+        assert!(matches!(
+            detail,
+            ToolDetail::ReplaceSymbolInput { replacements }
+                if replacements.len() == 2
+                    && replacements[0].path == "/workspace/src/lib.rs"
+                    && replacements[1].path == "/workspace/src/lib.rs"
+        ));
+    }
+
+    #[test]
+    fn todowrite_missing_and_empty_inputs_produce_no_detail() {
+        assert!(matches!(
+            parse("todowrite", serde_json::json!({})),
+            ToolDetail::None
+        ));
+        assert!(matches!(
+            parse("todowrite", serde_json::json!({ "todos": [] })),
+            ToolDetail::None
+        ));
+    }
+
+    #[test]
+    fn browse_keeps_utf8_url_without_parser_ellipsis() {
+        let url = format!("https://example.test/{}tail", "界".repeat(50));
+        assert!(matches!(
+            parse("browse", serde_json::json!({ "url": url })),
+            ToolDetail::Browse { url: parsed } if parsed == url
+        ));
+    }
+
+    #[test]
+    fn delegate_keeps_utf8_objective_without_parser_ellipsis() {
+        let objective = format!("{}tail", "界".repeat(50));
+        assert!(matches!(
+            parse(
+                "delegate",
+                serde_json::json!({
+                    "target_agent_id": "coder",
+                    "objective": objective,
+                }),
+            ),
+            ToolDetail::Delegate { target_agent_id, objective: parsed }
+                if target_agent_id == "coder" && parsed == objective
+        ));
+    }
+
+    #[test]
+    fn index_keeps_full_unshortened_path() {
+        let path = "/home/user/project/src/main.rs";
+        assert_eq!(
+            parse("index", serde_json::json!({ "path": path })),
+            ToolDetail::Index {
+                path: path.into(),
+                metadata: None,
+            }
+        );
+    }
+
+    #[test]
+    fn write_file_preserves_raw_unicode_path_and_content() {
+        assert_eq!(
+            parse(
+                "write_file",
+                serde_json::json!({
+                    "path": "/workspace/src/界.rs",
+                    "content": "fn 界() {\n    println!(\"ok\");\n}\n",
+                }),
+            ),
+            ToolDetail::WriteFile {
+                path: "/workspace/src/界.rs".into(),
+                content: "fn 界() {\n    println!(\"ok\");\n}\n".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_and_missing_arguments_produce_no_detail() {
+        assert!(matches!(
+            parse("unknown_tool", serde_json::json!({ "raw": true })),
+            ToolDetail::None
+        ));
+        assert!(matches!(parse_tool_detail("shell", None), ToolDetail::None));
     }
 
     #[test]
     fn failed_tool_end_marks_existing_tool_in_place() {
         let mut messages = vec![
-            ChatEntry::ToolCall {
-                tool_call_id: Some("tool-1".into()),
-                name: "shell".into(),
-                is_error: false,
-                detail: ToolDetail::Summary("echo ok".into()),
-            },
+            tool_call(
+                "tool-1",
+                "shell",
+                ToolDetail::Generic {
+                    input: Some("echo ok".into()),
+                    result: None,
+                },
+            ),
             ChatEntry::Assistant {
                 content: "done".into(),
                 thinking: None,
                 message_id: None,
             },
         ];
-
         assert!(mark_tool_call_failed(
             &mut messages,
             Some("tool-1"),
-            "shell"
+            "shell",
         ));
-
-        assert_eq!(messages.len(), 2, "must not append a stale failed badge");
-        match &messages[0] {
-            ChatEntry::ToolCall { name, is_error, .. } => {
-                assert_eq!(name, "shell");
-                assert!(*is_error);
-            }
-            other => panic!("expected ToolCall, got: {other:?}"),
-        }
+        assert_eq!(messages.len(), 2);
+        assert!(matches!(
+            messages[0],
+            ChatEntry::ToolCall { is_error: true, .. }
+        ));
         assert!(matches!(messages[1], ChatEntry::Assistant { .. }));
     }
 
@@ -1277,40 +1113,25 @@ mod tests {
                 detail: ToolDetail::None,
             },
         ];
-        let detail = parse_tool_detail(
+        let detail = parse(
             "shell",
-            Some(&serde_json::json!({
-                "command": "cargo test tool_detail_tests"
-            })),
-            None,
+            serde_json::json!({ "command": "cargo test tool_detail_tests" }),
         );
-
         assert!(reconcile_tool_call_start(
             &mut messages,
             Some("missing-start"),
             "shell",
-            detail
+            detail,
         ));
-        assert_eq!(
-            messages.len(),
-            2,
-            "start must not append a second tool entry"
-        );
-        match &messages[1] {
+        assert_eq!(messages.len(), 2);
+        assert!(matches!(
+            &messages[1],
             ChatEntry::ToolCall {
                 name,
-                is_error,
-                detail,
+                is_error: true,
+                detail: ToolDetail::Shell { command, .. },
                 ..
-            } => {
-                assert_eq!(name, "shell");
-                assert!(*is_error);
-                assert!(matches!(
-                    detail,
-                    ToolDetail::Shell { command, .. } if command == "cargo test tool_detail_tests"
-                ));
-            }
-            other => panic!("expected ToolCall, got: {other:?}"),
-        }
+            } if name == "shell" && command == "cargo test tool_detail_tests"
+        ));
     }
 }

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -9,14 +9,17 @@ use ratatui::{
 };
 
 use crate::app::App;
-use crate::composer_state::{InputVisualLayout, build_input_visual_layout};
+use crate::chat_state::{ChatState, ElicitationUiState};
+use crate::composer_state::ComposerState;
 use crate::domain::activity::{ActivityState, DelegateEntry, DelegateStatus, SessionOp};
 use crate::domain::chat::{ChatEntry, ElicitationResponseOutcome};
+use crate::domain::elicitation::ElicitationState;
 use crate::domain::tool::{
     MultiEditSection, ShellOutput, SymbolDiffSection, SymbolReplacement, ToolDetail,
 };
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
+use crate::input_layout::InputVisualLayout;
 use crate::markdown;
 use crate::render_state::{
     Card, CardKind, DelegatePresentationKeyRef, FinalizedCardKeyRef, FinalizedMessageKeyRef,
@@ -923,8 +926,13 @@ fn build_chat_header_spans(app: &App) -> (Vec<Span<'static>>, Vec<Span<'static>>
 pub(super) fn draw_delegate_view(f: &mut Frame, app: &mut App) {
     let area = f.area();
 
-    let (input_height, input_layout) = input_layout_metrics(app, area);
-    let elicitation_height = elicitation_popup_height(app, area);
+    let (input_height, input_layout) = input_layout_metrics(&app.composer, &mut app.render, area);
+    let elicitation_height = elicitation_popup_height(
+        app.chat.elicitation.as_ref(),
+        app.chat.elicitation_ui.as_ref(),
+        &mut app.render,
+        area,
+    );
 
     let chunks = if elicitation_height > 0 {
         Layout::default()
@@ -967,8 +975,18 @@ pub(super) fn draw_delegate_view(f: &mut Frame, app: &mut App) {
     draw_messages(f, chunks[1], input, &mut app.render);
 
     if elicitation_height > 0 {
-        draw_elicitation_popup(f, app, chunks[2]);
-        draw_input_panel(f, app, chunks[3], chunks[4], input_layout);
+        if let (Some(state), Some(ui)) = (&app.chat.elicitation, &app.chat.elicitation_ui) {
+            draw_elicitation_popup(f, state, ui, &mut app.render, chunks[2]);
+        }
+        draw_input_panel(
+            f,
+            &app.composer,
+            &app.chat,
+            &app.sessions.agent_mode,
+            &mut app.render,
+            (chunks[3], chunks[4]),
+            input_layout,
+        );
     }
 }
 
@@ -987,8 +1005,13 @@ pub(super) fn draw_chat(f: &mut Frame, app: &mut App) {
         0u16
     };
 
-    let (input_height, input_layout) = input_layout_metrics(app, area);
-    let elicitation_height = elicitation_popup_height(app, area);
+    let (input_height, input_layout) = input_layout_metrics(&app.composer, &mut app.render, area);
+    let elicitation_height = elicitation_popup_height(
+        app.chat.elicitation.as_ref(),
+        app.chat.elicitation_ui.as_ref(),
+        &mut app.render,
+        area,
+    );
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -1031,21 +1054,35 @@ pub(super) fn draw_chat(f: &mut Frame, app: &mut App) {
         }
     }
 
-    if elicitation_height > 0 {
-        draw_elicitation_popup(f, app, chunks[3]);
+    if elicitation_height > 0
+        && let (Some(state), Some(ui)) = (&app.chat.elicitation, &app.chat.elicitation_ui)
+    {
+        draw_elicitation_popup(f, state, ui, &mut app.render, chunks[3]);
     }
 
-    draw_input_panel(f, app, chunks[4], chunks[5], input_layout);
+    draw_input_panel(
+        f,
+        &app.composer,
+        &app.chat,
+        &app.sessions.agent_mode,
+        &mut app.render,
+        (chunks[4], chunks[5]),
+        input_layout,
+    );
 }
 
-fn input_layout_metrics(app: &App, area: Rect) -> (u16, InputVisualLayout) {
+fn input_layout_metrics(
+    composer: &ComposerState,
+    render: &mut RenderState,
+    area: Rect,
+) -> (u16, InputVisualLayout) {
     // Compute how many visual rows the input text needs when wrapped.
     let input_inner_width = area.width.saturating_sub(4) as usize;
     let prefix_width = 2usize; // "> "
-    let input_layout = build_input_visual_layout(
-        &app.composer.input,
-        app.composer.input_cursor,
-        input_inner_width.max(1),
+    let input_layout = render.prepare_composer_input_layout(
+        &composer.input,
+        composer.input_cursor,
+        input_inner_width,
         prefix_width,
     );
     let max_input_lines: u16 = 5;
@@ -1112,12 +1149,8 @@ fn elicitation_option_text(label: &str, description: Option<&str>) -> String {
         .unwrap_or_else(|| label.to_string())
 }
 
-fn elicitation_option_rows(app: &App, width: u16) -> u16 {
+fn elicitation_option_rows(state: &ElicitationState, ui: &ElicitationUiState, width: u16) -> u16 {
     use crate::domain::elicitation::ElicitationFieldKind;
-
-    let (Some(state), Some(ui)) = (&app.chat.elicitation, &app.chat.elicitation_ui) else {
-        return 0;
-    };
     let schema_rows = match ui
         .current_field_index(state.fields.len())
         .and_then(|index| state.fields.get(index))
@@ -1147,15 +1180,21 @@ fn elicitation_option_rows(app: &App, width: u16) -> u16 {
     schema_rows + u16::from(state.allow_custom && option_count > 0)
 }
 
-fn elicitation_popup_height(app: &App, area: Rect) -> u16 {
-    if let (Some(state), Some(ui)) = (&app.chat.elicitation, &app.chat.elicitation_ui) {
+fn elicitation_popup_height(
+    state: Option<&ElicitationState>,
+    ui: Option<&ElicitationUiState>,
+    render: &mut RenderState,
+    area: Rect,
+) -> u16 {
+    if let (Some(state), Some(ui)) = (state, ui) {
         let message_width = area.width.saturating_sub(4).max(1);
         let message_rows = wrapped_text_rows(&state.message, message_width);
         let option_width = area.width.saturating_sub(6).max(1);
-        let option_rows = elicitation_option_rows(app, option_width);
+        let option_rows = elicitation_option_rows(state, ui, option_width);
         let custom_rows = if ui.custom_active {
             let width = area.width.saturating_sub(4) as usize;
-            build_input_visual_layout(&state.custom_input, ui.custom_cursor, width.max(1), 2)
+            render
+                .prepare_elicitation_custom_layout(&state.custom_input, ui.custom_cursor, width, 2)
                 .total_rows() as u16
         } else {
             0
@@ -1171,22 +1210,25 @@ fn elicitation_popup_height(app: &App, area: Rect) -> u16 {
 
 fn draw_input_panel(
     f: &mut Frame,
-    app: &mut App,
-    border_area: Rect,
-    input_area: Rect,
+    _composer: &ComposerState,
+    chat: &ChatState,
+    agent_mode: &str,
+    render: &mut RenderState,
+    areas: (Rect, Rect),
     input_layout: InputVisualLayout,
 ) {
+    let (border_area, input_area) = areas;
     // input border line reflects active session state
-    let border_style = match &app.chat.activity {
+    let border_style = match &chat.activity {
         ActivityState::SessionOp(SessionOp::Undo) => Theme::input_border_undo(),
         ActivityState::SessionOp(SessionOp::Redo) => Theme::input_border_redo(),
-        _ if app.chat.cancel_confirm_active() => Theme::input_border_cancel_confirm(),
+        _ if chat.cancel_confirm_active() => Theme::input_border_cancel_confirm(),
         ActivityState::Compacting { .. } => Theme::input_border_compacting(),
         ActivityState::Thinking | ActivityState::Streaming | ActivityState::RunningTool { .. } => {
             Theme::input_border_thinking()
         }
-        _ if app.chat.elicitation.is_some() => Theme::input_border_thinking(), // accent while waiting
-        _ => Theme::mode_border(&app.sessions.agent_mode),
+        _ if chat.elicitation.is_some() => Theme::input_border_thinking(), // accent while waiting
+        _ => Theme::mode_border(agent_mode),
     };
     let border_line =
         Paragraph::new(INPUT_OVERLINE.repeat(border_area.width as usize)).style(border_style);
@@ -1197,28 +1239,21 @@ fn draw_input_panel(
         .padding(Padding::new(2, 2, 0, 1))
         .style(Theme::input());
     let inner = input_bg.inner(input_area);
-    app.composer.input_line_width = (inner.width as usize).max(1);
     f.render_widget(input_bg, input_area);
 
-    let (label_text, label_style) = match &app.chat.activity {
+    let (label_text, label_style) = match &chat.activity {
         ActivityState::SessionOp(SessionOp::Undo) => (
-            format!(
-                "{} undoing ",
-                spinner(SpinnerKind::Braille, app.render.tick)
-            ),
+            format!("{} undoing ", spinner(SpinnerKind::Braille, render.tick)),
             Theme::input_undo(),
         ),
         ActivityState::SessionOp(SessionOp::Redo) => (
-            format!(
-                "{} redoing ",
-                spinner(SpinnerKind::Braille, app.render.tick)
-            ),
+            format!("{} redoing ", spinner(SpinnerKind::Braille, render.tick)),
             Theme::input_redo(),
         ),
-        _ if app.chat.cancel_confirm_active() => (
+        _ if chat.cancel_confirm_active() => (
             format!(
                 "{} Esc again to stop ",
-                spinner(SpinnerKind::Braille, app.render.tick)
+                spinner(SpinnerKind::Braille, render.tick)
             ),
             Theme::input_cancel_confirm(),
         ),
@@ -1226,20 +1261,20 @@ fn draw_input_panel(
         | ActivityState::RunningTool { .. }
         | ActivityState::Thinking
         | ActivityState::Streaming => (
-            format!("{} ", spinner(SpinnerKind::Braille, app.render.tick)),
+            format!("{} ", spinner(SpinnerKind::Braille, render.tick)),
             Theme::input_thinking(),
         ),
-        _ if app.chat.elicitation.is_some() => (
+        _ if chat.elicitation.is_some() => (
             format!("  answer above {ARROW_UP} "),
             Theme::input_thinking(),
         ),
-        _ => ("> ".into(), Theme::mode_border(&app.sessions.agent_mode)),
+        _ => ("> ".into(), Theme::mode_border(agent_mode)),
     };
     let input_style = Theme::input();
-    let hide_input_contents = app.chat.should_hide_input_contents();
+    let hide_input_contents = chat.should_hide_input_contents();
 
     if hide_input_contents {
-        app.composer.input_scroll = 0;
+        render.ensure_composer_input_cursor_visible(inner.height, true);
         f.render_widget(
             Paragraph::new(Line::from(Span::styled(label_text, label_style))),
             inner,
@@ -1261,25 +1296,12 @@ fn draw_input_panel(
             lines.push(Line::from(Span::styled("", input_style)));
         }
 
-        let total_lines = lines.len() as u16;
         let visible = inner.height;
-        if (layout.cursor_row as u16) >= app.composer.input_scroll + visible {
-            app.composer.input_scroll = (layout.cursor_row as u16) - visible + 1;
-        }
-        if (layout.cursor_row as u16) < app.composer.input_scroll {
-            app.composer.input_scroll = layout.cursor_row as u16;
-        }
-        app.composer.input_scroll = app
-            .composer
-            .input_scroll
-            .min(total_lines.saturating_sub(visible));
+        let scroll = render.ensure_composer_input_cursor_visible(visible, false);
 
-        f.render_widget(
-            Paragraph::new(lines).scroll((app.composer.input_scroll, 0)),
-            inner,
-        );
+        f.render_widget(Paragraph::new(lines).scroll((scroll, 0)), inner);
 
-        let visual_row = (layout.cursor_row as u16).saturating_sub(app.composer.input_scroll);
+        let visual_row = (layout.cursor_row as u16).saturating_sub(scroll);
         if visual_row < visible {
             f.set_cursor_position((inner.x + layout.cursor_col as u16, inner.y + visual_row));
         }
@@ -1288,18 +1310,18 @@ fn draw_input_panel(
 
 // ── Elicitation popup ─────────────────────────────────────────────────────────
 
-fn draw_elicitation_popup(f: &mut Frame, app: &mut App, area: Rect) {
+fn draw_elicitation_popup(
+    f: &mut Frame,
+    state: &ElicitationState,
+    ui: &ElicitationUiState,
+    render: &mut RenderState,
+    area: Rect,
+) {
     use crate::domain::elicitation::ElicitationFieldKind;
 
     if area.height == 0 || area.width == 0 {
         return;
     }
-    let (Some(state), Some(ui)) = (
-        app.chat.elicitation.as_mut(),
-        app.chat.elicitation_ui.as_mut(),
-    ) else {
-        return;
-    };
 
     f.render_widget(Block::default().style(Theme::popup_bg()), area);
     let inner = Rect {
@@ -1451,23 +1473,16 @@ fn draw_elicitation_popup(f: &mut Frame, app: &mut App, area: Rect) {
             if ui.custom_active && row < max_y {
                 // Keep the custom editor visually separate from the choices.
                 row = row.saturating_add(1).min(max_y);
-                ui.custom_line_width = (inner.width.saturating_sub(2) as usize).max(1);
-                let layout = build_input_visual_layout(
+                let layout = render.prepare_elicitation_custom_layout(
                     &state.custom_input,
                     ui.custom_cursor,
-                    ui.custom_line_width,
+                    inner.width.saturating_sub(2) as usize,
                     2,
                 );
                 let total_rows = layout.total_rows() as u16;
                 // Reserve a spacer, the help row, and bottom padding below the editor.
                 let visible = total_rows.min(max_y.saturating_sub(row + 3)).min(5);
-                if layout.cursor_row as u16 >= ui.custom_scroll + visible {
-                    ui.custom_scroll = layout.cursor_row as u16 - visible + 1;
-                }
-                if (layout.cursor_row as u16) < ui.custom_scroll {
-                    ui.custom_scroll = layout.cursor_row as u16;
-                }
-                ui.custom_scroll = ui.custom_scroll.min(total_rows.saturating_sub(visible));
+                let scroll = render.ensure_elicitation_custom_cursor_visible(visible);
 
                 let lines: Vec<Line<'static>> = layout
                     .rows
@@ -1487,10 +1502,10 @@ fn draw_elicitation_popup(f: &mut Frame, app: &mut App, area: Rect) {
                 f.render_widget(
                     Paragraph::new(lines)
                         .style(Theme::popup_bg())
-                        .scroll((ui.custom_scroll, 0)),
+                        .scroll((scroll, 0)),
                     Rect::new(inner.x + 2, row, inner.width.saturating_sub(2), visible),
                 );
-                let cursor_row = (layout.cursor_row as u16).saturating_sub(ui.custom_scroll);
+                let cursor_row = (layout.cursor_row as u16).saturating_sub(scroll);
                 if cursor_row < visible {
                     f.set_cursor_position((
                         inner.x + 2 + layout.cursor_col as u16,

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -88,6 +88,20 @@ pub(crate) struct FinalizedRenderInput<'a> {
     pub(crate) now_unix_secs: i64,
 }
 
+struct MessagesRenderInput<'a> {
+    session_identity: SessionIdentity,
+    messages: &'a [ChatEntry],
+    delegates: &'a [DelegateEntry],
+    effective_cwd: Option<String>,
+    show_thinking: bool,
+    activity: &'a ActivityState,
+    is_turn_active: bool,
+    streaming_content: &'a str,
+    streaming_content_message_id: Option<&'a str>,
+    streaming_thinking: &'a str,
+    streaming_thinking_message_id: Option<&'a str>,
+}
+
 struct PlannedFinalizedCard<'a> {
     key: FinalizedCardKeyRef<'a>,
     source_start: usize,
@@ -935,7 +949,22 @@ pub(super) fn draw_delegate_view(f: &mut Frame, app: &mut App) {
 
     let (left_spans, right_spans) = build_chat_header_spans(app);
     draw_header(f, app, chunks[0], left_spans, right_spans);
-    draw_messages(f, app, chunks[1]);
+    let session_identity = render_session_identity(app);
+    let effective_cwd = app.current_session_cwd();
+    let input = MessagesRenderInput {
+        session_identity,
+        messages: &app.chat.messages,
+        delegates: &app.delegates.delegate_entries,
+        effective_cwd,
+        show_thinking: app.chat.show_thinking,
+        activity: &app.chat.activity,
+        is_turn_active: app.chat.is_turn_active(),
+        streaming_content: &app.chat.streaming_content,
+        streaming_content_message_id: app.chat.streaming_content_message_id.as_deref(),
+        streaming_thinking: &app.chat.streaming_thinking,
+        streaming_thinking_message_id: app.chat.streaming_thinking_message_id.as_deref(),
+    };
+    draw_messages(f, chunks[1], input, &mut app.render);
 
     if elicitation_height > 0 {
         draw_elicitation_popup(f, app, chunks[2]);
@@ -977,7 +1006,22 @@ pub(super) fn draw_chat(f: &mut Frame, app: &mut App) {
     draw_header(f, app, chunks[0], left_spans, right_spans);
 
     // messages
-    draw_messages(f, app, chunks[1]);
+    let session_identity = render_session_identity(app);
+    let effective_cwd = app.current_session_cwd();
+    let input = MessagesRenderInput {
+        session_identity,
+        messages: &app.chat.messages,
+        delegates: &app.delegates.delegate_entries,
+        effective_cwd,
+        show_thinking: app.chat.show_thinking,
+        activity: &app.chat.activity,
+        is_turn_active: app.chat.is_turn_active(),
+        streaming_content: &app.chat.streaming_content,
+        streaming_content_message_id: app.chat.streaming_content_message_id.as_deref(),
+        streaming_thinking: &app.chat.streaming_thinking,
+        streaming_thinking_message_id: app.chat.streaming_thinking_message_id.as_deref(),
+    };
+    draw_messages(f, chunks[1], input, &mut app.render);
 
     if completion_panel_height > 0 {
         if app.composer.slash_state.is_some() {
@@ -2259,66 +2303,58 @@ pub(crate) fn build_write_lines(content: &str) -> Vec<Line<'static>> {
 
 // ── Draw messages area ────────────────────────────────────────────────────────
 
-fn draw_messages(f: &mut Frame, app: &mut App, area: Rect) {
+fn draw_messages(
+    f: &mut Frame,
+    area: Rect,
+    input: MessagesRenderInput<'_>,
+    render: &mut RenderState,
+) {
     f.render_widget(Block::default().style(Theme::base()), area);
 
-    let session_identity = render_session_identity(app);
-    let effective_cwd = app.current_session_cwd();
     let theme = ThemeCacheKey::current_frame();
     let finalized_input = FinalizedRenderInput {
-        session_identity: session_identity.clone(),
-        messages: &app.chat.messages,
-        delegates: &app.delegates.delegate_entries,
-        effective_cwd,
-        show_thinking: app.chat.show_thinking,
+        session_identity: input.session_identity.clone(),
+        messages: input.messages,
+        delegates: input.delegates,
+        effective_cwd: input.effective_cwd,
+        show_thinking: input.show_thinking,
         full_width: area.width,
         theme,
         now_unix_secs: now_unix_secs(),
     };
-    build_finalized_cards(finalized_input, &mut app.render);
+    build_finalized_cards(finalized_input, render);
 
     let streaming_input = StreamingRenderInput {
-        session_identity,
-        fallback_ordinal: app.chat.messages.len(),
-        activity: &app.chat.activity,
-        is_turn_active: app.chat.is_turn_active(),
-        content: &app.chat.streaming_content,
-        content_message_id: app.chat.streaming_content_message_id.as_deref(),
-        thinking: &app.chat.streaming_thinking,
-        thinking_message_id: app.chat.streaming_thinking_message_id.as_deref(),
-        show_thinking: app.chat.show_thinking,
+        session_identity: input.session_identity,
+        fallback_ordinal: input.messages.len(),
+        activity: input.activity,
+        is_turn_active: input.is_turn_active,
+        content: input.streaming_content,
+        content_message_id: input.streaming_content_message_id,
+        thinking: input.streaming_thinking,
+        thinking_message_id: input.streaming_thinking_message_id,
+        show_thinking: input.show_thinking,
         full_width: area.width,
         theme,
-        tick: app.render.tick,
+        tick: render.tick,
     };
-    let streaming_card = build_streaming_card(streaming_input, &mut app.render);
+    let streaming_card = build_streaming_card(streaming_input, render);
 
-    let total_height: u16 = app
-        .render
+    let total_height: u16 = render
         .cards()
         .iter()
         .chain(streaming_card.iter())
         .map(|card| card.height(area.width))
         .sum();
 
-    if total_height == 0 && app.render.cards().is_empty() && streaming_card.is_none() {
+    if total_height == 0 && render.cards().is_empty() && streaming_card.is_none() {
         return;
     }
 
-    // Keep the existing viewport growth compensation and scroll ownership unchanged.
-    app.render
-        .compensate_scroll_for_growth(total_height, &mut app.chat.scroll_offset);
+    render.compensate_chat_growth(total_height);
+    let scroll = render.clamp_chat_scroll(total_height, area.height);
 
-    let max_scroll = total_height.saturating_sub(area.height);
-    app.chat.scroll_offset = app.chat.scroll_offset.min(max_scroll);
-    let scroll = max_scroll.saturating_sub(app.chat.scroll_offset);
-
-    let all_cards: Vec<&Card> = app
-        .render
-        .cards()
-        .iter()
-        .chain(streaming_card.iter())
-        .collect();
+    let all_cards: Vec<&Card> = render.cards().iter().chain(streaming_card.iter()).collect();
 
     let mut y: i32 = -(scroll as i32);
     for card in &all_cards {
@@ -2350,9 +2386,49 @@ fn draw_messages(f: &mut Frame, app: &mut App, area: Rect) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::activity::{DelegateChildState, DelegateStats};
+    use crate::domain::tool::ToolDetail;
 
     fn buffer_text(buffer: &ratatui::buffer::Buffer) -> String {
         buffer.content().iter().map(|cell| cell.symbol()).collect()
+    }
+
+    fn user(text: &str, id: &str) -> ChatEntry {
+        ChatEntry::User {
+            text: text.into(),
+            message_id: Some(id.into()),
+        }
+    }
+
+    fn render_messages_buffer(app: &mut App, width: u16, height: u16) -> ratatui::buffer::Buffer {
+        let session_identity = render_session_identity(app);
+        let effective_cwd = app.current_session_cwd();
+        let input = MessagesRenderInput {
+            session_identity,
+            messages: &app.chat.messages,
+            delegates: &app.delegates.delegate_entries,
+            effective_cwd,
+            show_thinking: app.chat.show_thinking,
+            activity: &app.chat.activity,
+            is_turn_active: app.chat.is_turn_active(),
+            streaming_content: &app.chat.streaming_content,
+            streaming_content_message_id: app.chat.streaming_content_message_id.as_deref(),
+            streaming_thinking: &app.chat.streaming_thinking,
+            streaming_thinking_message_id: app.chat.streaming_thinking_message_id.as_deref(),
+        };
+        let backend = ratatui::backend::TestBackend::new(width.max(1), height.max(1));
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                draw_messages(
+                    frame,
+                    Rect::new(0, 0, width, height),
+                    input,
+                    &mut app.render,
+                );
+            })
+            .unwrap();
+        terminal.backend().buffer().clone()
     }
 
     #[test]
@@ -2381,5 +2457,216 @@ mod tests {
         terminal.draw(|frame| draw_chat(frame, &mut app)).unwrap();
 
         assert!(buffer_text(terminal.backend().buffer()).contains("profile:Current (new:Next)"));
+    }
+
+    #[test]
+    fn draw_messages_mutates_only_render_state() {
+        let mut app = App::new();
+        app.sessions.session_id = Some("session-1".into());
+        app.chat.messages.push(user("hello", "user-1"));
+        app.chat.activity = ActivityState::Streaming;
+        app.chat.streaming_content = "answer".into();
+        app.chat.streaming_content_message_id = Some("assistant-1".into());
+        app.chat.streaming_thinking = "plan".into();
+        app.chat.streaming_thinking_message_id = Some("assistant-1".into());
+        app.delegates.delegate_entries.push(DelegateEntry {
+            delegation_id: "delegation-1".into(),
+            child_session_id: Some("child-1".into()),
+            delegate_tool_call_id: None,
+            target_agent_id: Some("coder".into()),
+            objective: "Implement the change".into(),
+            status: DelegateStatus::InProgress,
+            stats: DelegateStats::default(),
+            started_at: None,
+            ended_at: None,
+            child_state: DelegateChildState::None,
+        });
+        let messages = format!("{:?}", app.chat.messages);
+        let activity = app.chat.activity.clone();
+        let streaming_content = app.chat.streaming_content.clone();
+        let streaming_content_message_id = app.chat.streaming_content_message_id.clone();
+        let streaming_thinking = app.chat.streaming_thinking.clone();
+        let streaming_thinking_message_id = app.chat.streaming_thinking_message_id.clone();
+        let show_thinking = app.chat.show_thinking;
+        let session_id = app.sessions.session_id.clone();
+        let delegates = app.delegates.delegate_entries.clone();
+
+        let _ = render_messages_buffer(&mut app, 24, 5);
+
+        assert_eq!(format!("{:?}", app.chat.messages), messages);
+        assert_eq!(app.chat.activity, activity);
+        assert_eq!(app.chat.streaming_content, streaming_content);
+        assert_eq!(
+            app.chat.streaming_content_message_id,
+            streaming_content_message_id
+        );
+        assert_eq!(app.chat.streaming_thinking, streaming_thinking);
+        assert_eq!(
+            app.chat.streaming_thinking_message_id,
+            streaming_thinking_message_id
+        );
+        assert_eq!(app.chat.show_thinking, show_thinking);
+        assert_eq!(app.sessions.session_id, session_id);
+        assert_eq!(app.delegates.delegate_entries, delegates);
+        assert!(!app.render.cards().is_empty());
+        assert!(app.render.test_chat_previous_total_height() > 0);
+    }
+
+    #[test]
+    fn draw_messages_keeps_default_viewport_pinned_to_bottom() {
+        let mut app = App::new();
+        app.chat.messages = (0..4)
+            .map(|index| user(&format!("message {index}"), &format!("user-{index}")))
+            .collect();
+
+        let buffer = render_messages_buffer(&mut app, 30, 4);
+
+        assert_eq!(app.render.chat_scroll_offset(), 0);
+        assert!(buffer_text(&buffer).contains("message 3"));
+    }
+
+    #[test]
+    fn finalized_growth_compensates_scrolled_viewport_exactly() {
+        let mut app = App::new();
+        app.chat.messages = (0..3)
+            .map(|index| user(&format!("message {index}"), &format!("user-{index}")))
+            .collect();
+        let _ = render_messages_buffer(&mut app, 30, 4);
+        let previous_height = app.render.test_chat_previous_total_height();
+        app.render.set_chat_scroll_offset(2);
+
+        app.chat.messages.push(user("new message", "user-3"));
+        let _ = render_messages_buffer(&mut app, 30, 4);
+        let total_height = app.render.test_chat_previous_total_height();
+
+        assert!(total_height > previous_height);
+        assert_eq!(
+            app.render.chat_scroll_offset(),
+            2 + total_height.saturating_sub(previous_height)
+        );
+        let max_scroll = total_height.saturating_sub(4);
+        assert_eq!(max_scroll - app.render.chat_scroll_offset(), 3);
+    }
+
+    #[test]
+    fn streaming_growth_includes_wrapping_thinking_and_activity_row() {
+        let mut app = App::new();
+        app.chat.activity = ActivityState::Streaming;
+        app.chat.streaming_content = "short".into();
+        let _ = render_messages_buffer(&mut app, 20, 1);
+        let previous_height = app.render.test_chat_previous_total_height();
+        app.render.set_chat_scroll_offset(1);
+
+        app.chat.streaming_content =
+            "a much longer streaming answer that wraps over several terminal rows".into();
+        app.chat.streaming_thinking = "thinking also wraps over multiple rows".into();
+        let _ = render_messages_buffer(&mut app, 20, 1);
+        let total_height = app.render.test_chat_previous_total_height();
+
+        assert!(total_height > previous_height);
+        assert_eq!(
+            app.render.chat_scroll_offset(),
+            1 + total_height.saturating_sub(previous_height)
+        );
+        let card = build_streaming_card_for_test(&mut app, 20).expect("streaming card");
+        assert_eq!(card.height(20), total_height);
+    }
+
+    #[test]
+    fn shrink_and_height_resize_clamp_bottom_relative_scroll() {
+        let mut app = App::new();
+        app.chat.messages = (0..4)
+            .map(|index| user(&format!("message {index}"), &format!("user-{index}")))
+            .collect();
+        let _ = render_messages_buffer(&mut app, 30, 4);
+        app.render.set_chat_scroll_offset(7);
+
+        let _ = render_messages_buffer(&mut app, 30, 6);
+        assert_eq!(app.render.chat_scroll_offset(), 6);
+
+        app.chat.messages.truncate(2);
+        let _ = render_messages_buffer(&mut app, 30, 4);
+        assert_eq!(app.render.test_chat_previous_total_height(), 6);
+        assert_eq!(app.render.chat_scroll_offset(), 2);
+    }
+
+    #[test]
+    fn width_changes_compensate_growth_then_clamp_shrink() {
+        let mut app = App::new();
+        app.chat.messages.push(user(
+            "This deliberately long message wraps differently as the viewport width changes.",
+            "user-1",
+        ));
+        let _ = render_messages_buffer(&mut app, 40, 1);
+        let wide_height = app.render.test_chat_previous_total_height();
+        let wide_identity = app.render.test_card_identity(0);
+        app.render.set_chat_scroll_offset(1);
+
+        let _ = render_messages_buffer(&mut app, 18, 1);
+        let narrow_height = app.render.test_chat_previous_total_height();
+        let narrow_identity = app.render.test_card_identity(0);
+        assert!(narrow_height > wide_height);
+        assert_eq!(
+            app.render.chat_scroll_offset(),
+            1 + narrow_height.saturating_sub(wide_height)
+        );
+        assert_ne!(narrow_identity, wide_identity);
+
+        let _ = render_messages_buffer(&mut app, 40, 1);
+        assert_eq!(app.render.test_chat_previous_total_height(), wide_height);
+        assert_eq!(
+            app.render.chat_scroll_offset(),
+            (1 + narrow_height.saturating_sub(wide_height)).min(wide_height.saturating_sub(1))
+        );
+    }
+
+    #[test]
+    fn hidden_thinking_preserves_tool_batch_height_for_viewport() {
+        let mut app = App::new();
+        app.chat.show_thinking = false;
+        app.chat.messages = vec![
+            ChatEntry::ToolCall {
+                tool_call_id: Some("tool-1".into()),
+                name: "read".into(),
+                is_error: false,
+                detail: ToolDetail::None,
+            },
+            ChatEntry::Thinking {
+                content: "hidden".into(),
+                message_id: Some("thinking-1".into()),
+            },
+            ChatEntry::ToolCall {
+                tool_call_id: Some("tool-2".into()),
+                name: "write".into(),
+                is_error: false,
+                detail: ToolDetail::None,
+            },
+        ];
+
+        let _ = render_messages_buffer(&mut app, 30, 1);
+
+        assert_eq!(app.render.cards().len(), 1);
+        assert_eq!(
+            app.render.cards()[0].kind,
+            CardKind::Tool { compact: false }
+        );
+        assert_eq!(
+            app.render.test_chat_previous_total_height(),
+            app.render.cards()[0].height(30)
+        );
+    }
+
+    #[test]
+    fn empty_draw_preserves_stale_viewport_and_tiny_areas_do_not_panic() {
+        let mut app = App::new();
+        app.render.test_seed_chat_viewport(7, 19);
+
+        let _ = render_messages_buffer(&mut app, 0, 0);
+        assert_eq!(app.render.chat_scroll_offset(), 7);
+        assert_eq!(app.render.test_chat_previous_total_height(), 19);
+
+        app.chat.messages.push(user("tiny", "user-1"));
+        let _ = render_messages_buffer(&mut app, 0, 0);
+        let _ = render_messages_buffer(&mut app, 1, 1);
     }
 }

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -1,4 +1,7 @@
-use std::cell::{Cell, Ref, RefCell};
+use std::{
+    cell::{Cell, Ref, RefCell},
+    path::Path,
+};
 
 use ratatui::{
     Frame,
@@ -12,7 +15,9 @@ use crate::app::App;
 use crate::composer_state::{InputVisualLayout, build_input_visual_layout};
 use crate::domain::activity::{ActivityState, DelegateEntry, DelegateStatus, SessionOp};
 use crate::domain::chat::{ChatEntry, OUTCOME_BULLET};
-use crate::domain::tool::{DiffPreviewSection, ShellOutputTail, ToolDetail};
+use crate::domain::tool::{
+    MultiEditSection, ShellOutput, SymbolDiffSection, SymbolReplacement, ToolDetail,
+};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::markdown;
@@ -286,6 +291,7 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
 
     // Process new messages from start_idx
     let mut pending_tools: Vec<Line<'static>> = Vec::new();
+    let current_cwd = app.current_session_cwd();
 
     let flush_tools = |tools: &mut Vec<Line<'static>>, cards: &mut Vec<Card>| {
         if !tools.is_empty() {
@@ -423,6 +429,7 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                         old,
                         new,
                         start_line,
+                        ..
                     } => {
                         pending_tools.push(Line::from(vec![
                             Span::styled(format!("{sym} {name} "), style),
@@ -440,19 +447,32 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                             Span::styled(short_path(file).to_string(), Theme::diff_file()),
                             Span::styled(format!(" ({edit_count} edits)"), Theme::status_accent()),
                         ]));
-                        pending_tools.extend(build_sectioned_diff_lines(sections, 6));
+                        pending_tools.extend(build_multiedit_lines(sections, 6));
                     }
-                    ToolDetail::ReplaceSymbol { title, sections } => {
+                    ToolDetail::ReplaceSymbolInput { replacements } => {
+                        let title = replace_symbol_title(replacements, &[], current_cwd.as_deref());
                         pending_tools.push(Line::from(vec![
                             Span::styled(format!("{sym} {name} "), style),
-                            Span::styled(title.clone(), Theme::diff_file()),
+                            Span::styled(title, Theme::diff_file()),
                         ]));
-                        pending_tools.extend(build_sectioned_diff_lines(sections, 4));
+                    }
+                    ToolDetail::ReplaceSymbolDiff {
+                        replacements,
+                        sections,
+                    } => {
+                        let title =
+                            replace_symbol_title(replacements, sections, current_cwd.as_deref());
+                        pending_tools.push(Line::from(vec![
+                            Span::styled(format!("{sym} {name} "), style),
+                            Span::styled(title, Theme::diff_file()),
+                        ]));
+                        pending_tools.extend(build_symbol_diff_lines(sections, 4));
                     }
                     ToolDetail::Shell {
                         command,
+                        arguments,
                         workdir,
-                        output_tail,
+                        output,
                     } => {
                         let mut spans = vec![Span::styled(format!("{sym} {name}"), style)];
                         if let Some(workdir) = workdir.as_deref().filter(|s| !s.trim().is_empty()) {
@@ -460,11 +480,8 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                             spans.push(Span::styled(workdir.to_string(), Theme::diff_file()));
                         }
                         pending_tools.push(Line::from(spans));
-                        pending_tools.extend(build_shell_lines(
-                            command,
-                            workdir.as_deref(),
-                            output_tail.as_ref(),
-                        ));
+                        let command = shell_command_display(command, arguments);
+                        pending_tools.extend(build_shell_lines(&command, output.as_ref()));
                     }
                     ToolDetail::ReadTool {
                         path,
@@ -492,29 +509,110 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                         ]));
                         pending_tools.extend(build_write_lines(content));
                     }
-                    ToolDetail::SummaryWithOutput { header, output } => {
-                        pending_tools.push(Line::from(vec![
-                            Span::styled(format!("{sym} {name} "), style),
-                            Span::styled(header.clone(), Theme::diff_file()),
-                        ]));
-                        for line in output.lines() {
+                    ToolDetail::Generic { input, result } => {
+                        let (summary, output) = match (input.as_deref(), result.as_deref()) {
+                            (Some(input), result) => (input, result),
+                            (None, Some(result)) => (result, None),
+                            (None, None) => ("", None),
+                        };
+                        push_summary_lines(&mut pending_tools, sym, name, style, summary, output);
+                    }
+                    ToolDetail::SearchText {
+                        pattern,
+                        path,
+                        include,
+                        counts,
+                    } => {
+                        let location = if !include.is_empty() {
+                            include.as_str()
+                        } else if !path.is_empty() {
+                            short_path(path)
+                        } else {
+                            "."
+                        };
+                        let mut summary = format!("\"{pattern}\" {location}");
+                        if let Some(counts) = counts {
+                            summary.push_str(&format!(
+                                " ({} files, {} matches)",
+                                counts.files, counts.matches
+                            ));
+                        }
+                        push_summary_lines(&mut pending_tools, sym, name, style, &summary, None);
+                    }
+                    ToolDetail::Glob { pattern, path } => {
+                        let summary = if path.is_empty() {
+                            pattern.clone()
+                        } else {
+                            format!("{pattern} in {}", short_path(path))
+                        };
+                        push_summary_lines(&mut pending_tools, sym, name, style, &summary, None);
+                    }
+                    ToolDetail::List { path } => {
+                        let summary = if path.is_empty() {
+                            "."
+                        } else {
+                            short_path(path)
+                        };
+                        push_summary_lines(&mut pending_tools, sym, name, style, summary, None);
+                    }
+                    ToolDetail::Index { path, metadata } => {
+                        let mut summary = if path.is_empty() {
+                            ".".to_string()
+                        } else if metadata.is_some() {
+                            path.clone()
+                        } else {
+                            short_path(path).to_string()
+                        };
+                        if let Some(metadata) = metadata {
+                            summary.push_str(&format!(
+                                " ({}, {} imports, {} functions)",
+                                metadata.language, metadata.imports, metadata.functions
+                            ));
+                        }
+                        push_summary_lines(&mut pending_tools, sym, name, style, &summary, None);
+                    }
+                    ToolDetail::DeleteFile { path } => push_summary_lines(
+                        &mut pending_tools,
+                        sym,
+                        name,
+                        style,
+                        short_path(path),
+                        None,
+                    ),
+                    ToolDetail::Browse { url } => {
+                        let summary = truncate_summary(url, 60);
+                        push_summary_lines(&mut pending_tools, sym, name, style, &summary, None);
+                    }
+                    ToolDetail::Todo { items } => {
+                        pending_tools
+                            .push(Line::from(Span::styled(format!("{sym} {name}"), style)));
+                        for item in items {
+                            let check = if item.status == "completed" { "x" } else { " " };
                             pending_tools.push(Line::from(Span::styled(
-                                format!("  {line}"),
-                                Theme::tool_output(),
+                                format!("  [{check}] {}", item.content),
+                                Theme::diff_file(),
                             )));
                         }
                     }
-                    ToolDetail::Summary(info) => {
-                        // Delegate tool calls: split "(agent:dur) objective" into
-                        // accent-colored label + normal objective.
-                        if name == "delegate" && info.starts_with('(') {
-                            let close = info.find(')').unwrap_or(0);
-                            let label_inner = &info[1..close]; // "coder"
-                            let objective = info[close + 1..].trim_start();
+                    ToolDetail::Delegate {
+                        target_agent_id,
+                        objective,
+                    } => {
+                        let objective = truncate_summary(objective, 50);
+                        if target_agent_id.is_empty() {
+                            push_summary_lines(
+                                &mut pending_tools,
+                                sym,
+                                name,
+                                style,
+                                &objective,
+                                None,
+                            );
+                        } else {
                             let label = if delegate_duration.is_empty() {
-                                format!("({label_inner})")
+                                format!("({target_agent_id})")
                             } else {
-                                format!("({label_inner}{delegate_duration})")
+                                format!("({target_agent_id}{delegate_duration})")
                             };
                             let (delegate_status, delegate_status_style) = match delegate_entry {
                                 Some(entry) if entry.awaiting_input() => {
@@ -537,39 +635,20 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                                 delegate_status_style,
                             ));
                             if !objective.is_empty() {
-                                spans.push(Span::styled(objective.to_string(), Theme::diff_file()));
+                                spans.push(Span::styled(objective, Theme::diff_file()));
                             }
                             pending_tools.push(Line::from(spans));
-                        } else if info.contains('\n') {
-                            pending_tools
-                                .push(Line::from(Span::styled(format!("{sym} {name}"), style)));
-                            for line in info.lines() {
-                                pending_tools.push(Line::from(Span::styled(
-                                    format!("  {line}"),
-                                    Theme::diff_file(),
-                                )));
-                            }
-                        } else if matches!(name.as_str(), "index" | "search_text")
-                            && info.ends_with(')')
-                        {
-                            if let Some((summary, metadata)) = info.rsplit_once(" (") {
-                                pending_tools.push(Line::from(vec![
-                                    Span::styled(format!("{sym} {name} "), style),
-                                    Span::styled(summary.to_string(), Theme::diff_file()),
-                                    Span::styled(format!(" ({metadata}"), Theme::status_accent()),
-                                ]));
-                            } else {
-                                pending_tools.push(Line::from(vec![
-                                    Span::styled(format!("{sym} {name} "), style),
-                                    Span::styled(info.clone(), Theme::diff_file()),
-                                ]));
-                            }
-                        } else {
-                            pending_tools.push(Line::from(vec![
-                                Span::styled(format!("{sym} {name} "), style),
-                                Span::styled(info.clone(), Theme::diff_file()),
-                            ]));
                         }
+                    }
+                    ToolDetail::LanguageQuery { action, uri } => {
+                        let summary = format!("{action} {}", short_path(uri));
+                        push_summary_lines(&mut pending_tools, sym, name, style, &summary, None);
+                    }
+                    ToolDetail::Question { .. } => {
+                        push_summary_lines(&mut pending_tools, sym, name, style, "asking...", None)
+                    }
+                    ToolDetail::ApplyPatch { .. } => {
+                        push_summary_lines(&mut pending_tools, sym, name, style, "patch", None)
                     }
                     ToolDetail::None => {
                         pending_tools
@@ -1712,28 +1791,161 @@ fn short_path(path: &str) -> &str {
     path
 }
 
-pub(crate) fn build_sectioned_diff_lines(
-    sections: &[DiffPreviewSection],
+fn strip_cwd(path: &str, cwd: Option<&str>) -> String {
+    cwd.and_then(|cwd| Path::new(path).strip_prefix(cwd).ok())
+        .map(|path| path.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.to_string())
+}
+
+fn truncate_summary(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    let mut out = value
+        .chars()
+        .take(max_chars.saturating_sub(1))
+        .collect::<String>();
+    out.push('\u{2026}');
+    out
+}
+
+fn push_summary_lines(
+    pending_tools: &mut Vec<Line<'static>>,
+    sym: &str,
+    name: &str,
+    style: Style,
+    summary: &str,
+    output: Option<&str>,
+) {
+    if let Some(output) = output {
+        pending_tools.push(Line::from(vec![
+            Span::styled(format!("{sym} {name} "), style),
+            Span::styled(summary.to_string(), Theme::diff_file()),
+        ]));
+        for line in output.lines() {
+            pending_tools.push(Line::from(Span::styled(
+                format!("  {line}"),
+                Theme::tool_output(),
+            )));
+        }
+    } else if summary.contains('\n') {
+        pending_tools.push(Line::from(Span::styled(format!("{sym} {name}"), style)));
+        for line in summary.lines() {
+            pending_tools.push(Line::from(Span::styled(
+                format!("  {line}"),
+                Theme::diff_file(),
+            )));
+        }
+    } else if matches!(name, "index" | "search_text") && summary.ends_with(')') {
+        if let Some((summary, metadata)) = summary.rsplit_once(" (") {
+            pending_tools.push(Line::from(vec![
+                Span::styled(format!("{sym} {name} "), style),
+                Span::styled(summary.to_string(), Theme::diff_file()),
+                Span::styled(format!(" ({metadata}"), Theme::status_accent()),
+            ]));
+        } else {
+            pending_tools.push(Line::from(vec![
+                Span::styled(format!("{sym} {name} "), style),
+                Span::styled(summary.to_string(), Theme::diff_file()),
+            ]));
+        }
+    } else {
+        pending_tools.push(Line::from(vec![
+            Span::styled(format!("{sym} {name} "), style),
+            Span::styled(summary.to_string(), Theme::diff_file()),
+        ]));
+    }
+}
+
+fn replace_symbol_title(
+    replacements: &[SymbolReplacement],
+    sections: &[SymbolDiffSection],
+    cwd: Option<&str>,
+) -> String {
+    if replacements.is_empty() && !sections.is_empty() {
+        let first = &sections[0];
+        return if first.symbol.is_empty() {
+            first.path.clone()
+        } else {
+            format!("{} {}", first.path, first.symbol)
+        };
+    }
+
+    let mut files = replacements
+        .iter()
+        .filter(|replacement| !replacement.path.is_empty())
+        .map(|replacement| strip_cwd(&replacement.path, cwd))
+        .collect::<Vec<_>>();
+    files.sort();
+    files.dedup();
+    match files.as_slice() {
+        [] => "symbols".into(),
+        [one] => short_path(one).to_string(),
+        [first, ..] => format!("{} (+{})", short_path(first), files.len() - 1),
+    }
+}
+
+fn build_multiedit_lines(sections: &[MultiEditSection], max_sections: usize) -> Vec<Line<'static>> {
+    build_sectioned_diff_lines(
+        sections
+            .iter()
+            .map(|section| {
+                let header = if section.replace_all {
+                    format!("edit {} (all)", section.edit_index)
+                } else {
+                    format!("edit {}", section.edit_index)
+                };
+                (
+                    header,
+                    &section.old,
+                    &section.new,
+                    section.start_line,
+                    Theme::status_accent(),
+                )
+            })
+            .collect::<Vec<_>>(),
+        max_sections,
+    )
+}
+
+fn build_symbol_diff_lines(
+    sections: &[SymbolDiffSection],
+    max_sections: usize,
+) -> Vec<Line<'static>> {
+    build_sectioned_diff_lines(
+        sections
+            .iter()
+            .map(|section| {
+                (
+                    section.symbol.clone(),
+                    &section.old,
+                    &section.new,
+                    section.start_line,
+                    Theme::diff_file(),
+                )
+            })
+            .collect::<Vec<_>>(),
+        max_sections,
+    )
+}
+
+fn build_sectioned_diff_lines(
+    sections: Vec<(String, &String, &String, Option<usize>, Style)>,
     max_sections: usize,
 ) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     let preview_count = sections.len().min(max_sections.max(1));
 
-    for (idx, section) in sections.iter().take(preview_count).enumerate() {
-        if !section.header.is_empty() {
-            let mut spans = vec![Span::styled("  @@ ", Theme::diff_context())];
-            if section.header.starts_with("edit ") {
-                spans.push(Span::styled(section.header.clone(), Theme::status_accent()));
-            } else {
-                spans.push(Span::styled(section.header.clone(), Theme::diff_file()));
-            }
-            lines.push(Line::from(spans));
+    for (idx, (header, old, new, start_line, header_style)) in
+        sections.iter().take(preview_count).enumerate()
+    {
+        if !header.is_empty() {
+            lines.push(Line::from(vec![
+                Span::styled("  @@ ", Theme::diff_context()),
+                Span::styled(header.clone(), *header_style),
+            ]));
         }
-        lines.extend(build_diff_lines(
-            &section.old,
-            &section.new,
-            section.start_line,
-        ));
+        lines.extend(build_diff_lines(old, new, *start_line));
         if idx + 1 < preview_count {
             lines.push(Line::default());
         }
@@ -1752,11 +1964,31 @@ pub(crate) fn build_sectioned_diff_lines(
     lines
 }
 
-pub(crate) fn build_shell_lines(
-    command: &str,
-    _workdir: Option<&str>,
-    output_tail: Option<&ShellOutputTail>,
-) -> Vec<Line<'static>> {
+fn shell_command_display(command: &str, arguments: &[String]) -> String {
+    if arguments.is_empty() {
+        return command.to_string();
+    }
+    std::iter::once(command)
+        .chain(arguments.iter().map(String::as_str))
+        .map(shell_quote_arg)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn shell_quote_arg(arg: &str) -> String {
+    if arg.is_empty() {
+        return "''".to_string();
+    }
+    if arg
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '/' | ':' | '='))
+    {
+        return arg.to_string();
+    }
+    format!("'{}'", arg.replace('\'', "'\\''"))
+}
+
+pub(crate) fn build_shell_lines(command: &str, output: Option<&ShellOutput>) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
 
     let mut command_lines = command.lines();
@@ -1779,26 +2011,33 @@ pub(crate) fn build_shell_lines(
         ]));
     }
 
-    if let Some(tail) = output_tail
-        && !tail.lines.is_empty()
-    {
+    let output_lines = output
+        .into_iter()
+        .flat_map(|output| output.stdout.lines().chain(output.stderr.lines()))
+        .map(str::trim_end)
+        .filter(|line| !line.trim().is_empty())
+        .collect::<Vec<_>>();
+    if !output_lines.is_empty() {
+        let keep = 5;
+        let display_hidden_count = output_lines.len().saturating_sub(keep);
+        let hidden_line_count = output
+            .map(|output| output.preceding_line_count)
+            .unwrap_or_default()
+            .saturating_add(display_hidden_count);
         lines.push(Line::default());
         lines.push(Line::from(Span::styled(
             "  output tail:",
             Theme::diff_file(),
         )));
-        for line in &tail.lines {
+        for line in output_lines.into_iter().skip(display_hidden_count) {
             lines.push(Line::from(Span::styled(
                 format!("    {line}"),
                 Theme::tool_output(),
             )));
         }
-        if tail.hidden_line_count > 0 {
+        if hidden_line_count > 0 {
             lines.push(Line::from(Span::styled(
-                format!(
-                    "  ... {} earlier output lines hidden",
-                    tail.hidden_line_count
-                ),
+                format!("  ... {hidden_line_count} earlier output lines hidden"),
                 Theme::diff_context(),
             )));
         }

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -14,7 +14,7 @@ use ratatui::{
 use crate::app::App;
 use crate::composer_state::{InputVisualLayout, build_input_visual_layout};
 use crate::domain::activity::{ActivityState, DelegateEntry, DelegateStatus, SessionOp};
-use crate::domain::chat::{ChatEntry, OUTCOME_BULLET};
+use crate::domain::chat::{ChatEntry, ElicitationResponseOutcome};
 use crate::domain::tool::{
     MultiEditSection, ShellOutput, SymbolDiffSection, SymbolReplacement, ToolDetail,
 };
@@ -54,6 +54,7 @@ pub(crate) fn spinner(kind: SpinnerKind, tick: u64) -> &'static str {
 }
 
 // ── Elicitation symbols ───────────────────────────────────────────────────────
+const OUTCOME_BULLET: &str = "\u{25B8} ";
 const RADIO_SELECTED: &str = "\u{25CF} "; // ● filled circle  – single-select active
 const RADIO_UNSELECTED: &str = "\u{25CB} "; // ○ empty circle   – single-select inactive
 pub(crate) const CHECK_CHECKED: &str = "\u{2611} "; // ☑ ballot box checked   – success/done
@@ -734,24 +735,16 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                     Span::styled(message.clone(), Theme::status_accent()),
                 ]));
                 let mut card_blocks = vec![header];
-                match outcome.as_deref() {
+                match outcome {
                     None => {
                         card_blocks.push(crate::markdown::CardBlock::Text(Line::from(
                             Span::styled("  waiting for response\u{2026}", Theme::thinking()),
                         )));
                     }
-                    Some("declined") | Some("cancelled") => {
-                        card_blocks.push(crate::markdown::CardBlock::Text(Line::from(
-                            Span::styled(
-                                format!("  {}", outcome.as_deref().unwrap()),
-                                Theme::status(),
-                            ),
-                        )));
-                    }
-                    Some(text) => {
-                        for part in text.lines() {
+                    Some(outcome) => {
+                        for (text, style) in elicitation_outcome_lines(outcome) {
                             card_blocks.push(crate::markdown::CardBlock::Text(Line::from(
-                                Span::styled(format!("  {part}"), Theme::info_text()),
+                                Span::styled(format!("  {text}"), style),
                             )));
                         }
                     }
@@ -771,6 +764,36 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
 }
 
 // ── Shared header builder ─────────────────────────────────────────────────────
+
+fn elicitation_outcome_lines(outcome: &ElicitationResponseOutcome) -> Vec<(String, Style)> {
+    let (texts, style) = match outcome {
+        ElicitationResponseOutcome::Selected(labels) => (
+            labels
+                .iter()
+                .map(|label| format!("{OUTCOME_BULLET}{label}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+                .lines()
+                .map(str::to_string)
+                .collect(),
+            Theme::info_text(),
+        ),
+        ElicitationResponseOutcome::Text(text) => (
+            text.lines().map(str::to_string).collect(),
+            Theme::info_text(),
+        ),
+        ElicitationResponseOutcome::Boolean(true) => (vec!["Yes".into()], Theme::info_text()),
+        ElicitationResponseOutcome::Boolean(false) => (vec!["No".into()], Theme::info_text()),
+        ElicitationResponseOutcome::Declined => (vec!["declined".into()], Theme::status()),
+        ElicitationResponseOutcome::Cancelled => (vec!["cancelled".into()], Theme::status()),
+        ElicitationResponseOutcome::UnsupportedSchema => (
+            vec!["unsupported schema - cannot answer in TUI".into()],
+            Theme::info_text(),
+        ),
+        ElicitationResponseOutcome::Responded => (vec!["responded".into()], Theme::info_text()),
+    };
+    texts.into_iter().map(|text| (text, style)).collect()
+}
 
 fn format_status_duration(duration: std::time::Duration) -> String {
     let secs = duration.as_secs();

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -1,7 +1,4 @@
-use std::{
-    cell::{Cell, Ref, RefCell},
-    path::Path,
-};
+use std::path::Path;
 
 use ratatui::{
     Frame,
@@ -21,6 +18,11 @@ use crate::domain::tool::{
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::markdown;
+use crate::render_state::{
+    Card, CardKind, DelegatePresentationKeyRef, FinalizedCardKeyRef, FinalizedMessageKeyRef,
+    FinalizedRenderContextKey, RenderState, SessionIdentity, StreamKind, StreamingCacheKeyRef,
+    ThemeCacheKey,
+};
 use crate::theme::Theme;
 
 use super::start::short_cwd;
@@ -71,228 +73,144 @@ pub(crate) const ICON_MESH: &str = "\u{1F5A7}"; // mesh nodes (U+1F5A7)
 // ── General text symbols ──────────────────────────────────────────────────────
 const ARROW_UP: &str = "\u{2191}"; // ↑ upwards arrow
 
-// ── Card types ────────────────────────────────────────────────────────────────
-
-/// Cache for cards built from finalized messages.
-/// Auto-invalidates when `messages` shrinks (clear/retain).
-pub(crate) struct CardCache {
-    pub(crate) cards: Vec<Card>,
-    pub(crate) processed_messages: usize,
-}
-
-impl CardCache {
-    pub(crate) fn new() -> Self {
-        Self {
-            cards: Vec::new(),
-            processed_messages: 0,
-        }
-    }
-
-    pub(crate) fn invalidate(&mut self) {
-        self.cards.clear();
-        self.processed_messages = 0;
-    }
-}
-
-// -- message cards: background color only, no borders --
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum CardKind {
-    User,
-    Assistant,
-    Tool { compact: bool }, // compact=true: no top padding (follows assistant)
-    Streaming,
-    Thinking,
-    Compaction,
-    Error,
-    Info,
-    Elicitation,
-}
-
-pub(crate) struct Card {
-    pub(crate) kind: CardKind,
-    pub(crate) blocks: Vec<crate::markdown::CardBlock>,
-    top_pad: u16,
-    bottom_pad: u16,
-    cached_width: Cell<Option<u16>>,
-    cached_lines: RefCell<Vec<Line<'static>>>,
-}
-
-impl Card {
-    pub(crate) fn new(kind: CardKind, blocks: Vec<crate::markdown::CardBlock>) -> Self {
-        let (top_pad, bottom_pad): (u16, u16) = match kind {
-            CardKind::Tool { compact: true } => (0, 0),
-            CardKind::Tool { compact: false } => (1, 0),
-            _ => (1, 1),
-        };
-        Self {
-            kind,
-            blocks,
-            top_pad,
-            bottom_pad,
-            cached_width: Cell::new(None),
-            cached_lines: RefCell::new(Vec::new()),
-        }
-    }
-
-    /// Rebuild cached lines if the width has changed, then return a borrow.
-    pub(crate) fn lines_for(&self, inner_w: u16) -> Ref<'_, Vec<Line<'static>>> {
-        if self.cached_width.get() != Some(inner_w) {
-            let mut lines = Vec::new();
-            for block in &self.blocks {
-                match block {
-                    crate::markdown::CardBlock::Text(line) => lines.push(line.clone()),
-                    crate::markdown::CardBlock::Table(table) => {
-                        lines.extend(table.layout(inner_w as usize));
-                    }
-                }
-            }
-            *self.cached_lines.borrow_mut() = lines;
-            self.cached_width.set(Some(inner_w));
-        }
-        self.cached_lines.borrow()
-    }
-
-    /// Compute the visual height of this card given the full card render width.
-    /// Each logical line is wrapped at `(width - 4)` columns (the 2+2 horizontal
-    /// padding used by `render()`), and the result is rounded up.
-    pub(crate) fn height(&self, width: u16) -> u16 {
-        let inner_w = width.saturating_sub(4);
-        let lines = self.lines_for(inner_w);
-        let line_rows: u16 = lines
-            .iter()
-            .map(|l| {
-                let w = l.width();
-                let iw = inner_w as usize;
-                if iw == 0 || w == 0 {
-                    1
-                } else {
-                    w.div_ceil(iw) as u16
-                }
-            })
-            .sum::<u16>()
-            .max(1);
-        self.top_pad + line_rows + self.bottom_pad
-    }
-
-    /// `clip_top`: number of rows clipped off the top of this card
-    fn render(&self, f: &mut Frame, area: Rect, clip_top: u16) {
-        if area.height == 0 || area.width == 0 {
-            return;
-        }
-
-        let (bg_style, text_style) = match self.kind {
-            CardKind::User => (Theme::user_card(), Theme::user_text()),
-            CardKind::Assistant | CardKind::Streaming => {
-                (Theme::assistant_card(), Theme::assistant_text())
-            }
-            CardKind::Tool { .. } => (Theme::assistant_card(), Theme::tool_text()),
-            CardKind::Thinking => (Theme::assistant_card(), Theme::thinking()),
-            CardKind::Compaction => (Theme::assistant_card(), Theme::status_accent()),
-            CardKind::Error => (Theme::assistant_card(), Theme::error_text()),
-            CardKind::Info => (Theme::assistant_card(), Theme::info_text()),
-            CardKind::Elicitation => (Theme::assistant_card(), Theme::status_accent()),
-        };
-
-        // fill background
-        f.render_widget(Block::default().style(bg_style), area);
-
-        // the card has: 1 row top padding, N content lines, 1 row bottom padding
-        // when clipped, we skip the top padding first, then content lines
-        let has_top_pad = !matches!(self.kind, CardKind::Tool { compact: true });
-        let pad_top_visible = if clip_top == 0 && has_top_pad {
-            1u16
-        } else {
-            0
-        };
-        let content_skip = clip_top.saturating_sub(1); // rows of content to skip
-
-        let content_y = area.y + pad_top_visible;
-        let content_h = area.height.saturating_sub(pad_top_visible);
-
-        if content_h == 0 {
-            return;
-        }
-
-        let content_area = Rect {
-            x: area.x + 2,
-            y: content_y,
-            width: area.width.saturating_sub(4),
-            height: content_h,
-        };
-
-        let inner_w = area.width.saturating_sub(4);
-        let lines = self.lines_for(inner_w);
-        let styled_lines: Vec<Line<'static>> = lines
-            .iter()
-            .map(|l| {
-                Line::from(
-                    l.spans
-                        .iter()
-                        .map(|s| {
-                            let style = if s.style.fg.is_some() {
-                                s.style.bg(bg_style.bg.unwrap_or(Theme::bg()))
-                            } else {
-                                text_style
-                            };
-                            Span::styled(s.content.clone(), style)
-                        })
-                        .collect::<Vec<_>>(),
-                )
-            })
-            .collect();
-        f.render_widget(
-            Paragraph::new(styled_lines)
-                .wrap(Wrap { trim: false })
-                .scroll((content_skip, 0)),
-            content_area,
-        );
-    }
-}
-
 // ── Build message cards (cached) ──────────────────────────────────────────────
 
 /// Build cards for finalized messages incrementally (cached).
 /// Does NOT include the streaming/thinking card — that's built separately.
-pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
-    let cache = &app.render.card_cache;
+pub(crate) struct FinalizedRenderInput<'a> {
+    pub(crate) session_identity: SessionIdentity,
+    pub(crate) messages: &'a [ChatEntry],
+    pub(crate) delegates: &'a [DelegateEntry],
+    pub(crate) effective_cwd: Option<String>,
+    pub(crate) show_thinking: bool,
+    pub(crate) full_width: u16,
+    pub(crate) theme: ThemeCacheKey,
+    pub(crate) now_unix_secs: i64,
+}
 
-    // Auto-invalidate if messages shrank (clear/retain)
-    if app.chat.messages.len() < cache.processed_messages {
-        app.render.card_cache.invalidate();
+struct PlannedFinalizedCard<'a> {
+    key: FinalizedCardKeyRef<'a>,
+    source_start: usize,
+}
+
+fn flush_tool_plan<'a>(
+    planned: &mut Vec<PlannedFinalizedCard<'a>>,
+    pending: &mut Vec<FinalizedMessageKeyRef<'a>>,
+    source_start: &mut Option<usize>,
+) {
+    if pending.is_empty() {
+        return;
     }
+    let compact = matches!(
+        planned.last().map(|card| card.key.kind()),
+        Some(CardKind::Assistant | CardKind::Streaming | CardKind::Thinking)
+    );
+    planned.push(PlannedFinalizedCard {
+        key: FinalizedCardKeyRef::new(CardKind::Tool { compact }, std::mem::take(pending)),
+        source_start: source_start.take().expect("tool plan source"),
+    });
+}
 
-    // Cache hit — nothing new
-    if app.chat.messages.len() == app.render.card_cache.processed_messages {
-        return &app.render.card_cache.cards;
-    }
+fn plan_finalized_cards<'a>(input: &'a FinalizedRenderInput<'a>) -> Vec<PlannedFinalizedCard<'a>> {
+    let mut planned = Vec::new();
+    let mut pending_tools = Vec::new();
+    let mut tool_source_start = None;
+    let mut delegate_idx = 0;
 
-    // Determine where to start processing. If the last cached card is a tool
-    // batch, we need to pop it and re-process from the batch start, because
-    // new tool messages might need to merge into that batch.
-    let start_idx = if matches!(
-        app.render.card_cache.cards.last().map(|c| &c.kind),
-        Some(CardKind::Tool { .. })
-    ) {
-        app.render.card_cache.cards.pop();
-        // Scan backwards to find where the tool batch started. Hidden thinking
-        // entries are transparent and should not split a tool batch.
-        let mut idx = app.render.card_cache.processed_messages;
-        while idx > 0 {
-            match app.chat.messages.get(idx - 1) {
-                Some(ChatEntry::ToolCall { .. }) => idx -= 1,
-                Some(ChatEntry::Thinking { .. }) if !app.chat.show_thinking => idx -= 1,
-                _ => break,
+    for (ordinal, entry) in input.messages.iter().enumerate() {
+        let delegate = if let ChatEntry::ToolCall {
+            name, tool_call_id, ..
+        } = entry
+            && name == "delegate"
+        {
+            let matched = tool_call_id
+                .as_deref()
+                .and_then(|id| {
+                    input
+                        .delegates
+                        .iter()
+                        .find(|entry| entry.delegate_tool_call_id.as_deref() == Some(id))
+                })
+                .or_else(|| input.delegates.get(delegate_idx));
+            delegate_idx += 1;
+            Some(DelegatePresentationKeyRef::from_entry(
+                matched,
+                input.now_unix_secs,
+            ))
+        } else {
+            None
+        };
+        let message_key = FinalizedMessageKeyRef::new(ordinal, entry, delegate);
+
+        match entry {
+            ChatEntry::ToolCall { .. } => {
+                tool_source_start.get_or_insert(ordinal);
+                pending_tools.push(message_key);
+            }
+            ChatEntry::Thinking { .. } if !input.show_thinking => {}
+            _ => {
+                flush_tool_plan(&mut planned, &mut pending_tools, &mut tool_source_start);
+                let kind = match entry {
+                    ChatEntry::User { .. } => CardKind::User,
+                    ChatEntry::Assistant { .. } => CardKind::Assistant,
+                    ChatEntry::Thinking { .. } => CardKind::Thinking,
+                    ChatEntry::CompactionStart { .. } | ChatEntry::CompactionEnd { .. } => {
+                        CardKind::Compaction
+                    }
+                    ChatEntry::Info(_) => CardKind::Info,
+                    ChatEntry::Error(_) => CardKind::Error,
+                    ChatEntry::Elicitation { .. } => CardKind::Elicitation,
+                    ChatEntry::ToolCall { .. } => unreachable!("tool calls are batched"),
+                };
+                planned.push(PlannedFinalizedCard {
+                    key: FinalizedCardKeyRef::new(kind, vec![message_key]),
+                    source_start: ordinal,
+                });
             }
         }
-        idx
-    } else {
-        app.render.card_cache.processed_messages
-    };
+    }
+    flush_tool_plan(&mut planned, &mut pending_tools, &mut tool_source_start);
+    planned
+}
 
-    // Process new messages from start_idx
+pub(crate) fn build_finalized_cards<'a>(
+    input: FinalizedRenderInput<'_>,
+    render: &'a mut RenderState,
+) -> &'a [Card] {
+    let session = render.observe_session(&input.session_identity);
+    let context = FinalizedRenderContextKey::new(
+        session,
+        input.full_width,
+        input.theme,
+        input.show_thinking,
+        input.effective_cwd.clone(),
+    );
+    let planned = plan_finalized_cards(&input);
+    let desired: Vec<_> = planned.iter().map(|card| card.key.clone()).collect();
+    let mismatch = render.prepare_finalized_cards(context, &desired);
+
+    if let Some(first) = planned.get(mismatch) {
+        let prior_kind = render.cards().last().map(|card| card.kind.clone());
+        let rebuilt =
+            render_card_suffix(&input, render.highlighter(), first.source_start, prior_kind);
+        debug_assert_eq!(rebuilt.len(), planned.len() - mismatch);
+        for (planned_card, card) in planned[mismatch..].iter().zip(rebuilt) {
+            render.push_finalized_card(&planned_card.key, card);
+        }
+    }
+    render.finish_finalized_cards(input.messages.len());
+    render.cards()
+}
+
+fn render_card_suffix(
+    input: &FinalizedRenderInput<'_>,
+    highlighter: &crate::highlight::Highlighter,
+    start_idx: usize,
+    prior_kind: Option<CardKind>,
+) -> Vec<Card> {
+    let mut cards = Vec::new();
     let mut pending_tools: Vec<Line<'static>> = Vec::new();
-    let current_cwd = app.current_session_cwd();
+    let current_cwd = input.effective_cwd.as_deref();
 
     let flush_tools = |tools: &mut Vec<Line<'static>>, cards: &mut Vec<Card>| {
         if !tools.is_empty() {
@@ -301,16 +219,12 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                 .into_iter()
                 .map(crate::markdown::CardBlock::Text)
                 .collect();
-            let prev_is_assistant = matches!(
-                cards.last().map(|c| &c.kind),
+            let previous_kind = cards.last().map(|card| &card.kind).or(prior_kind.as_ref());
+            let compact = matches!(
+                previous_kind,
                 Some(CardKind::Assistant | CardKind::Streaming | CardKind::Thinking)
             );
-            cards.push(Card::new(
-                CardKind::Tool {
-                    compact: prev_is_assistant,
-                },
-                blocks,
-            ));
+            cards.push(Card::new(CardKind::Tool { compact }, blocks));
         }
     };
 
@@ -318,41 +232,35 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
         |tool_call_id: Option<&String>, sequential_idx: usize| -> Option<&DelegateEntry> {
             tool_call_id
                 .and_then(|id| {
-                    app.delegates
-                        .delegate_entries
+                    input
+                        .delegates
                         .iter()
                         .find(|entry| entry.delegate_tool_call_id.as_deref() == Some(id.as_str()))
                 })
-                .or_else(|| app.delegates.delegate_entries.get(sequential_idx))
+                .or_else(|| input.delegates.get(sequential_idx))
         };
-    let mut delegate_idx = app.chat.messages[..start_idx]
+    let mut delegate_idx = input.messages[..start_idx]
         .iter()
         .filter(|entry| matches!(entry, ChatEntry::ToolCall { name, .. } if name == "delegate"))
         .count();
 
-    for entry in &app.chat.messages[start_idx..] {
+    for entry in &input.messages[start_idx..] {
         match entry {
             ChatEntry::User { text, .. } => {
-                flush_tools(&mut pending_tools, &mut app.render.card_cache.cards);
-                let blocks = markdown::render(text, Theme::user_text(), &app.render.highlighter);
-                app.render
-                    .card_cache
-                    .cards
-                    .push(Card::new(CardKind::User, blocks));
+                flush_tools(&mut pending_tools, &mut cards);
+                let blocks = markdown::render(text, Theme::user_text(), highlighter);
+                cards.push(Card::new(CardKind::User, blocks));
             }
             ChatEntry::Assistant {
                 content, thinking, ..
             } => {
-                flush_tools(&mut pending_tools, &mut app.render.card_cache.cards);
+                flush_tools(&mut pending_tools, &mut cards);
                 let mut blocks = Vec::new();
-                if app.chat.show_thinking
+                if input.show_thinking
                     && let Some(thinking_text) = thinking
                 {
-                    let mut rendered = markdown::render(
-                        thinking_text,
-                        Theme::thinking_text(),
-                        &app.render.highlighter,
-                    );
+                    let mut rendered =
+                        markdown::render(thinking_text, Theme::thinking_text(), highlighter);
                     markdown::prepend_span_to_first_text(
                         &mut rendered,
                         Span::styled("\u{25CF} ", Theme::thinking()),
@@ -363,26 +271,19 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                 blocks.extend(markdown::render(
                     content,
                     Theme::assistant_text(),
-                    &app.render.highlighter,
+                    highlighter,
                 ));
-                app.render
-                    .card_cache
-                    .cards
-                    .push(Card::new(CardKind::Assistant, blocks));
+                cards.push(Card::new(CardKind::Assistant, blocks));
             }
             ChatEntry::Thinking { content, .. } => {
-                if app.chat.show_thinking {
-                    flush_tools(&mut pending_tools, &mut app.render.card_cache.cards);
-                    let mut blocks =
-                        markdown::render(content, Theme::thinking_text(), &app.render.highlighter);
+                if input.show_thinking {
+                    flush_tools(&mut pending_tools, &mut cards);
+                    let mut blocks = markdown::render(content, Theme::thinking_text(), highlighter);
                     markdown::prepend_span_to_first_text(
                         &mut blocks,
                         Span::styled("\u{25CF} ", Theme::thinking()),
                     );
-                    app.render
-                        .card_cache
-                        .cards
-                        .push(Card::new(CardKind::Thinking, blocks));
+                    cards.push(Card::new(CardKind::Thinking, blocks));
                 }
             }
             ChatEntry::ToolCall {
@@ -409,12 +310,7 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                 let delegate_duration = delegate_entry
                     .and_then(|entry| {
                         let start = entry.started_at?;
-                        let end = entry.ended_at.unwrap_or_else(|| {
-                            std::time::SystemTime::now()
-                                .duration_since(std::time::UNIX_EPOCH)
-                                .map(|duration| duration.as_secs() as i64)
-                                .unwrap_or(start)
-                        });
+                        let end = entry.ended_at.unwrap_or(input.now_unix_secs);
                         let secs = (end - start).max(0) as u64;
                         Some(if secs < 60 {
                             format!(":{secs}s")
@@ -451,7 +347,7 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                         pending_tools.extend(build_multiedit_lines(sections, 6));
                     }
                     ToolDetail::ReplaceSymbolInput { replacements } => {
-                        let title = replace_symbol_title(replacements, &[], current_cwd.as_deref());
+                        let title = replace_symbol_title(replacements, &[], current_cwd);
                         pending_tools.push(Line::from(vec![
                             Span::styled(format!("{sym} {name} "), style),
                             Span::styled(title, Theme::diff_file()),
@@ -461,8 +357,7 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                         replacements,
                         sections,
                     } => {
-                        let title =
-                            replace_symbol_title(replacements, sections, current_cwd.as_deref());
+                        let title = replace_symbol_title(replacements, sections, current_cwd);
                         pending_tools.push(Line::from(vec![
                             Span::styled(format!("{sym} {name} "), style),
                             Span::styled(title, Theme::diff_file()),
@@ -658,9 +553,9 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                 }
             }
             ChatEntry::CompactionStart { token_estimate } => {
-                flush_tools(&mut pending_tools, &mut app.render.card_cache.cards);
+                flush_tools(&mut pending_tools, &mut cards);
                 let token_str = format!("~{} tokens", token_estimate);
-                app.render.card_cache.cards.push(Card::new(
+                cards.push(Card::new(
                     CardKind::Compaction,
                     vec![
                         crate::markdown::CardBlock::Text(Line::from(vec![
@@ -682,7 +577,7 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                 summary,
                 summary_len,
             } => {
-                flush_tools(&mut pending_tools, &mut app.render.card_cache.cards);
+                flush_tools(&mut pending_tools, &mut cards);
                 let mut blocks = vec![crate::markdown::CardBlock::Text(Line::from(vec![
                     Span::styled("[compact] ", Theme::status_accent()),
                     Span::styled("Conversation summarized", Theme::status_accent()),
@@ -702,23 +597,20 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                 blocks.extend(markdown::render(
                     summary,
                     Theme::assistant_text(),
-                    &app.render.highlighter,
+                    highlighter,
                 ));
-                app.render
-                    .card_cache
-                    .cards
-                    .push(Card::new(CardKind::Compaction, blocks));
+                cards.push(Card::new(CardKind::Compaction, blocks));
             }
             ChatEntry::Info(text) => {
-                flush_tools(&mut pending_tools, &mut app.render.card_cache.cards);
-                app.render.card_cache.cards.push(Card::new(
+                flush_tools(&mut pending_tools, &mut cards);
+                cards.push(Card::new(
                     CardKind::Info,
                     vec![crate::markdown::CardBlock::Text(Line::from(text.clone()))],
                 ));
             }
             ChatEntry::Error(text) => {
-                flush_tools(&mut pending_tools, &mut app.render.card_cache.cards);
-                app.render.card_cache.cards.push(Card::new(
+                flush_tools(&mut pending_tools, &mut cards);
+                cards.push(Card::new(
                     CardKind::Error,
                     vec![crate::markdown::CardBlock::Text(Line::from(text.clone()))],
                 ));
@@ -729,7 +621,7 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                 outcome,
                 ..
             } => {
-                flush_tools(&mut pending_tools, &mut app.render.card_cache.cards);
+                flush_tools(&mut pending_tools, &mut cards);
                 let header = crate::markdown::CardBlock::Text(Line::from(vec![
                     Span::styled("[?] ", Theme::status_accent()),
                     Span::styled(message.clone(), Theme::status_accent()),
@@ -749,18 +641,63 @@ pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
                         }
                     }
                 }
-                app.render
-                    .card_cache
-                    .cards
-                    .push(Card::new(CardKind::Elicitation, card_blocks));
+                cards.push(Card::new(CardKind::Elicitation, card_blocks));
             }
         }
     }
 
-    flush_tools(&mut pending_tools, &mut app.render.card_cache.cards);
-    app.render.card_cache.processed_messages = app.chat.messages.len();
+    flush_tools(&mut pending_tools, &mut cards);
+    cards
+}
 
-    &app.render.card_cache.cards
+fn render_session_identity(app: &App) -> SessionIdentity {
+    let session_id = app.sessions.session_id.clone();
+    let remote_node_id = session_id
+        .as_deref()
+        .and_then(|id| app.sessions.session_remote_node_id(id))
+        .map(str::to_string);
+    let is_remote = session_id
+        .as_deref()
+        .is_some_and(|id| app.sessions.is_remote_session_id(id));
+    SessionIdentity::new(session_id, remote_node_id, is_remote)
+}
+
+fn now_unix_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+pub(crate) fn build_message_cards(app: &mut App) -> &[Card] {
+    build_message_cards_for_width(app, 120)
+}
+
+#[cfg(test)]
+pub(crate) fn build_message_cards_for_width(app: &mut App, full_width: u16) -> &[Card] {
+    build_message_cards_for_width_at(app, full_width, now_unix_secs())
+}
+
+#[cfg(test)]
+pub(crate) fn build_message_cards_for_width_at(
+    app: &mut App,
+    full_width: u16,
+    now_unix_secs: i64,
+) -> &[Card] {
+    let session_identity = render_session_identity(app);
+    let effective_cwd = app.current_session_cwd();
+    let input = FinalizedRenderInput {
+        session_identity,
+        messages: &app.chat.messages,
+        delegates: &app.delegates.delegate_entries,
+        effective_cwd,
+        show_thinking: app.chat.show_thinking,
+        full_width,
+        theme: ThemeCacheKey::current_frame(),
+        now_unix_secs,
+    };
+    build_finalized_cards(input, &mut app.render)
 }
 
 // ── Shared header builder ─────────────────────────────────────────────────────
@@ -1704,54 +1641,66 @@ fn draw_mention_panel(f: &mut Frame, app: &App, area: Rect) {
 // ── Streaming card (transient, not cached) ────────────────────────────────────
 
 /// Build the transient streaming/thinking card (not cached, rebuilt every frame).
-fn build_streaming_card(app: &mut App) -> Option<Card> {
-    let activity_text = match &app.chat.activity {
+pub(crate) struct StreamingRenderInput<'a> {
+    pub(crate) session_identity: SessionIdentity,
+    pub(crate) fallback_ordinal: usize,
+    pub(crate) activity: &'a ActivityState,
+    pub(crate) is_turn_active: bool,
+    pub(crate) content: &'a str,
+    pub(crate) content_message_id: Option<&'a str>,
+    pub(crate) thinking: &'a str,
+    pub(crate) thinking_message_id: Option<&'a str>,
+    pub(crate) show_thinking: bool,
+    pub(crate) full_width: u16,
+    pub(crate) theme: ThemeCacheKey,
+    pub(crate) tick: u64,
+}
+
+/// Build the transient card while caching only its markdown blocks.
+pub(crate) fn build_streaming_card(
+    input: StreamingRenderInput<'_>,
+    render: &mut RenderState,
+) -> Option<Card> {
+    let activity_text = match input.activity {
         ActivityState::RunningTool { name } => {
-            format!(
-                "{} tool: {name}",
-                spinner(SpinnerKind::Braille, app.render.tick)
-            )
+            format!("{} tool: {name}", spinner(SpinnerKind::Braille, input.tick))
         }
         ActivityState::Compacting { .. } => {
-            format!(
-                "{} compacting",
-                spinner(SpinnerKind::Braille, app.render.tick)
-            )
+            format!("{} compacting", spinner(SpinnerKind::Braille, input.tick))
         }
         ActivityState::Streaming => {
-            format!(
-                "{} streaming",
-                spinner(SpinnerKind::Braille, app.render.tick)
-            )
+            format!("{} streaming", spinner(SpinnerKind::Braille, input.tick))
         }
-        _ => format!(
-            "{} thinking",
-            spinner(SpinnerKind::Braille, app.render.tick)
-        ),
+        _ => format!("{} thinking", spinner(SpinnerKind::Braille, input.tick)),
     };
 
-    let has_thinking = app.chat.show_thinking && !app.chat.streaming_thinking.is_empty();
-    let has_content = !app.chat.streaming_content.is_empty();
+    let session = render.observe_session(&input.session_identity);
+    let has_thinking = input.show_thinking && !input.thinking.is_empty();
+    let has_content = !input.content.is_empty();
 
     if has_thinking || has_content {
         let mut blocks = Vec::new();
 
         if has_thinking {
-            let thinking_len = app.chat.streaming_thinking.len();
-            let mut thinking_blocks =
-                if let Some(cached) = app.render.streaming_thinking_cache.get(thinking_len) {
-                    cached.to_vec()
-                } else {
-                    let rendered = markdown::render(
-                        &app.chat.streaming_thinking,
-                        Theme::thinking_text(),
-                        &app.render.highlighter,
-                    );
-                    app.render
-                        .streaming_thinking_cache
-                        .store(thinking_len, rendered.clone());
-                    rendered
-                };
+            let key = StreamingCacheKeyRef::new(
+                &session,
+                StreamKind::Thinking,
+                input.thinking_message_id,
+                input.content_message_id,
+                input.fallback_ordinal,
+                input.thinking,
+                input.full_width,
+                input.theme,
+                input.show_thinking,
+            );
+            let mut thinking_blocks = if let Some(cached) = render.streaming_blocks(key) {
+                cached.to_vec()
+            } else {
+                let rendered =
+                    markdown::render(input.thinking, Theme::thinking_text(), render.highlighter());
+                render.store_streaming_blocks(key, rendered.clone());
+                rendered
+            };
             markdown::prepend_span_to_first_text(
                 &mut thinking_blocks,
                 Span::styled("\u{25CF} ", Theme::thinking()),
@@ -1763,18 +1712,23 @@ fn build_streaming_card(app: &mut App) -> Option<Card> {
         }
 
         if has_content {
-            let content_len = app.chat.streaming_content.len();
-            let content_blocks = if let Some(cached) = app.render.streaming_cache.get(content_len) {
+            let key = StreamingCacheKeyRef::new(
+                &session,
+                StreamKind::Content,
+                input.content_message_id,
+                input.thinking_message_id,
+                input.fallback_ordinal,
+                input.content,
+                input.full_width,
+                input.theme,
+                input.show_thinking,
+            );
+            let content_blocks = if let Some(cached) = render.streaming_blocks(key) {
                 cached.to_vec()
             } else {
-                let rendered = markdown::render(
-                    &app.chat.streaming_content,
-                    Theme::assistant_text(),
-                    &app.render.highlighter,
-                );
-                app.render
-                    .streaming_cache
-                    .store(content_len, rendered.clone());
+                let rendered =
+                    markdown::render(input.content, Theme::assistant_text(), render.highlighter());
+                render.store_streaming_blocks(key, rendered.clone());
                 rendered
             };
             blocks.extend(content_blocks);
@@ -1785,7 +1739,7 @@ fn build_streaming_card(app: &mut App) -> Option<Card> {
             Theme::thinking(),
         ))));
         Some(Card::new(CardKind::Streaming, blocks))
-    } else if app.chat.is_turn_active() {
+    } else if input.is_turn_active {
         Some(Card::new(
             CardKind::Thinking,
             vec![crate::markdown::CardBlock::Text(Line::from(Span::styled(
@@ -1796,6 +1750,25 @@ fn build_streaming_card(app: &mut App) -> Option<Card> {
     } else {
         None
     }
+}
+
+#[cfg(test)]
+pub(crate) fn build_streaming_card_for_test(app: &mut App, full_width: u16) -> Option<Card> {
+    let input = StreamingRenderInput {
+        session_identity: render_session_identity(app),
+        fallback_ordinal: app.chat.messages.len(),
+        activity: &app.chat.activity,
+        is_turn_active: app.chat.is_turn_active(),
+        content: &app.chat.streaming_content,
+        content_message_id: app.chat.streaming_content_message_id.as_deref(),
+        thinking: &app.chat.streaming_thinking,
+        thinking_message_id: app.chat.streaming_thinking_message_id.as_deref(),
+        show_thinking: app.chat.show_thinking,
+        full_width,
+        theme: ThemeCacheKey::current_frame(),
+        tick: app.render.tick,
+    };
+    build_streaming_card(input, &mut app.render)
 }
 
 // ── Diff / write helpers ──────────────────────────────────────────────────────
@@ -2289,42 +2262,60 @@ pub(crate) fn build_write_lines(content: &str) -> Vec<Line<'static>> {
 fn draw_messages(f: &mut Frame, app: &mut App, area: Rect) {
     f.render_widget(Block::default().style(Theme::base()), area);
 
-    // Update cached message cards incrementally, then build transient card
-    build_message_cards(app);
-    let streaming_card = build_streaming_card(app);
-
-    // Compute total_height in a temporary scope so we can mutably access app
-    // for scroll compensation before borrowing card_cache again for rendering.
-    let total_height: u16 = {
-        let cards = app
-            .render
-            .card_cache
-            .cards
-            .iter()
-            .chain(streaming_card.iter());
-        cards.map(|c| c.height(area.width)).sum()
+    let session_identity = render_session_identity(app);
+    let effective_cwd = app.current_session_cwd();
+    let theme = ThemeCacheKey::current_frame();
+    let finalized_input = FinalizedRenderInput {
+        session_identity: session_identity.clone(),
+        messages: &app.chat.messages,
+        delegates: &app.delegates.delegate_entries,
+        effective_cwd,
+        show_thinking: app.chat.show_thinking,
+        full_width: area.width,
+        theme,
+        now_unix_secs: now_unix_secs(),
     };
+    build_finalized_cards(finalized_input, &mut app.render);
 
-    if total_height == 0 && app.render.card_cache.cards.is_empty() && streaming_card.is_none() {
+    let streaming_input = StreamingRenderInput {
+        session_identity,
+        fallback_ordinal: app.chat.messages.len(),
+        activity: &app.chat.activity,
+        is_turn_active: app.chat.is_turn_active(),
+        content: &app.chat.streaming_content,
+        content_message_id: app.chat.streaming_content_message_id.as_deref(),
+        thinking: &app.chat.streaming_thinking,
+        thinking_message_id: app.chat.streaming_thinking_message_id.as_deref(),
+        show_thinking: app.chat.show_thinking,
+        full_width: area.width,
+        theme,
+        tick: app.render.tick,
+    };
+    let streaming_card = build_streaming_card(streaming_input, &mut app.render);
+
+    let total_height: u16 = app
+        .render
+        .cards()
+        .iter()
+        .chain(streaming_card.iter())
+        .map(|card| card.height(area.width))
+        .sum();
+
+    if total_height == 0 && app.render.cards().is_empty() && streaming_card.is_none() {
         return;
     }
 
-    // When the user is scrolled up, bump scroll_offset by however much
-    // content grew so the viewport stays at the same absolute position.
+    // Keep the existing viewport growth compensation and scroll ownership unchanged.
     app.render
         .compensate_scroll_for_growth(total_height, &mut app.chat.scroll_offset);
 
-    // max scroll = how far we can scroll from the bottom
     let max_scroll = total_height.saturating_sub(area.height);
-    // clamp so we never scroll past the top
     app.chat.scroll_offset = app.chat.scroll_offset.min(max_scroll);
-    // scroll_offset 0 = pinned to bottom, higher = scrolled up
     let scroll = max_scroll.saturating_sub(app.chat.scroll_offset);
 
     let all_cards: Vec<&Card> = app
         .render
-        .card_cache
-        .cards
+        .cards()
         .iter()
         .chain(streaming_card.iter())
         .collect();
@@ -2338,7 +2329,7 @@ fn draw_messages(f: &mut Frame, app: &mut App, area: Rect) {
         if card_bottom > 0 && card_top < area.height as i32 {
             let render_y = card_top.max(0) as u16;
             let visible_h = (card_bottom.min(area.height as i32) - render_y as i32) as u16;
-            let clip_top = (-card_top).max(0) as u16; // rows clipped off top
+            let clip_top = (-card_top).max(0) as u16;
 
             card.render(
                 f,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,7 +2,6 @@ mod chat;
 mod popups;
 mod start;
 
-pub(crate) use chat::CardCache;
 use chat::{draw_chat, draw_delegate_view};
 use popups::{
     draw_auth_popup, draw_command_palette_popup, draw_fork_turn_popup, draw_help_popup,
@@ -14,10 +13,14 @@ use start::draw_start;
 
 // Re-exports used only by the test module (via `use super::*`).
 #[cfg(test)]
-pub(crate) use crate::markdown::CardBlock;
+pub(crate) use crate::markdown::{CardBlock, MD_BULLET};
+#[cfg(test)]
+pub(crate) use crate::render_state::{Card, CardKind};
 #[cfg(test)]
 pub(crate) use chat::{
-    Card, CardKind, ICON_DELEGATES, ICON_MULTI_SESSION, SpinnerKind, build_message_cards, spinner,
+    ICON_DELEGATES, ICON_MULTI_SESSION, SpinnerKind, build_message_cards,
+    build_message_cards_for_width, build_message_cards_for_width_at, build_streaming_card_for_test,
+    spinner,
 };
 #[cfg(test)]
 pub(crate) use popups::{
@@ -45,8 +48,6 @@ pub(crate) const ELLIPSIS: &str = "\u{2026}"; // … horizontal ellipsis – tru
 pub(super) const ARROW_UP: &str = "\u{2191}"; // ↑ upwards arrow
 pub(super) const ARROW_DOWN: &str = "\u{2193}"; // ↓ downwards arrow
 pub(crate) const INPUT_OVERLINE: &str = "\u{00AF}"; // ¯ overline-like separator above chat input
-pub(crate) const MD_HRULE_CHAR: &str = "\u{2500}"; // ─ box drawings light horizontal – HR
-pub(crate) const MD_BULLET: &str = "\u{2022} "; // • bullet – unordered list item prefix
 
 // ── Connection indicators ─────────────────────────────────────────────────────
 const CONN_ONLINE: &str = "\u{25CF}"; // ● filled circle – connected / disconnected
@@ -234,7 +235,8 @@ mod tests {
     use crate::chat_state::ElicitationUiState;
     use crate::diagnostics::LogLevel;
     use crate::domain::activity::{
-        DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus, SessionActivity,
+        ActivityState, DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus,
+        SessionActivity,
     };
     use crate::domain::auth::{
         AuthProviderEntry, OAuthFlow, OAuthFlowKind, OAuthResult, OAuthResultStatus, OAuthStatus,
@@ -311,7 +313,7 @@ mod tests {
     }
 
     fn rendered_card_snapshot(app: &mut App, width: u16) -> Vec<(CardKind, Vec<String>, u16)> {
-        build_message_cards(app)
+        build_message_cards_for_width(app, width)
             .iter()
             .map(|card| {
                 let lines = card
@@ -2505,7 +2507,7 @@ mod tests {
         let mut app = App::new();
         let cards = build_message_cards(&mut app);
         assert!(cards.is_empty());
-        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert_eq!(app.render.test_card_source_entry_count(), 0);
     }
 
     fn elicitation_card_snapshot(
@@ -2618,7 +2620,7 @@ mod tests {
         let cards = build_message_cards(&mut app);
         assert_eq!(cards.len(), 1);
         assert_eq!(cards[0].kind, CardKind::User);
-        assert_eq!(app.render.card_cache.processed_messages, 1);
+        assert_eq!(app.render.test_card_source_entry_count(), 1);
     }
 
     #[test]
@@ -2681,12 +2683,12 @@ mod tests {
             message_id: None,
         });
         build_message_cards(&mut app);
-        assert_eq!(app.render.card_cache.processed_messages, 1);
+        assert_eq!(app.render.test_card_source_entry_count(), 1);
 
         // Second call with no new messages — cache hit
         let cards = build_message_cards(&mut app);
         assert_eq!(cards.len(), 1);
-        assert_eq!(app.render.card_cache.processed_messages, 1);
+        assert_eq!(app.render.test_card_source_entry_count(), 1);
     }
 
     #[test]
@@ -2711,7 +2713,7 @@ mod tests {
         let lines = rendered_card_lines(&mut app);
         assert!(!lines.iter().any(|line| line.contains("awaiting input")));
         assert_eq!(
-            app.render.card_cache.processed_messages,
+            app.render.test_card_source_entry_count(),
             app.chat.messages.len()
         );
 
@@ -2721,7 +2723,6 @@ mod tests {
             requested_schema: serde_json::json!({ "properties": {} }),
             source: "builtin:question".into(),
         };
-        app.render.invalidate_card_cache();
         let lines = rendered_card_lines(&mut app);
 
         assert_eq!(
@@ -2859,13 +2860,13 @@ mod tests {
             message_id: None,
         });
         build_message_cards(&mut app);
-        assert_eq!(app.render.card_cache.processed_messages, 1);
+        assert_eq!(app.render.test_card_source_entry_count(), 1);
 
         app.chat.messages.clear();
-        app.render.card_cache.invalidate();
+        app.render.invalidate_card_cache();
         let cards = build_message_cards(&mut app);
         assert!(cards.is_empty());
-        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert_eq!(app.render.test_card_source_entry_count(), 0);
     }
 
     #[test]
@@ -2881,7 +2882,7 @@ mod tests {
             message_id: None,
         });
         build_message_cards(&mut app);
-        assert_eq!(app.render.card_cache.processed_messages, 2);
+        assert_eq!(app.render.test_card_source_entry_count(), 2);
 
         // Simulate retain() shrinking messages (like compaction does)
         app.chat
@@ -2890,6 +2891,509 @@ mod tests {
         let cards = build_message_cards(&mut app);
         assert_eq!(cards.len(), 1);
         assert_eq!(cards[0].kind, CardKind::User);
+    }
+
+    #[test]
+    fn same_length_content_replacement_rebuilds_only_the_changed_suffix() {
+        let mut app = App::new();
+        app.chat.messages = vec![
+            ChatEntry::User {
+                text: "stable prefix".into(),
+                message_id: Some("user-1".into()),
+            },
+            ChatEntry::Assistant {
+                content: "aaaa".into(),
+                thinking: None,
+                message_id: Some("assistant-1".into()),
+            },
+        ];
+        let _ = rendered_card_snapshot(&mut app, 80);
+        let prefix_identity = app.render.test_card_identity(0);
+        let changed_identity = app.render.test_card_identity(1);
+
+        let ChatEntry::Assistant { content, .. } = &mut app.chat.messages[1] else {
+            unreachable!("assistant fixture")
+        };
+        *content = "bbbb".into();
+
+        let warm = rendered_card_snapshot(&mut app, 80);
+        assert_eq!(app.render.test_card_identity(0), prefix_identity);
+        assert_ne!(app.render.test_card_identity(1), changed_identity);
+        app.render.invalidate_card_cache();
+        let cold = rendered_card_snapshot(&mut app, 80);
+        assert_eq!(warm, cold);
+    }
+
+    #[test]
+    fn same_count_tool_detail_mutation_rebuilds_affected_batch_and_preserves_prefix() {
+        let mut app = App::new();
+        app.chat.messages = vec![
+            ChatEntry::User {
+                text: "stable prefix".into(),
+                message_id: Some("user-1".into()),
+            },
+            ChatEntry::ToolCall {
+                tool_call_id: Some("tool-1".into()),
+                name: "shell".into(),
+                is_error: false,
+                detail: ToolDetail::Generic {
+                    input: Some("aaaa".into()),
+                    result: None,
+                },
+            },
+        ];
+        let _ = rendered_card_snapshot(&mut app, 80);
+        let prefix_identity = app.render.test_card_identity(0);
+        let tool_identity = app.render.test_card_identity(1);
+
+        let ChatEntry::ToolCall { detail, .. } = &mut app.chat.messages[1] else {
+            unreachable!("tool fixture")
+        };
+        *detail = ToolDetail::Generic {
+            input: Some("bbbb".into()),
+            result: None,
+        };
+
+        let warm = rendered_card_snapshot(&mut app, 80);
+        assert_eq!(app.render.test_card_identity(0), prefix_identity);
+        assert_ne!(app.render.test_card_identity(1), tool_identity);
+        app.render.invalidate_card_cache();
+        let cold = rendered_card_snapshot(&mut app, 80);
+        assert_eq!(warm, cold);
+    }
+
+    #[test]
+    fn width_change_matches_cold_table_relayout() {
+        let mut app = App::new();
+        app.chat.messages.push(ChatEntry::Assistant {
+            content:
+                "| Column one | Column two |\n| --- | --- |\n| a long value | another long value |"
+                    .into(),
+            thinking: None,
+            message_id: Some("table-1".into()),
+        });
+
+        let wide = rendered_card_snapshot(&mut app, 100);
+        let warm_narrow = rendered_card_snapshot(&mut app, 30);
+        assert_ne!(wide, warm_narrow);
+        app.render.invalidate_card_cache();
+        let cold_narrow = rendered_card_snapshot(&mut app, 30);
+        assert_eq!(warm_narrow, cold_narrow);
+    }
+
+    #[test]
+    fn shrink_truncates_stale_suffix_without_rebuilding_prefix() {
+        let mut app = App::new();
+        app.chat.messages = vec![
+            ChatEntry::User {
+                text: "keep".into(),
+                message_id: Some("user-1".into()),
+            },
+            ChatEntry::Assistant {
+                content: "remove".into(),
+                thinking: None,
+                message_id: Some("assistant-1".into()),
+            },
+        ];
+        let _ = rendered_card_snapshot(&mut app, 80);
+        let prefix_identity = app.render.test_card_identity(0);
+
+        app.chat.messages.truncate(1);
+        let cards = build_message_cards_for_width(&mut app, 80);
+        assert_eq!(cards.len(), 1);
+        assert_eq!(app.render.test_card_identity(0), prefix_identity);
+    }
+
+    #[test]
+    fn out_of_order_reordering_preserves_unchanged_prefix_and_matches_cold() {
+        let mut app = App::new();
+        app.chat.messages = vec![
+            ChatEntry::User {
+                text: "stable".into(),
+                message_id: Some("user-1".into()),
+            },
+            ChatEntry::Assistant {
+                content: "second".into(),
+                thinking: None,
+                message_id: Some("assistant-2".into()),
+            },
+            ChatEntry::Assistant {
+                content: "third".into(),
+                thinking: None,
+                message_id: Some("assistant-3".into()),
+            },
+        ];
+        let _ = rendered_card_snapshot(&mut app, 80);
+        let prefix_identity = app.render.test_card_identity(0);
+        let old_second_identity = app.render.test_card_identity(1);
+
+        app.chat.messages.swap(1, 2);
+        let warm = rendered_card_snapshot(&mut app, 80);
+        assert_eq!(app.render.test_card_identity(0), prefix_identity);
+        assert_ne!(app.render.test_card_identity(1), old_second_identity);
+        app.render.invalidate_card_cache();
+        let cold = rendered_card_snapshot(&mut app, 80);
+        assert_eq!(warm, cold);
+    }
+
+    #[test]
+    fn session_identity_change_rebuilds_equal_content_and_matches_cold() {
+        let mut app = App::new();
+        app.sessions.session_id = Some("session-a".into());
+        app.chat.messages.push(ChatEntry::User {
+            text: "same content".into(),
+            message_id: Some("user-1".into()),
+        });
+        let _ = rendered_card_snapshot(&mut app, 80);
+        let old_identity = app.render.test_card_identity(0);
+
+        app.sessions.session_id = Some("session-b".into());
+        let warm = rendered_card_snapshot(&mut app, 80);
+        assert_ne!(app.render.test_card_identity(0), old_identity);
+        app.render.invalidate_card_cache();
+        let cold = rendered_card_snapshot(&mut app, 80);
+        assert_eq!(warm, cold);
+    }
+
+    #[test]
+    fn streaming_keys_rebuild_exact_content_ids_and_visibility_axes() {
+        let mut app = App::new();
+        app.sessions.session_id = Some("session-1".into());
+        app.chat.activity = ActivityState::Streaming;
+        app.chat.streaming_content = "aaaa".into();
+        app.chat.streaming_content_message_id = Some("content-1".into());
+        app.chat.streaming_thinking = "plan".into();
+        app.chat.streaming_thinking_message_id = Some("thinking-1".into());
+
+        let _ = build_streaming_card_for_test(&mut app, 80);
+        let content_identity = app
+            .render
+            .test_streaming_cache_identity(crate::render_state::StreamKind::Content);
+        let thinking_identity = app
+            .render
+            .test_streaming_cache_identity(crate::render_state::StreamKind::Thinking);
+        let _ = build_streaming_card_for_test(&mut app, 80);
+        assert_eq!(
+            app.render
+                .test_streaming_cache_identity(crate::render_state::StreamKind::Content),
+            content_identity
+        );
+        assert_eq!(
+            app.render
+                .test_streaming_cache_identity(crate::render_state::StreamKind::Thinking),
+            thinking_identity
+        );
+
+        app.chat.streaming_content = "bbbb".into();
+        let _ = build_streaming_card_for_test(&mut app, 80);
+        let replaced_content_identity = app
+            .render
+            .test_streaming_cache_identity(crate::render_state::StreamKind::Content);
+        assert_ne!(replaced_content_identity, content_identity);
+        assert_eq!(
+            app.render
+                .test_streaming_cache_identity(crate::render_state::StreamKind::Thinking),
+            thinking_identity,
+            "the thinking key does not include the other stream's content"
+        );
+
+        app.chat.streaming_content_message_id = Some("content-2".into());
+        let _ = build_streaming_card_for_test(&mut app, 80);
+        assert_ne!(
+            app.render
+                .test_streaming_cache_identity(crate::render_state::StreamKind::Content),
+            replaced_content_identity
+        );
+        assert_ne!(
+            app.render
+                .test_streaming_cache_identity(crate::render_state::StreamKind::Thinking),
+            thinking_identity,
+            "the paired content ID participates in the thinking key"
+        );
+
+        let visible_content_identity = app
+            .render
+            .test_streaming_cache_identity(crate::render_state::StreamKind::Content);
+        app.chat.show_thinking = false;
+        let _ = build_streaming_card_for_test(&mut app, 80);
+        assert_ne!(
+            app.render
+                .test_streaming_cache_identity(crate::render_state::StreamKind::Content),
+            visible_content_identity
+        );
+    }
+
+    #[test]
+    fn thinking_visibility_regroups_finalized_tools_without_manual_invalidation() {
+        let mut app = App::new();
+        app.chat.show_thinking = false;
+        app.chat.messages = vec![
+            tool_call("glob"),
+            ChatEntry::Thinking {
+                content: "visible when enabled".into(),
+                message_id: Some("thinking-1".into()),
+            },
+            tool_call("read_tool"),
+        ];
+
+        let hidden = rendered_card_snapshot(&mut app, 80);
+        assert_eq!(hidden.len(), 1);
+        assert_eq!(hidden[0].0, CardKind::Tool { compact: false });
+
+        app.chat.show_thinking = true;
+        let warm_visible = rendered_card_snapshot(&mut app, 80);
+        assert_eq!(
+            warm_visible
+                .iter()
+                .map(|card| card.0.clone())
+                .collect::<Vec<_>>(),
+            vec![
+                CardKind::Tool { compact: false },
+                CardKind::Thinking,
+                CardKind::Tool { compact: true },
+            ]
+        );
+        app.render.invalidate_card_cache();
+        let cold_visible = rendered_card_snapshot(&mut app, 80);
+        assert_eq!(warm_visible, cold_visible);
+    }
+
+    #[test]
+    fn delegate_duration_and_status_rekey_tool_batch_without_manual_invalidation() {
+        let mut app = App::new();
+        app.chat
+            .messages
+            .push(delegate_tool_call("tool-1", "coder", "Fix cache bug"));
+        app.delegates.delegate_entries.push(DelegateEntry {
+            delegation_id: "delegation-1".into(),
+            child_session_id: Some("child-1".into()),
+            delegate_tool_call_id: Some("tool-1".into()),
+            target_agent_id: Some("coder".into()),
+            objective: "Fix cache bug".into(),
+            status: DelegateStatus::InProgress,
+            stats: DelegateStats::default(),
+            started_at: Some(90),
+            ended_at: None,
+            child_state: DelegateChildState::None,
+        });
+
+        let _ = build_message_cards_for_width_at(&mut app, 80, 100);
+        let running_identity = app.render.test_card_identity(0);
+        let running_lines = app.render.cards()[0]
+            .lines_for(76)
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>();
+        assert!(running_lines.iter().any(|line| line.contains("coder:10s")));
+
+        let _ = build_message_cards_for_width_at(&mut app, 80, 101);
+        let duration_identity = app.render.test_card_identity(0);
+        assert_ne!(duration_identity, running_identity);
+
+        app.delegates.delegate_entries[0].status = DelegateStatus::Completed;
+        app.delegates.delegate_entries[0].ended_at = Some(101);
+        let warm = {
+            let cards = build_message_cards_for_width_at(&mut app, 80, 101);
+            cards[0]
+                .lines_for(76)
+                .iter()
+                .map(|line| {
+                    line.spans
+                        .iter()
+                        .map(|span| span.content.as_ref())
+                        .collect::<String>()
+                })
+                .collect::<Vec<_>>()
+        };
+        assert!(warm.iter().any(|line| line.contains("done")));
+        assert_ne!(app.render.test_card_identity(0), duration_identity);
+        app.render.invalidate_card_cache();
+        let cold = {
+            let cards = build_message_cards_for_width_at(&mut app, 80, 101);
+            cards[0]
+                .lines_for(76)
+                .iter()
+                .map(|line| {
+                    line.spans
+                        .iter()
+                        .map(|span| span.content.as_ref())
+                        .collect::<String>()
+                })
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(warm, cold);
+    }
+
+    #[test]
+    #[serial]
+    fn theme_revision_rekeys_finalized_and_both_streaming_caches_without_invalidation() {
+        Theme::set_by_index(0);
+        Theme::begin_frame();
+        let mut app = App::new();
+        app.chat.messages.push(ChatEntry::User {
+            text: "styled".into(),
+            message_id: Some("user-1".into()),
+        });
+        app.chat.activity = ActivityState::Streaming;
+        app.chat.streaming_content = "content".into();
+        app.chat.streaming_content_message_id = Some("content-1".into());
+        app.chat.streaming_thinking = "thinking".into();
+        app.chat.streaming_thinking_message_id = Some("thinking-1".into());
+
+        let _ = build_message_cards_for_width(&mut app, 80);
+        let _ = build_streaming_card_for_test(&mut app, 80);
+        let card_identity = app.render.test_card_identity(0);
+        let content_identity = app
+            .render
+            .test_streaming_cache_identity(crate::render_state::StreamKind::Content);
+        let thinking_identity = app
+            .render
+            .test_streaming_cache_identity(crate::render_state::StreamKind::Thinking);
+
+        Theme::set_by_index(2);
+        Theme::begin_frame();
+        let _ = build_message_cards_for_width(&mut app, 80);
+        let _ = build_streaming_card_for_test(&mut app, 80);
+        assert_ne!(app.render.test_card_identity(0), card_identity);
+        assert_ne!(
+            app.render
+                .test_streaming_cache_identity(crate::render_state::StreamKind::Content),
+            content_identity
+        );
+        assert_ne!(
+            app.render
+                .test_streaming_cache_identity(crate::render_state::StreamKind::Thinking),
+            thinking_identity
+        );
+
+        Theme::set_by_index(0);
+        Theme::begin_frame();
+    }
+
+    #[test]
+    #[serial]
+    fn stable_key_axes_match_cold_rebuild_table() {
+        for axis in [
+            "content",
+            "tool",
+            "delegate",
+            "width",
+            "theme",
+            "session",
+            "visibility",
+        ] {
+            Theme::set_by_index(0);
+            Theme::begin_frame();
+            let mut app = App::new();
+            app.sessions.session_id = Some("session-a".into());
+            app.chat.show_thinking = false;
+            app.chat.messages = vec![
+                ChatEntry::User {
+                    text: "prefix".into(),
+                    message_id: Some("user-1".into()),
+                },
+                ChatEntry::Assistant {
+                    content: "aaaa".into(),
+                    thinking: None,
+                    message_id: Some("assistant-1".into()),
+                },
+                ChatEntry::ToolCall {
+                    tool_call_id: Some("tool-1".into()),
+                    name: "shell".into(),
+                    is_error: false,
+                    detail: ToolDetail::Generic {
+                        input: Some("first".into()),
+                        result: None,
+                    },
+                },
+                ChatEntry::Thinking {
+                    content: "hidden".into(),
+                    message_id: Some("thinking-1".into()),
+                },
+                delegate_tool_call("delegate-1", "coder", "task"),
+            ];
+            app.delegates.delegate_entries.push(DelegateEntry {
+                delegation_id: "delegation-1".into(),
+                child_session_id: Some("child-1".into()),
+                delegate_tool_call_id: Some("delegate-1".into()),
+                target_agent_id: Some("coder".into()),
+                objective: "task".into(),
+                status: DelegateStatus::InProgress,
+                stats: DelegateStats::default(),
+                started_at: None,
+                ended_at: None,
+                child_state: DelegateChildState::None,
+            });
+            let mut width = 80;
+            let _ = rendered_card_snapshot(&mut app, width);
+
+            match axis {
+                "content" => {
+                    let ChatEntry::Assistant { content, .. } = &mut app.chat.messages[1] else {
+                        unreachable!("assistant fixture")
+                    };
+                    *content = "bbbb".into();
+                }
+                "tool" => {
+                    let ChatEntry::ToolCall { detail, .. } = &mut app.chat.messages[2] else {
+                        unreachable!("tool fixture")
+                    };
+                    *detail = ToolDetail::Generic {
+                        input: Some("second".into()),
+                        result: None,
+                    };
+                }
+                "delegate" => app.delegates.delegate_entries[0].status = DelegateStatus::Completed,
+                "width" => width = 40,
+                "theme" => {
+                    Theme::set_by_index(2);
+                    Theme::begin_frame();
+                }
+                "session" => app.sessions.session_id = Some("session-b".into()),
+                "visibility" => app.chat.show_thinking = true,
+                _ => unreachable!("known stable-key axis"),
+            }
+
+            let warm = rendered_card_snapshot(&mut app, width);
+            app.render.invalidate_card_cache();
+            let cold = rendered_card_snapshot(&mut app, width);
+            assert_eq!(warm, cold, "warm/cold mismatch for {axis}");
+        }
+
+        Theme::set_by_index(0);
+        Theme::begin_frame();
+    }
+
+    #[test]
+    fn effective_cwd_change_rekeys_replace_symbol_title() {
+        let mut app = App::new();
+        app.connection.launch_cwd = Some("/workspace/one".into());
+        app.chat.messages.push(ChatEntry::ToolCall {
+            tool_call_id: Some("replace-1".into()),
+            name: "replace_symbol".into(),
+            is_error: false,
+            detail: ToolDetail::ReplaceSymbolInput {
+                replacements: vec![SymbolReplacement {
+                    path: "/workspace/one/src/deep/lib.rs".into(),
+                    symbol: "run".into(),
+                    new_text: "fn run() {}".into(),
+                }],
+            },
+        });
+
+        let _ = rendered_card_snapshot(&mut app, 80);
+        let old_identity = app.render.test_card_identity(0);
+        app.connection.launch_cwd = Some("/workspace/two".into());
+        let warm = rendered_card_snapshot(&mut app, 80);
+        assert_ne!(app.render.test_card_identity(0), old_identity);
+        app.render.invalidate_card_cache();
+        let cold = rendered_card_snapshot(&mut app, 80);
+        assert_eq!(warm, cold);
     }
 
     #[test]
@@ -2920,11 +3424,12 @@ mod tests {
             ChatEntry::ToolCall { is_error: true, .. }
         ));
         assert_eq!(
-            app.render.card_cache.processed_messages, 0,
+            app.render.test_card_source_entry_count(),
+            0,
             "cache must invalidate"
         );
         let rebuilt_from_warm_update = rendered_card_snapshot(&mut app, 80);
-        app.render.card_cache.invalidate();
+        app.render.invalidate_card_cache();
         let cold_full_rebuild = rendered_card_snapshot(&mut app, 80);
         assert_eq!(rebuilt_from_warm_update, cold_full_rebuild);
         let lines = rebuilt_from_warm_update
@@ -2954,7 +3459,7 @@ mod tests {
         assert!(warm_lines.iter().any(|line| line.contains("$ cargo test")));
         assert!(!warm_lines.iter().any(|line| line.contains("tail sentinel")));
         assert_eq!(
-            app.render.card_cache.processed_messages,
+            app.render.test_card_source_entry_count(),
             app.chat.messages.len()
         );
 
@@ -2975,11 +3480,12 @@ mod tests {
             "tool detail update should be in place"
         );
         assert_eq!(
-            app.render.card_cache.processed_messages, 0,
+            app.render.test_card_source_entry_count(),
+            0,
             "semantic update should invalidate the warm card"
         );
         let rebuilt_from_warm_update = rendered_card_snapshot(&mut app, 80);
-        app.render.card_cache.invalidate();
+        app.render.invalidate_card_cache();
         let cold_full_rebuild = rendered_card_snapshot(&mut app, 80);
         assert_eq!(rebuilt_from_warm_update, cold_full_rebuild);
         let rebuilt_lines = &rebuilt_from_warm_update[0].1;
@@ -3021,7 +3527,7 @@ mod tests {
                 .any(|line| line.contains("  1 ") && line.contains("- before"))
         );
         assert_eq!(
-            app.render.card_cache.processed_messages,
+            app.render.test_card_source_entry_count(),
             app.chat.messages.len()
         );
 
@@ -3042,11 +3548,12 @@ mod tests {
             "tool detail update should be in place"
         );
         assert_eq!(
-            app.render.card_cache.processed_messages, 0,
+            app.render.test_card_source_entry_count(),
+            0,
             "semantic update should invalidate the warm card"
         );
         let rebuilt_from_warm_update = rendered_card_snapshot(&mut app, 80);
-        app.render.card_cache.invalidate();
+        app.render.invalidate_card_cache();
         let cold_full_rebuild = rendered_card_snapshot(&mut app, 80);
         assert_eq!(rebuilt_from_warm_update, cold_full_rebuild);
         let rebuilt_lines = &rebuilt_from_warm_update[0].1;
@@ -3099,10 +3606,10 @@ mod tests {
                 ),
             },
         );
-        assert_eq!(app.render.card_cache.processed_messages, 0);
+        assert_eq!(app.render.test_card_source_entry_count(), 0);
 
         let rebuilt_from_warm_update = rendered_card_snapshot(&mut app, 34);
-        app.render.card_cache.invalidate();
+        app.render.invalidate_card_cache();
         let cold_full_rebuild = rendered_card_snapshot(&mut app, 34);
 
         assert_eq!(rebuilt_from_warm_update, cold_full_rebuild);
@@ -3149,7 +3656,7 @@ mod tests {
         );
 
         let warm_reconciled = rendered_card_snapshot(&mut app, 42);
-        app.render.card_cache.invalidate();
+        app.render.invalidate_card_cache();
         let cold_full_rebuild = rendered_card_snapshot(&mut app, 42);
         assert_eq!(warm_reconciled, cold_full_rebuild);
 
@@ -3218,7 +3725,7 @@ mod tests {
         });
         let incremental = rendered_card_snapshot(&mut app, 42);
 
-        app.render.card_cache.invalidate();
+        app.render.invalidate_card_cache();
         let cold_full_rebuild = rendered_card_snapshot(&mut app, 42);
 
         assert_eq!(incremental, cold_full_rebuild);
@@ -3253,12 +3760,12 @@ mod tests {
             message_id: None,
         });
         build_message_cards(&mut app);
-        assert_eq!(app.render.card_cache.processed_messages, 2);
+        assert_eq!(app.render.test_card_source_entry_count(), 2);
 
         load_session(&mut app, "delegate-session", "agent-2");
         assert!(app.chat.messages.is_empty());
-        assert_eq!(app.render.card_cache.processed_messages, 0);
-        assert!(app.render.card_cache.cards.is_empty());
+        assert_eq!(app.render.test_card_source_entry_count(), 0);
+        assert!(app.render.cards().is_empty());
 
         replay_session(
             &mut app,
@@ -4558,14 +5065,14 @@ mod tests {
             let cards = build_message_cards(&mut app);
             cards.iter().map(|card| card.kind.clone()).collect()
         };
-        let incremental_tool_lines = app.render.card_cache.cards[0].lines_for(80).len();
+        let incremental_tool_lines = app.render.cards()[0].lines_for(80).len();
 
-        app.render.card_cache.invalidate();
+        app.render.invalidate_card_cache();
         let full_kinds: Vec<_> = {
             let cards = build_message_cards(&mut app);
             cards.iter().map(|card| card.kind.clone()).collect()
         };
-        let full_tool_lines = app.render.card_cache.cards[0].lines_for(80).len();
+        let full_tool_lines = app.render.cards()[0].lines_for(80).len();
 
         assert_eq!(incremental_kinds, full_kinds);
         assert_eq!(incremental_kinds, vec![CardKind::Tool { compact: false }]);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -161,7 +161,9 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         Popup::MeshInvite => draw_mesh_invite_popup(f, app),
         Popup::MeshInviteQr => draw_mesh_invite_qr_popup(f, app),
         Popup::ModelSelect => draw_model_popup(f, app),
-        Popup::SessionSelect => draw_session_popup(f, app),
+        Popup::SessionSelect => {
+            draw_session_popup(f, &app.sessions, &app.delegates, &mut app.render)
+        }
         Popup::NewSession => draw_new_session_popup(f, app),
         Popup::ThemeSelect => draw_theme_popup(f, app),
         Popup::Help => draw_help_popup(f, app),
@@ -342,6 +344,46 @@ mod tests {
         let backend = ratatui::backend::TestBackend::new(width, height);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
         terminal.draw(|f| draw_delegate_view(f, app)).unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    fn draw_session_popup_for_test(f: &mut Frame, app: &mut App) {
+        draw_session_popup(f, &app.sessions, &app.delegates, &mut app.render);
+    }
+
+    fn session_draw_snapshot(app: &App) -> String {
+        format!(
+            "groups={:?};cursor={};filter={:?};tab={};collapsed={:?};popup_collapsed={:?};discovery={};discovery_cursors={:?};pending_groups={:?};hydrated={:?};expanded={:?};pending_children={:?};session={:?};agent={:?};mode={:?};review={:?};new_path={:?};new_cursor={};completion={:?};activity={:?};remote={:?}",
+            app.sessions.session_groups,
+            app.sessions.session_cursor,
+            app.sessions.session_filter,
+            app.sessions.session_popup_tab,
+            app.sessions.collapsed_groups,
+            app.sessions.popup_collapsed_groups,
+            app.sessions.session_discovery_in_progress,
+            app.sessions.session_discovery_cursors,
+            app.sessions.pending_session_group_loads,
+            app.sessions.hydrated_session_groups,
+            app.sessions.expanded_session_children,
+            app.sessions.pending_session_child_loads,
+            app.sessions.session_id,
+            app.sessions.agent_id,
+            app.sessions.agent_mode,
+            app.sessions.mode_before_review,
+            app.sessions.new_session_path,
+            app.sessions.new_session_cursor,
+            app.sessions.new_session_completion,
+            app.sessions.session_activity,
+            app.sessions.remote_session_locations,
+        )
+    }
+
+    fn render_session_popup(app: &mut App, width: u16, height: u16) -> ratatui::buffer::Buffer {
+        let backend = ratatui::backend::TestBackend::new(width, height);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| draw_session_popup_for_test(f, app))
+            .unwrap();
         terminal.backend().buffer().clone()
     }
 
@@ -756,6 +798,42 @@ mod tests {
     }
 
     #[test]
+    fn session_popup_draw_publishes_only_active_metric_and_preserves_feature_state() {
+        let mut app = App::new();
+        app.navigation.popup = Popup::SessionSelect;
+        app.render.publish_session_popup_visible_rows(11);
+        app.render.publish_delegate_popup_visible_rows(13);
+        let sessions_before = session_draw_snapshot(&app);
+        let delegates_before = app.delegates.clone();
+
+        let buffer = render_session_popup(&mut app, 90, 20);
+        assert!(buffer_text(&buffer).contains("sessions"));
+        assert_eq!(app.render.test_session_popup_visible_rows(), 6);
+        assert_eq!(app.render.test_delegate_popup_visible_rows(), 13);
+        assert_eq!(session_draw_snapshot(&app), sessions_before);
+        assert_eq!(app.delegates, delegates_before);
+
+        render_session_popup(&mut app, 36, 8);
+        assert_eq!(app.render.test_session_popup_visible_rows(), 1);
+        assert_eq!(app.render.test_delegate_popup_visible_rows(), 13);
+        render_session_popup(&mut app, 36, 1);
+        assert_eq!(app.render.test_session_popup_visible_rows(), 0);
+        assert_eq!(app.render.test_delegate_popup_visible_rows(), 13);
+
+        app.sessions.session_popup_tab = 1;
+        let sessions_before = session_draw_snapshot(&app);
+        let delegates_before = app.delegates.clone();
+        render_session_popup(&mut app, 36, 8);
+        assert_eq!(app.render.test_session_popup_visible_rows(), 0);
+        assert_eq!(app.render.test_delegate_popup_visible_rows(), 1);
+        render_session_popup(&mut app, 36, 1);
+        assert_eq!(app.render.test_session_popup_visible_rows(), 0);
+        assert_eq!(app.render.test_delegate_popup_visible_rows(), 0);
+        assert_eq!(session_draw_snapshot(&app), sessions_before);
+        assert_eq!(app.delegates, delegates_before);
+    }
+
+    #[test]
     fn draw_delegate_popup_uses_aligned_stat_columns_without_header() {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
@@ -803,7 +881,9 @@ mod tests {
 
         let backend = ratatui::backend::TestBackend::new(90, 20);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
-        terminal.draw(|f| draw_session_popup(f, &mut app)).unwrap();
+        terminal
+            .draw(|f| draw_session_popup_for_test(f, &mut app))
+            .unwrap();
         let buffer = terminal.backend().buffer().clone();
 
         let (tool_x1, row1) = find_buffer_text(&buffer, "⚒7").expect("missing row1 tools");
@@ -845,7 +925,9 @@ mod tests {
 
         let backend = ratatui::backend::TestBackend::new(90, 20);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
-        terminal.draw(|f| draw_session_popup(f, &mut app)).unwrap();
+        terminal
+            .draw(|f| draw_session_popup_for_test(f, &mut app))
+            .unwrap();
         let buffer = terminal.backend().buffer().clone();
         let rendered: String = buffer.content().iter().map(|c| c.symbol()).collect();
 
@@ -913,7 +995,9 @@ mod tests {
 
         let backend = ratatui::backend::TestBackend::new(90, 20);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
-        terminal.draw(|f| draw_session_popup(f, &mut app)).unwrap();
+        terminal
+            .draw(|f| draw_session_popup_for_test(f, &mut app))
+            .unwrap();
         let rendered: String = terminal
             .backend()
             .buffer()
@@ -960,7 +1044,9 @@ mod tests {
 
         let backend = ratatui::backend::TestBackend::new(70, 12);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
-        terminal.draw(|f| draw_session_popup(f, &mut app)).unwrap();
+        terminal
+            .draw(|f| draw_session_popup_for_test(f, &mut app))
+            .unwrap();
         let rendered: String = terminal
             .backend()
             .buffer()
@@ -1011,7 +1097,9 @@ mod tests {
 
         let backend = ratatui::backend::TestBackend::new(90, 20);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
-        terminal.draw(|f| draw_session_popup(f, &mut app)).unwrap();
+        terminal
+            .draw(|f| draw_session_popup_for_test(f, &mut app))
+            .unwrap();
         let buffer = terminal.backend().buffer().clone();
         let (x, y) = find_buffer_text(&buffer, "☒").expect("missing failed symbol");
         assert_eq!(
@@ -1071,7 +1159,9 @@ mod tests {
 
         let backend = ratatui::backend::TestBackend::new(90, 20);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
-        terminal.draw(|f| draw_session_popup(f, &mut app)).unwrap();
+        terminal
+            .draw(|f| draw_session_popup_for_test(f, &mut app))
+            .unwrap();
         let buffer = terminal.backend().buffer().clone();
 
         let (_, first_y) = find_buffer_text(&buffer, "First row").expect("missing first row");
@@ -1145,7 +1235,9 @@ mod tests {
 
         let backend = ratatui::backend::TestBackend::new(90, 20);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
-        terminal.draw(|f| draw_session_popup(f, &mut app)).unwrap();
+        terminal
+            .draw(|f| draw_session_popup_for_test(f, &mut app))
+            .unwrap();
         let rendered: String = terminal
             .backend()
             .buffer()
@@ -1955,7 +2047,9 @@ mod tests {
 
         let backend = ratatui::backend::TestBackend::new(80, 20);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
-        terminal.draw(|f| draw_session_popup(f, &mut app)).unwrap();
+        terminal
+            .draw(|f| draw_session_popup_for_test(f, &mut app))
+            .unwrap();
         let buffer = terminal.backend().buffer().clone();
         let rendered = buffer
             .content()
@@ -1976,7 +2070,9 @@ mod tests {
 
         let backend = ratatui::backend::TestBackend::new(80, 20);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
-        terminal.draw(|f| draw_session_popup(f, &mut app)).unwrap();
+        terminal
+            .draw(|f| draw_session_popup_for_test(f, &mut app))
+            .unwrap();
         let buffer = terminal.backend().buffer().clone();
 
         let (marker_x, marker_y) = find_buffer_text(&buffer, "●").expect("active marker missing");
@@ -1997,7 +2093,9 @@ mod tests {
 
         let backend = ratatui::backend::TestBackend::new(80, 20);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
-        terminal.draw(|f| draw_session_popup(f, &mut app)).unwrap();
+        terminal
+            .draw(|f| draw_session_popup_for_test(f, &mut app))
+            .unwrap();
         let buffer = terminal.backend().buffer().clone();
         let rendered = buffer_text(&buffer);
 
@@ -2027,7 +2125,9 @@ mod tests {
 
         let backend = ratatui::backend::TestBackend::new(60, 20);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
-        terminal.draw(|f| draw_session_popup(f, &mut app)).unwrap();
+        terminal
+            .draw(|f| draw_session_popup_for_test(f, &mut app))
+            .unwrap();
         let buffer = terminal.backend().buffer().clone();
         let rendered = buffer
             .content()
@@ -4978,7 +5078,7 @@ mod tests {
     #[test]
     fn start_page_rows_empty_groups_yields_empty_rows() {
         let app = App::new();
-        let rows = build_start_page_rows(&app, 80);
+        let rows = build_start_page_rows(&app.sessions, 80);
         assert!(rows.is_empty());
     }
 
@@ -4987,7 +5087,7 @@ mod tests {
     fn start_page_rows_single_expanded_group() {
         let mut app = App::new();
         app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
-        let rows = build_start_page_rows(&app, 80);
+        let rows = build_start_page_rows(&app.sessions, 80);
         assert_eq!(rows.len(), 3);
         assert!(matches!(rows[0].item, StartPageItem::GroupHeader { .. }));
         assert!(matches!(rows[1].item, StartPageItem::Session { .. }));
@@ -5000,7 +5100,7 @@ mod tests {
         let mut app = App::new();
         app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
         app.sessions.collapsed_groups.insert("/a".to_string());
-        let rows = build_start_page_rows(&app, 80);
+        let rows = build_start_page_rows(&app.sessions, 80);
         assert_eq!(rows.len(), 1);
         assert!(matches!(
             rows[0].item,
@@ -5017,7 +5117,7 @@ mod tests {
         let mut app = App::new();
         app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2"])];
         app.sessions.session_cursor = 1; // points at first session row (index 1)
-        let rows = build_start_page_rows(&app, 80);
+        let rows = build_start_page_rows(&app.sessions, 80);
         assert!(!rows[0].selected); // header not selected
         assert!(rows[1].selected); // first session selected
         assert!(!rows[2].selected);
@@ -5028,7 +5128,7 @@ mod tests {
     fn start_page_rows_header_contains_cwd() {
         let mut app = App::new();
         app.sessions.session_groups = vec![make_group(Some("/home/user/proj"), &["s1"])];
-        let rows = build_start_page_rows(&app, 80);
+        let rows = build_start_page_rows(&app.sessions, 80);
         // The header line should contain the cwd somewhere in its text
         let header_text = rows[0]
             .line
@@ -5047,7 +5147,7 @@ mod tests {
         let mut app = App::new();
         app.sessions.session_groups = vec![make_group(Some("/home/user/proj"), &["s1", "s2"])];
         app.sessions.session_groups[0].total_count = Some(5);
-        let rows = build_start_page_rows(&app, 80);
+        let rows = build_start_page_rows(&app.sessions, 80);
         let header_text = row_text(&rows[0]);
 
         assert!(header_text.contains("(2/5)"), "header text: {header_text}");
@@ -5058,7 +5158,7 @@ mod tests {
         let mut app = App::new();
         app.sessions.session_groups = vec![make_group(Some("/home/user/proj"), &["s1", "s2"])];
         app.sessions.session_groups[0].total_count = None;
-        let rows = build_start_page_rows(&app, 80);
+        let rows = build_start_page_rows(&app.sessions, 80);
         let header_text = row_text(&rows[0]);
 
         assert!(header_text.contains("(2)"), "header text: {header_text}");
@@ -5070,7 +5170,7 @@ mod tests {
     fn start_page_rows_session_contains_id() {
         let mut app = App::new();
         app.sessions.session_groups = vec![make_group(Some("/a"), &["abcdef12"])];
-        let rows = build_start_page_rows(&app, 80);
+        let rows = build_start_page_rows(&app.sessions, 80);
         let session_text = rows[1]
             .line
             .spans
@@ -5089,7 +5189,7 @@ mod tests {
         app.sessions.session_groups = vec![make_group(Some("/a"), &["abcdef12"])];
         app.sessions.session_groups[0].sessions[0].fork_count = 3;
 
-        let rows = build_start_page_rows(&app, 80);
+        let rows = build_start_page_rows(&app.sessions, 80);
         let session_text = row_text(&rows[1]);
 
         assert!(
@@ -5119,7 +5219,7 @@ mod tests {
         let mut app = App::new();
         app.sessions.session_groups = vec![make_group(Some("/a"), &["abcdef12"])];
 
-        let rows = build_start_page_rows(&app, 80);
+        let rows = build_start_page_rows(&app.sessions, 80);
         let session_text = row_text(&rows[1]);
 
         assert!(
@@ -5134,7 +5234,7 @@ mod tests {
         let mut app = App::new();
         app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
         app.sessions.collapsed_groups.insert("/a".to_string());
-        let rows = build_start_page_rows(&app, 80);
+        let rows = build_start_page_rows(&app.sessions, 80);
         let text = rows[0]
             .line
             .spans
@@ -5153,7 +5253,7 @@ mod tests {
         let mut app = App::new();
         app.sessions.session_groups = vec![make_group(Some("/a"), &["s1"])];
         // not collapsed
-        let rows = build_start_page_rows(&app, 80);
+        let rows = build_start_page_rows(&app.sessions, 80);
         let text = rows[0]
             .line
             .spans
@@ -5170,7 +5270,7 @@ mod tests {
     fn start_page_show_more_row_uses_show_all_label_not_load_more() {
         let mut app = App::new();
         app.sessions.session_groups = vec![make_group(Some("/a"), &["s1", "s2", "s3", "s4"])];
-        let rows = build_start_page_rows(&app, 80);
+        let rows = build_start_page_rows(&app.sessions, 80);
         let text = row_text(rows.last().expect("missing show more row"));
 
         assert!(text.contains("show all"), "row text: {text}");
@@ -5182,7 +5282,7 @@ mod tests {
     #[test]
     fn start_page_rows_no_sessions_yields_empty_state_row() {
         let app = App::new();
-        let rows = build_start_page_rows(&app, 80);
+        let rows = build_start_page_rows(&app.sessions, 80);
         assert!(
             rows.is_empty(),
             "no groups means no rows (empty state handled in draw_start)"

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -245,7 +245,10 @@ mod tests {
     };
     use crate::domain::model::ModelEntry;
     use crate::domain::session::{SessionGroup, SessionSummary};
-    use crate::domain::tool::{DiffPreviewSection, ShellOutputTail, ToolDetail};
+    use crate::domain::tool::{
+        IndexMetadata, MultiEditSection, SearchResultCounts, ShellOutput, SymbolDiffSection,
+        SymbolReplacement, TodoItem, ToolDetail,
+    };
     use ratatui::backend::Backend;
     use ratatui::layout::Position;
     use ratatui::widgets::ListItem;
@@ -283,7 +286,10 @@ mod tests {
             tool_call_id: Some(id.into()),
             name: "delegate".into(),
             is_error: false,
-            detail: ToolDetail::Summary(format!("({agent}) {objective}")),
+            detail: ToolDetail::Delegate {
+                target_agent_id: agent.into(),
+                objective: objective.into(),
+            },
         }
     }
 
@@ -1167,7 +1173,10 @@ mod tests {
             tool_call_id: None,
             name: "delegate".into(),
             is_error: false,
-            detail: ToolDetail::Summary("(coder) Fix the bug".into()),
+            detail: ToolDetail::Delegate {
+                target_agent_id: "coder".into(),
+                objective: "Fix the bug".into(),
+            },
         });
         app.delegates.delegate_entries.push(DelegateEntry {
             delegation_id: "del-1".into(),
@@ -1207,9 +1216,14 @@ mod tests {
             tool_call_id: None,
             name: "index".into(),
             is_error: false,
-            detail: ToolDetail::Summary(
-                "src/(generated)/main.rs (rust, 2 imports, 1 functions)".into(),
-            ),
+            detail: ToolDetail::Index {
+                path: "src/(generated)/main.rs".into(),
+                metadata: Some(IndexMetadata {
+                    language: "rust".into(),
+                    imports: 2,
+                    functions: 1,
+                }),
+            },
         });
 
         let cards = build_message_cards(&mut app);
@@ -1235,7 +1249,15 @@ mod tests {
             tool_call_id: None,
             name: "search_text".into(),
             is_error: false,
-            detail: ToolDetail::Summary("\"needle\" *.rs (5 files, 28 matches)".into()),
+            detail: ToolDetail::SearchText {
+                pattern: "needle".into(),
+                path: String::new(),
+                include: "*.rs".into(),
+                counts: Some(SearchResultCounts {
+                    files: 5,
+                    matches: 28,
+                }),
+            },
         });
 
         let cards = build_message_cards(&mut app);
@@ -1307,21 +1329,34 @@ mod tests {
                 tool_call_id: None,
                 name: "browse".into(),
                 is_error: false,
-                detail: ToolDetail::Summary("https://例.test/文档…".into()),
+                detail: ToolDetail::Browse {
+                    url: "https://例.test/文档…".into(),
+                },
             },
             ChatEntry::ToolCall {
                 tool_call_id: None,
                 name: "todowrite".into(),
                 is_error: false,
-                detail: ToolDetail::Summary("[x] done\n[ ] next".into()),
+                detail: ToolDetail::Todo {
+                    items: vec![
+                        TodoItem {
+                            content: "done".into(),
+                            status: "completed".into(),
+                        },
+                        TodoItem {
+                            content: "next".into(),
+                            status: "pending".into(),
+                        },
+                    ],
+                },
             },
             ChatEntry::ToolCall {
                 tool_call_id: None,
                 name: "inspect".into(),
                 is_error: false,
-                detail: ToolDetail::SummaryWithOutput {
-                    header: "src/lib.rs".into(),
-                    output: "language: rust\nsymbols: 3".into(),
+                detail: ToolDetail::Generic {
+                    input: Some("src/lib.rs".into()),
+                    result: Some("language: rust\nsymbols: 3".into()),
                 },
             },
             ChatEntry::ToolCall {
@@ -1372,6 +1407,40 @@ mod tests {
     }
 
     #[test]
+    fn tool_summary_utf8_truncation_is_render_owned_and_char_safe() {
+        let browse_url = format!("https://example.test/{}tail", "界".repeat(50));
+        let objective = format!("{}tail", "界".repeat(50));
+        let expected_url = format!("{}…", browse_url.chars().take(59).collect::<String>());
+        let expected_objective = format!("{}…", objective.chars().take(49).collect::<String>());
+        let mut app = App::new();
+        app.chat.messages.extend([
+            ChatEntry::ToolCall {
+                tool_call_id: None,
+                name: "browse".into(),
+                is_error: false,
+                detail: ToolDetail::Browse { url: browse_url },
+            },
+            ChatEntry::ToolCall {
+                tool_call_id: None,
+                name: "delegate".into(),
+                is_error: false,
+                detail: ToolDetail::Delegate {
+                    target_agent_id: String::new(),
+                    objective,
+                },
+            },
+        ]);
+
+        assert_eq!(
+            rendered_card_lines(&mut app),
+            [
+                format!("> browse {expected_url}"),
+                format!("> delegate {expected_objective}"),
+            ]
+        );
+    }
+
+    #[test]
     fn delegate_tool_call_shows_awaiting_input_marker() {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
@@ -1380,7 +1449,10 @@ mod tests {
             tool_call_id: None,
             name: "delegate".into(),
             is_error: false,
-            detail: ToolDetail::Summary("(coder) Fix the bug".into()),
+            detail: ToolDetail::Delegate {
+                target_agent_id: "coder".into(),
+                objective: "Fix the bug".into(),
+            },
         });
         app.delegates.delegate_entries.push(DelegateEntry {
             delegation_id: "del-1".into(),
@@ -3015,10 +3087,12 @@ mod tests {
             is_error: false,
             detail: ToolDetail::Shell {
                 command: "printf '界界界 wide output'".into(),
+                arguments: Vec::new(),
                 workdir: Some("/repo/工作".into()),
-                output_tail: Some(ShellOutputTail {
-                    lines: vec!["第一行".into(), "last line".into()],
-                    hidden_line_count: 3,
+                output: Some(ShellOutput {
+                    stdout: "第一行\nlast line".into(),
+                    stderr: String::new(),
+                    preceding_line_count: 3,
                 }),
             },
         });
@@ -3032,6 +3106,7 @@ mod tests {
                 file: "src/lib.rs".into(),
                 old: "before 界\n".into(),
                 new: "after 界\n".into(),
+                replace_all: false,
                 start_line: Some(99),
             },
         });
@@ -3324,6 +3399,7 @@ mod tests {
                 file: "f.rs".into(),
                 old: old.into(),
                 new: new.into(),
+                replace_all: false,
                 start_line: Some(41),
             },
         });
@@ -3369,12 +3445,9 @@ mod tests {
     fn message_cards_multiedit_tool_includes_sectioned_diff_lines() {
         let mut app = App::new();
         let sections = (1..=8)
-            .map(|index| DiffPreviewSection {
-                header: if index == 1 {
-                    "edit 1 (all)".into()
-                } else {
-                    format!("edit {index}")
-                },
+            .map(|index| MultiEditSection {
+                edit_index: index,
+                replace_all: index == 1,
                 old: format!("old {index}\n"),
                 new: format!("new {index}\n"),
                 start_line: Some(index * 10),
@@ -3441,8 +3514,9 @@ mod tests {
     fn message_cards_replace_symbol_tool_includes_symbol_diff_lines() {
         let mut app = App::new();
         let sections = (1..=6)
-            .map(|index| DiffPreviewSection {
-                header: if index == 1 {
+            .map(|index| SymbolDiffSection {
+                path: "src/ui/chat.rs".into(),
+                symbol: if index == 1 {
                     "build_message_cards".into()
                 } else {
                     format!("symbol_{index}")
@@ -3456,8 +3530,8 @@ mod tests {
             tool_call_id: None,
             name: "replace_symbol".into(),
             is_error: false,
-            detail: ToolDetail::ReplaceSymbol {
-                title: "src/ui/chat.rs build_message_cards".into(),
+            detail: ToolDetail::ReplaceSymbolDiff {
+                replacements: Vec::new(),
                 sections,
             },
         });
@@ -3513,16 +3587,95 @@ mod tests {
     }
 
     #[test]
+    fn replace_symbol_titles_are_derived_from_semantic_paths() {
+        let cases = [
+            (Vec::new(), "symbols"),
+            (
+                vec![SymbolReplacement {
+                    path: String::new(),
+                    symbol: "missing".into(),
+                    new_text: "fn missing() {}".into(),
+                }],
+                "symbols",
+            ),
+            (
+                vec![SymbolReplacement {
+                    path: "/workspace/project/src/nested/lib.rs".into(),
+                    symbol: "run".into(),
+                    new_text: "fn run() {}".into(),
+                }],
+                "nested/lib.rs",
+            ),
+            (
+                vec![
+                    SymbolReplacement {
+                        path: "/workspace/project/src/nested/lib.rs".into(),
+                        symbol: "run".into(),
+                        new_text: "fn run() {}".into(),
+                    },
+                    SymbolReplacement {
+                        path: "/workspace/project/src/nested/lib.rs".into(),
+                        symbol: "stop".into(),
+                        new_text: "fn stop() {}".into(),
+                    },
+                ],
+                "nested/lib.rs",
+            ),
+            (
+                vec![
+                    SymbolReplacement {
+                        path: "/workspace/project/src/one.rs".into(),
+                        symbol: "one".into(),
+                        new_text: "fn one() {}".into(),
+                    },
+                    SymbolReplacement {
+                        path: "/workspace/project/src/two.rs".into(),
+                        symbol: "two".into(),
+                        new_text: "fn two() {}".into(),
+                    },
+                ],
+                "src/one.rs (+1)",
+            ),
+        ];
+
+        for (replacements, expected_title) in cases {
+            let mut app = App::new();
+            app.sessions.session_id = Some("session-1".into());
+            app.sessions.session_groups = vec![SessionGroup {
+                cwd: Some("/workspace/project".into()),
+                sessions: vec![SessionSummary {
+                    session_id: "session-1".into(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }];
+            app.chat.messages.push(ChatEntry::ToolCall {
+                tool_call_id: None,
+                name: "replace_symbol".into(),
+                is_error: false,
+                detail: ToolDetail::ReplaceSymbolInput { replacements },
+            });
+
+            assert_eq!(
+                rendered_card_lines(&mut app),
+                [format!("> replace_symbol {expected_title}")]
+            );
+        }
+    }
+
+    #[test]
     fn message_cards_shell_tool_shows_command_and_last_output_lines() {
         let mut app = App::new();
         let command = "cargo \\\ntest \\\n--lib";
-        let output_tail = ShellOutputTail {
-            lines: vec![
-                "running 1 test".into(),
-                "test ui::tests::shell ... ok".into(),
-                "test result: ok".into(),
-            ],
-            hidden_line_count: 12,
+        let output = ShellOutput {
+            stdout: [
+                "running 1 test",
+                "test ui::tests::shell ... ok",
+                "test result: ok",
+            ]
+            .join("\n"),
+            stderr: String::new(),
+            preceding_line_count: 12,
         };
         app.chat.messages.push(ChatEntry::ToolCall {
             tool_call_id: None,
@@ -3530,8 +3683,9 @@ mod tests {
             is_error: false,
             detail: ToolDetail::Shell {
                 command: command.into(),
+                arguments: Vec::new(),
                 workdir: Some("/repo".into()),
-                output_tail: Some(output_tail),
+                output: Some(output),
             },
         });
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -239,7 +239,7 @@ mod tests {
     use crate::domain::auth::{
         AuthProviderEntry, OAuthFlow, OAuthFlowKind, OAuthResult, OAuthResultStatus, OAuthStatus,
     };
-    use crate::domain::chat::ChatEntry;
+    use crate::domain::chat::{ChatEntry, ElicitationResponseOutcome};
     use crate::domain::elicitation::{
         ElicitationField, ElicitationFieldKind, ElicitationOption, ElicitationState,
     };
@@ -1707,7 +1707,7 @@ mod tests {
         let rendered = buffer_text(&buffer);
 
         assert!(
-            rendered.contains("Question"),
+            rendered.contains("\u{25B8} Question"),
             "missing popup title: {rendered}"
         );
         assert!(
@@ -2508,6 +2508,106 @@ mod tests {
         assert_eq!(app.render.card_cache.processed_messages, 0);
     }
 
+    fn elicitation_card_snapshot(
+        outcome: Option<ElicitationResponseOutcome>,
+    ) -> Vec<(String, ratatui::style::Style)> {
+        let mut app = App::new();
+        app.chat.messages.push(ChatEntry::Elicitation {
+            elicitation_id: "elic-1".into(),
+            message: "Choose".into(),
+            source: "builtin:question".into(),
+            outcome,
+        });
+        let cards = build_message_cards(&mut app);
+        assert_eq!(cards.len(), 1);
+        assert_eq!(cards[0].kind, CardKind::Elicitation);
+        cards[0]
+            .lines_for(120)
+            .iter()
+            .map(|line| {
+                (
+                    line.spans
+                        .iter()
+                        .map(|span| span.content.as_ref())
+                        .collect(),
+                    line.spans.first().expect("elicitation line span").style,
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn elicitation_cards_render_every_semantic_outcome_exactly() {
+        let cases = [
+            (
+                None,
+                vec![("  waiting for response\u{2026}", Theme::thinking())],
+            ),
+            (
+                Some(ElicitationResponseOutcome::Selected(vec![
+                    "Alpha".into(),
+                    "custom\nanswer".into(),
+                    "Beta".into(),
+                ])),
+                vec![
+                    ("  \u{25B8} Alpha", Theme::info_text()),
+                    ("  \u{25B8} custom", Theme::info_text()),
+                    ("  answer", Theme::info_text()),
+                    ("  \u{25B8} Beta", Theme::info_text()),
+                ],
+            ),
+            (
+                Some(ElicitationResponseOutcome::Text(
+                    "line one\nline two".into(),
+                )),
+                vec![
+                    ("  line one", Theme::info_text()),
+                    ("  line two", Theme::info_text()),
+                ],
+            ),
+            (
+                Some(ElicitationResponseOutcome::Boolean(true)),
+                vec![("  Yes", Theme::info_text())],
+            ),
+            (
+                Some(ElicitationResponseOutcome::Boolean(false)),
+                vec![("  No", Theme::info_text())],
+            ),
+            (
+                Some(ElicitationResponseOutcome::Declined),
+                vec![("  declined", Theme::status())],
+            ),
+            (
+                Some(ElicitationResponseOutcome::Cancelled),
+                vec![("  cancelled", Theme::status())],
+            ),
+            (
+                Some(ElicitationResponseOutcome::UnsupportedSchema),
+                vec![(
+                    "  unsupported schema - cannot answer in TUI",
+                    Theme::info_text(),
+                )],
+            ),
+            (
+                Some(ElicitationResponseOutcome::Responded),
+                vec![("  responded", Theme::info_text())],
+            ),
+        ];
+
+        for (outcome, expected_outcome) in cases {
+            let snapshot = elicitation_card_snapshot(outcome);
+            assert_eq!(
+                snapshot.first(),
+                Some(&("[?] Choose".into(), Theme::status_accent()))
+            );
+            let expected: Vec<(String, ratatui::style::Style)> = expected_outcome
+                .into_iter()
+                .map(|(text, style)| (text.into(), style))
+                .collect();
+            assert_eq!(&snapshot[1..], expected, "unexpected outcome rendering");
+        }
+    }
+
     #[test]
     fn message_cards_single_user() {
         let mut app = App::new();
@@ -3204,7 +3304,7 @@ mod tests {
             elicitation_id: "elic-1".into(),
             message: "Need approval".into(),
             source: "builtin:question".into(),
-            outcome: Some("responded".into()),
+            outcome: Some(ElicitationResponseOutcome::Responded),
         });
         replay_session(
             &mut app,
@@ -3218,9 +3318,13 @@ mod tests {
             }],
         );
         assert!(app.chat.elicitation.is_none());
-        assert!(
-            matches!(app.chat.messages.as_slice(), [ChatEntry::Elicitation { outcome: Some(outcome), .. }] if outcome == "responded")
-        );
+        assert!(matches!(
+            app.chat.messages.as_slice(),
+            [ChatEntry::Elicitation {
+                outcome: Some(ElicitationResponseOutcome::Responded),
+                ..
+            }]
+        ));
     }
 
     #[test]
@@ -3293,7 +3397,7 @@ mod tests {
         );
         assert!(app.chat.elicitation.is_none());
         assert!(
-            matches!(app.chat.messages.as_slice(), [ChatEntry::Elicitation { elicitation_id, outcome: Some(outcome), .. }] if elicitation_id == "elic-1" && outcome == "unsupported schema - cannot answer in TUI")
+            matches!(app.chat.messages.as_slice(), [ChatEntry::Elicitation { elicitation_id, outcome: Some(ElicitationResponseOutcome::UnsupportedSchema), .. }] if elicitation_id == "elic-1")
         );
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1463,6 +1463,56 @@ mod tests {
                     end_line: Some(9),
                 },
             },
+            ChatEntry::ToolCall {
+                tool_call_id: None,
+                name: "glob".into(),
+                is_error: false,
+                detail: ToolDetail::Glob {
+                    pattern: "*.rs".into(),
+                    path: "project/src".into(),
+                },
+            },
+            ChatEntry::ToolCall {
+                tool_call_id: None,
+                name: "ls".into(),
+                is_error: false,
+                detail: ToolDetail::List {
+                    path: "project/src".into(),
+                },
+            },
+            ChatEntry::ToolCall {
+                tool_call_id: None,
+                name: "delete_file".into(),
+                is_error: false,
+                detail: ToolDetail::DeleteFile {
+                    path: "tmp/out.txt".into(),
+                },
+            },
+            ChatEntry::ToolCall {
+                tool_call_id: None,
+                name: "language_query".into(),
+                is_error: false,
+                detail: ToolDetail::LanguageQuery {
+                    action: "definition".into(),
+                    uri: "src/lib.rs".into(),
+                },
+            },
+            ChatEntry::ToolCall {
+                tool_call_id: None,
+                name: "question".into(),
+                is_error: false,
+                detail: ToolDetail::Question {
+                    prompt: "Which option?".into(),
+                },
+            },
+            ChatEntry::ToolCall {
+                tool_call_id: None,
+                name: "apply_patch".into(),
+                is_error: false,
+                detail: ToolDetail::ApplyPatch {
+                    patch: "*** Begin Patch\n*** End Patch".into(),
+                },
+            },
         ]);
 
         let cards = build_message_cards(&mut app);
@@ -1489,15 +1539,25 @@ mod tests {
                 "  language: rust",
                 "  symbols: 3",
                 "> read_tool src/lib.rs:7-9",
+                "> glob *.rs in project/src",
+                "> ls project/src",
+                "> delete_file tmp/out.txt",
+                "> language_query definition src/lib.rs",
+                "> question asking...",
+                "> apply_patch patch",
             ]
         );
+        assert_eq!(cards[0].kind, CardKind::Tool { compact: false });
         assert_eq!(lines[1].spans[1].style.fg, Theme::diff_file().fg);
         assert_eq!(lines[3].spans[0].style.fg, Theme::diff_file().fg);
         assert_eq!(lines[5].spans[1].style.fg, Theme::diff_file().fg);
         assert_eq!(lines[6].spans[0].style.fg, Theme::tool_output().fg);
         assert_eq!(lines[8].spans[3].style.fg, Theme::status_accent().fg);
+        for line in &lines[9..=14] {
+            assert_eq!(line.spans[1].style.fg, Theme::diff_file().fg);
+        }
         drop(lines);
-        assert_eq!(cards[0].height(20), 13, "narrow Unicode rows must wrap");
+        assert_eq!(cards[0].height(20), 25, "narrow Unicode rows must wrap");
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -304,6 +304,25 @@ mod tests {
             .collect()
     }
 
+    fn rendered_card_snapshot(app: &mut App, width: u16) -> Vec<(CardKind, Vec<String>, u16)> {
+        build_message_cards(app)
+            .iter()
+            .map(|card| {
+                let lines = card
+                    .lines_for(width.saturating_sub(4))
+                    .iter()
+                    .map(|line| {
+                        line.spans
+                            .iter()
+                            .map(|span| span.content.as_ref())
+                            .collect::<String>()
+                    })
+                    .collect();
+                (card.kind.clone(), lines, card.height(width))
+            })
+            .collect()
+    }
+
     fn render_chat_buffer(app: &mut App, width: u16, height: u16) -> ratatui::buffer::Buffer {
         let backend = ratatui::backend::TestBackend::new(width, height);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
@@ -1275,6 +1294,84 @@ mod tests {
     }
 
     #[test]
+    fn summary_tool_detail_families_preserve_exact_visible_lines_and_styles() {
+        let mut app = App::new();
+        app.chat.messages.extend([
+            ChatEntry::ToolCall {
+                tool_call_id: None,
+                name: "mystery".into(),
+                is_error: false,
+                detail: ToolDetail::None,
+            },
+            ChatEntry::ToolCall {
+                tool_call_id: None,
+                name: "browse".into(),
+                is_error: false,
+                detail: ToolDetail::Summary("https://例.test/文档…".into()),
+            },
+            ChatEntry::ToolCall {
+                tool_call_id: None,
+                name: "todowrite".into(),
+                is_error: false,
+                detail: ToolDetail::Summary("[x] done\n[ ] next".into()),
+            },
+            ChatEntry::ToolCall {
+                tool_call_id: None,
+                name: "inspect".into(),
+                is_error: false,
+                detail: ToolDetail::SummaryWithOutput {
+                    header: "src/lib.rs".into(),
+                    output: "language: rust\nsymbols: 3".into(),
+                },
+            },
+            ChatEntry::ToolCall {
+                tool_call_id: None,
+                name: "read_tool".into(),
+                is_error: false,
+                detail: ToolDetail::ReadTool {
+                    path: "/workspace/project/src/lib.rs".into(),
+                    start_line: Some(7),
+                    end_line: Some(9),
+                },
+            },
+        ]);
+
+        let cards = build_message_cards(&mut app);
+        assert_eq!(cards.len(), 1);
+        let lines = cards[0].lines_for(120);
+        let visible_lines = lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            visible_lines,
+            [
+                "> mystery",
+                "> browse https://例.test/文档…",
+                "> todowrite",
+                "  [x] done",
+                "  [ ] next",
+                "> inspect src/lib.rs",
+                "  language: rust",
+                "  symbols: 3",
+                "> read_tool src/lib.rs:7-9",
+            ]
+        );
+        assert_eq!(lines[1].spans[1].style.fg, Theme::diff_file().fg);
+        assert_eq!(lines[3].spans[0].style.fg, Theme::diff_file().fg);
+        assert_eq!(lines[5].spans[1].style.fg, Theme::diff_file().fg);
+        assert_eq!(lines[6].spans[0].style.fg, Theme::tool_output().fg);
+        assert_eq!(lines[8].spans[3].style.fg, Theme::status_accent().fg);
+        drop(lines);
+        assert_eq!(cards[0].height(20), 13, "narrow Unicode rows must wrap");
+    }
+
+    #[test]
     fn delegate_tool_call_shows_awaiting_input_marker() {
         let mut app = App::new();
         app.navigation.screen = Screen::Chat;
@@ -1302,6 +1399,9 @@ mod tests {
                 source: "builtin:question".into(),
             },
         });
+
+        let lines = rendered_card_lines(&mut app);
+        assert_eq!(lines, ["> delegate (coder:45s) awaiting input Fix the bug"]);
 
         let buffer = render_chat_buffer(&mut app, 90, 10);
         let rendered: String = buffer.content().iter().map(|c| c.symbol()).collect();
@@ -2651,7 +2751,14 @@ mod tests {
             app.render.card_cache.processed_messages, 0,
             "cache must invalidate"
         );
-        let lines = rendered_card_lines(&mut app);
+        let rebuilt_from_warm_update = rendered_card_snapshot(&mut app, 80);
+        app.render.card_cache.invalidate();
+        let cold_full_rebuild = rendered_card_snapshot(&mut app, 80);
+        assert_eq!(rebuilt_from_warm_update, cold_full_rebuild);
+        let lines = rebuilt_from_warm_update
+            .iter()
+            .flat_map(|(_, lines, _)| lines)
+            .collect::<Vec<_>>();
         assert!(lines.iter().any(|line| line.contains("x shell")));
         assert!(!lines.iter().any(|line| line.contains("shell (failed)")));
         assert!(matches!(app.chat.messages[1], ChatEntry::Assistant { .. }));
@@ -2699,7 +2806,11 @@ mod tests {
             app.render.card_cache.processed_messages, 0,
             "semantic update should invalidate the warm card"
         );
-        let rebuilt_lines = rendered_card_lines(&mut app);
+        let rebuilt_from_warm_update = rendered_card_snapshot(&mut app, 80);
+        app.render.card_cache.invalidate();
+        let cold_full_rebuild = rendered_card_snapshot(&mut app, 80);
+        assert_eq!(rebuilt_from_warm_update, cold_full_rebuild);
+        let rebuilt_lines = &rebuilt_from_warm_update[0].1;
         assert!(
             rebuilt_lines
                 .iter()
@@ -2762,12 +2873,78 @@ mod tests {
             app.render.card_cache.processed_messages, 0,
             "semantic update should invalidate the warm card"
         );
-        let rebuilt_lines = rendered_card_lines(&mut app);
+        let rebuilt_from_warm_update = rendered_card_snapshot(&mut app, 80);
+        app.render.card_cache.invalidate();
+        let cold_full_rebuild = rendered_card_snapshot(&mut app, 80);
+        assert_eq!(rebuilt_from_warm_update, cold_full_rebuild);
+        let rebuilt_lines = &rebuilt_from_warm_update[0].1;
         assert!(
             rebuilt_lines
                 .iter()
                 .any(|line| line.contains("  42 ") && line.contains("- before")),
             "rebuilt card returned stale edit detail: {rebuilt_lines:?}"
+        );
+    }
+
+    #[test]
+    fn warm_tool_detail_update_matches_cold_full_rebuild() {
+        let mut app = App::new();
+        app.sessions.session_id = Some("test-session".into());
+        live_update(
+            &mut app,
+            "test-session",
+            AcpSessionUpdate::ToolCallStart {
+                tool_call_id: Some("shell-parity".into()),
+                name: "shell".into(),
+                arguments: Some(serde_json::json!({
+                    "command": "printf",
+                    "args": ["界 output"],
+                    "workdir": "/repo/工作",
+                })),
+            },
+        );
+        let warm_start = rendered_card_snapshot(&mut app, 34);
+        assert!(
+            warm_start[0]
+                .1
+                .iter()
+                .any(|line| line.contains("$ printf '界 output'"))
+        );
+
+        live_update(
+            &mut app,
+            "test-session",
+            AcpSessionUpdate::ToolCallEnd {
+                tool_call_id: Some("shell-parity".into()),
+                name: "shell".into(),
+                is_error: false,
+                result: Some(
+                    serde_json::json!({
+                        "stdout": "one\ntwo\nthree\nfour\nfive\nsix\n",
+                        "stderr": "错误\n",
+                    })
+                    .to_string(),
+                ),
+            },
+        );
+        assert_eq!(app.render.card_cache.processed_messages, 0);
+
+        let rebuilt_from_warm_update = rendered_card_snapshot(&mut app, 34);
+        app.render.card_cache.invalidate();
+        let cold_full_rebuild = rendered_card_snapshot(&mut app, 34);
+
+        assert_eq!(rebuilt_from_warm_update, cold_full_rebuild);
+        assert!(
+            rebuilt_from_warm_update[0]
+                .1
+                .iter()
+                .any(|line| line == "  ... 2 earlier output lines hidden")
+        );
+        assert!(
+            rebuilt_from_warm_update[0]
+                .1
+                .iter()
+                .any(|line| line == "    错误")
         );
     }
 
@@ -2799,7 +2976,16 @@ mod tests {
             failed_tool_end("tool-out-of-order", "shell"),
         );
 
-        let lines = rendered_card_lines(&mut app);
+        let warm_reconciled = rendered_card_snapshot(&mut app, 42);
+        app.render.card_cache.invalidate();
+        let cold_full_rebuild = rendered_card_snapshot(&mut app, 42);
+        assert_eq!(warm_reconciled, cold_full_rebuild);
+
+        let lines = warm_reconciled
+            .iter()
+            .flat_map(|(_, lines, _)| lines)
+            .cloned()
+            .collect::<Vec<_>>();
         assert!(lines.iter().any(|line| line.contains("x shell")));
         assert!(lines.iter().any(|line| line.contains("$ echo replay")));
         assert!(!lines.iter().any(|line| line.contains("shell (failed)")));
@@ -2810,40 +2996,73 @@ mod tests {
     fn message_cards_incremental_matches_full_rebuild() {
         let mut app = App::new();
 
-        // Build incrementally
         app.chat.messages.push(ChatEntry::User {
             text: "q1".into(),
             message_id: None,
         });
-        build_message_cards(&mut app);
+        rendered_card_snapshot(&mut app, 42);
 
         app.chat.messages.push(ChatEntry::Assistant {
             content: "a1".into(),
             thinking: None,
             message_id: None,
         });
-        build_message_cards(&mut app);
+        rendered_card_snapshot(&mut app, 42);
 
-        app.chat.messages.push(tool_call("edit"));
-        build_message_cards(&mut app);
+        app.chat.messages.push(ChatEntry::ToolCall {
+            tool_call_id: Some("shell-1".into()),
+            name: "shell".into(),
+            is_error: false,
+            detail: ToolDetail::Shell {
+                command: "printf '界界界 wide output'".into(),
+                workdir: Some("/repo/工作".into()),
+                output_tail: Some(ShellOutputTail {
+                    lines: vec!["第一行".into(), "last line".into()],
+                    hidden_line_count: 3,
+                }),
+            },
+        });
+        rendered_card_snapshot(&mut app, 42);
+
+        app.chat.messages.push(ChatEntry::ToolCall {
+            tool_call_id: Some("edit-1".into()),
+            name: "edit".into(),
+            is_error: false,
+            detail: ToolDetail::Edit {
+                file: "src/lib.rs".into(),
+                old: "before 界\n".into(),
+                new: "after 界\n".into(),
+                start_line: Some(99),
+            },
+        });
+        rendered_card_snapshot(&mut app, 42);
 
         app.chat.messages.push(ChatEntry::User {
             text: "q2".into(),
             message_id: None,
         });
-        let incremental_kinds: Vec<_> = {
-            let cards = build_message_cards(&mut app);
-            cards.iter().map(|c| c.kind.clone()).collect()
-        };
+        let incremental = rendered_card_snapshot(&mut app, 42);
 
-        // Full rebuild from scratch
         app.render.card_cache.invalidate();
-        let full_kinds: Vec<_> = {
-            let cards = build_message_cards(&mut app);
-            cards.iter().map(|c| c.kind.clone()).collect()
-        };
+        let cold_full_rebuild = rendered_card_snapshot(&mut app, 42);
 
-        assert_eq!(incremental_kinds, full_kinds);
+        assert_eq!(incremental, cold_full_rebuild);
+        let all_visible_lines = incremental
+            .iter()
+            .flat_map(|(_, lines, _)| lines)
+            .cloned()
+            .collect::<Vec<_>>();
+        assert!(
+            all_visible_lines
+                .iter()
+                .any(|line| line == "> shell@/repo/工作")
+        );
+        assert!(all_visible_lines.iter().any(|line| line.contains("第一行")));
+        assert!(
+            all_visible_lines
+                .iter()
+                .any(|line| line.contains("99 - before 界"))
+        );
     }
 
     #[test]
@@ -3105,57 +3324,62 @@ mod tests {
                 file: "f.rs".into(),
                 old: old.into(),
                 new: new.into(),
-                start_line: Some(1),
+                start_line: Some(41),
             },
         });
 
-        let cards = build_message_cards(&mut app);
-        assert_eq!(cards.len(), 1);
-        // header line + diff lines (at least equal + changed = 2 original lines)
-        assert!(
-            cards[0].lines_for(80).len() > 1,
-            "tool card should include header + diff lines, got {} lines",
-            cards[0].lines_for(80).len()
+        let snapshot = rendered_card_snapshot(&mut app, 80);
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot[0].0, CardKind::Tool { compact: false });
+        assert_eq!(
+            snapshot[0].1,
+            ["> edit f.rs", "  41   aaa", "  42 - bbb", "  42 + ccc",]
         );
+        assert_eq!(snapshot[0].2, 5);
     }
 
     #[test]
     fn message_cards_write_tool_includes_content_lines() {
         let mut app = App::new();
-        let content = "fn main() {}\n";
+        let content = (1..=22)
+            .map(|line| format!("line {line} 界"))
+            .collect::<Vec<_>>()
+            .join("\n");
         app.chat.messages.push(ChatEntry::ToolCall {
             tool_call_id: None,
             name: "write_file".into(),
             is_error: false,
             detail: ToolDetail::WriteFile {
-                path: "out.rs".into(),
-                content: content.into(),
+                path: "/workspace/src/out.rs".into(),
+                content,
             },
         });
 
-        let cards = build_message_cards(&mut app);
-        assert_eq!(cards.len(), 1);
-        // header line + 1 content line
-        assert_eq!(cards[0].lines_for(80).len(), 2);
+        let snapshot = rendered_card_snapshot(&mut app, 80);
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot[0].1.len(), 22);
+        assert_eq!(snapshot[0].1[0], "> write_file src/out.rs");
+        assert_eq!(snapshot[0].1[1], "   1 + line 1 界");
+        assert_eq!(snapshot[0].1[20], "  20 + line 20 界");
+        assert_eq!(snapshot[0].1[21], "       ... (2 more lines)");
+        assert_eq!(snapshot[0].2, 23);
     }
 
     #[test]
     fn message_cards_multiedit_tool_includes_sectioned_diff_lines() {
         let mut app = App::new();
-        let sections = vec![
-            DiffPreviewSection {
-                header: "edit 1".into(),
-                old: "aaa\n".into(),
-                new: "bbb\n".into(),
-                start_line: Some(10),
-            },
-            DiffPreviewSection {
-                header: "edit 2".into(),
-                old: "ccc\n".into(),
-                new: "ddd\n".into(),
-                start_line: Some(20),
-            },
-        ];
+        let sections = (1..=8)
+            .map(|index| DiffPreviewSection {
+                header: if index == 1 {
+                    "edit 1 (all)".into()
+                } else {
+                    format!("edit {index}")
+                },
+                old: format!("old {index}\n"),
+                new: format!("new {index}\n"),
+                start_line: Some(index * 10),
+            })
+            .collect::<Vec<_>>();
         app.chat.messages.push(ChatEntry::ToolCall {
             tool_call_id: None,
             name: "multiedit".into(),
@@ -3185,11 +3409,17 @@ mod tests {
         assert!(
             lines
                 .iter()
-                .any(|line| line.contains("> multiedit src/lib.rs (2 edits)"))
+                .any(|line| line.contains("> multiedit src/lib.rs (8 edits)"))
         );
-        assert!(lines.iter().any(|line| line.contains("@@ edit 1")));
-        assert!(lines.iter().any(|line| line.contains("- aaa")));
-        assert!(lines.iter().any(|line| line.contains("+ bbb")));
+        assert!(lines.iter().any(|line| line.contains("@@ edit 1 (all)")));
+        assert!(lines.iter().any(|line| line.contains("  10 - old 1")));
+        assert!(lines.iter().any(|line| line.contains("  10 + new 1")));
+        assert!(
+            lines
+                .iter()
+                .any(|line| line == "  ... 2 more sections collapsed")
+        );
+        assert!(!lines.iter().any(|line| line.contains("@@ edit 7")));
 
         let section_line = card_lines
             .iter()
@@ -3198,24 +3428,30 @@ mod tests {
                     .iter()
                     .map(|span| span.content.as_ref())
                     .collect::<String>()
-                    .contains("@@ edit 1")
+                    .contains("@@ edit 1 (all)")
             })
             .expect("missing multiedit section header");
         assert_eq!(section_line.spans[0].content, "  @@ ");
         assert_eq!(section_line.spans[0].style.fg, Theme::diff_context().fg);
-        assert_eq!(section_line.spans[1].content, "edit 1");
+        assert_eq!(section_line.spans[1].content, "edit 1 (all)");
         assert_eq!(section_line.spans[1].style.fg, Theme::status_accent().fg);
     }
 
     #[test]
     fn message_cards_replace_symbol_tool_includes_symbol_diff_lines() {
         let mut app = App::new();
-        let sections = vec![DiffPreviewSection {
-            header: "build_message_cards".into(),
-            old: "fn build_message_cards() {\n    old();\n}\n".into(),
-            new: "fn build_message_cards() {\n    new();\n}\n".into(),
-            start_line: Some(211),
-        }];
+        let sections = (1..=6)
+            .map(|index| DiffPreviewSection {
+                header: if index == 1 {
+                    "build_message_cards".into()
+                } else {
+                    format!("symbol_{index}")
+                },
+                old: format!("fn symbol_{index}() {{\n    old();\n}}\n"),
+                new: format!("fn symbol_{index}() {{\n    new();\n}}\n"),
+                start_line: Some(210 + index),
+            })
+            .collect::<Vec<_>>();
         app.chat.messages.push(ChatEntry::ToolCall {
             tool_call_id: None,
             name: "replace_symbol".into(),
@@ -3253,6 +3489,12 @@ mod tests {
         );
         assert!(lines.iter().any(|line| line.contains("-     old();")));
         assert!(lines.iter().any(|line| line.contains("+     new();")));
+        assert!(
+            lines
+                .iter()
+                .any(|line| line == "  ... 2 more sections collapsed")
+        );
+        assert!(!lines.iter().any(|line| line.contains("@@ symbol_5")));
 
         let section_line = card_lines
             .iter()
@@ -3308,16 +3550,20 @@ mod tests {
             })
             .collect();
 
-        assert!(lines.iter().any(|line| line == "> shell@/repo"));
-        assert!(!lines.iter().any(|line| line.contains("cwd:")));
-        assert!(lines.iter().any(|line| line.contains("$ cargo \\")));
-        assert!(lines.iter().any(|line| line.contains("test \\")));
-        assert!(lines.iter().any(|line| line.contains("output tail:")));
-        assert!(lines.iter().any(|line| line.contains("test result: ok")));
-        assert!(
-            lines
-                .iter()
-                .any(|line| line.contains("12 earlier output lines hidden"))
+        assert_eq!(
+            lines,
+            [
+                "> shell@/repo",
+                "  $ cargo \\",
+                "    test \\",
+                "    --lib",
+                "",
+                "  output tail:",
+                "    running 1 test",
+                "    test ui::tests::shell ... ok",
+                "    test result: ok",
+                "  ... 12 earlier output lines hidden",
+            ]
         );
 
         let command_line = card_lines

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -15,7 +15,7 @@ use start::draw_start;
 #[cfg(test)]
 pub(crate) use crate::markdown::{CardBlock, MD_BULLET};
 #[cfg(test)]
-pub(crate) use crate::render_state::{Card, CardKind};
+pub(crate) use crate::render_state::{Card, CardKind, RenderChange};
 #[cfg(test)]
 pub(crate) use chat::{
     ICON_DELEGATES, ICON_MULTI_SESSION, SpinnerKind, build_message_cards,
@@ -2782,7 +2782,8 @@ mod tests {
                 child_state: DelegateChildState::None,
             },
         ];
-        app.render.invalidate_card_cache();
+        app.render
+            .apply_change(RenderChange::FinalizedMessagesChanged);
 
         let lines = rendered_card_lines(&mut app);
         let first = lines
@@ -2863,7 +2864,8 @@ mod tests {
         assert_eq!(app.render.test_card_source_entry_count(), 1);
 
         app.chat.messages.clear();
-        app.render.invalidate_card_cache();
+        app.render
+            .apply_change(RenderChange::FinalizedMessagesChanged);
         let cards = build_message_cards(&mut app);
         assert!(cards.is_empty());
         assert_eq!(app.render.test_card_source_entry_count(), 0);
@@ -2919,7 +2921,8 @@ mod tests {
         let warm = rendered_card_snapshot(&mut app, 80);
         assert_eq!(app.render.test_card_identity(0), prefix_identity);
         assert_ne!(app.render.test_card_identity(1), changed_identity);
-        app.render.invalidate_card_cache();
+        app.render
+            .apply_change(RenderChange::FinalizedMessagesChanged);
         let cold = rendered_card_snapshot(&mut app, 80);
         assert_eq!(warm, cold);
     }
@@ -2957,7 +2960,8 @@ mod tests {
         let warm = rendered_card_snapshot(&mut app, 80);
         assert_eq!(app.render.test_card_identity(0), prefix_identity);
         assert_ne!(app.render.test_card_identity(1), tool_identity);
-        app.render.invalidate_card_cache();
+        app.render
+            .apply_change(RenderChange::FinalizedMessagesChanged);
         let cold = rendered_card_snapshot(&mut app, 80);
         assert_eq!(warm, cold);
     }
@@ -2976,7 +2980,8 @@ mod tests {
         let wide = rendered_card_snapshot(&mut app, 100);
         let warm_narrow = rendered_card_snapshot(&mut app, 30);
         assert_ne!(wide, warm_narrow);
-        app.render.invalidate_card_cache();
+        app.render
+            .apply_change(RenderChange::FinalizedMessagesChanged);
         let cold_narrow = rendered_card_snapshot(&mut app, 30);
         assert_eq!(warm_narrow, cold_narrow);
     }
@@ -3031,7 +3036,8 @@ mod tests {
         let warm = rendered_card_snapshot(&mut app, 80);
         assert_eq!(app.render.test_card_identity(0), prefix_identity);
         assert_ne!(app.render.test_card_identity(1), old_second_identity);
-        app.render.invalidate_card_cache();
+        app.render
+            .apply_change(RenderChange::FinalizedMessagesChanged);
         let cold = rendered_card_snapshot(&mut app, 80);
         assert_eq!(warm, cold);
     }
@@ -3050,7 +3056,8 @@ mod tests {
         app.sessions.session_id = Some("session-b".into());
         let warm = rendered_card_snapshot(&mut app, 80);
         assert_ne!(app.render.test_card_identity(0), old_identity);
-        app.render.invalidate_card_cache();
+        app.render
+            .apply_change(RenderChange::FinalizedMessagesChanged);
         let cold = rendered_card_snapshot(&mut app, 80);
         assert_eq!(warm, cold);
     }
@@ -3153,7 +3160,8 @@ mod tests {
                 CardKind::Tool { compact: true },
             ]
         );
-        app.render.invalidate_card_cache();
+        app.render
+            .apply_change(RenderChange::FinalizedMessagesChanged);
         let cold_visible = rendered_card_snapshot(&mut app, 80);
         assert_eq!(warm_visible, cold_visible);
     }
@@ -3212,7 +3220,8 @@ mod tests {
         };
         assert!(warm.iter().any(|line| line.contains("done")));
         assert_ne!(app.render.test_card_identity(0), duration_identity);
-        app.render.invalidate_card_cache();
+        app.render
+            .apply_change(RenderChange::FinalizedMessagesChanged);
         let cold = {
             let cards = build_message_cards_for_width_at(&mut app, 80, 101);
             cards[0]
@@ -3360,7 +3369,8 @@ mod tests {
             }
 
             let warm = rendered_card_snapshot(&mut app, width);
-            app.render.invalidate_card_cache();
+            app.render
+                .apply_change(RenderChange::FinalizedMessagesChanged);
             let cold = rendered_card_snapshot(&mut app, width);
             assert_eq!(warm, cold, "warm/cold mismatch for {axis}");
         }
@@ -3391,7 +3401,8 @@ mod tests {
         app.connection.launch_cwd = Some("/workspace/two".into());
         let warm = rendered_card_snapshot(&mut app, 80);
         assert_ne!(app.render.test_card_identity(0), old_identity);
-        app.render.invalidate_card_cache();
+        app.render
+            .apply_change(RenderChange::FinalizedMessagesChanged);
         let cold = rendered_card_snapshot(&mut app, 80);
         assert_eq!(warm, cold);
     }
@@ -3429,7 +3440,8 @@ mod tests {
             "cache must invalidate"
         );
         let rebuilt_from_warm_update = rendered_card_snapshot(&mut app, 80);
-        app.render.invalidate_card_cache();
+        app.render
+            .apply_change(RenderChange::FinalizedMessagesChanged);
         let cold_full_rebuild = rendered_card_snapshot(&mut app, 80);
         assert_eq!(rebuilt_from_warm_update, cold_full_rebuild);
         let lines = rebuilt_from_warm_update
@@ -3485,7 +3497,8 @@ mod tests {
             "semantic update should invalidate the warm card"
         );
         let rebuilt_from_warm_update = rendered_card_snapshot(&mut app, 80);
-        app.render.invalidate_card_cache();
+        app.render
+            .apply_change(RenderChange::FinalizedMessagesChanged);
         let cold_full_rebuild = rendered_card_snapshot(&mut app, 80);
         assert_eq!(rebuilt_from_warm_update, cold_full_rebuild);
         let rebuilt_lines = &rebuilt_from_warm_update[0].1;
@@ -3553,7 +3566,8 @@ mod tests {
             "semantic update should invalidate the warm card"
         );
         let rebuilt_from_warm_update = rendered_card_snapshot(&mut app, 80);
-        app.render.invalidate_card_cache();
+        app.render
+            .apply_change(RenderChange::FinalizedMessagesChanged);
         let cold_full_rebuild = rendered_card_snapshot(&mut app, 80);
         assert_eq!(rebuilt_from_warm_update, cold_full_rebuild);
         let rebuilt_lines = &rebuilt_from_warm_update[0].1;
@@ -3609,7 +3623,8 @@ mod tests {
         assert_eq!(app.render.test_card_source_entry_count(), 0);
 
         let rebuilt_from_warm_update = rendered_card_snapshot(&mut app, 34);
-        app.render.invalidate_card_cache();
+        app.render
+            .apply_change(RenderChange::FinalizedMessagesChanged);
         let cold_full_rebuild = rendered_card_snapshot(&mut app, 34);
 
         assert_eq!(rebuilt_from_warm_update, cold_full_rebuild);
@@ -3656,7 +3671,8 @@ mod tests {
         );
 
         let warm_reconciled = rendered_card_snapshot(&mut app, 42);
-        app.render.invalidate_card_cache();
+        app.render
+            .apply_change(RenderChange::FinalizedMessagesChanged);
         let cold_full_rebuild = rendered_card_snapshot(&mut app, 42);
         assert_eq!(warm_reconciled, cold_full_rebuild);
 
@@ -3725,7 +3741,8 @@ mod tests {
         });
         let incremental = rendered_card_snapshot(&mut app, 42);
 
-        app.render.invalidate_card_cache();
+        app.render
+            .apply_change(RenderChange::FinalizedMessagesChanged);
         let cold_full_rebuild = rendered_card_snapshot(&mut app, 42);
 
         assert_eq!(incremental, cold_full_rebuild);
@@ -5067,7 +5084,8 @@ mod tests {
         };
         let incremental_tool_lines = app.render.cards()[0].lines_for(80).len();
 
-        app.render.invalidate_card_cache();
+        app.render
+            .apply_change(RenderChange::FinalizedMessagesChanged);
         let full_kinds: Vec<_> = {
             let cards = build_message_cards(&mut app);
             cards.iter().map(|card| card.kind.clone()).collect()

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -236,7 +236,7 @@ mod tests {
     use crate::diagnostics::LogLevel;
     use crate::domain::activity::{
         ActivityState, DelegateChildState, DelegateEntry, DelegateStats, DelegateStatus,
-        SessionActivity,
+        SessionActivity, SessionOp,
     };
     use crate::domain::auth::{
         AuthProviderEntry, OAuthFlow, OAuthFlowKind, OAuthResult, OAuthResultStatus, OAuthStatus,
@@ -1531,17 +1531,125 @@ mod tests {
     }
 
     #[test]
+    fn composer_draw_publishes_resized_geometry_scrolls_both_ways_and_preserves_semantics() {
+        let mut app = App::new();
+        app.navigation.screen = Screen::Chat;
+        app.sessions.agent_mode = "build".into();
+        app.composer.input = "a\nb\nc\nd\ne\nf\ng\nh".into();
+        app.composer.input_cursor = app.composer.input.len();
+        app.composer.input_preferred_col = Some(3);
+        app.composer.file_index = vec![crate::composer_state::FileIndexEntryLite {
+            path: "src/main.rs".into(),
+            is_dir: false,
+        }];
+        app.composer.file_index_generated_at = Some(7);
+        app.composer.file_index_error = Some("preserved".into());
+        app.composer.mention_state = Some(crate::composer_state::MentionState {
+            trigger_start: 1,
+            query: "src".into(),
+            selected_index: 2,
+            results: app.composer.file_index.clone(),
+        });
+        app.composer.slash_state = Some(crate::composer_state::SlashCompletionState {
+            query: "mo".into(),
+            selected_index: 1,
+            results: vec![&crate::slash::SLASH_COMMANDS[0]],
+        });
+        let semantic_snapshot = (
+            app.composer.input.clone(),
+            app.composer.input_cursor,
+            app.composer.input_preferred_col,
+            app.composer.file_index.clone(),
+            app.composer.file_index_generated_at,
+            app.composer.file_index_loading,
+            app.composer.file_index_error.clone(),
+            app.composer.mention_state.as_ref().map(|mention| {
+                (
+                    mention.trigger_start,
+                    mention.query.clone(),
+                    mention.selected_index,
+                    mention.results.clone(),
+                )
+            }),
+            app.composer.slash_state.as_ref().map(|slash| {
+                (
+                    slash.query.clone(),
+                    slash.selected_index,
+                    slash
+                        .results
+                        .iter()
+                        .map(|command| command.name)
+                        .collect::<Vec<_>>(),
+                )
+            }),
+        );
+
+        render_chat_buffer(&mut app, 40, 14);
+        assert_eq!(app.render.test_composer_input_geometry(), (36, 3, true));
+        assert_eq!(
+            (
+                app.composer.input.clone(),
+                app.composer.input_cursor,
+                app.composer.input_preferred_col,
+                app.composer.file_index.clone(),
+                app.composer.file_index_generated_at,
+                app.composer.file_index_loading,
+                app.composer.file_index_error.clone(),
+                app.composer.mention_state.as_ref().map(|mention| (
+                    mention.trigger_start,
+                    mention.query.clone(),
+                    mention.selected_index,
+                    mention.results.clone(),
+                )),
+                app.composer.slash_state.as_ref().map(|slash| (
+                    slash.query.clone(),
+                    slash.selected_index,
+                    slash
+                        .results
+                        .iter()
+                        .map(|command| command.name)
+                        .collect::<Vec<_>>(),
+                )),
+            ),
+            semantic_snapshot
+        );
+
+        app.composer.input_cursor = 0;
+        render_chat_buffer(&mut app, 20, 14);
+        assert_eq!(app.render.test_composer_input_geometry(), (16, 0, true));
+        render_chat_buffer(&mut app, 60, 14);
+        assert_eq!(app.render.test_composer_input_geometry(), (56, 0, true));
+    }
+
+    #[test]
+    fn hidden_composer_draw_resets_only_render_scroll() {
+        let mut app = App::new();
+        app.navigation.screen = Screen::Chat;
+        app.composer.input = "draft\nkept".into();
+        app.composer.input_cursor = app.composer.input.len();
+        app.composer.input_preferred_col = Some(2);
+        app.render.test_seed_composer_input_geometry(12, 4);
+        app.chat.activity = ActivityState::SessionOp(SessionOp::Undo);
+
+        render_chat_buffer(&mut app, 40, 12);
+
+        assert_eq!(app.render.test_composer_input_geometry(), (36, 0, true));
+        assert_eq!(app.composer.input, "draft\nkept");
+        assert_eq!(app.composer.input_cursor, "draft\nkept".len());
+        assert_eq!(app.composer.input_preferred_col, Some(2));
+    }
+
+    #[test]
     fn custom_editor_visual_movement_crosses_wrapped_rows() {
         let mut ui = ElicitationUiState {
             custom_cursor: 5,
-            custom_line_width: 5,
             ..Default::default()
         };
         let input = "abcdefghij";
 
-        ui.custom_move_visual(input, 1);
+        ui.custom_move_visual(input, 5, 1);
         assert_eq!(ui.custom_cursor, 10);
-        ui.custom_move_visual(input, -1);
+        ui.custom_move_visual(input, 5, -1);
         assert_eq!(ui.custom_cursor, 5);
     }
 
@@ -1549,15 +1657,98 @@ mod tests {
     fn custom_editor_visual_movement_crosses_explicit_newline() {
         let mut ui = ElicitationUiState {
             custom_cursor: 2,
-            custom_line_width: 20,
             ..Default::default()
         };
         let input = "ab\ncdef";
 
-        ui.custom_move_visual(input, 1);
+        ui.custom_move_visual(input, 20, 1);
         assert_eq!(ui.custom_cursor, 5);
-        ui.custom_move_visual(input, -1);
+        ui.custom_move_visual(input, 20, -1);
         assert_eq!(ui.custom_cursor, 2);
+    }
+
+    #[test]
+    fn custom_editor_draw_owns_scroll_resize_and_preserves_elicitation_semantics() {
+        let mut app = App::new();
+        app.navigation.screen = Screen::Chat;
+        let mut state = ElicitationState::new_for_test(vec![ElicitationField {
+            name: "choice".into(),
+            title: "Choice".into(),
+            description: Some("description".into()),
+            required: true,
+            kind: ElicitationFieldKind::SingleSelect {
+                options: vec![ElicitationOption {
+                    value: serde_json::json!("a"),
+                    label: "Alpha".into(),
+                    description: None,
+                }],
+            },
+        }]);
+        state.custom_input = "a\nb\nc\nd\ne\nf\ng".into();
+        state.text_input = "semantic text".into();
+        state
+            .selected
+            .insert("choice".into(), serde_json::json!("a"));
+        let ui = ElicitationUiState {
+            field_cursor: 0,
+            option_cursor: 1,
+            text_cursor: 4,
+            custom_active: true,
+            custom_cursor: state.custom_input.len(),
+        };
+        let state_snapshot = (
+            state.elicitation_id.clone(),
+            state.message.clone(),
+            state.source.clone(),
+            state.fields.clone(),
+            state.selected.clone(),
+            state.text_input.clone(),
+            state.custom_input.clone(),
+            state.allow_custom,
+        );
+        let ui_snapshot = (
+            ui.field_cursor,
+            ui.option_cursor,
+            ui.text_cursor,
+            ui.custom_active,
+            ui.custom_cursor,
+        );
+        app.chat.elicitation = Some(state);
+        app.chat.elicitation_ui = Some(ui);
+
+        render_chat_buffer(&mut app, 40, 24);
+        assert_eq!(app.render.test_elicitation_custom_geometry(), (36, 2, true));
+        let state = app.chat.elicitation.as_ref().unwrap();
+        let ui = app.chat.elicitation_ui.as_ref().unwrap();
+        assert_eq!(
+            (
+                state.elicitation_id.clone(),
+                state.message.clone(),
+                state.source.clone(),
+                state.fields.clone(),
+                state.selected.clone(),
+                state.text_input.clone(),
+                state.custom_input.clone(),
+                state.allow_custom,
+            ),
+            state_snapshot
+        );
+        assert_eq!(
+            (
+                ui.field_cursor,
+                ui.option_cursor,
+                ui.text_cursor,
+                ui.custom_active,
+                ui.custom_cursor,
+            ),
+            ui_snapshot
+        );
+
+        app.chat.elicitation_ui.as_mut().unwrap().custom_cursor = 0;
+        render_chat_buffer(&mut app, 20, 24);
+        assert_eq!(app.render.test_elicitation_custom_geometry(), (16, 0, true));
+        render_chat_buffer(&mut app, 3, 4);
+        assert_eq!(app.render.elicitation_custom_line_width(), 1);
     }
 
     #[test]

--- a/src/ui/popups.rs
+++ b/src/ui/popups.rs
@@ -9,13 +9,15 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::app::App;
 use crate::auth_state::AuthPanel;
+use crate::delegates_state::DelegatesState;
 use crate::diagnostics::LogLevel;
 use crate::domain::activity::DelegateStats;
 use crate::domain::auth::{AuthMethod, AuthStatus, OAuthFlowKind, OAuthStatus};
 use crate::domain::model::ModelEntry;
 use crate::domain::profile::ProfileInfo;
 use crate::models_state::ModelPopupItem;
-use crate::session_state::session_group_count_text;
+use crate::render_state::RenderState;
+use crate::session_state::{SessionsState, session_group_count_text};
 use crate::theme::Theme;
 
 use super::chat::{CHECK_CHECKED, CHECK_FAILED, SpinnerKind, spinner};
@@ -363,7 +365,12 @@ pub(super) fn draw_model_popup(f: &mut Frame, app: &App) {
 
 // ── Session popup ─────────────────────────────────────────────────────────────
 
-pub(super) fn draw_session_popup(f: &mut Frame, app: &mut App) {
+pub(super) fn draw_session_popup(
+    f: &mut Frame,
+    sessions: &SessionsState,
+    delegates: &DelegatesState,
+    render: &mut RenderState,
+) {
     const SESSION_POPUP_MAX_W: u16 = 86;
     const SESSION_POPUP_MIN_W: u16 = 36;
 
@@ -404,7 +411,7 @@ pub(super) fn draw_session_popup(f: &mut Frame, app: &mut App) {
     let tab_labels = ["sessions", "delegates"];
     let mut tab_spans = Vec::new();
     for (i, label) in tab_labels.iter().enumerate() {
-        let is_active = i == app.sessions.session_popup_tab;
+        let is_active = i == sessions.session_popup_tab;
         let style = if is_active {
             Theme::popup_title().add_modifier(Modifier::UNDERLINED)
         } else {
@@ -420,21 +427,27 @@ pub(super) fn draw_session_popup(f: &mut Frame, app: &mut App) {
         chunks[0],
     );
 
-    if app.sessions.session_popup_tab == 0 {
-        draw_session_tab_content(f, app, &chunks);
+    if sessions.session_popup_tab == 0 {
+        draw_session_tab_content(f, sessions, delegates, render, &chunks);
     } else {
-        draw_delegate_tab_content(f, app, &chunks);
+        draw_delegate_tab_content(f, sessions, delegates, render, &chunks);
     }
 }
 
-fn draw_session_tab_content(f: &mut Frame, app: &mut App, chunks: &std::rc::Rc<[Rect]>) {
+fn draw_session_tab_content(
+    f: &mut Frame,
+    sessions: &SessionsState,
+    delegates: &DelegatesState,
+    render: &mut RenderState,
+    chunks: &std::rc::Rc<[Rect]>,
+) {
     use crate::session_state::PopupItem;
 
     // filter
     let avail = chunks[1].width.saturating_sub(2) as usize;
     let (session_filter_display, session_filter_cur) = scroll_input(
-        &app.sessions.session_filter,
-        app.sessions.session_filter.len(),
+        &sessions.session_filter,
+        sessions.session_filter.len(),
         avail,
     );
     let filter_line = Line::from(vec![
@@ -448,16 +461,16 @@ fn draw_session_tab_content(f: &mut Frame, app: &mut App, chunks: &std::rc::Rc<[
     f.set_cursor_position((chunks[1].x + 2 + session_filter_cur as u16, chunks[1].y));
 
     // grouped session list
-    let popup_items = app.sessions.visible_popup_items();
+    let popup_items = sessions.visible_popup_items();
     let list_w = chunks[3].width as usize;
     let visible_rows = chunks[3].height as usize;
-    app.sessions.session_popup_visible_rows = visible_rows;
+    render.publish_session_popup_visible_rows(visible_rows);
 
     let items: Vec<ListItem> = popup_items
         .iter()
         .enumerate()
         .map(|(i, item)| {
-            let selected = i == app.sessions.session_cursor;
+            let selected = i == sessions.session_cursor;
             match item {
                 PopupItem::GroupHeader {
                     cwd,
@@ -489,7 +502,7 @@ fn draw_session_tab_content(f: &mut Frame, app: &mut App, chunks: &std::rc::Rc<[
                     path,
                     depth,
                 } => {
-                    let Some(s) = app.sessions.session_by_path(*group_idx, path) else {
+                    let Some(s) = sessions.session_by_path(*group_idx, path) else {
                         return ListItem::new(Line::from(""));
                     };
                     let id_short: String = s.session_id.chars().take(8).collect();
@@ -500,10 +513,9 @@ fn draw_session_tab_content(f: &mut Frame, app: &mut App, chunks: &std::rc::Rc<[
                         .unwrap_or_default();
                     let title = s.title.as_deref().unwrap_or("(untitled)");
 
-                    let is_active =
-                        app.sessions.session_id.as_deref() == Some(s.session_id.as_str());
+                    let is_active = sessions.session_id.as_deref() == Some(s.session_id.as_str());
                     let is_parent =
-                        app.delegates.parent_session_id.as_deref() == Some(s.session_id.as_str());
+                        delegates.parent_session_id.as_deref() == Some(s.session_id.as_str());
                     let marker_part = if is_active {
                         " ● "
                     } else if is_parent {
@@ -513,16 +525,13 @@ fn draw_session_tab_content(f: &mut Frame, app: &mut App, chunks: &std::rc::Rc<[
                     };
                     let indent = "  ".repeat(*depth);
                     let id_part = format!(" {indent}{id_short} ");
-                    let fork_marker = if app.sessions.expandable_root_session(*group_idx, path) {
-                        let indicator = if app
-                            .sessions
-                            .expanded_session_children
-                            .contains(&s.session_id)
-                        {
-                            COLLAPSE_OPEN
-                        } else {
-                            COLLAPSE_CLOSED
-                        };
+                    let fork_marker = if sessions.expandable_root_session(*group_idx, path) {
+                        let indicator =
+                            if sessions.expanded_session_children.contains(&s.session_id) {
+                                COLLAPSE_OPEN
+                            } else {
+                                COLLAPSE_CLOSED
+                            };
                         format!(" {indicator} ↳ {}", s.fork_count)
                     } else if s.fork_count > 0 && *depth == 0 {
                         format!(" ↳ {}", s.fork_count)
@@ -594,13 +603,12 @@ fn draw_session_tab_content(f: &mut Frame, app: &mut App, chunks: &std::rc::Rc<[
         .collect();
 
     let list = List::new(items).block(Block::default().style(Theme::popup_bg()));
-    let offset = app
-        .sessions
+    let offset = sessions
         .session_cursor
         .saturating_sub(visible_rows.saturating_sub(1));
     let mut state = ListState::default()
         .with_offset(offset)
-        .with_selected(Some(app.sessions.session_cursor));
+        .with_selected(Some(sessions.session_cursor));
     f.render_stateful_widget(list, chunks[3], &mut state);
 
     // hint
@@ -684,14 +692,20 @@ fn delegate_display_width(text: &str) -> u16 {
     UnicodeWidthStr::width(text) as u16
 }
 
-fn draw_delegate_tab_content(f: &mut Frame, app: &mut App, chunks: &std::rc::Rc<[Rect]>) {
+fn draw_delegate_tab_content(
+    f: &mut Frame,
+    sessions: &SessionsState,
+    delegates: &DelegatesState,
+    render: &mut RenderState,
+    chunks: &std::rc::Rc<[Rect]>,
+) {
     use crate::domain::activity::DelegateStatus;
 
     // filter
     let avail = chunks[1].width.saturating_sub(2) as usize;
     let (filter_display, filter_cur) = scroll_input(
-        &app.delegates.delegate_filter,
-        app.delegates.delegate_filter.len(),
+        &delegates.delegate_filter,
+        delegates.delegate_filter.len(),
         avail,
     );
     let filter_line = Line::from(vec![
@@ -706,8 +720,8 @@ fn draw_delegate_tab_content(f: &mut Frame, app: &mut App, chunks: &std::rc::Rc<
 
     // delegate entry list (built from event stream)
     let visible_rows = chunks[3].height as usize;
-    app.delegates.delegate_popup_visible_rows = visible_rows;
-    let entries = app.delegates.visible_entries();
+    render.publish_delegate_popup_visible_rows(visible_rows);
+    let entries = delegates.visible_entries();
 
     if entries.is_empty() {
         let list = List::new(vec![ListItem::new(Line::from(Span::styled(
@@ -723,7 +737,7 @@ fn draw_delegate_tab_content(f: &mut Frame, app: &mut App, chunks: &std::rc::Rc<
             .map(|entry| {
                 let status_badge = match entry.status {
                     DelegateStatus::InProgress => {
-                        spinner(SpinnerKind::Braille, app.render.tick).to_string()
+                        spinner(SpinnerKind::Braille, render.tick).to_string()
                     }
                     DelegateStatus::Completed => CHECK_CHECKED.to_string(),
                     DelegateStatus::Failed => CHECK_FAILED.to_string(),
@@ -742,7 +756,7 @@ fn draw_delegate_tab_content(f: &mut Frame, app: &mut App, chunks: &std::rc::Rc<
                 };
 
                 let is_current =
-                    entry.child_session_id.as_deref() == app.sessions.session_id.as_deref();
+                    entry.child_session_id.as_deref() == sessions.session_id.as_deref();
                 let duration = entry
                     .started_at
                     .map(|start| {
@@ -926,8 +940,7 @@ fn draw_delegate_tab_content(f: &mut Frame, app: &mut App, chunks: &std::rc::Rc<
             .style(Theme::popup_bg())
             .row_highlight_style(Theme::selected());
 
-        let selected_idx = app
-            .delegates
+        let selected_idx = delegates
             .delegate_cursor
             .min(entries.len().saturating_sub(1));
         let offset = selected_idx.saturating_sub(visible_rows.saturating_sub(1));
@@ -940,7 +953,7 @@ fn draw_delegate_tab_content(f: &mut Frame, app: &mut App, chunks: &std::rc::Rc<
 
     // hint
     let selected_entry = entries.get(
-        app.delegates
+        delegates
             .delegate_cursor
             .min(entries.len().saturating_sub(1)),
     );

--- a/src/ui/popups.rs
+++ b/src/ui/popups.rs
@@ -11,7 +11,7 @@ use crate::app::App;
 use crate::auth_state::AuthPanel;
 use crate::diagnostics::LogLevel;
 use crate::domain::activity::DelegateStats;
-use crate::domain::auth::{OAuthFlowKind, OAuthStatus};
+use crate::domain::auth::{AuthMethod, AuthStatus, OAuthFlowKind, OAuthStatus};
 use crate::domain::model::ModelEntry;
 use crate::domain::profile::ProfileInfo;
 use crate::models_state::ModelPopupItem;
@@ -2533,6 +2533,23 @@ pub(super) fn draw_help_popup(f: &mut Frame, app: &App) {
 const AUTH_POPUP_MAX_W: u16 = 68;
 const AUTH_POPUP_MIN_W: u16 = 44;
 
+fn auth_method_label(method: AuthMethod) -> &'static str {
+    match method {
+        AuthMethod::OAuth => "OAuth",
+        AuthMethod::ApiKey => "API Key",
+        AuthMethod::EnvVar => "Env",
+    }
+}
+
+fn auth_status_label(status: AuthStatus) -> &'static str {
+    match status {
+        AuthStatus::Unconfigurable => "OAuth required",
+        AuthStatus::Expired => "Expired",
+        AuthStatus::Active(method) => auth_method_label(method),
+        AuthStatus::NotConfigured => "Not configured",
+    }
+}
+
 pub(super) fn draw_auth_popup(f: &mut Frame, app: &App) {
     let area = f.area();
     let popup_width = area
@@ -2620,7 +2637,8 @@ pub(super) fn draw_auth_popup(f: &mut Frame, app: &App) {
         .enumerate()
         .map(|(i, (_, provider))| {
             let selected = i == app.auth.cursor;
-            let badge = provider.auth_badge_label();
+            let status = provider.auth_status();
+            let badge = auth_status_label(status);
             let badge_active = provider.is_auth_active();
             let is_expired = provider.oauth_status == Some(OAuthStatus::Expired);
 
@@ -2756,7 +2774,7 @@ fn draw_auth_detail_panel(f: &mut Frame, app: &App, area: Rect) {
             // Show selected provider status summary
             let mut lines: Vec<Line<'static>> = Vec::new();
 
-            let status_label = provider.auth_badge_label();
+            let status_label = auth_status_label(provider.auth_status());
             let is_active = provider.is_auth_active();
             let status_style = if is_active {
                 ratatui::style::Style::default()
@@ -3051,7 +3069,40 @@ fn draw_auth_clipboard_fallback(f: &mut Frame, area: Rect, url: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::auth::AuthProviderEntry;
     use crate::domain::profile::ProfileInfo;
+
+    fn auth_provider(display_name: &str, status: AuthStatus) -> AuthProviderEntry {
+        let (supports_oauth, env_var_name) = match status {
+            AuthStatus::Unconfigurable => (false, None),
+            AuthStatus::Active(AuthMethod::OAuth) | AuthStatus::Expired => (true, None),
+            AuthStatus::Active(AuthMethod::ApiKey) | AuthStatus::Active(AuthMethod::EnvVar) => (
+                false,
+                Some(format!("{}_API_KEY", display_name.to_uppercase())),
+            ),
+            AuthStatus::NotConfigured => (
+                true,
+                Some(format!("{}_API_KEY", display_name.to_uppercase())),
+            ),
+        };
+        AuthProviderEntry {
+            provider: display_name.to_lowercase().replace(' ', "-"),
+            display_name: display_name.into(),
+            oauth_status: match status {
+                AuthStatus::Expired => Some(OAuthStatus::Expired),
+                AuthStatus::Active(AuthMethod::OAuth) => Some(OAuthStatus::Connected),
+                AuthStatus::Unconfigurable
+                | AuthStatus::Active(AuthMethod::ApiKey)
+                | AuthStatus::Active(AuthMethod::EnvVar) => None,
+                AuthStatus::NotConfigured => Some(OAuthStatus::NotAuthenticated),
+            },
+            has_stored_api_key: status == AuthStatus::Active(AuthMethod::ApiKey),
+            has_env_api_key: status == AuthStatus::Active(AuthMethod::EnvVar),
+            env_var_name,
+            supports_oauth,
+            preferred_method: None,
+        }
+    }
 
     fn profile(id: &str, name: &str) -> ProfileInfo {
         ProfileInfo {
@@ -3075,6 +3126,108 @@ mod tests {
             }
         }
         None
+    }
+
+    fn find_last_buffer_text(buffer: &ratatui::buffer::Buffer, needle: &str) -> Option<(u16, u16)> {
+        for y in (0..buffer.area.height).rev() {
+            let line = buffer_line(buffer, y);
+            if let Some(byte_idx) = line.find(needle) {
+                return Some((line[..byte_idx].chars().count() as u16, y));
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn auth_labels_map_semantic_methods_and_statuses() {
+        assert_eq!(auth_method_label(AuthMethod::OAuth), "OAuth");
+        assert_eq!(auth_method_label(AuthMethod::ApiKey), "API Key");
+        assert_eq!(auth_method_label(AuthMethod::EnvVar), "Env");
+        assert_eq!(
+            auth_status_label(AuthStatus::Unconfigurable),
+            "OAuth required"
+        );
+        assert_eq!(auth_status_label(AuthStatus::Expired), "Expired");
+        assert_eq!(
+            auth_status_label(AuthStatus::Active(AuthMethod::OAuth)),
+            "OAuth"
+        );
+        assert_eq!(
+            auth_status_label(AuthStatus::Active(AuthMethod::ApiKey)),
+            "API Key"
+        );
+        assert_eq!(
+            auth_status_label(AuthStatus::Active(AuthMethod::EnvVar)),
+            "Env"
+        );
+        assert_eq!(
+            auth_status_label(AuthStatus::NotConfigured),
+            "Not configured"
+        );
+    }
+
+    #[test]
+    fn auth_popup_renders_exact_badges_and_styles_in_list_and_detail() {
+        let mut app = App::new();
+        app.auth.providers = vec![
+            auth_provider("OAuth Active", AuthStatus::Active(AuthMethod::OAuth)),
+            auth_provider("API Active", AuthStatus::Active(AuthMethod::ApiKey)),
+            auth_provider("Env Active", AuthStatus::Active(AuthMethod::EnvVar)),
+            auth_provider("Expired Auth", AuthStatus::Expired),
+            auth_provider("OAuth Missing", AuthStatus::Unconfigurable),
+            auth_provider("No Auth", AuthStatus::NotConfigured),
+        ];
+        app.auth.cursor = app.auth.providers.len();
+
+        let backend = ratatui::backend::TestBackend::new(80, 24);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal.draw(|frame| draw_auth_popup(frame, &app)).unwrap();
+        let buffer = terminal.backend().buffer();
+
+        for (name, label, foreground) in [
+            ("OAuth Active", "[OAuth]", Theme::ok()),
+            ("API Active", "[API Key]", Theme::ok()),
+            ("Env Active", "[Env]", Theme::ok()),
+            ("Expired Auth", "[Expired]", Theme::warn()),
+        ] {
+            let row = find_buffer_text(buffer, name).expect("provider row").1;
+            let badge = find_buffer_text(buffer, label).expect("provider badge");
+            assert_eq!(badge.1, row);
+            assert_eq!(buffer[badge].fg, foreground);
+        }
+        for (name, label) in [
+            ("OAuth Missing", "[OAuth required]"),
+            ("No Auth", "[Not configured]"),
+        ] {
+            let row = find_buffer_text(buffer, name).expect("provider row").1;
+            let badge = find_buffer_text(buffer, label).expect("provider badge");
+            assert_eq!(badge.1, row);
+            assert_eq!(buffer[badge].fg, Theme::status().fg.unwrap());
+            assert_eq!(buffer[badge].bg, Theme::status().bg.unwrap());
+        }
+
+        for (index, label, active) in [
+            (0, "[OAuth]", true),
+            (1, "[API Key]", true),
+            (2, "[Env]", true),
+            (3, "[Expired]", false),
+            (4, "[OAuth required]", false),
+            (5, "[Not configured]", false),
+        ] {
+            app.auth.selected = Some(index);
+            let backend = ratatui::backend::TestBackend::new(80, 24);
+            let mut terminal = ratatui::Terminal::new(backend).unwrap();
+            terminal.draw(|frame| draw_auth_popup(frame, &app)).unwrap();
+            let buffer = terminal.backend().buffer();
+            let badge = find_last_buffer_text(buffer, label).expect("detail badge");
+            let (expected_fg, expected_bg) = if active {
+                (Theme::ok(), Theme::bg_dim())
+            } else {
+                (Theme::status().fg.unwrap(), Theme::status().bg.unwrap())
+            };
+            assert_eq!(buffer[badge].fg, expected_fg);
+            assert_eq!(buffer[badge].bg, expected_bg);
+        }
     }
 
     #[test]

--- a/src/ui/start.rs
+++ b/src/ui/start.rs
@@ -6,7 +6,7 @@ use ratatui::{
 };
 
 use crate::app::App;
-use crate::session_state::{StartPageItem, session_group_count_text};
+use crate::session_state::{SessionsState, StartPageItem, session_group_count_text};
 use crate::theme::Theme;
 
 use super::{ELLIPSIS, draw_header, mesh_header_span, relative_time};
@@ -32,12 +32,15 @@ pub(crate) struct StartPageRow {
 ///
 /// Pure function — does not touch the frame. Accepts `area_width` for
 /// truncating long paths/titles.
-pub(crate) fn build_start_page_rows(app: &App, area_width: usize) -> Vec<StartPageRow> {
-    let items = app.sessions.visible_start_items();
+pub(crate) fn build_start_page_rows(
+    sessions: &SessionsState,
+    area_width: usize,
+) -> Vec<StartPageRow> {
+    let items = sessions.visible_start_items();
     let mut rows = Vec::with_capacity(items.len());
 
     for (idx, item) in items.iter().enumerate() {
-        let selected = idx == app.sessions.session_cursor;
+        let selected = idx == sessions.session_cursor;
 
         let (header_style, dim_style) = if selected {
             (Theme::selected(), Theme::selected())
@@ -78,7 +81,7 @@ pub(crate) fn build_start_page_rows(app: &App, area_width: usize) -> Vec<StartPa
                 path,
                 depth,
             } => {
-                let Some(session) = app.sessions.session_by_path(*group_idx, path) else {
+                let Some(session) = sessions.session_by_path(*group_idx, path) else {
                     continue;
                 };
                 let id_short: String = session.session_id.chars().take(8).collect();
@@ -89,9 +92,8 @@ pub(crate) fn build_start_page_rows(app: &App, area_width: usize) -> Vec<StartPa
                     .map(relative_time)
                     .unwrap_or_default();
 
-                let fork_marker = if app.sessions.expandable_root_session(*group_idx, path) {
-                    let indicator = if app
-                        .sessions
+                let fork_marker = if sessions.expandable_root_session(*group_idx, path) {
+                    let indicator = if sessions
                         .expanded_session_children
                         .contains(&session.session_id)
                     {
@@ -204,6 +206,9 @@ pub(super) fn draw_start(f: &mut Frame, app: &mut App) {
         right,
     );
 
+    let sessions = &app.sessions;
+    let render = &mut app.render;
+
     // ── hints ─────────────────────────────────────────────────────────────────
     // Rendered now (fixed bottom) so we can focus the rest on centring.
     let hint_area = outer[2];
@@ -225,7 +230,7 @@ pub(super) fn draw_start(f: &mut Frame, app: &mut App) {
 
     // ── glitch / wave variables (shared by art and button) ───────────────────
     const GLITCH_CHARS: &str = "░▒▓█▌▐▄▀┃╋╳";
-    let tick = app.render.tick as usize;
+    let tick = render.tick as usize;
     let prng = |seed: usize| -> usize {
         let mut h = seed.wrapping_mul(2654435761);
         h ^= h >> 16;
@@ -247,7 +252,7 @@ pub(super) fn draw_start(f: &mut Frame, app: &mut App) {
 
     // ── compute content block height for vertical centring ────────────────────
     // Build rows first so we know how many there are.
-    let rows = build_start_page_rows(app, col_w as usize);
+    let rows = build_start_page_rows(sessions, col_w as usize);
     let rows_h = rows.len() as u16;
 
     // Button: 1 gap row + 1 text row (no border).
@@ -371,7 +376,7 @@ pub(super) fn draw_start(f: &mut Frame, app: &mut App) {
     };
     let filter_line = Line::from(vec![
         Span::styled(" > ", Theme::start_header()),
-        Span::styled(app.sessions.session_filter.clone(), Theme::fg()),
+        Span::styled(sessions.session_filter.clone(), Theme::fg()),
     ]);
     f.render_widget(
         Paragraph::new(filter_line).style(Theme::base()),
@@ -379,7 +384,7 @@ pub(super) fn draw_start(f: &mut Frame, app: &mut App) {
     );
     // Show cursor at the end of the typed filter text
     f.set_cursor_position((
-        filter_area.x + 3 + app.sessions.session_filter.chars().count() as u16,
+        filter_area.x + 3 + sessions.session_filter.chars().count() as u16,
         filter_area.y,
     ));
 
@@ -388,7 +393,7 @@ pub(super) fn draw_start(f: &mut Frame, app: &mut App) {
 
     if rows.is_empty() {
         // Empty state
-        let msg = if app.sessions.session_filter.is_empty() {
+        let msg = if sessions.session_filter.is_empty() {
             "No sessions yet.  C-x n to start a new one."
         } else {
             "No sessions match the filter."
@@ -410,24 +415,10 @@ pub(super) fn draw_start(f: &mut Frame, app: &mut App) {
         let visible_rows = list_area.height as usize;
         let total_rows = rows.len();
 
-        // Clamp scroll so cursor is in view.
-        if app.sessions.session_cursor >= app.sessions.start_page_scroll + visible_rows {
-            app.sessions.start_page_scroll = app.sessions.session_cursor + 1 - visible_rows;
-        }
-        if app.sessions.session_cursor < app.sessions.start_page_scroll {
-            app.sessions.start_page_scroll = app.sessions.session_cursor;
-        }
-        app.sessions.start_page_scroll = app
-            .sessions
-            .start_page_scroll
-            .min(total_rows.saturating_sub(visible_rows));
+        let scroll =
+            render.clamp_start_page_scroll(sessions.session_cursor, total_rows, visible_rows);
 
-        for (display_row, row) in rows
-            .iter()
-            .skip(app.sessions.start_page_scroll)
-            .take(visible_rows)
-            .enumerate()
-        {
+        for (display_row, row) in rows.iter().skip(scroll).take(visible_rows).enumerate() {
             let y = list_area.y + display_row as u16;
             if y >= list_area.y + list_area.height {
                 break;
@@ -461,7 +452,7 @@ pub(super) fn draw_start(f: &mut Frame, app: &mut App) {
         height: 1,
     };
 
-    let button_focused = app.sessions.session_cursor == rows.len();
+    let button_focused = sessions.session_cursor == rows.len();
 
     // Build text spans: glitch only when focused, always bold
     let text_spans: Vec<Span<'static>> = if button_focused {
@@ -509,6 +500,116 @@ pub(super) fn draw_start(f: &mut Frame, app: &mut App) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::session::{SessionGroup, SessionSummary};
+
+    fn group(cwd: &str, count: usize) -> SessionGroup {
+        SessionGroup {
+            cwd: Some(cwd.into()),
+            sessions: (0..count)
+                .map(|index| SessionSummary {
+                    session_id: format!("{cwd}-{index}"),
+                    title: Some(format!("Session {index}")),
+                    ..Default::default()
+                })
+                .collect(),
+            total_count: Some(count as u64),
+            ..Default::default()
+        }
+    }
+
+    fn session_semantics(app: &App) -> String {
+        format!(
+            "groups={:?};cursor={};filter={:?};tab={};collapsed={:?};popup_collapsed={:?};discovery={};discovery_cursors={:?};pending_groups={:?};hydrated={:?};expanded={:?};pending_children={:?};session={:?};agent={:?};mode={:?};review={:?};new_path={:?};new_cursor={};completion={:?};activity={:?};remote={:?}",
+            app.sessions.session_groups,
+            app.sessions.session_cursor,
+            app.sessions.session_filter,
+            app.sessions.session_popup_tab,
+            app.sessions.collapsed_groups,
+            app.sessions.popup_collapsed_groups,
+            app.sessions.session_discovery_in_progress,
+            app.sessions.session_discovery_cursors,
+            app.sessions.pending_session_group_loads,
+            app.sessions.hydrated_session_groups,
+            app.sessions.expanded_session_children,
+            app.sessions.pending_session_child_loads,
+            app.sessions.session_id,
+            app.sessions.agent_id,
+            app.sessions.agent_mode,
+            app.sessions.mode_before_review,
+            app.sessions.new_session_path,
+            app.sessions.new_session_cursor,
+            app.sessions.new_session_completion,
+            app.sessions.session_activity,
+            app.sessions.remote_session_locations,
+        )
+    }
+
+    fn draw_at(app: &mut App, width: u16, height: u16) -> String {
+        let backend = ratatui::backend::TestBackend::new(width, height);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal.draw(|frame| draw_start(frame, app)).unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect()
+    }
+
+    #[test]
+    fn start_draw_clamps_resize_button_and_short_lists_without_mutating_sessions() {
+        let mut app = App::new();
+        app.sessions.session_groups =
+            vec![group("repo-a", 4), group("repo-b", 4), group("repo-c", 4)];
+        let row_count = build_start_page_rows(&app.sessions, 64).len();
+        assert_eq!(row_count, 15);
+        app.sessions.session_cursor = row_count;
+        app.render.test_seed_start_page_scroll(usize::MAX);
+        let before = session_semantics(&app);
+
+        draw_at(&mut app, 100, 10);
+        assert_eq!(app.render.start_page_scroll(), 11);
+        assert_eq!(session_semantics(&app), before);
+
+        draw_at(&mut app, 100, 14);
+        assert_eq!(app.render.start_page_scroll(), 7);
+        assert_eq!(session_semantics(&app), before);
+
+        draw_at(&mut app, 100, 30);
+        assert_eq!(app.render.start_page_scroll(), 0);
+        assert_eq!(session_semantics(&app), before);
+
+        app.sessions.session_groups = vec![group("short", 1)];
+        app.sessions.session_cursor = 1;
+        app.render.test_seed_start_page_scroll(9);
+        let short_before = session_semantics(&app);
+        draw_at(&mut app, 80, 20);
+        assert_eq!(app.render.start_page_scroll(), 0);
+        assert_eq!(session_semantics(&app), short_before);
+    }
+
+    #[test]
+    fn start_draw_preserves_empty_scroll_and_handles_zero_height_list() {
+        let mut app = App::new();
+        app.render.test_seed_start_page_scroll(7);
+        let before = session_semantics(&app);
+        let rendered = draw_at(&mut app, 80, 20);
+        assert!(rendered.contains("No sessions yet"));
+        assert_eq!(app.render.start_page_scroll(), 7);
+        assert_eq!(session_semantics(&app), before);
+
+        app.sessions.session_groups = vec![group("tiny", 4)];
+        app.sessions.session_cursor = 2;
+        app.render.test_seed_start_page_scroll(0);
+        let tiny_before = session_semantics(&app);
+        draw_at(&mut app, 20, 3);
+        assert_eq!(app.render.start_page_scroll(), 2);
+        app.render.test_seed_start_page_scroll(0);
+        draw_at(&mut app, 20, 2);
+        assert_eq!(app.render.start_page_scroll(), 2);
+        assert_eq!(session_semantics(&app), tiny_before);
+    }
 
     #[test]
     fn start_page_header_uses_active_profile_label() {
@@ -519,18 +620,7 @@ mod tests {
             ..Default::default()
         }];
         app.profiles.active_profile_id = Some("fast".into());
-        let backend = ratatui::backend::TestBackend::new(100, 20);
-        let mut terminal = ratatui::Terminal::new(backend).unwrap();
-
-        terminal.draw(|frame| draw_start(frame, &mut app)).unwrap();
-
-        let text = terminal
-            .backend()
-            .buffer()
-            .content()
-            .iter()
-            .map(|cell| cell.symbol())
-            .collect::<String>();
+        let text = draw_at(&mut app, 100, 20);
         assert!(text.contains("profile:Fast"));
     }
 }


### PR DESCRIPTION
## Scope

- Keep domain/tool data semantic and rendering-neutral; move shell, diff, write, multiedit, summary, elicitation, and auth presentation into UI adapters.
- Move `Card`/`CardKind`, finalized and streaming caches, stable identity/content/width/theme keys, theme revision, and session epoch under `RenderState`.
- Centralize the seven-variant semantic `RenderChange` invalidation policy outside reducers.
- Move chat viewport, composer/elicitation geometry, and start/session/delegate render metrics into `RenderState`; rendering reads feature state without mutating it.
- Add test-only closure coverage for direct rendering of every semantic `ToolDetail` variant.

## Validation

- Exact independently approved head: `4cde4a92e1499f72e312e5d773c207c89887eb6e`
- Exact base: `refactor/components@9b396011a03ad3071b2df499831b9beb923909fc`
- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Debug and release builds
- Full debug suite: 1,068 passed, 0 failed/ignored
- Full release suite: 1,068 passed, 0 failed/ignored
- `git diff --check`
- Aggregate independent review approved the exact head with no unresolved findings

## Boundaries

This is Phase 8 only. It does not include the Phase 9 handler/view split, dependency or workflow changes, ACP transport/replay/protocol/schema changes, or persistence changes. Live ACP/UI smoke remains unavailable and is not claimed.